### PR TITLE
fix(securityGroup): sg description is not mutable in clouddriver

### DIFF
--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/SecurityGroupIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/SecurityGroupIntentProcessor.kt
@@ -152,7 +152,7 @@ class SecurityGroupIntentProcessor
         desiredState = it.second,
         modelClass = SecurityGroup::class,
         specClass = SecurityGroupSpec::class,
-        ignoreKeys = setOf("type", "id", "moniker", "summary")
+        ignoreKeys = setOf("type", "id", "moniker", "summary", "description")
       )
     }.toSet()
     changeSummary.diff = diff


### PR DESCRIPTION
This field is not mutable in clouddriver so we shouldn't consider it in the diff.