### PR TITLE
feat(dryRun): improve dry run messaging a bit

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentProcessor.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/IntentProcessor.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.keel
 
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 
 interface IntentProcessor<in I : Intent<IntentSpec>> {
@@ -31,5 +32,5 @@ enum class ConvergeReason(val reason: String) {
 
 data class ConvergeResult(
   val orchestrations: List<OrchestrationRequest>,
-  val reason: String
+  val changeSummary: ChangeSummary = ChangeSummary()
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/dryrun/ChangeSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/dryrun/ChangeSummary.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.keel.dryrun
+
+import com.netflix.spinnaker.keel.state.FieldState
+
+data class ChangeSummary(
+  private val summary: MutableList<String> = mutableListOf()
+) {
+  var type: ChangeType = ChangeType.NO_CHANGE
+  var diff: List<FieldState> = emptyList()
+
+  fun addMessage(msg: String) {
+    summary.add(msg)
+  }
+
+  override fun toString(): String {
+    // TODO eb: more readable friendly format for logs/response?
+    var msg = "ChangeSummary(type=$type, summary=$summary"
+    if (!listOf(ChangeType.CREATE, ChangeType.NO_CHANGE, ChangeType.FAILED_PRECONDITIONS).contains(type)) msg += ", diff=$diff"
+    msg += ")"
+    return msg
+  }
+}
+
+enum class ChangeType {
+  CREATE,
+  UPDATE,
+  DELETE,
+  NO_CHANGE,
+  FAILED_PRECONDITIONS
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/dryrun/DryRunIntentLauncher.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/dryrun/DryRunIntentLauncher.kt
@@ -17,7 +17,11 @@ package com.netflix.spinnaker.keel.dryrun
 
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.keel.*
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentLauncher
+import com.netflix.spinnaker.keel.IntentProcessor
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.LaunchedIntentResult
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -39,8 +43,8 @@ class DryRunIntentLauncher
     val tasks = processor.converge(intent)
 
     return DryRunLaunchedIntentResult(
-      reason = tasks.reason,
-      steps = collectSteps(tasks.orchestrations)
+      steps = collectSteps(tasks.orchestrations),
+      summary = tasks.changeSummary
     )
   }
 
@@ -55,6 +59,6 @@ class DryRunIntentLauncher
 }
 
 data class DryRunLaunchedIntentResult(
-  val reason: String?,
-  val steps: List<DryRunStep>
+  val steps: List<DryRunStep>,
+  val summary: ChangeSummary
 ) : LaunchedIntentResult

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ParrotIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ParrotIntentProcessor.kt
@@ -15,7 +15,11 @@
  */
 package com.netflix.spinnaker.keel.intent.processor
 
-import com.netflix.spinnaker.keel.*
+import com.netflix.spinnaker.keel.ConvergeResult
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentProcessor
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.intent.ParrotIntent
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -34,6 +38,8 @@ class ParrotIntentProcessor
   override fun supports(intent: Intent<IntentSpec>) = intent is ParrotIntent
 
   override fun converge(intent: ParrotIntent): ConvergeResult {
+    val changeSummary = ChangeSummary()
+    changeSummary.addMessage("Squawk!")
     traceRepository.record(Trace(mapOf(), intent))
     return ConvergeResult(listOf(
       OrchestrationRequest(
@@ -45,6 +51,6 @@ class ParrotIntentProcessor
         ),
         trigger = Trigger(intent.id)
       )
-    ), ConvergeReason.CHANGED.reason)
+    ), changeSummary)
   }
 }

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/ApplicationConverter.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/ApplicationConverter.kt
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.keel.intent.processor.converter
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.front50.model.Application
 import com.netflix.spinnaker.keel.intent.ANY_MAP_TYPE
 import com.netflix.spinnaker.keel.intent.BaseApplicationSpec
@@ -55,7 +56,7 @@ class ApplicationConverter(
     TODO("not implemented ")
   }
 
-  override fun convertToJob(spec: BaseApplicationSpec): List<Job> {
+  override fun convertToJob(spec: BaseApplicationSpec, changeSummary: ChangeSummary): List<Job> {
     TODO("not implemented")
   }
 

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/LoadBalancerConverter.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/LoadBalancerConverter.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.model.ElasticLoadBalancer
 import com.netflix.spinnaker.keel.clouddriver.model.ElasticLoadBalancer.HealthCheck
 import com.netflix.spinnaker.keel.clouddriver.model.ElasticLoadBalancer.ListenerDescription
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.intent.AmazonElasticLoadBalancerSpec
 import com.netflix.spinnaker.keel.intent.AvailabilityZoneConfig.Automatic
 import com.netflix.spinnaker.keel.intent.AvailabilityZoneConfig.Manual
@@ -11,7 +12,11 @@ import com.netflix.spinnaker.keel.intent.HealthCheckSpec
 import com.netflix.spinnaker.keel.intent.HealthEndpoint
 import com.netflix.spinnaker.keel.intent.LoadBalancerSpec
 import com.netflix.spinnaker.keel.model.Job
-import com.netflix.spinnaker.keel.model.Protocol.*
+import com.netflix.spinnaker.keel.model.Protocol.HTTP
+import com.netflix.spinnaker.keel.model.Protocol.HTTPS
+import com.netflix.spinnaker.keel.model.Protocol.SSL
+import com.netflix.spinnaker.keel.model.Protocol.TCP
+import com.netflix.spinnaker.keel.model.Protocol.valueOf
 import org.springframework.stereotype.Component
 
 @Component
@@ -66,7 +71,7 @@ class LoadBalancerConverter(
       )
     }
 
-  override fun convertToJob(spec: LoadBalancerSpec): List<Job> {
+  override fun convertToJob(spec: LoadBalancerSpec, changeSummary: ChangeSummary): List<Job> {
     TODO("not implemented")
   }
 

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/SpecConverter.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/SpecConverter.kt
@@ -16,13 +16,14 @@
 package com.netflix.spinnaker.keel.intent.processor.converter
 
 import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.model.Job
 
 interface SpecConverter<I : IntentSpec, S : Any> {
 
   fun convertToState(spec: I): S
   fun convertFromState(state: S): I?
-  fun convertToJob(spec: I): List<Job>
+  fun convertToJob(spec: I, changeSummary: ChangeSummary): List<Job>
 }
 
 const val COMPUTED_VALUE = "<computed>"

--- a/keel-intent/src/test/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/SecurityGroupConverterTest.kt
+++ b/keel-intent/src/test/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/SecurityGroupConverterTest.kt
@@ -24,11 +24,16 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.Moniker
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroup
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.intent.AmazonSecurityGroupSpec
 import com.netflix.spinnaker.keel.intent.ReferenceSecurityGroupRule
 import com.netflix.spinnaker.keel.intent.SecurityGroupPortRange
 import com.netflix.spinnaker.keel.intent.SecurityGroupSpec
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.jupiter.api.Test
 
 object SecurityGroupConverterTest {
@@ -144,6 +149,7 @@ object SecurityGroupConverterTest {
 
   @Test
   fun `should convert spec to orchestration job`() {
+    val changeSummary = ChangeSummary()
     val spec = AmazonSecurityGroupSpec(
       application = "keel",
       name = "keel",
@@ -162,7 +168,7 @@ object SecurityGroupConverterTest {
       description = "app sg"
     )
 
-    val result = subject.convertToJob(spec)
+    val result = subject.convertToJob(spec,changeSummary)
 
     result.size shouldMatch equalTo(1)
     result[0]["application"] shouldMatch equalTo<Any>("keel")

--- a/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandlerTest.kt
+++ b/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandlerTest.kt
@@ -18,13 +18,20 @@ package com.netflix.spinnaker.keel.scheduler.handler
 import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.keel.IntentActivityRepository
 import com.netflix.spinnaker.keel.IntentRepository
+import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.orca.OrcaIntentLauncher
 import com.netflix.spinnaker.keel.orca.OrcaLaunchedIntentResult
 import com.netflix.spinnaker.keel.scheduler.ConvergeIntent
 import com.netflix.spinnaker.keel.test.TestIntent
 import com.netflix.spinnaker.keel.test.TestIntentSpec
 import com.netflix.spinnaker.q.Queue
-import com.nhaarman.mockito_kotlin.*
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.reset
+import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import com.nhaarman.mockito_kotlin.whenever
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -83,7 +90,7 @@ object ConvergeIntentHandlerTest {
 
     val refreshedIntent = TestIntent(TestIntentSpec("1", mapOf("refreshed" to true)))
     whenever(intentRepository.getIntent("test:1")) doReturn refreshedIntent
-    whenever(orcaIntentLauncher.launch(refreshedIntent)) doReturn OrcaLaunchedIntentResult(listOf("one"), "mmkay")
+    whenever(orcaIntentLauncher.launch(refreshedIntent)) doReturn OrcaLaunchedIntentResult(listOf("one"), ChangeSummary())
 
     subject.handle(message)
 


### PR DESCRIPTION
Trying to improve the messaging around dry run. Have added the type of change to be made, a summary (which I want to act like a list of steps that were taken while putting together the tasks submitted to orca), and the diff. 

My hope is that intent creators will add messaging to the summary so someone who submits this intent will be able to see something like:
```
Generating job for upsertSecurityGroup,
Adding port range support,
Creating dependent security group blah
Generating job for upsertSecurityGroup blah
Adding ingress rules for security group blah
```
along with the diff to tell what the final value of the fields are going to be.

I think this needs to be massaged as we continue development. Suggestions welcome!