### PR TITLE
chore(*): Constrain dependency lock versions

### DIFF
--- a/keel-clouddriver/dependencies.lock
+++ b/keel-clouddriver/dependencies.lock
@@ -43,13 +43,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -59,13 +59,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -83,13 +83,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -156,13 +156,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -172,13 +172,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -196,13 +196,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -269,13 +269,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -285,13 +285,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -309,13 +309,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -402,13 +402,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -418,13 +418,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -442,13 +442,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -515,13 +515,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -531,13 +531,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -555,13 +555,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -639,13 +639,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -659,13 +659,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -681,19 +681,19 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -705,15 +705,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -784,13 +784,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -804,13 +804,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -826,19 +826,19 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -850,15 +850,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -929,13 +929,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -949,13 +949,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -971,19 +971,19 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -995,23 +995,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1082,13 +1082,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -1102,13 +1102,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1124,19 +1124,19 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "io.reactivex:rxjava": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1148,23 +1148,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-clouddriver/keel-clouddriver.gradle
+++ b/keel-clouddriver/keel-clouddriver.gradle
@@ -3,5 +3,5 @@ dependencies {
   compile "com.netflix.spinnaker.moniker:moniker:+"
 
   testCompile project(":keel-test")
-  testCompile "com.squareup.retrofit:retrofit-mock:+"
+  testCompile "com.squareup.retrofit:retrofit-mock:1.9.+"
 }

--- a/keel-core/dependencies.lock
+++ b/keel-core/dependencies.lock
@@ -2,31 +2,31 @@
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "locked": "1.1.60",
@@ -34,41 +34,41 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "locked": "1.1.60",
@@ -76,41 +76,41 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "default": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "locked": "1.1.60",
@@ -118,11 +118,11 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "junitPlatform": {
@@ -148,31 +148,31 @@
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "locked": "1.1.60",
@@ -180,41 +180,41 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "locked": "1.1.60",
@@ -222,11 +222,11 @@
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "testCompile": {
@@ -235,35 +235,35 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -285,7 +285,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -294,14 +294,14 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -312,15 +312,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -328,14 +328,14 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "testCompileClasspath": {
@@ -344,35 +344,35 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -394,7 +394,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -403,14 +403,14 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -421,15 +421,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -437,14 +437,14 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "testRuntime": {
@@ -453,35 +453,35 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -503,7 +503,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -512,14 +512,14 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -530,23 +530,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -554,14 +554,14 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     },
     "testRuntimeClasspath": {
@@ -570,35 +570,35 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.2",
-            "requested": "+"
+            "requested": "2.9.+"
         },
         "com.github.jonpeterson:jackson-module-model-versioning": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2",
-            "requested": "+"
+            "requested": "1.2.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -620,7 +620,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -629,14 +629,14 @@
         },
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.9.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10",
-            "requested": "+"
+            "locked": "4.11",
+            "requested": "4.+"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -647,23 +647,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -671,14 +671,14 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.7.25",
-            "requested": "+"
+            "requested": "1.7.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "2.9.0",
-            "requested": "+"
+            "requested": "2.+"
         }
     }
 }

--- a/keel-core/keel-core.gradle
+++ b/keel-core/keel-core.gradle
@@ -15,18 +15,18 @@
  */
 
 dependencies {
-  compile "org.slf4j:slf4j-api:+"
+  compile "org.slf4j:slf4j-api:1.7.+"
   compile "com.netflix.spinnaker.kork:kork-core:+"
-  compile "redis.clients:jedis:+"
-  compile "net.logstash.logback:logstash-logback-encoder:+"
+  compile "redis.clients:jedis:2.+"
+  compile "net.logstash.logback:logstash-logback-encoder:4.+"
 
-  compile "com.fasterxml.jackson.core:jackson-databind:+"
-  compile "com.fasterxml.jackson.core:jackson-annotations:+"
+  compile "com.fasterxml.jackson.core:jackson-databind:2.9.+"
+  compile "com.fasterxml.jackson.core:jackson-annotations:2.9.+"
 
-  compile "com.fasterxml.jackson.module:jackson-module-kotlin:+"
-  compile "com.github.jonpeterson:jackson-module-model-versioning:+"
-  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:+"
+  compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+"
+  compile "com.github.jonpeterson:jackson-module-model-versioning:1.2.+"
+  compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.+"
 
-  testCompile "com.squareup.retrofit:retrofit-mock:+"
+  testCompile "com.squareup.retrofit:retrofit-mock:1.9.+"
   testCompile project(":keel-test")
 }

--- a/keel-eureka/dependencies.lock
+++ b/keel-eureka/dependencies.lock
@@ -37,13 +37,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -103,13 +103,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -169,13 +169,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -255,13 +255,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -321,13 +321,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -391,7 +391,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -401,7 +401,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -411,15 +411,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -477,7 +477,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -487,7 +487,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -497,15 +497,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -563,7 +563,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -573,7 +573,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -583,23 +583,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -657,7 +657,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -667,7 +667,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -677,23 +677,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-front50/dependencies.lock
+++ b/keel-front50/dependencies.lock
@@ -43,25 +43,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -79,13 +79,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -152,25 +152,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -188,13 +188,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -261,25 +261,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -297,13 +297,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -390,25 +390,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -426,13 +426,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -499,25 +499,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -535,13 +535,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -612,13 +612,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -628,13 +628,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -652,13 +652,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -669,15 +669,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -741,13 +741,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -757,13 +757,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -781,13 +781,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -798,15 +798,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -870,13 +870,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -886,13 +886,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -910,13 +910,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -927,23 +927,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1007,13 +1007,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -1023,13 +1023,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1047,13 +1047,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1064,23 +1064,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-intent-aws/dependencies.lock
+++ b/keel-intent-aws/dependencies.lock
@@ -31,15 +31,25 @@
             "locked": "1.2.2"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -108,6 +118,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.1.60",
@@ -158,15 +169,25 @@
             "locked": "1.2.2"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -235,6 +256,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.1.60",
@@ -285,15 +307,25 @@
             "locked": "1.2.2"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -362,6 +394,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.1.60",
@@ -432,15 +465,25 @@
             "locked": "1.2.2"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -509,6 +552,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.1.60",
@@ -559,15 +603,25 @@
             "locked": "1.2.2"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -636,6 +690,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.1.60",
@@ -693,16 +748,26 @@
             "requested": "+"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -778,6 +843,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
@@ -848,16 +914,26 @@
             "requested": "+"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -933,6 +1009,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
@@ -1003,16 +1080,26 @@
             "requested": "+"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -1088,6 +1175,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
@@ -1166,16 +1254,26 @@
             "requested": "+"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-front50": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-retrofit": {
@@ -1251,6 +1349,7 @@
                 "com.netflix.spinnaker.keel:keel-clouddriver",
                 "com.netflix.spinnaker.keel:keel-core",
                 "com.netflix.spinnaker.keel:keel-front50",
+                "com.netflix.spinnaker.keel:keel-intent",
                 "com.netflix.spinnaker.keel:keel-retrofit",
                 "com.netflix.spinnaker.keel:keel-test"
             ],

--- a/keel-orca/dependencies.lock
+++ b/keel-orca/dependencies.lock
@@ -49,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -67,13 +67,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -91,13 +91,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -171,13 +171,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -189,13 +189,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -213,13 +213,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -293,13 +293,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -311,13 +311,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -335,13 +335,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -435,13 +435,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -453,13 +453,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -477,13 +477,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -557,13 +557,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -575,13 +575,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -599,13 +599,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -683,13 +683,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -705,13 +705,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -729,13 +729,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -747,15 +747,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -825,13 +825,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -847,13 +847,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -871,13 +871,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -889,15 +889,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -967,13 +967,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -989,13 +989,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1013,13 +1013,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1031,23 +1031,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1117,13 +1117,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1139,13 +1139,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1163,13 +1163,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1181,23 +1181,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-redis/dependencies.lock
+++ b/keel-redis/dependencies.lock
@@ -37,21 +37,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -111,21 +111,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -185,21 +185,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -279,21 +279,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -353,21 +353,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -440,18 +440,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -462,7 +462,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -473,15 +473,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -548,18 +548,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -570,7 +570,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -581,15 +581,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -656,18 +656,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -678,7 +678,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -689,23 +689,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -772,18 +772,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -794,7 +794,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -805,23 +805,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-retrofit/dependencies.lock
+++ b/keel-retrofit/dependencies.lock
@@ -37,37 +37,37 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -127,37 +127,37 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -217,37 +217,37 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -327,37 +327,37 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -417,37 +417,37 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -511,10 +511,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -522,30 +522,30 @@
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -555,15 +555,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -621,10 +621,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -632,30 +632,30 @@
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -665,15 +665,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -731,10 +731,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -742,30 +742,30 @@
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -775,23 +775,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -849,10 +849,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.107.0",
+            "locked": "1.108.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -860,30 +860,30 @@
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
-            "locked": "2.7.0",
-            "requested": "+"
+            "locked": "2.7.5",
+            "requested": "2.+"
         },
         "com.squareup.retrofit:converter-jackson": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
-            "requested": "+"
+            "requested": "1.+"
         },
         "io.reactivex:rxjava": {
-            "locked": "1.0.16",
-            "requested": "+"
+            "locked": "1.0.17",
+            "requested": "1.0.+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -893,23 +893,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-retrofit/keel-retrofit.gradle
+++ b/keel-retrofit/keel-retrofit.gradle
@@ -17,11 +17,11 @@
 dependencies {
   compile project(":keel-core")
 
-  compile "com.squareup.retrofit:retrofit:+"
-  compile "com.squareup.okhttp:okhttp-urlconnection:+"
-  compile "com.squareup.okhttp:okhttp-apache:+"
-  compile "com.squareup.retrofit:converter-jackson:+"
+  compile "com.squareup.retrofit:retrofit:1.+"
+  compile "com.squareup.okhttp:okhttp-urlconnection:2.+"
+  compile "com.squareup.okhttp:okhttp-apache:2.+"
+  compile "com.squareup.retrofit:converter-jackson:1.+"
 
   compile "com.netflix.spinnaker.kork:kork-web:+"
-  compile "io.reactivex:rxjava:+"
+  compile "io.reactivex:rxjava:1.0.+"
 }

--- a/keel-scheduler/dependencies.lock
+++ b/keel-scheduler/dependencies.lock
@@ -59,13 +59,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -77,13 +77,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -101,13 +101,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -192,13 +192,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -210,13 +210,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -234,13 +234,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -325,13 +325,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -343,13 +343,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -367,13 +367,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -478,13 +478,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -496,13 +496,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -520,13 +520,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -611,13 +611,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -629,13 +629,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -653,13 +653,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -755,13 +755,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -777,13 +777,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -801,13 +801,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -821,15 +821,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -916,13 +916,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -938,13 +938,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -962,13 +962,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -982,15 +982,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1077,13 +1077,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1099,13 +1099,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1123,13 +1123,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1143,23 +1143,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1246,13 +1246,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1268,13 +1268,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1292,13 +1292,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1312,23 +1312,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-test/dependencies.lock
+++ b/keel-test/dependencies.lock
@@ -41,13 +41,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -111,13 +111,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -181,13 +181,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -271,13 +271,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -341,13 +341,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -411,7 +411,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -421,7 +421,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -431,15 +431,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -497,7 +497,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -507,7 +507,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -517,15 +517,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -583,7 +583,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -593,7 +593,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -603,23 +603,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -677,7 +677,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -687,7 +687,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -697,23 +697,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {

--- a/keel-web/dependencies.lock
+++ b/keel-web/dependencies.lock
@@ -57,6 +57,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -88,25 +94,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -118,13 +124,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -142,13 +148,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -157,6 +163,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -172,16 +179,16 @@
             "locked": "1.7.25"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "locked": "1.5.8.RELEASE",
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
-            "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "locked": "1.5.8.RELEASE",
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "locked": "1.5.8.RELEASE",
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -248,6 +255,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -279,25 +292,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -309,13 +322,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -333,13 +346,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -348,6 +361,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -364,15 +378,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -439,6 +453,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -470,25 +490,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -500,13 +520,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -524,13 +544,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -539,6 +559,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -555,15 +576,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -650,6 +671,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -681,25 +708,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -711,13 +738,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -735,13 +762,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -750,6 +777,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -766,15 +794,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -841,6 +869,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -872,25 +906,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -902,13 +936,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -926,13 +960,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -941,6 +975,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -957,15 +992,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -1036,6 +1071,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -1067,25 +1108,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1101,13 +1142,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1125,13 +1166,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1140,6 +1181,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -1149,15 +1191,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1168,15 +1210,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -1247,6 +1289,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -1278,25 +1326,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1312,13 +1360,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1336,13 +1384,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1351,6 +1399,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -1360,15 +1409,15 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1379,15 +1428,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -1458,6 +1507,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -1489,25 +1544,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1523,13 +1578,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1547,13 +1602,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1562,6 +1617,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -1571,23 +1627,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1598,15 +1654,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [
@@ -1677,6 +1733,12 @@
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-intent": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-intent-aws"
+            ],
+            "project": true
+        },
+        "com.netflix.spinnaker.keel:keel-intent-aws": {
             "project": true
         },
         "com.netflix.spinnaker.keel:keel-orca": {
@@ -1708,25 +1770,25 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.107.0"
+            "locked": "1.108.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1742,13 +1804,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.okhttp:okhttp-urlconnection": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "2.7.0"
+            "locked": "2.7.5"
         },
         "com.squareup.retrofit:converter-jackson": {
             "firstLevelTransitive": [
@@ -1766,13 +1828,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.0.16"
+            "locked": "1.0.17"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "4.10"
+            "locked": "4.11"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jre8": {
             "firstLevelTransitive": [
@@ -1781,6 +1843,7 @@
                 "com.netflix.spinnaker.keel:keel-eureka",
                 "com.netflix.spinnaker.keel:keel-front50",
                 "com.netflix.spinnaker.keel:keel-intent",
+                "com.netflix.spinnaker.keel:keel-intent-aws",
                 "com.netflix.spinnaker.keel:keel-orca",
                 "com.netflix.spinnaker.keel:keel-redis",
                 "com.netflix.spinnaker.keel:keel-retrofit",
@@ -1790,23 +1853,23 @@
             "requested": "1.1.60"
         },
         "org.junit.jupiter:junit-jupiter-api": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-engine": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.jupiter:junit-jupiter-params": {
-            "locked": "5.0.0",
+            "locked": "5.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-launcher": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.junit.platform:junit-platform-runner": {
-            "locked": "1.0.0",
+            "locked": "1.1.0-M1",
             "requested": "+"
         },
         "org.slf4j:slf4j-api": {
@@ -1817,15 +1880,15 @@
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
             "locked": "1.5.7.RELEASE",
-            "requested": "+"
+            "requested": "1.5.+"
         },
         "redis.clients:jedis": {
             "firstLevelTransitive": [

--- a/keel-web/keel-web.gradle
+++ b/keel-web/keel-web.gradle
@@ -30,9 +30,9 @@ springBoot {
 }
 
 dependencies {
-  compile "org.springframework.boot:spring-boot-starter-actuator:+"
-  compile "org.springframework.boot:spring-boot-starter-web:+"
-  compile "org.springframework.boot:spring-boot-starter-data-rest:+"
+  compile "org.springframework.boot:spring-boot-starter-actuator:1.5.+"
+  compile "org.springframework.boot:spring-boot-starter-web:1.5.+"
+  compile "org.springframework.boot:spring-boot-starter-data-rest:1.5+"
 
   compile project(":keel-core")
   compile project(":keel-eureka")
@@ -40,6 +40,7 @@ dependencies {
   compile project(":keel-orca")
   compile project(":keel-clouddriver")
   compile project(":keel-intent")
+  compile project(":keel-intent-aws")
   compile project(":keel-redis")
   compile project(":keel-scheduler")
 }


### PR DESCRIPTION
Attempting to `+` major versions caused some anarchy, so reigned it in a little bit on the versions that we can jump across on.