### PR TITLE
fix(dryrun): Require converge reason

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentProcessor.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentProcessor.kt
@@ -25,10 +25,11 @@ interface IntentProcessor<in I : Intent<IntentSpec>> {
 }
 
 enum class ConvergeReason(val reason: String) {
-  UNCHANGED("System state matches desired state")
+  UNCHANGED("System state matches desired state"),
+  CHANGED("System state does not match desired state")
 }
 
 data class ConvergeResult(
   val orchestrations: List<OrchestrationRequest>,
-  val reason: String? = null
+  val reason: String
 )

--- a/keel-core/src/test/groovy/com/netflix/spinnaker/keel/dryrun/DryRunIntentLauncherSpec.groovy
+++ b/keel-core/src/test/groovy/com/netflix/spinnaker/keel/dryrun/DryRunIntentLauncherSpec.groovy
@@ -55,9 +55,10 @@ class DryRunIntentLauncherSpec extends Specification {
           new Job("wait", [waitTime: 5]),
           new Job("wait", [name: "wait for more time", waitTime: 5])
         ], new Trigger("1", "keel", "keel"))
-      ], null)
+      ], "Raisins")
     }
     result instanceof DryRunLaunchedIntentResult
+    result.reason == "Raisins"
     result.steps.size() == 1
     result.steps[0].name == "my orchestration"
     result.steps[0].description == "testing dry-runs"

--- a/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/ApplicationIntentProcessor.kt
+++ b/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/ApplicationIntentProcessor.kt
@@ -57,19 +57,21 @@ class ApplicationIntentProcessor
     ))
 
     return ConvergeResult(listOf(
-      OrchestrationRequest(
-        name = if (currentState == null) "Create application" else "Update application",
-        application = intent.spec.name,
-        description = "Converging on desired application state",
-        job = listOf(
-          Job(
-            type = "upsertApplication",
-            m = objectMapper.convertValue(intent.spec, ANY_MAP_TYPE)
-          )
-        ),
-        trigger = Trigger(intent.getId())
-      )
-    ))
+        OrchestrationRequest(
+          name = if (currentState == null) "Create application" else "Update application",
+          application = intent.spec.name,
+          description = "Converging on desired application state",
+          job = listOf(
+            Job(
+              type = "upsertApplication",
+              m = objectMapper.convertValue(intent.spec, ANY_MAP_TYPE)
+            )
+          ),
+          trigger = Trigger(intent.getId())
+        )
+      ),
+      if (currentState == null) "Application does not exist" else "Application has been updated"
+    )
   }
 
   private fun getApplication(name: String): Application? {

--- a/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/ParrotIntentProcessor.kt
+++ b/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/ParrotIntentProcessor.kt
@@ -15,10 +15,7 @@
  */
 package com.netflix.spinnaker.keel.intents.processors
 
-import com.netflix.spinnaker.keel.ConvergeResult
-import com.netflix.spinnaker.keel.Intent
-import com.netflix.spinnaker.keel.IntentProcessor
-import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.intents.ParrotIntent
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -48,6 +45,6 @@ class ParrotIntentProcessor
         ),
         trigger = Trigger(intent.getId())
       )
-    ))
+    ), ConvergeReason.CHANGED.reason)
   }
 }

--- a/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/SecurityGroupIntentProcessor.kt
+++ b/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/SecurityGroupIntentProcessor.kt
@@ -66,19 +66,21 @@ class SecurityGroupIntentProcessor
     }
 
     return ConvergeResult(listOf(
-      OrchestrationRequest(
-        name = "Upsert security group",
-        application = intent.spec.application,
-        description = "Converging on desired security group state",
-        job = listOf(
-          Job(
-            type = "upsertSecurityGroup",
-            m = securityGroupConverter.convertToJob(intent.spec)
-          )
-        ),
-        trigger = Trigger(intent.getId())
-      )
-    ))
+        OrchestrationRequest(
+          name = "Upsert security group",
+          application = intent.spec.application,
+          description = "Converging on desired security group state",
+          job = listOf(
+            Job(
+              type = "upsertSecurityGroup",
+              m = securityGroupConverter.convertToJob(intent.spec)
+            )
+          ),
+          trigger = Trigger(intent.getId())
+        )
+      ),
+      ConvergeReason.CHANGED.reason
+    )
   }
 
   private fun getSecurityGroups(spec: SecurityGroupSpec): Set<SecurityGroup> {


### PR DESCRIPTION
I didn't like that the dry-run functionality had empty reasons. I want to avoid the whole Orca "No reason provided" fiasco in keel outputs. Future refactoring will be done to give additional context around actual operations that are performed (rather than just outputting the name of the affected app). Dry run is still pretty useless:

```json
[
  {
    "reason": "System state does not match desired state",
    "steps": [
      {
        "name": "Upsert security group",
        "description": "Converging on desired security group state",
        "operations": [
          "keel"
        ]
      }
    ]
  },
  {
    "reason": "Application does not exist",
    "steps": [
      {
        "name": "Create application",
        "description": "Converging on desired application state",
        "operations": [
          "keel"
        ]
      }
    ]
  }
]
```