### PR TITLE
feat(activity): monitor and emit metrics on orch status

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentActivityRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentActivityRepository.kt
@@ -21,5 +21,21 @@ interface IntentActivityRepository {
 
   fun addOrchestrations(intentId: String, orchestrations: List<String>)
 
+  fun getCurrent(intentId: String): List<String>
+
+  fun upsertCurrent(intentId: String, orchestrations: List<String>)
+
+  fun upsertCurrent(intentId: String, orchestration: String)
+
+  fun removeCurrent(intentId: String, orchestrationId: String)
+
+  fun removeCurrent(intentId: String)
+
   fun getHistory(intentId: String): List<String>
+
+  /**
+   * If orchestrationId is passed in as a link to the task in orca, strip the leading path
+   * off so that we're storing the actual orchestrationId
+   */
+  fun parseOrchestrationId(orchestrationId: String) = orchestrationId.removePrefix("/tasks/")
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryIntentActivityRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryIntentActivityRepository.kt
@@ -17,13 +17,16 @@ package com.netflix.spinnaker.keel.memory
 
 import com.netflix.spinnaker.keel.IntentActivityRepository
 import org.slf4j.LoggerFactory
+import java.util.concurrent.ConcurrentHashMap
 import javax.annotation.PostConstruct
 
 class MemoryIntentActivityRepository : IntentActivityRepository {
 
   private val log = LoggerFactory.getLogger(javaClass)
 
-  private val orchestrations: MutableMap<String, MutableList<String>> = mutableMapOf()
+  private val currentOrchestrations: ConcurrentHashMap<String, MutableSet<String>> = ConcurrentHashMap()
+
+  private val orchestrations: ConcurrentHashMap<String, MutableSet<String>> = ConcurrentHashMap()
 
   @PostConstruct
   fun init() {
@@ -31,11 +34,16 @@ class MemoryIntentActivityRepository : IntentActivityRepository {
   }
 
   override fun addOrchestration(intentId: String, orchestrationId: String) {
+    val orchestrationUUID = parseOrchestrationId(orchestrationId)
     if (!orchestrations.containsKey(intentId)) {
-      orchestrations[intentId] = mutableListOf()
+      orchestrations[intentId] = mutableSetOf()
     }
-    if (orchestrations[intentId]?.contains(orchestrationId) == false) {
-      orchestrations[intentId]?.add(orchestrationId)
+    if (orchestrations[intentId]?.contains(orchestrationUUID) == false) {
+      orchestrations[intentId]?.add(orchestrationUUID)
+      if (!currentOrchestrations.containsKey(intentId)) {
+        currentOrchestrations.put(intentId, mutableSetOf())
+      }
+      currentOrchestrations[intentId]?.add(orchestrationUUID)
     }
   }
 
@@ -43,5 +51,29 @@ class MemoryIntentActivityRepository : IntentActivityRepository {
     orchestrations.forEach { addOrchestration(intentId, it) }
   }
 
+  override fun getCurrent(intentId: String): List<String> {
+    return currentOrchestrations.getOrDefault(intentId, listOf<String>()).toList()
+  }
+
+  override fun upsertCurrent(intentId: String, orchestrations: List<String>) {
+    if (!currentOrchestrations.containsKey(intentId)) {
+      currentOrchestrations.put(intentId, mutableSetOf())
+    }
+    currentOrchestrations[intentId]?.addAll(orchestrations.toMutableSet())
+  }
+
+  override fun upsertCurrent(intentId: String, orchestration: String) {
+    upsertCurrent(intentId, listOf(orchestration))
+  }
+
+  override fun removeCurrent(intentId: String, orchestrationId: String) {
+    currentOrchestrations[intentId]?.remove(orchestrationId)
+  }
+
+  override fun removeCurrent(intentId: String) {
+    currentOrchestrations.remove(intentId)
+  }
+
   override fun getHistory(intentId: String) = orchestrations.getOrDefault(intentId, listOf<String>()).toList()
+
 }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaExecutionStatus.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaExecutionStatus.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.keel.orca
+
+enum class OrcaExecutionStatus {
+  NOT_STARTED,
+  RUNNING,
+  PAUSED,
+  SUSPENDED,
+  SUCCEEDED,
+  FAILED_CONTINUE,
+  TERMINAL,
+  CANCELED,
+  REDIRECT,
+  STOPPED,
+  SKIPPED;
+
+  fun isFailure() = listOf(TERMINAL, FAILED_CONTINUE, STOPPED, CANCELED).contains(this)
+  fun isSuccess() = listOf(SUCCEEDED).contains(this)
+  fun isIncomplete() = listOf(NOT_STARTED, RUNNING).contains(this)
+}

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -16,18 +16,30 @@
 package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
-import retrofit.http.Body
-import retrofit.http.Headers
-import retrofit.http.POST
+import retrofit.http.*
 
 // TODO Origin needs to be set on executions
+// origin is used for dynamic routing by orca to different clouddriver instances
 interface OrcaService {
 
   @POST("/ops")
   @Headers("Content-Type: application/context+json")
   fun orchestrate(@Body request: OrchestrationRequest): TaskRefResponse
+
+  @GET("/tasks/{id}")
+  fun getTask(@Path("id") id: String): TaskDetailResponse
 }
 
 data class TaskRefResponse(
   val ref: String
+)
+
+data class TaskDetailResponse(
+  val id: String,
+  val name: String,
+  val application: String,
+  val buildTime: String,
+  val startTime: String,
+  val endTime: String,
+  val status: OrcaExecutionStatus
 )

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/MonitorOrchestrationsHandler.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/MonitorOrchestrationsHandler.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.keel.scheduler.handler
+
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.keel.IntentActivityRepository
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.scheduler.MonitorOrchestrations
+import com.netflix.spinnaker.q.MessageHandler
+import com.netflix.spinnaker.q.Queue
+import net.logstash.logback.argument.StructuredArguments.value
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+
+/**
+ * This handler follows up on the launched orchestrations, and records
+ * success and failure by kind.
+ */
+@Component
+class MonitorOrchestrationsHandler
+@Autowired constructor(
+  override val queue: Queue,
+  private val intentActivityRepository: IntentActivityRepository,
+  private val orcaService: OrcaService,
+  private val registry: Registry
+) : MessageHandler<MonitorOrchestrations> {
+
+  private val backoffMs = Duration.ofMillis(10000)
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  private val orchestrationsStatusId = registry.createId("intent.orchestrations.status")
+
+  override fun handle(message: MonitorOrchestrations) {
+    val orchestrationIds = intentActivityRepository.getCurrent(message.intentId)
+    orchestrationIds.forEach {
+      val orcaExecutionStatus = orcaService.getTask(it).status
+
+      when {
+        orcaExecutionStatus.isIncomplete() -> {
+          log.debug("orchestration for intent has not completed (intentId: {}, taskId: {})", value("intent", message.intentId), value("task", it))
+        }
+        orcaExecutionStatus.isSuccess() -> {
+          log.debug("orchestration for intent has succeeded (intentId: {}, taskId: {})", value("intent", message.intentId), value("task", it))
+          intentActivityRepository.removeCurrent(message.intentId, it)
+          registry.counter(orchestrationsStatusId.withTag("kind", message.kind).withTag("status", "success")).increment()
+          //TODO eb: record duration metric
+        }
+        orcaExecutionStatus.isFailure() -> {
+          log.debug("orchestration for intent has failed (intentId: {}, taskId: {})", value("intent", message.intentId), value("task", it))
+          intentActivityRepository.removeCurrent(message.intentId, it)
+          registry.counter(orchestrationsStatusId.withTag("kind", message.kind).withTag("status", "failure")).increment()
+          //TODO eb: record duration metric
+        }
+        else -> {
+          log.debug("orchestration for intent has unhandled status $orcaExecutionStatus (intentId: {}, taskId: {})", value("intent", message.intentId), value("task", it))
+          registry.counter(orchestrationsStatusId.withTag("kind", message.kind).withTag("status", "unhandled").withTag("executionStatus", orcaExecutionStatus.toString())).increment()
+        }
+      }
+    }
+    if (intentActivityRepository.getCurrent(message.intentId).isNotEmpty()){
+      queue.push(MonitorOrchestrations(message.intentId, message.kind), backoffMs)
+    }
+  }
+
+  override val messageType = MonitorOrchestrations::class.java
+
+}

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/messages.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/messages.kt
@@ -36,3 +36,9 @@ data class ConvergeIntent(
   // ... Unless the timeout ttl is elapsed.
   val timeoutTtl: Long
 ) : Message()
+
+
+data class MonitorOrchestrations(
+  val intentId: String,
+  val kind: String
+) : Message()

--- a/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/MonitorOrchestrationsHandlerTest.kt
+++ b/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/MonitorOrchestrationsHandlerTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.keel.scheduler.handler
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.keel.IntentActivityRepository
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.orca.TaskDetailResponse
+import com.netflix.spinnaker.keel.scheduler.MonitorOrchestrations
+import com.netflix.spinnaker.q.Queue
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+object MonitorOrchestrationsHandlerTest {
+  val queue = mock<Queue>()
+  val intentActivityRepository = mock<IntentActivityRepository>()
+  val orcaService = mock<OrcaService>()
+  val registry = NoopRegistry()
+
+  val subject = MonitorOrchestrationsHandler(queue, intentActivityRepository, orcaService, registry)
+
+  val intentId = "Application:emilykeeltest"
+  val orchestrationsStatusId = registry.createId("intent.orchestrations.status")
+  val orchestrationId = "a36ccc2c-8f40-4e63-852c-8107dd819ada"
+
+  @Test
+  fun `succeeded message is recorded and cleared`() {
+
+    val message = MonitorOrchestrations(intentId, "Application")
+
+    whenever(intentActivityRepository.getCurrent(intentId))
+      .doReturn(listOf(orchestrationId))
+      .doReturn(emptyList<String>())
+    whenever(orcaService.getTask(orchestrationId)) doReturn TaskDetailResponse(
+      orchestrationId,
+      "Converging on desired application state",
+      "emilykeeltest",
+      "1511998323980",
+      "1511998324027",
+      "1511998324552",
+      OrcaExecutionStatus.SUCCEEDED)
+
+    subject.handle(message)
+
+    verifyNoMoreInteractions(queue)
+  }
+
+  @Test
+  fun `running message is followed up on`() {
+    val message = MonitorOrchestrations(intentId, "Application")
+
+    whenever(intentActivityRepository.getCurrent(intentId)) doReturn listOf(orchestrationId)
+    whenever(orcaService.getTask(orchestrationId)) doReturn TaskDetailResponse(
+      orchestrationId,
+      "Converging on desired application state",
+      "emilykeeltest",
+      "1511998323980",
+      "1511998324027",
+      "1511998324552",
+      OrcaExecutionStatus.RUNNING)
+
+    subject.handle(message)
+
+    verify(queue).push(message, Duration.ofMillis(10000))
+    verifyNoMoreInteractions(queue)
+  }
+}


### PR DESCRIPTION
We'd like to track, by intent kind, whether orchestrations for an intent succeed or fail. This is a first pass at that.