### PR TITLE
feat(front50): adding front50 support for intents

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
@@ -31,7 +31,6 @@ abstract class Intent<out S : IntentSpec>
 
   val status: IntentStatus = IntentStatus.ACTIVE
 
-  @JsonIgnore
   abstract fun getId(): String
 
   @JsonIgnore

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentRepository.kt
@@ -17,11 +17,11 @@ package com.netflix.spinnaker.keel
 
 interface IntentRepository {
 
-  fun upsertIntent(intent: Intent<IntentSpec>)
+  fun upsertIntent(intent: Intent<IntentSpec>): Intent<IntentSpec>
 
   fun getIntents(): List<Intent<IntentSpec>>
 
-  fun getIntents(statuses: List<IntentStatus>): List<Intent<IntentSpec>>
+  fun getIntents(status: List<IntentStatus>): List<Intent<IntentSpec>>
 
   fun getIntent(id: String): Intent<IntentSpec>?
 }

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Configuration.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Configuration.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.keel.front50.Front50Service
 import com.netflix.spinnaker.keel.retrofit.RetrofitConfiguration
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
 import retrofit.Endpoint
@@ -30,6 +31,9 @@ import retrofit.client.Client
 import retrofit.converter.JacksonConverter
 
 @Configuration
+@ComponentScan(
+  basePackages = arrayOf("com.netflix.spinnaker.keel.front50")
+)
 @Import(RetrofitConfiguration::class)
 open class Front50Configuration {
 

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50IntentRepository.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50IntentRepository.kt
@@ -1,11 +1,11 @@
 /*
  * Copyright 2017 Netflix, Inc.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
+ * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,34 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.keel.memory
 
+package com.netflix.spinnaker.keel.front50
+
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.Intent
 import com.netflix.spinnaker.keel.IntentRepository
 import com.netflix.spinnaker.keel.IntentSpec
 import com.netflix.spinnaker.keel.IntentStatus
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
 import javax.annotation.PostConstruct
 
-class MemoryIntentRepository : IntentRepository {
+@Component
+class Front50IntentRepository
+@Autowired constructor(
+    private val front50Service: Front50Service,
+    private val objectMapper: ObjectMapper
+): IntentRepository {
 
   private val log = LoggerFactory.getLogger(javaClass)
 
-  private val intents: MutableMap<String, Intent<IntentSpec>> = mutableMapOf()
-
-  @PostConstruct fun init() {
+  @PostConstruct
+  fun init() {
     log.info("Using ${javaClass.simpleName}")
   }
 
-  override fun upsertIntent(intent: Intent<IntentSpec>): Intent<IntentSpec> {
-    intents.put(intent.getId(), intent)
-    return intent
-  }
+  override fun upsertIntent(intent: Intent<IntentSpec>) = front50Service.upsertIntent(intent)
 
-  override fun getIntents() = intents.values.toList()
+  override fun getIntents() = front50Service.getIntents()
 
-  override fun getIntents(status: List<IntentStatus>)
-    = intents.values.filter { status.contains(it.status) }.toList()
+  override fun getIntents(status: List<IntentStatus>) = front50Service.getIntentsByStatus(status)
 
-  override fun getIntent(id: String) = intents[id]
+  override fun getIntent(id: String) = front50Service.getIntent(id)
 }

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.front50
 
 import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentSpec
 import com.netflix.spinnaker.keel.IntentStatus
 import com.netflix.spinnaker.keel.front50.model.Application
 import retrofit.http.*
@@ -23,10 +24,16 @@ import retrofit.http.*
 interface Front50Service {
 
   @GET("/intents")
-  fun getIntentsByStatuses(@Query("statuses") statuses: List<IntentStatus>): List<Intent<*>>
+  fun getIntents(): List<Intent<IntentSpec>>
 
-  @PUT("/intents")
-  fun upsertIntent(@Body intent: Intent<*>)
+  @GET("/intents")
+  fun getIntentsByStatus(@Query("status") status: List<IntentStatus>?): List<Intent<IntentSpec>>
+
+  @GET("/intents/{id}")
+  fun getIntent(@Path("id") id: String): Intent<IntentSpec>
+
+  @POST("/intents")
+  fun upsertIntent(@Body intent: Intent<IntentSpec>): Intent<IntentSpec>
 
   @GET("/v2/applications/{applicationName}")
   fun getApplication(@Path("applicationName") applicationName: String): Application

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ScheduleConvergeHandler.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ScheduleConvergeHandler.kt
@@ -48,7 +48,7 @@ class ScheduleConvergeHandler
     log.info("Scheduling intent convergence work")
 
     try {
-      intentRepository.getIntents(statuses = listOf(IntentStatus.ACTIVE))
+      intentRepository.getIntents(status = listOf(IntentStatus.ACTIVE))
         .also { log.info("Scheduling ${it.size} active intents") }
         .forEach {
           queue.push(ConvergeIntent(

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/TestIntent.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/TestIntent.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.test
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonTypeName
 import com.github.jonpeterson.jackson.module.versioning.JsonVersionedModel
 import com.netflix.spinnaker.keel.Intent
@@ -25,6 +26,7 @@ import com.netflix.spinnaker.keel.IntentSpec
 @JsonVersionedModel(currentVersion = "1", propertyName = "schema")
 class TestIntent
 @JsonCreator constructor(spec: TestIntentSpec) : Intent<TestIntentSpec>("1", "Test", spec) {
+  @JsonIgnore
   override fun getId() = "test:${spec.id}"
 }
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/model/UpsertIntentRequest.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/model/UpsertIntentRequest.kt
@@ -16,8 +16,9 @@
 package com.netflix.spinnaker.keel.model
 
 import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentSpec
 
 data class UpsertIntentRequest(
-  val intents: List<Intent<*>>,
+  val intents: List<Intent<IntentSpec>>,
   val dryRun: Boolean = false
 )

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/web/config/WebConfiguration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/web/config/WebConfiguration.kt
@@ -55,7 +55,7 @@ open class WebConfiguration
             response.setHeader("Access-Control-Max-Age", "3600")
             response.setHeader("Access-Control-Allow-Headers", "x-requested-with, content-type")
           }
-          chain.doFilter(request, response);
+          chain.doFilter(request, response)
         }
 
         override fun init(filterConfig: FilterConfig?) {}


### PR DESCRIPTION
- Adding support for front50
- changing get by status API to use parameter `status` instead of `statuses` for filtering by status. still is a list.
 