### PR TITLE
chore(*): Converting to structured logs where applicable

### DIFF
--- a/keel-core/keel-core.gradle
+++ b/keel-core/keel-core.gradle
@@ -18,7 +18,9 @@ dependencies {
   compile spinnaker.dependency('slf4jApi')
   compile spinnaker.dependency('kork')
   compile spinnaker.dependency('jedis')
+  compile spinnaker.dependency("logstashEncoder")
 
+  spinnaker.group('retrofitDefault')
   spinnaker.group('jackson')
 
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:${spinnaker.version("jackson")}"

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/filter/ExecutionWindowFilter.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/filter/ExecutionWindowFilter.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.keel.Intent
 import com.netflix.spinnaker.keel.IntentSpec
 import com.netflix.spinnaker.keel.attribute.ExecutionWindow
 import com.netflix.spinnaker.keel.attribute.ExecutionWindowAttribute
+import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -56,7 +57,7 @@ class ExecutionWindowFilter
     }
 
     val executionWindow = intent.getAttribute(ExecutionWindowAttribute::class)!!
-    log.info("Calculating scheduled time for ${intent.id}; $executionWindow")
+    log.info("Calculating scheduled time for {}; $executionWindow", value("intent", intent.id))
 
     val now = Date.from(clock.instant())
     val scheduledTime: Date
@@ -68,7 +69,7 @@ class ExecutionWindowFilter
       return config.allowExecutionOnFailure
     }
 
-    log.debug("Calculated schedule time for ${intent.id}: $scheduledTime")
+    log.debug("Calculated schedule time for {}: $scheduledTime", value("intent", intent.id))
 
     return now >= scheduledTime
   }

--- a/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/ApplicationIntentProcessor.kt
+++ b/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/ApplicationIntentProcessor.kt
@@ -37,6 +37,8 @@ import retrofit.RetrofitError
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.primaryConstructor
 
+import net.logstash.logback.argument.StructuredArguments.value
+
 @Component
 class ApplicationIntentProcessor
 @Autowired constructor(
@@ -51,7 +53,7 @@ class ApplicationIntentProcessor
   override fun supports(intent: Intent<IntentSpec>) = intent is ApplicationIntent
 
   override fun converge(intent: ApplicationIntent): ConvergeResult {
-    log.info("Converging state for ${intent.id}")
+    log.info("Converging state for {}", value("intent", intent.id))
 
     val currentState = getApplication(intent.spec.name)
 

--- a/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/SecurityGroupIntentProcessor.kt
+++ b/keel-intents/src/main/kotlin/com/netflix/spinnaker/keel/intents/processors/SecurityGroupIntentProcessor.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.Trigger
 import com.netflix.spinnaker.keel.tracing.Trace
 import com.netflix.spinnaker.keel.tracing.TraceRepository
+import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -44,7 +45,7 @@ class SecurityGroupIntentProcessor
   override fun supports(intent: Intent<IntentSpec>) = intent is SecurityGroupIntent
 
   override fun converge(intent: SecurityGroupIntent): ConvergeResult {
-    log.info("Converging state for ${intent.id}")
+    log.info("Converging state for {}", value("intent", intent.id))
 
     val currentState = getSecurityGroups(intent.spec)
 

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel.orca
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.keel.*
+import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
@@ -46,14 +47,15 @@ open class OrcaIntentLauncher
             applicationEventPublisher.publishEvent(ConvergenceRequiredEvent(intent))
           }
         }.orchestrations.map {
-        log.info("Launching orchestration for intent (kind: ${intent.kind})")
+        log.info("Launching orchestration for {}", value("intent", intent.id))
         orcaService.orchestrate(it).ref
       }
 
-      log.info("Launched orchestrations for intent (" +
-        "kind: ${intent.kind}, " +
-        "tasks: $orchestrationIds" +
-        ")")
+      log.info(
+        "Launched orchestrations for intent (intent: {}, tasks: {})",
+        value("intent", intent.id),
+        value("tasks", orchestrationIds)
+      )
       OrcaLaunchedIntentResult(orchestrationIds)
     }
   }

--- a/keel-web/keel-web.gradle
+++ b/keel-web/keel-web.gradle
@@ -41,8 +41,6 @@ dependencies {
   compile project(":keel-redis")
   compile project(":keel-scheduler")
 
-  compile spinnaker.dependency("logstashEncoder")
-
   spinnaker.group('test')
 }
 


### PR DESCRIPTION
FYI @robfletcher @emjburns -- Any logs you do from here on out, structured. `value("intent", intentId)` should be used any place that you're logging about a specific intent (should make tracing intent behavior in logs pretty clear). Prefer the intent ID over `kind`, since the ID will include the intent kind anyway.