### PR TITLE
fix(orca): Fix ops endpoint

### DIFF
--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -28,10 +28,10 @@ data class Application(
   val platformHealthOnlyShowOverride: Boolean
 ) {
 
-  private val details: MutableMap<String, Any> = mutableMapOf()
+  private val details: MutableMap<String, Any?> = mutableMapOf()
 
   @JsonAnySetter
-  fun set(name: String, value: Any) {
+  fun set(name: String, value: Any?) {
     details[name] = value
   }
 

--- a/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/ApplicationIntent.kt
+++ b/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/ApplicationIntent.kt
@@ -184,10 +184,10 @@ data class NetflixApplicationSpec(
   val pdApiKey: String,
   val propertyRolloutConfigId: String?,
   val legacyUdf: Boolean,
-  val monitorBucketType: String,
+  val monitorBucketType: String?,
   val criticalityRules: List<CriticalityRuleSpec>,
-  val ccpService: String,
-  val timelines: List<TimelineSpec>
+  val ccpService: String?,
+  val timelines: List<TimelineSpec>?
 ) : BaseApplicationSpec()
 
 data class CriticalityRuleSpec(

--- a/keel-intents/src/test/groovy/com/netflix/spinnaker/keel/intents/processors/ApplicationIntentProcessorSpec.groovy
+++ b/keel-intents/src/test/groovy/com/netflix/spinnaker/keel/intents/processors/ApplicationIntentProcessorSpec.groovy
@@ -76,7 +76,7 @@ class ApplicationIntentProcessorSpec extends Specification {
     }
     1 * traceRepository.record(_)
     result.orchestrations[0].name == "Update application"
-    result.orchestrations[0].job[0]["description"] == "my updated description"
+    result.orchestrations[0].job[0]['application']["description"] == "my updated description"
   }
 
   static ApplicationSpec createApplicationSpec(String description) {

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
@@ -38,12 +38,16 @@ open class OrcaIntentLauncher
     registry.counter(invocationsId.withTags(intent.getMetricTags())).increment()
 
     return registry.timer(invocationTimeId.withTags(intent.getMetricTags())).record<OrcaLaunchedIntentResult> {
-      OrcaLaunchedIntentResult(
-        orchestrationIds = intentProcessor(intentProcessors, intent).converge(intent).orchestrations.map {
-          log.info("Launching orchestration for intent (kind: ${intent.kind})")
-          orcaService.orchestrate(it).ref
-        }
-      )
+      val orchestrationIds = intentProcessor(intentProcessors, intent).converge(intent).orchestrations.map {
+        log.info("Launching orchestration for intent (kind: ${intent.kind})")
+        orcaService.orchestrate(it).ref
+      }
+
+      log.info("Launched orchestrations for intent (" +
+        "kind: ${intent.kind}, " +
+        "tasks: $orchestrationIds" +
+        ")")
+      OrcaLaunchedIntentResult(orchestrationIds)
     }
   }
 }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -17,11 +17,14 @@ package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import retrofit.http.Body
+import retrofit.http.Headers
 import retrofit.http.POST
 
+// TODO Origin needs to be set on executions
 interface OrcaService {
 
   @POST("/ops")
+  @Headers("Content-Type: application/context+json")
   fun orchestrate(@Body request: OrchestrationRequest): TaskRefResponse
 }
 


### PR DESCRIPTION
Actually fixes a few issues.

* Fixes ops endpoint headers
* Application orchestration wrapper
* Improves logging of orchestrations
* Scaffold diffing for ApplicationIntent
* Correctly marking optional NetflixApplicationIntentSpec fields.