### PR TITLE
feat(web): API for retrieving JSON schema of models

### DIFF
--- a/keel-clouddriver/dependencies.lock
+++ b/keel-clouddriver/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -43,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -117,19 +123,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -142,6 +148,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -156,13 +168,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -230,19 +242,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -255,6 +267,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -269,13 +287,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -363,19 +381,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -388,6 +406,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -402,13 +426,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -476,19 +500,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -501,6 +525,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -515,13 +545,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -589,19 +619,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -614,6 +644,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -639,13 +675,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -734,19 +770,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -759,6 +795,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -784,13 +826,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -879,19 +921,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -904,6 +946,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -929,13 +977,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -1032,19 +1080,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1057,6 +1105,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1082,13 +1136,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",

--- a/keel-core/dependencies.lock
+++ b/keel-core/dependencies.lock
@@ -1,15 +1,15 @@
 {
     "compile": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -20,8 +20,12 @@
             "locked": "1.2.2",
             "requested": "1.2.+"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "locked": "1.0.25",
+            "requested": "1.0.+"
+        },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -43,15 +47,15 @@
     },
     "compileClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -62,8 +66,12 @@
             "locked": "1.2.2",
             "requested": "1.2.+"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "locked": "1.0.25",
+            "requested": "1.0.+"
+        },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -85,15 +93,15 @@
     },
     "default": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -104,8 +112,12 @@
             "locked": "1.2.2",
             "requested": "1.2.+"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "locked": "1.0.25",
+            "requested": "1.0.+"
+        },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -147,15 +159,15 @@
     },
     "runtime": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -166,8 +178,12 @@
             "locked": "1.2.2",
             "requested": "1.2.+"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "locked": "1.0.25",
+            "requested": "1.0.+"
+        },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -189,15 +205,15 @@
     },
     "runtimeClasspath": {
         "com.fasterxml.jackson.core:jackson-annotations": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -208,8 +224,12 @@
             "locked": "1.2.2",
             "requested": "1.2.+"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "locked": "1.0.25",
+            "requested": "1.0.+"
+        },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -234,21 +254,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -264,6 +284,13 @@
             ],
             "locked": "1.2.2",
             "requested": "1.2.+"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25",
+            "requested": "1.0.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -285,7 +312,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -343,21 +370,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -373,6 +400,13 @@
             ],
             "locked": "1.2.2",
             "requested": "1.2.+"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25",
+            "requested": "1.0.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -394,7 +428,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -452,21 +486,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -482,6 +516,13 @@
             ],
             "locked": "1.2.2",
             "requested": "1.2.+"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25",
+            "requested": "1.0.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -503,7 +544,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -569,21 +610,21 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2",
+            "locked": "2.9.3",
             "requested": "2.9.+"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
@@ -599,6 +640,13 @@
             ],
             "locked": "1.2.2",
             "requested": "1.2.+"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25",
+            "requested": "1.0.+"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -620,7 +668,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {

--- a/keel-core/keel-core.gradle
+++ b/keel-core/keel-core.gradle
@@ -26,6 +26,7 @@ dependencies {
   compile "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+"
   compile "com.github.jonpeterson:jackson-module-model-versioning:1.2.+"
   compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.9.+"
+  compile "com.kjetland:mbknor-jackson-jsonschema_2.12:1.0.+"
 
   testCompile "com.squareup.retrofit:retrofit-mock:1.9.+"
   testCompile project(":keel-test")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.keel
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.github.jonpeterson.jackson.module.versioning.JsonSerializeToVersion
 import com.netflix.spectator.api.BasicTag
@@ -28,7 +29,7 @@ import kotlin.reflect.KClass
 abstract class Intent<out S : IntentSpec>
 @JsonCreator constructor(
   @JsonSerializeToVersion(defaultToSource = true) val schema: String,
-  val kind: String,
+  @JsonPropertyDescription("Hello") val kind: String,
   val spec: S,
   val status: IntentStatus = IntentStatus.ACTIVE,
   val labels: Labels = mapOf(),

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/Computed.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/Computed.kt
@@ -16,6 +16,12 @@
 
 package com.netflix.spinnaker.keel.annotation
 
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+
+/**
+ * TODO rz - JsonSchemaInject doesn't get picked up here. Very needed.
+ */
+@JsonSchemaInject(json = "{ \"computed\": true }")
 @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Computed(val ignore: Boolean = true)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/attribute/attributes.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/attribute/attributes.kt
@@ -18,7 +18,10 @@ package com.netflix.spinnaker.keel.attribute
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaDescription
 import com.netflix.spinnaker.keel.IntentPriority
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 
 /**
  * An Attribute is a strictly typed key/value pair. They're attached as a collection of metadata on Intents and used
@@ -38,6 +41,7 @@ class PriorityAttribute(value: IntentPriority) : Attribute<IntentPriority>("Prio
 class EnabledAttribute(value: Boolean) : Attribute<Boolean>("Enabled", value)
 
 @JsonTypeName("ExecutionWindow")
+@JsonSchemaDescription("Defines when an intent will be allowed to converge on state changes")
 class ExecutionWindowAttribute(value: ExecutionWindow) : Attribute<ExecutionWindow>("ExecutionWindow", value) {
   override fun toString(): String {
     return "ExecutionWindowAttribute(days=${value.days}, timeWindows=${value.timeWindows})"
@@ -50,8 +54,8 @@ data class ExecutionWindow(
 )
 
 data class TimeWindow(
-  val startHour: Int,
-  val startMin: Int,
-  val endHour: Int,
-  val endMin: Int
+  @Min(0) @Max(23) val startHour: Int,
+  @Min(0) @Max(60) val startMin: Int,
+  @Min(0) @Max(23) val endHour: Int,
+  @Min(0) @Max(60) val endMin: Int
 )

--- a/keel-echo/dependencies.lock
+++ b/keel-echo/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -43,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -113,19 +119,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -138,6 +144,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -152,13 +164,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -222,19 +234,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -247,6 +259,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -261,13 +279,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -351,19 +369,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -376,6 +394,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -390,13 +414,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -460,19 +484,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -485,6 +509,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -499,13 +529,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -569,19 +599,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -594,6 +624,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -619,13 +655,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -706,19 +742,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -731,6 +767,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -756,13 +798,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -843,19 +885,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -868,6 +910,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -893,13 +941,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -988,19 +1036,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1013,6 +1061,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1038,13 +1092,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-eureka/dependencies.lock
+++ b/keel-eureka/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -30,6 +30,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -37,7 +43,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -70,19 +76,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -96,6 +102,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -103,7 +115,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -136,19 +148,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -162,6 +174,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -169,7 +187,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -222,19 +240,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -248,6 +266,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -255,7 +279,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -288,19 +312,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -314,6 +338,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -321,7 +351,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -354,19 +384,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -380,6 +410,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -391,7 +427,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -440,19 +476,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -466,6 +502,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -477,7 +519,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -526,19 +568,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -552,6 +594,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -563,7 +611,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -620,19 +668,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -646,6 +694,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -657,7 +711,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-front50/dependencies.lock
+++ b/keel-front50/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -43,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -113,19 +119,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -138,6 +144,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -152,13 +164,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -222,19 +234,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -247,6 +259,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -261,13 +279,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -351,19 +369,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -376,6 +394,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -390,13 +414,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -460,19 +484,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -485,6 +509,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-core": {
             "firstLevelTransitive": [
@@ -499,13 +529,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -569,19 +599,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -594,6 +624,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -612,13 +648,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -698,19 +734,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -723,6 +759,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -741,13 +783,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -827,19 +869,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -852,6 +894,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -870,13 +918,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -964,19 +1012,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -989,6 +1037,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -1007,13 +1061,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-intent-aws/dependencies.lock
+++ b/keel-intent-aws/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -63,13 +69,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -142,19 +148,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -167,6 +173,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -201,13 +213,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -280,19 +292,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -305,6 +317,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -339,13 +357,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -438,19 +456,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -463,6 +481,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -497,13 +521,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -576,19 +600,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -601,6 +625,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -635,13 +665,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -714,19 +744,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -739,6 +769,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -784,13 +820,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -880,19 +916,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -905,6 +941,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -950,13 +992,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1046,19 +1088,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1071,6 +1113,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1116,13 +1164,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1220,19 +1268,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1245,6 +1293,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1290,13 +1344,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-intent/dependencies.lock
+++ b/keel-intent/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -53,13 +59,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -131,19 +137,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -156,6 +162,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -180,13 +192,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -258,19 +270,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -283,6 +295,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -307,13 +325,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -405,19 +423,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -430,6 +448,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -454,13 +478,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -532,19 +556,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -557,6 +581,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -581,13 +611,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -659,19 +689,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -684,6 +714,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -719,13 +755,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -814,19 +850,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -839,6 +875,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -874,13 +916,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -969,19 +1011,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -994,6 +1036,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1029,13 +1077,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1132,19 +1180,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1157,6 +1205,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1192,13 +1246,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-orca/dependencies.lock
+++ b/keel-orca/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -49,13 +55,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -126,19 +132,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -151,6 +157,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -171,13 +183,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -248,19 +260,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -273,6 +285,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -293,13 +311,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -390,19 +408,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -415,6 +433,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -435,13 +459,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -512,19 +536,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -537,6 +561,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "project": true
@@ -557,13 +587,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -634,19 +664,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -659,6 +689,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -683,13 +719,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -776,19 +812,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -801,6 +837,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -825,13 +867,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -918,19 +960,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -943,6 +985,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -967,13 +1015,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1068,19 +1116,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1093,6 +1141,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
@@ -1117,13 +1171,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-redis/dependencies.lock
+++ b/keel-redis/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -30,6 +30,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -37,14 +43,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -78,19 +84,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -104,6 +110,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -111,14 +123,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -152,19 +164,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -178,6 +190,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -185,14 +203,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -246,19 +264,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -272,6 +290,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -279,14 +303,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -320,19 +344,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -346,6 +370,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -353,14 +383,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -394,19 +424,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -419,6 +449,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -440,18 +476,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -502,19 +538,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -527,6 +563,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -548,18 +590,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -610,19 +652,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -635,6 +677,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -656,18 +704,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -726,19 +774,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -751,6 +799,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -772,18 +826,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {

--- a/keel-retrofit/dependencies.lock
+++ b/keel-retrofit/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -30,6 +30,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -37,10 +43,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -94,19 +100,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -120,6 +126,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -127,10 +139,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -184,19 +196,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -210,6 +222,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -217,10 +235,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -294,19 +312,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -320,6 +338,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -327,10 +351,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -384,19 +408,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -410,6 +434,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-core": {
             "project": true
         },
@@ -417,10 +447,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -474,19 +504,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -500,6 +530,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -511,10 +547,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -584,19 +620,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -610,6 +646,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -621,10 +663,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -694,19 +736,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -720,6 +762,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -731,10 +779,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -812,19 +860,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -838,6 +886,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -849,10 +903,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.109.0",
+            "locked": "1.111.0",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {

--- a/keel-scheduler/dependencies.lock
+++ b/keel-scheduler/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -29,6 +29,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -52,20 +58,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -137,19 +143,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -162,6 +168,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -185,20 +197,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -270,19 +282,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -295,6 +307,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -318,20 +336,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -423,19 +441,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -448,6 +466,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -471,20 +495,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -556,19 +580,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -581,6 +605,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -604,20 +634,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -689,19 +719,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -714,6 +744,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -748,20 +784,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -850,19 +886,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -875,6 +911,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -909,20 +951,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1011,19 +1053,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1036,6 +1078,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1070,20 +1118,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1180,19 +1228,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -1205,6 +1253,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.natpryce:hamkrest": {
             "firstLevelTransitive": [
@@ -1239,20 +1293,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "1.4.1",
+            "locked": "1.5.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-test/dependencies.lock
+++ b/keel-test/dependencies.lock
@@ -4,19 +4,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -30,6 +30,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -41,7 +47,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -74,19 +80,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -100,6 +106,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -111,7 +123,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -144,19 +156,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -170,6 +182,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -181,7 +199,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -234,19 +252,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -260,6 +278,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -271,7 +295,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -304,19 +328,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -330,6 +354,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -341,7 +371,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -374,19 +404,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -400,6 +430,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -411,7 +447,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -460,19 +496,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -486,6 +522,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -497,7 +539,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -546,19 +588,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -572,6 +614,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -583,7 +631,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -640,19 +688,19 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.core:jackson-databind": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "2.9.2"
+            "locked": "2.9.3"
         },
         "com.fasterxml.jackson.module:jackson-module-kotlin": {
             "firstLevelTransitive": [
@@ -666,6 +714,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -677,7 +731,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-web/dependencies.lock
+++ b/keel-web/dependencies.lock
@@ -30,6 +30,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-intent",
@@ -93,31 +99,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -185,15 +191,15 @@
             "locked": "1.7.25"
         },
         "org.springframework.boot:spring-boot-starter-actuator": {
-            "locked": "1.5.8.RELEASE",
+            "locked": "1.5.9.RELEASE",
             "requested": "1.5.+"
         },
         "org.springframework.boot:spring-boot-starter-data-rest": {
-            "locked": "1.5.8.RELEASE",
+            "locked": "1.5.9.RELEASE",
             "requested": "1.5+"
         },
         "org.springframework.boot:spring-boot-starter-web": {
-            "locked": "1.5.8.RELEASE",
+            "locked": "1.5.9.RELEASE",
             "requested": "1.5.+"
         },
         "redis.clients:jedis": {
@@ -233,6 +239,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.2.2"
+        },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
         },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
@@ -297,31 +309,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -438,6 +450,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-intent",
@@ -501,31 +519,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -662,6 +680,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-intent",
@@ -725,31 +749,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -866,6 +890,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.netflix.spinnaker.keel:keel-clouddriver": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-intent",
@@ -929,31 +959,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1070,6 +1100,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -1137,31 +1173,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1294,6 +1330,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -1361,31 +1403,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1518,6 +1560,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -1585,31 +1633,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1750,6 +1798,12 @@
             ],
             "locked": "1.2.2"
         },
+        "com.kjetland:mbknor-jackson-jsonschema_2.12": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.0.25"
+        },
         "com.natpryce:hamkrest": {
             "locked": "1.4.2.2",
             "requested": "+"
@@ -1817,31 +1871,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "1.4.1"
+            "locked": "1.5.0"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.109.0"
+            "locked": "1.111.0"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/SchemaController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/SchemaController.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2017 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.controllers.v1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.attribute.Attribute
+import com.netflix.spinnaker.keel.controllers.v1.SchemaController.SchemaType.ATTRIBUTE
+import com.netflix.spinnaker.keel.controllers.v1.SchemaController.SchemaType.INTENT
+import com.netflix.spinnaker.keel.controllers.v1.SchemaController.SchemaType.INTENT_SPEC
+import com.netflix.spinnaker.keel.controllers.v1.SchemaController.SchemaType.POLICY
+import com.netflix.spinnaker.keel.controllers.v1.SchemaController.SchemaType.POLICY_SPEC
+import com.netflix.spinnaker.keel.controllers.v1.SchemaController.SchemaType.values
+import com.netflix.spinnaker.keel.exceptions.DeclarativeException
+import com.netflix.spinnaker.keel.policy.Policy
+import com.netflix.spinnaker.keel.policy.PolicySpec
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.type.filter.AssignableTypeFilter
+import org.springframework.util.ClassUtils
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+import javax.ws.rs.QueryParam
+
+/**
+ * TODO rz - Better querying / indexing ability
+ * TODO rz - Computed annotation needs to inject computed schema property
+ * TODO rz - Polymorphism doesn't inherit schema property descriptions
+ */
+@RestController
+@RequestMapping("/v1/schemas")
+class SchemaController
+@Autowired constructor(
+  private val objectMapper: ObjectMapper
+) {
+
+  private val generator = JsonSchemaGenerator(objectMapper)
+
+  @RequestMapping(value = "/{type}", method = arrayOf(RequestMethod.GET))
+  fun getSchemas(@PathVariable("type") type: String, @QueryParam("name") name: String?): String {
+    if (name != null) {
+      return objectMapper.writeValueAsString(generator.generateJsonSchema(
+        findSchemaByName(typeFromString(type), name)
+      ))
+    }
+    return objectMapper.writeValueAsString(generator.generateJsonSchema(typeFromString(type)))
+  }
+
+  private fun typeFromString(type: String) =
+    when(type) {
+      INTENT.toString() -> INTENT.klass
+      INTENT_SPEC.toString() -> INTENT_SPEC.klass
+      ATTRIBUTE.toString() -> ATTRIBUTE.klass
+      POLICY.toString() -> POLICY.klass
+      POLICY_SPEC.toString() -> POLICY_SPEC.klass
+      else -> throw DeclarativeException("Unknown schema type: $type (must be one of ${values().map { it.name }})")
+    }
+
+  private fun findSchemaByName(klass: Class<*>, name: String): Class<*>? {
+    return ClassPathScanningCandidateComponentProvider(false)
+      .apply { addIncludeFilter(AssignableTypeFilter(klass)) }
+      .findCandidateComponents("com.netflix.spinnaker.keel")
+      .map { ClassUtils.resolveClassName(it.beanClassName, ClassUtils.getDefaultClassLoader()) }
+      .firstOrNull { it.simpleName == name }
+  }
+
+  private enum class SchemaType(val klass: Class<*>) {
+    INTENT(Intent::class.java),
+    INTENT_SPEC(IntentSpec::class.java),
+    ATTRIBUTE(Attribute::class.java),
+    POLICY(Policy::class.java),
+    POLICY_SPEC(PolicySpec::class.java)
+  }
+}


### PR DESCRIPTION
Kicking around the idea of exposing model JSON schemas for external client use. This could be handy for people who want to build DSLs / templating around Keel, as well as generate clients.

Very much a WIP, but think this could be a decent way to keep things documented. Still some wonkiness around subtypes (seems to only be direct children that are supported) and inheriting property descriptions, as well as auto-adding schema properties from other annotations (like `@Computed`).