### PR TITLE
feat(logging): convergence logging now in intentActivityRepo

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelConfiguration.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelConfiguration.kt
@@ -26,8 +26,8 @@ import com.netflix.spinnaker.keel.Intent
 import com.netflix.spinnaker.keel.IntentActivityRepository
 import com.netflix.spinnaker.keel.IntentRepository
 import com.netflix.spinnaker.keel.IntentSpec
-import com.netflix.spinnaker.keel.findAllSubtypes
 import com.netflix.spinnaker.keel.attribute.Attribute
+import com.netflix.spinnaker.keel.findAllSubtypes
 import com.netflix.spinnaker.keel.memory.MemoryIntentActivityRepository
 import com.netflix.spinnaker.keel.memory.MemoryIntentRepository
 import com.netflix.spinnaker.keel.memory.MemoryTraceRepository
@@ -83,7 +83,7 @@ open class KeelConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(IntentActivityRepository::class)
-  open fun memoryIntentActivityRepository(): IntentActivityRepository = MemoryIntentActivityRepository()
+  open fun memoryIntentActivityRepository(): IntentActivityRepository = MemoryIntentActivityRepository(properties)
 
   @Bean
   @ConditionalOnMissingBean(TraceRepository::class)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelProperties.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelProperties.kt
@@ -6,4 +6,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 class KeelProperties {
   var prettyPrintJson: Boolean = false
   var immediatelyRunIntents: Boolean = true
+  var maxConvergenceLogEntriesPerIntent: Int = 720 // one entry every 30 s, this will keep 6 hours of logs
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryIntentActivityRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryIntentActivityRepository.kt
@@ -15,18 +15,26 @@
  */
 package com.netflix.spinnaker.keel.memory
 
+import com.netflix.spinnaker.config.KeelProperties
 import com.netflix.spinnaker.keel.IntentActivityRepository
+import com.netflix.spinnaker.keel.IntentConvergenceRecord
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
 import java.util.concurrent.ConcurrentHashMap
 import javax.annotation.PostConstruct
 
-class MemoryIntentActivityRepository : IntentActivityRepository {
+class MemoryIntentActivityRepository
+@Autowired constructor(
+  private val keelProperties: KeelProperties
+) : IntentActivityRepository {
 
   private val log = LoggerFactory.getLogger(javaClass)
 
   private val currentOrchestrations: ConcurrentHashMap<String, MutableSet<String>> = ConcurrentHashMap()
 
   private val orchestrations: ConcurrentHashMap<String, MutableSet<String>> = ConcurrentHashMap()
+
+  private val convergenceLog: ConcurrentHashMap<String, MutableList<IntentConvergenceRecord>> = ConcurrentHashMap()
 
   @PostConstruct
   fun init() {
@@ -76,4 +84,33 @@ class MemoryIntentActivityRepository : IntentActivityRepository {
 
   override fun getHistory(intentId: String) = orchestrations.getOrDefault(intentId, listOf<String>()).toList()
 
+  override fun logConvergence(intentConvergenceRecord: IntentConvergenceRecord) {
+    val intentId = intentConvergenceRecord.intentId
+    if (!convergenceLog.containsKey(intentId)){
+      convergenceLog[intentId] = mutableListOf(intentConvergenceRecord)
+    } else {
+      if (convergenceLog[intentId] == null) {
+        convergenceLog[intentId] = mutableListOf(intentConvergenceRecord)
+      } else {
+        convergenceLog[intentId]?.let { l ->
+          l.add(intentConvergenceRecord)
+          // Drop oldest entries if we're over the message limit
+          val numMsgsLeft = keelProperties.maxConvergenceLogEntriesPerIntent - l.count()
+          if (numMsgsLeft < 0){
+            convergenceLog[intentId] = l.drop(-1*numMsgsLeft).toMutableList()
+          }
+        }
+      }
+    }
+  }
+
+  override fun getLog(intentId: String): List<IntentConvergenceRecord>
+    = convergenceLog[intentId] ?: emptyList()
+
+  // if there are multiple messages with the same timestamp, return the first
+  override fun getLogEntry(intentId: String, timestampMillis: Long)
+    = convergenceLog[intentId]?.filter { it.timestampMillis == timestampMillis }?.toList()?.also {
+      // The same intent shouldn't be processed more than once at the exact same time.
+      if (it.size > 1) log.warn("Two messages with the same timestampMillis. This shouldn't happen.")
+    }?.first()
 }

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ApplicationIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ApplicationIntentProcessor.kt
@@ -35,7 +35,6 @@ import com.netflix.spinnaker.keel.state.FieldMutator
 import com.netflix.spinnaker.keel.state.StateInspector
 import com.netflix.spinnaker.keel.tracing.Trace
 import com.netflix.spinnaker.keel.tracing.TraceRepository
-import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -54,8 +53,6 @@ class ApplicationIntentProcessor
   override fun supports(intent: Intent<IntentSpec>) = intent is ApplicationIntent
 
   override fun converge(intent: ApplicationIntent): ConvergeResult {
-    log.info("Converging state for {}", value("intent", intent.id()))
-
     val changeSummary = ChangeSummary(intent.id())
 
     val currentState = getApplication(intent.spec.name)

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/SecurityGroupIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/SecurityGroupIntentProcessor.kt
@@ -37,7 +37,6 @@ import com.netflix.spinnaker.keel.model.Trigger
 import com.netflix.spinnaker.keel.state.StateInspector
 import com.netflix.spinnaker.keel.tracing.Trace
 import com.netflix.spinnaker.keel.tracing.TraceRepository
-import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
@@ -59,8 +58,6 @@ class SecurityGroupIntentProcessor
 
   override fun converge(intent: SecurityGroupIntent): ConvergeResult {
     val changeSummary = ChangeSummary(intent.id())
-
-    log.info("Converging state for {}", value("intent", intent.id()))
 
     val currentState = getSecurityGroups(intent.spec)
 

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandler.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandler.kt
@@ -60,8 +60,6 @@ class ConvergeIntentHandler
   private val refreshesId = registry.createId("intent.refreshes")
 
   override fun handle(message: ConvergeIntent) {
-    log.debug("Converging {}", value("intent", message.intent.id()))
-
     if (clock.millis() > message.timeoutTtl) {
       log.warn("Intent timed out, canceling converge for {}", value("intent", message.intent.id()))
       applicationEventPublisher.publishEvent(IntentConvergeTimeoutEvent(message.intent))
@@ -105,7 +103,7 @@ class ConvergeIntentHandler
       return message.intent
     }
 
-    log.info("Refreshing intent state for {}", value("intent", message.intent.id()))
+    log.debug("Refreshing intent state for {}", value("intent", message.intent.id()))
     registry.counter(refreshesId.withTags(message.intent.getMetricTags())).increment()
 
     return intentRepository.getIntent(message.intent.id())

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
@@ -116,6 +116,13 @@ class IntentController
 
   @RequestMapping(value = "/{id}/traces", method = arrayOf(RequestMethod.GET))
   fun getIntentTrace(@PathVariable("id") id: String) = traceRepository.getForIntent(id)
+
+  @RequestMapping(value = "/{id}/log", method = arrayOf(RequestMethod.GET))
+  fun getLog(@PathVariable("id") id: String) = intentActivityRepository.getLog(id)
+
+  @RequestMapping(value = "/{id}/log/{timestampMillis}", method = arrayOf(RequestMethod.GET))
+  fun getLogEntry(@PathVariable("id") id: String, @PathVariable("timestampMillis") timestampMillis: Long)
+    = intentActivityRepository.getLogEntry(id, timestampMillis)
 }
 
 data class UpsertIntentResponse(


### PR DESCRIPTION
In order to make logging more manageable for each intent for each convergence, I've moved everything but the `com.netflix.spinnaker.q.QueueProcessor   : [] Received message ConvergeIntent(` messages to the intentActivityRepository. 

Hitting `v1/intents/{intentId}/convergenceLog` will give you all the messages for each intent with the format 
```{
"intentId": "Application:emilykeeltest",
"changeType": "NO_CHANGE",
"orchestrations": [],
"messages": [
  "System state matches desired state"
],
"diff": [],
"actor": "keel:scheduledConvergence",
"timeMs": 1516214128706
}
```

Each message is identified by its timestamp, which is created when the log message is created in `OrcaIntentLauncher`. This message is created right after orchestrations are launched in orca.

`v1/intents/{intentId}/convergenceLog/{timeMs}` is a permalink to the specific log message, while it exists. 

The number of messages kept is configurable. I've set it to keep logs for about 6 hours right now (a message is posted for each intent convergence every 30 seconds).



