### PR TITLE
feat(core): Intent-level execution window support

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/attribute/attributes.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/attribute/attributes.kt
@@ -36,3 +36,22 @@ class PriorityAttribute(value: IntentPriority) : Attribute<IntentPriority>("Prio
 
 @JsonTypeName("Enabled")
 class EnabledAttribute(value: Boolean) : Attribute<Boolean>("Enabled", value)
+
+@JsonTypeName("ExecutionWindow")
+class ExecutionWindowAttribute(value: ExecutionWindow) : Attribute<ExecutionWindow>("ExecutionWindow", value) {
+  override fun toString(): String {
+    return "ExecutionWindowAttribute(days=${value.days}, timeWindows=${value.timeWindows})"
+  }
+}
+
+data class ExecutionWindow(
+  val days: List<Int>,
+  val timeWindows: List<TimeWindow>
+)
+
+data class TimeWindow(
+  val startHour: Int,
+  val startMin: Int,
+  val endHour: Int,
+  val endMin: Int
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/filter/ExecutionWindowFilter.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/filter/ExecutionWindowFilter.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.filter
+
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.attribute.ExecutionWindow
+import com.netflix.spinnaker.keel.attribute.ExecutionWindowAttribute
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.util.*
+
+private const val ACTION_PROCEED = "proceeding as if inside of execution window"
+private const val ACTION_HALT = "assuming outside of execution window"
+
+/**
+ * Filters out Intents that are not in their defined execution windows (configured via the ExecutionWindowAttribute).
+ */
+@Component
+@EnableConfigurationProperties(ExecutionWindowFilter.Configuration::class)
+class ExecutionWindowFilter
+@Autowired constructor(
+  private val config: Configuration,
+  private val clock: Clock
+): Filter {
+
+  private val DAY_START_HOUR = 0
+  private val DAY_START_MIN = 0
+  private val DAY_END_HOUR = 23
+  private val DAY_END_MIN = 59
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  override fun getOrder() = 50
+
+  override fun filter(intent: Intent<IntentSpec>): Boolean {
+    if (!intent.hasAttribute(ExecutionWindowAttribute::class)) {
+      return true
+    }
+
+    val executionWindow = intent.getAttribute(ExecutionWindowAttribute::class)!!
+    log.info("Calculating scheduled time for ${intent.id}; $executionWindow")
+
+    val now = Date.from(clock.instant())
+    val scheduledTime: Date
+    try {
+      scheduledTime = getTimeInWindow(executionWindow.value, now)
+    } catch (e: Exception) {
+      val action = if (config.allowExecutionOnFailure) ACTION_PROCEED else ACTION_HALT
+      log.error("Exception occurred while calculating time window, $action: ${e.message}")
+      return config.allowExecutionOnFailure
+    }
+
+    log.debug("Calculated schedule time for ${intent.id}: $scheduledTime")
+
+    return now >= scheduledTime
+  }
+
+  @ConfigurationProperties
+  open class Configuration {
+    val allowExecutionOnFailure: Boolean = false
+  }
+
+  private fun getTimeInWindow(executionWindow: ExecutionWindow, scheduledTime: Date): Date {
+    val timeWindows = executionWindow.timeWindows.map {
+      TimeWindow(HourMinute(it.startHour, it.startMin), HourMinute(it.endHour, it.endMin))
+    }
+    return calculateScheduledTime(scheduledTime, timeWindows, executionWindow.days)
+  }
+
+  private fun calculateScheduledTime(scheduledTime: Date,
+                                     whitelistWindows: List<TimeWindow>,
+                                     whitelistDays: List<Int>)
+    = calculateScheduledTime(scheduledTime, whitelistWindows, whitelistDays, false)
+
+  private fun calculateScheduledTime(scheduledTime: Date,
+                                     timeWindows: List<TimeWindow>,
+                                     whitelistDays: List<Int>,
+                                     dayIncremented: Boolean): Date {
+    val whitelistWindows = normalizeTimeWindows(
+      if (timeWindows.isEmpty() && whitelistDays.isNotEmpty())
+        listOf(TimeWindow(HourMinute(0, 0), HourMinute(23, 59))) else timeWindows.sorted()
+    )
+
+    val calendar = Calendar.getInstance()
+    calendar.timeZone = TimeZone.getTimeZone(clock.zone)
+    calendar.time = scheduledTime
+
+    var inWindow = false
+    var todayIsValid = true
+
+    if (whitelistDays.isNotEmpty()) {
+      var daysIncremented = 0
+      while (daysIncremented < 7) {
+        var nextDayFound = false
+        if (whitelistDays.contains(calendar.get(Calendar.DAY_OF_WEEK))) {
+          nextDayFound = true
+          todayIsValid = daysIncremented == 0
+        }
+        if (nextDayFound) {
+          break
+        }
+        calendar.add(Calendar.DAY_OF_MONTH, 1)
+        resetToTomorrow(calendar)
+        daysIncremented++
+      }
+    }
+    if (todayIsValid) {
+      for (timeWindow in whitelistWindows) {
+        val hourMin = HourMinute(calendar[Calendar.HOUR_OF_DAY], calendar[Calendar.MINUTE])
+        val index = timeWindow.indexOf(hourMin)
+        if (index == -1) {
+          calendar[Calendar.HOUR_OF_DAY] = timeWindow.start.hour
+          calendar[Calendar.MINUTE] = timeWindow.start.min
+          calendar[Calendar.SECOND] = 0
+          inWindow = true
+          break
+        } else if (index == 0) {
+          inWindow = true
+          break
+        }
+      }
+    }
+
+    if (!inWindow) {
+      if (!dayIncremented) {
+        resetToTomorrow(calendar)
+        return calculateScheduledTime(scheduledTime, whitelistWindows, whitelistDays, true)
+      } else {
+        throw IncorrectTimeWindowsException("Couldn't calculate a suitable time within the given time windows")
+      }
+    }
+
+    if (dayIncremented) {
+      calendar.add(Calendar.DAY_OF_MONTH, 1)
+    }
+
+    return calendar.time
+  }
+
+  private fun normalizeTimeWindows(timeWindows: List<TimeWindow>): List<TimeWindow> {
+    return timeWindows.flatMap {
+      return@flatMap if (it.start.hour > it.end.hour) {
+        listOf(
+          TimeWindow(HourMinute(it.start.hour, it.start.min), HourMinute(DAY_END_HOUR, DAY_END_MIN)),
+          TimeWindow(HourMinute(DAY_START_HOUR, DAY_START_MIN), HourMinute(it.end.hour, it.end.min))
+        )
+      } else {
+        listOf(it)
+      }
+    }.sorted()
+  }
+
+  private fun resetToTomorrow(calendar: Calendar) {
+    calendar[Calendar.HOUR_OF_DAY] = DAY_START_HOUR
+    calendar[Calendar.MINUTE] = DAY_START_MIN
+    calendar[Calendar.SECOND] = 0
+  }
+}
+
+private class HourMinute(
+  val hour: Int,
+  val min: Int
+) : Comparable<HourMinute> {
+
+  fun before(that: HourMinute)
+    = when {
+        hour < that.hour -> true
+        hour > that.hour -> false
+        min < that.min -> true
+        else -> false
+      }
+
+  fun after(that: HourMinute) = !before(that)
+
+  override fun compareTo(other: HourMinute) = if (before(other)) -1 else if (after(other)) 1 else 0
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as HourMinute
+
+    if (hour != other.hour) return false
+    if (min != other.min) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = hour
+    result = 31 * result + min
+    return result
+  }
+}
+
+private class TimeWindow(
+  val start: HourMinute,
+  val end: HourMinute
+) : Comparable<TimeWindow> {
+
+  override fun compareTo(other: TimeWindow): Int = start.compareTo(other.start)
+
+  fun indexOf(current: HourMinute): Int {
+    if (current.before(start)) {
+      return -1
+    } else if ((current.after(start) || current == start) && (current.before(end) || current == end)) {
+      return 0
+    }
+    return 1
+  }
+}
+
+private class IncorrectTimeWindowsException(message: String) : Exception(message)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/policy/Policy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/policy/Policy.kt
@@ -28,8 +28,6 @@ import kotlin.reflect.KClass
  * via execution windows). In these cases, it will be desired to allow an Intent to self-define the acceptable windows
  * to execute in. Policies can define a list of required Intent Attributes that must be set before the Policy will be
  * enacted.
- *
- *  TODO rz - Impl early ExecutionWindowPolicy
  */
 abstract class Policy<out S : PolicySpec>(
   val kind: String,

--- a/keel-core/src/test/groovy/com/netflix/spinnaker/keel/filter/ExecutionWindowFilterSpec.groovy
+++ b/keel-core/src/test/groovy/com/netflix/spinnaker/keel/filter/ExecutionWindowFilterSpec.groovy
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.filter
+
+import com.netflix.spinnaker.keel.attribute.ExecutionWindow
+import com.netflix.spinnaker.keel.attribute.ExecutionWindowAttribute
+import com.netflix.spinnaker.keel.test.TestIntent
+import com.netflix.spinnaker.keel.test.TestIntentSpec
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.text.SimpleDateFormat
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+@Unroll
+class ExecutionWindowFilterSpec extends Specification {
+
+  def "intent should be filtered at #scheduledTime with time windows #timeWindows"() {
+    when:
+    def subject = new ExecutionWindowFilter(
+      new ExecutionWindowFilter.Configuration(),
+      Clock.fixed(Instant.ofEpochMilli(scheduledTime.time), ZoneId.of("America/Los_Angeles"))
+    )
+    def intent = new TestIntent(new TestIntentSpec("1", [:]), [:], [
+      new ExecutionWindowAttribute(new ExecutionWindow([], timeWindows))
+    ])
+
+    then:
+    expectedResult == subject.filter(intent)
+
+    where:
+    scheduledTime          | expectedResult | timeWindows
+
+    date("02/14 01:00:00") | true           | [window(hourMinute("22:00"), hourMinute("05:00"))]
+
+    date("02/13 21:45:00") | false          | [window(hourMinute("06:00"), hourMinute("10:00"))]
+
+    date("02/13 13:45:00") | false          | [window(hourMinute("22:00"), hourMinute("05:00"))]
+    date("02/13 06:30:00") | false          | [window(hourMinute("10:00"), hourMinute("13:00"))]
+    date("02/13 09:59:59") | false          | [window(hourMinute("10:00"), hourMinute("13:00"))]
+    date("02/13 10:00:00") | true           | [window(hourMinute("10:00"), hourMinute("13:00"))]
+    date("02/13 10:00:35") | true           | [window(hourMinute("10:00"), hourMinute("13:00"))]
+    date("02/13 10:01:35") | true           | [window(hourMinute("10:00"), hourMinute("13:00"))]
+
+    date("02/13 09:59:59") | false          | [window(hourMinute("10:00"), hourMinute("13:00")), window(hourMinute("16:00"), hourMinute("18:00"))]
+    date("02/13 10:00:00") | true           | [window(hourMinute("10:00"), hourMinute("13:00")), window(hourMinute("16:00"), hourMinute("18:00"))]
+    date("02/13 10:01:35") | true           | [window(hourMinute("10:00"), hourMinute("13:00")), window(hourMinute("16:00"), hourMinute("18:00"))]
+    date("02/13 10:01:35") | true           | [window(hourMinute("16:00"), hourMinute("18:00")), window(hourMinute("10:00"), hourMinute("13:00"))]
+
+    date("02/13 14:30:00") | true           | [window(hourMinute("13:00"), hourMinute("18:00"))]
+
+    date("02/13 00:00:00") | false          | [window(hourMinute("10:00"), hourMinute("13:00"))]
+    date("02/13 00:01:00") | false          | [window(hourMinute("10:00"), hourMinute("13:00"))]
+
+    date("02/13 00:01:00") | false          | [window(hourMinute("15:00"), hourMinute("18:00"))]
+    date("02/13 11:01:00") | false          | [window(hourMinute("15:00"), hourMinute("18:00"))]
+
+    date("02/13 14:01:00") | false          | [window(hourMinute("13:00"), hourMinute("14:00"))]
+
+    date("02/13 22:00:00") | true           | [window(hourMinute("22:00"), hourMinute("05:00"))]
+
+    date("02/13 01:00:00") | true           | [window(hourMinute("00:00"), hourMinute("05:00")), window(hourMinute("22:00"), hourMinute("23:59"))]
+
+    date("02/13 00:59:59") | false          | [window(hourMinute("10:00"), hourMinute("11:00")), window(hourMinute("13:00"), hourMinute("14:00")),
+                                               window(hourMinute("15:00"), hourMinute("16:00"))]
+    date("02/13 10:30:59") | true           | [window(hourMinute("10:00"), hourMinute("11:00")), window(hourMinute("13:00"), hourMinute("14:00")),
+                                               window(hourMinute("15:00"), hourMinute("16:00"))]
+    date("02/13 12:30:59") | false          | [window(hourMinute("10:00"), hourMinute("11:00")), window(hourMinute("13:00"), hourMinute("14:00")),
+                                               window(hourMinute("15:00"), hourMinute("16:00"))]
+    date("02/13 16:00:00") | true           | [window(hourMinute("10:00"), hourMinute("11:00")), window(hourMinute("13:00"), hourMinute("14:00")),
+                                               window(hourMinute("15:00"), hourMinute("16:00"))]
+    date("02/13 16:01:00") | false          | [window(hourMinute("10:00"), hourMinute("11:00")), window(hourMinute("13:00"), hourMinute("14:00")),
+                                               window(hourMinute("15:00"), hourMinute("16:00"))]
+  }
+
+  def 'should consider whitelisted days when calculating scheduled time'() {
+    when:
+    def subject = new ExecutionWindowFilter(
+      new ExecutionWindowFilter.Configuration(),
+      Clock.fixed(Instant.ofEpochMilli(scheduledTime.time), ZoneId.of("America/Los_Angeles"))
+    )
+    def intent = new TestIntent(new TestIntentSpec("1", [:]), [:], [
+      new ExecutionWindowAttribute(new ExecutionWindow(days, timeWindows))
+    ])
+
+    then:
+    expectedResult == subject.filter(intent)
+
+    where:
+    scheduledTime           | timeWindows                                        | days            || expectedResult
+
+    date("02/25 01:00:00")  | [window(hourMinute("22:00"), hourMinute("05:00"))] | [1,2,3,4,5,6,7] || true
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | []              || false
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [4]             || false
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [5]             || false
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3]             || false
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3,4,5]         || false
+    date("02/25 21:45:00")  | [window(hourMinute("06:00"), hourMinute("10:00"))] | [3,5]           || false
+  }
+
+  def 'should be valid all day if no time window selected but some days are selected'() {
+    when:
+    def subject = new ExecutionWindowFilter(
+      new ExecutionWindowFilter.Configuration(),
+      Clock.fixed(Instant.ofEpochMilli(scheduledTime.time), ZoneId.of("America/Los_Angeles"))
+    )
+    def intent = new TestIntent(new TestIntentSpec("1", [:]), [:], [
+      new ExecutionWindowAttribute(new ExecutionWindow(days, timeWindows))
+    ])
+
+    then:
+    expectedResult == subject.filter(intent)
+
+    where:
+    scheduledTime           | timeWindows | days            || expectedResult
+
+    date("02/25 01:00:00")  | []          | [1,2,3,4,5,6,7] || true
+    date("02/25 00:00:00")  | []          | [1,2,3,4,5,6,7] || true
+    date("02/25 23:59:00")  | []          | [1,2,3,4,5,6,7] || true
+    date("02/25 01:00:00")  | []          | [1]             || false
+  }
+
+  private hourMinute(String hourMinuteStr) {
+    int hour = hourMinuteStr.tokenize(":").get(0) as Integer
+    int min = hourMinuteStr.tokenize(":").get(1) as Integer
+    return new HourMinute(hour, min)
+  }
+
+  private Date date(String dateStr) {
+    SimpleDateFormat sdf = new SimpleDateFormat("MM/dd HH:mm:ss z yyyy");
+    sdf.setTimeZone(TimeZone.getTimeZone("America/Los_Angeles"));
+    return sdf.parse(dateStr + " PST 2015")
+  }
+
+  private com.netflix.spinnaker.keel.attribute.TimeWindow window(HourMinute start, HourMinute end) {
+    return new com.netflix.spinnaker.keel.attribute.TimeWindow(start.hour, start.min, end.hour, end.min)
+  }
+}

--- a/keel-redis/src/test/groovy/com/netflix/spinnaker/keel/redis/RedisTraceRepositorySpec.groovy
+++ b/keel-redis/src/test/groovy/com/netflix/spinnaker/keel/redis/RedisTraceRepositorySpec.groovy
@@ -64,9 +64,9 @@ class RedisTraceRepositorySpec extends Specification {
 
   def "listing traces for an intent returns ordered traces"() {
     given:
-    traceRepository.record(new Trace([:], new TestIntent(new TestIntentSpec("1", [placement: 1])), null))
-    traceRepository.record(new Trace([:], new TestIntent(new TestIntentSpec("1", [placement: 2])), null))
-    traceRepository.record(new Trace([:], new TestIntent(new TestIntentSpec("2", [placement: 3])), null))
+    traceRepository.record(new Trace([:], new TestIntent(new TestIntentSpec("1", [placement: 1]), [:], []), null))
+    traceRepository.record(new Trace([:], new TestIntent(new TestIntentSpec("1", [placement: 2]), [:], []), null))
+    traceRepository.record(new Trace([:], new TestIntent(new TestIntentSpec("2", [placement: 3]), [:], []), null))
 
     when:
     def result = traceRepository.getForIntent("test:1")

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/TestIntent.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/TestIntent.kt
@@ -28,8 +28,10 @@ import com.netflix.spinnaker.keel.attribute.Attribute
 @JsonVersionedModel(currentVersion = "1", propertyName = "schema")
 class TestIntent
 @JsonCreator constructor(
-  spec: TestIntentSpec
-) : Intent<TestIntentSpec>("1", "Test", spec, IntentStatus.ACTIVE, mapOf<String, String>(), listOf<Attribute<Any>>()) {
+  spec: TestIntentSpec,
+  labels: Map<String, String> = mapOf(),
+  attributes: List<Attribute<Any>> = listOf()
+) : Intent<TestIntentSpec>("1", "Test", spec, IntentStatus.ACTIVE, labels, attributes) {
   @JsonIgnore
   override val id = "test:${spec.id}"
 }


### PR DESCRIPTION
We support execution windows in Orca at the stage-level, but not at the entire orchestration/pipeline level. This adds support for execution windows around converge times, which can be helpful for ensuring deployments or infrastructure changes don't occur in peak times.

Primarily a showcase for how Attributes & Filters work.

cc @emjburns @robfletcher 