### PR TITLE
feat(core): Generic computed functionality; security group diffing support

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroup.kt
@@ -15,14 +15,33 @@
  */
 package com.netflix.spinnaker.keel.clouddriver.model
 
+import com.netflix.spinnaker.keel.annotation.Computed
+
 data class SecurityGroup(
-  val type: String,
+  @Computed val type: String,
   val id: String?,
   val name: String,
   val description: String?,
   val accountName: String,
   val region: String,
   val vpcId: String?,
-  val inboundRules: List<Map<String, Any>> = emptyList(),
-  val moniker: Moniker
-)
+  val inboundRules: List<SecurityGroupRule> = emptyList(),
+  @Computed val moniker: Moniker
+) {
+  data class SecurityGroupRule(
+    val protocol: String?,
+    val portRanges: List<SecurityGroupRulePortRange>?,
+    val securityGroup: SecurityGroupRuleReference?
+  )
+
+  data class SecurityGroupRulePortRange(
+    val startPort: Int,
+    val endPort: Int
+  )
+
+  data class SecurityGroupRuleReference(
+    val name: String,
+    val accountName: String?,
+    val region: String?
+  )
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/Computed.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/Computed.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.keel.front50.annotations
+package com.netflix.spinnaker.keel.annotation
 
 @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/state/ComputedPropertyProvider.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/state/ComputedPropertyProvider.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.state
+
+/**
+ * Allows specs & models to provide runtime computed properties.
+ *
+ * TODO rz - This is a hack around not being able to access the correct class parameter annotations at runtime
+ * because of erasure. I'm sure if I were a better Kotlin developer, I could finagle this into working better.
+ */
+interface ComputedPropertyProvider {
+
+  fun additionalComputedProperties(): List<String>
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/state/StateInspector.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/state/StateInspector.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.state
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.annotation.Computed
+import org.slf4j.LoggerFactory
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.primaryConstructor
+
+data class FieldState(
+  val name: String,
+  val current: Any?,
+  val desired: Any?
+) {
+  fun changed() = current != desired
+}
+
+/**
+ * Allows callback mutations of individual fields before building FieldState objects.
+ */
+data class FieldMutator(
+  val name: String,
+  val mutator: (v: Any?) -> Any?
+)
+
+/**
+ * Performs basic state diffing to determine whether or not system state needs to be converged on the desired spec.
+ */
+class StateInspector(
+  private val objectMapper: ObjectMapper
+) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  fun getDiff(intentId: String,
+              currentState: Any,
+              desiredState: Any,
+              modelClass: KClass<*>,
+              specClass: KClass<*>,
+              currentStateFieldMutators: List<FieldMutator> = listOf(),
+              ignoreKeys: List<String?> = listOf()): List<FieldState> {
+    val ignoredCurrentStateParams = getComputedParameters(currentState, modelClass.primaryConstructor!!)
+    val currentStateMap = objectMapper.convertValue<Map<String, Any?>>(currentState, ANY_MAP_TYPE).filterNot {
+      ignoredCurrentStateParams.contains(it.key)
+    }
+    val desiredStateMap = objectMapper.convertValue<Map<String, Any?>>(desiredState, ANY_MAP_TYPE)
+
+    val allIgnoredKeys = ignoreKeys.plus(getJsonTypePropertyName(specClass)).toMutableList()
+    if (desiredState is ComputedPropertyProvider) {
+      allIgnoredKeys.addAll(desiredState.additionalComputedProperties())
+    }
+
+    val fields = getChangedFields(
+      currentStateMap,
+      desiredStateMap,
+      allIgnoredKeys,
+      currentStateFieldMutators
+    )
+
+    if (fields.isNotEmpty()) {
+      log.debug("Actual state has diverged from desired state: $fields (intent: $intentId)")
+    }
+    return fields
+  }
+
+  private fun getChangedFields(currentState: Map<String, Any?>,
+                               desiredState: Map<String, Any?>,
+                               ignoreKeys: List<String?>,
+                               currentFieldMutators: List<FieldMutator>)
+    = desiredState
+    .filterKeys { !ignoreKeys.contains(it) }
+    .map {
+      val mutator = currentFieldMutators.find { (name) -> name == it.key }?.mutator
+      FieldState(it.key, if (mutator == null) currentState[it.key] else mutator.invoke(currentState[it.key]), it.value)
+    }
+    .filter { it.changed() }
+
+  private fun getJsonTypePropertyName(k: KClass<*>): String? = k.findAnnotation<JsonTypeInfo>()?.property
+
+  private fun getComputedParameters(o: Any, c: KFunction<*>): List<String> {
+    val params = c.parameters.filter { it.findAnnotation<Computed>()?.ignore == true }.mapNotNull { it.name }
+    if (o is ComputedPropertyProvider) {
+      params.toMutableList().addAll(o.additionalComputedProperties())
+    }
+    return params.distinct().toList()
+  }
+}
+
+private val ANY_MAP_TYPE = object : TypeReference<MutableMap<String, Any?>>(){}

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -17,7 +17,8 @@ package com.netflix.spinnaker.keel.front50.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
-import com.netflix.spinnaker.keel.front50.annotations.Computed
+import com.netflix.spinnaker.keel.annotation.Computed
+import com.netflix.spinnaker.keel.state.ComputedPropertyProvider
 
 data class Application(
   val name: String,
@@ -28,7 +29,7 @@ data class Application(
   val platformHealthOnly: Boolean,
   val platformHealthOnlyShowOverride: Boolean,
   val owner: String
-) {
+) : ComputedPropertyProvider {
 
   val details: MutableMap<String, Any?> = mutableMapOf()
 
@@ -51,7 +52,10 @@ data class Application(
    * Need to identify additional ignored properties that are in
    * the 'details' map
    */
+  @Deprecated(message = "use method from ComputedPropertyProvider")
   fun computedPropertiesToIgnore(): List<String> {
     return listOf("user","lastModifiedBy","requiredGroupMembership")
   }
+
+  override fun additionalComputedProperties(): List<String> = computedPropertiesToIgnore()
 }

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ApplicationIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ApplicationIntent.kt
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName
 import com.github.jonpeterson.jackson.module.versioning.JsonVersionedModel
 import com.netflix.spinnaker.keel.Intent
 import com.netflix.spinnaker.keel.IntentSpec
-import com.netflix.spinnaker.keel.front50.annotations.Computed
+import com.netflix.spinnaker.keel.annotation.Computed
+import com.netflix.spinnaker.keel.state.ComputedPropertyProvider
 
 private const val KIND = "Application"
 private const val CURRENT_SCHEMA = "1"
@@ -149,7 +150,10 @@ data class ApplicationSpec(
   override val platformHealthOnlyShowOverride: Boolean,
   override val platformHealthOnly: Boolean,
   override val notifications: NotificationSpec?
-) : BaseApplicationSpec()
+) : BaseApplicationSpec(), ComputedPropertyProvider {
+
+  override fun additionalComputedProperties() = listOf("requiredGroupMembership")
+}
 
 // TODO rz - Move to -nflx, figure out a better wiring strategy?
 @JsonTypeName("NetflixApplication")
@@ -177,13 +181,16 @@ data class NetflixApplicationSpec(
   val repoProjectKey: String?,
   val repoType: String?,
   val pdApiKey: String,
-  val propertyRolloutConfigId: String?,
+  @Computed val propertyRolloutConfigId: String?,
   val legacyUdf: Boolean,
   val monitorBucketType: String?,
   val criticalityRules: List<CriticalityRuleSpec>,
   val ccpService: String?,
   val timelines: List<TimelineSpec>?
-) : BaseApplicationSpec()
+) : BaseApplicationSpec(), ComputedPropertyProvider {
+
+  override fun additionalComputedProperties() = listOf("requiredGroupMembership", "propertyRolloutConfigId")
+}
 
 data class CriticalityRuleSpec(
   val account: String,


### PR DESCRIPTION
Builds on the work that @emjburns did for the `@Computed` annotation, moving some of the functionality into a utility `StateInspector` class and implemented for both `ApplicationIntent` and `SecurityGroupIntent`.

While it all works, I don't think it's as good as it could be. I'm running into some type erasure issues (and fun reified generics issues) that prevent me from runtime processing the computed annotations on Specs, so I created an interface that provides additional ignoreable fields. I'd really like to get rid of this, since it'll make auto-generating API docs / json schemas substantially more difficult.