### PR TITLE
feat(intent): Scaffolding pipeline intent spec

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/ForcesNew.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/ForcesNew.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.annotation
+
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+
+/**
+ * Flags IntentSpec parameters that cannot change once created without
+ * recreating the intent.
+ */
+@JsonSchemaInject(json = "{ \"forcesNew\": true }")
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ForcesNew(val value: Boolean = true)

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/PipelineIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/PipelineIntent.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.intent
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import com.github.jonpeterson.jackson.module.versioning.JsonVersionedModel
+import com.netflix.spinnaker.keel.ApplicationAwareIntentSpec
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.annotation.ForcesNew
+
+private const val KIND = "Pipeline"
+private const val CURRENT_SCHEMA = "0"
+
+@JsonTypeName(KIND)
+@JsonVersionedModel(currentVersion = CURRENT_SCHEMA, propertyName = SCHEMA_PROPERTY)
+class PipelineIntent
+@JsonCreator constructor(spec: PipelineSpec) : Intent<PipelineSpec>(
+  kind = KIND,
+  schema = CURRENT_SCHEMA,
+  spec = spec
+) {
+  @JsonIgnore override val defaultId = "$KIND:${spec.application}:${spec.slug}"
+}
+
+data class PipelineSpec(
+  override val application: String,
+  // Used for idempotency of id
+  @ForcesNew val slug: String,
+  val stages: List<Map<String, Any?>>,
+  val triggers: List<Trigger>,
+  val flags: Flags,
+  val properties: Properties
+) : ApplicationAwareIntentSpec()
+
+class Flags : HashMap<String, Boolean>() {
+
+  val keepWaitingPipelines: Boolean
+    get() = get("keepWaitingPipelines") ?: true
+
+  val limitConcurrent: Boolean
+    get() = get("limitConcurrent") ?: false
+}
+
+class Properties : HashMap<String, String>() {
+
+  val executionEngine: String?
+    get() = get("executionEngine")
+
+  val spelEvaluator: String?
+    get() = get("spelEvaluator")
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+abstract class Trigger : HashMap<String, Any?>()
+
+@JsonTypeName("cron")
+class CronTrigger : Trigger()
+
+@JsonTypeName("docker")
+class DockerTrigger : Trigger()
+
+@JsonTypeName("dryRun")
+class DryRunTrigger : Trigger()
+
+@JsonTypeName("git")
+class GitTrigger : Trigger()
+
+@JsonTypeName("jenkins")
+class JenkinsTrigger : Trigger()
+
+@JsonTypeName("manual")
+class ManualTrigger : Trigger()
+
+@JsonTypeName("pipeline")
+class PipelineTrigger : Trigger()


### PR DESCRIPTION
I don't really expect we'll be able to get keel to strongly type pipelines this quarter. Still made some schema changes from a keel perspective, however. Namely, boolean flags were thrown into a `flags` bucket, and feature toggles were thrown into a `properties` bucket. I type-casted the few things that I think will be sticking around for quite some time, but otherwise a map seems a good fit in here.