### PR TITLE
fix(*): Fixing keiko 2.x upgrade; fumbling around with objectmapper subtypes

### DIFF
--- a/keel-clouddriver/dependencies.lock
+++ b/keel-clouddriver/dependencies.lock
@@ -49,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -168,13 +168,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -287,13 +287,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -426,13 +426,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -545,13 +545,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -675,13 +675,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -826,13 +826,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -977,13 +977,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",
@@ -1136,13 +1136,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "locked": "0.2.0",

--- a/keel-core/dependencies.lock
+++ b/keel-core/dependencies.lock
@@ -25,7 +25,7 @@
             "requested": "1.0.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -71,7 +71,7 @@
             "requested": "1.0.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -117,7 +117,7 @@
             "requested": "1.0.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -183,7 +183,7 @@
             "requested": "1.0.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -229,7 +229,7 @@
             "requested": "1.0.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -312,7 +312,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -428,7 +428,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -544,7 +544,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -668,7 +668,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelConfiguration.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelConfiguration.kt
@@ -54,6 +54,7 @@ open class KeelConfiguration {
 
   // Autowired so that we use the Spring object mapper; otherwise not all instances of ObjectMapper will
   // have the subtypes registered.
+  // TODO rz - Move keiko subtype configurer into kork so we can use it here instead
   @Autowired
   open fun objectMapper(objectMapper: ObjectMapper) =
     objectMapper.apply {
@@ -87,4 +88,16 @@ open class KeelConfiguration {
   open fun memoryTraceRepository(): TraceRepository = MemoryTraceRepository()
 
   @Bean open fun clock(): Clock = Clock.systemDefaultZone()
+
+  @Bean open fun intentSubTypeLocator() =
+    KeelSubTypeLocator(Intent::class.java, properties.intentPackages)
+
+  @Bean open fun intentSpecSubTypeLocator() =
+    KeelSubTypeLocator(IntentSpec::class.java, properties.intentSpecPackages)
+
+  @Bean open fun policySubTypeLocator() =
+    KeelSubTypeLocator(Policy::class.java, properties.policyPackages)
+
+  @Bean open fun attributeSubTypeLocator() =
+    KeelSubTypeLocator(Attribute::class.java, properties.attributePackages)
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelProperties.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelProperties.kt
@@ -6,4 +6,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 class KeelProperties {
   var prettyPrintJson: Boolean = false
   var immediatelyRunIntents: Boolean = true
+
+  var intentPackages: List<String> = listOf("com.netflix.spinnaker.keel.intent")
+  var intentSpecPackages: List<String> = listOf("com.netflix.spinnaker.keel.intent")
+  var policyPackages: List<String> = listOf("com.netflix.spinnaker.keel.policy")
+  var attributePackages: List<String> = listOf("com.netflix.spinnaker.keel.attribute")
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelSubTypeLocator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelSubTypeLocator.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.config
+
+data class KeelSubTypeLocator(
+  val cls: Class<*>,
+  val packages: List<String>
+)

--- a/keel-echo/dependencies.lock
+++ b/keel-echo/dependencies.lock
@@ -49,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -164,13 +164,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -279,13 +279,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -414,13 +414,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -529,13 +529,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -655,13 +655,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -798,13 +798,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -941,13 +941,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -1092,13 +1092,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-eureka/dependencies.lock
+++ b/keel-eureka/dependencies.lock
@@ -43,7 +43,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -115,7 +115,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -187,7 +187,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -279,7 +279,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -351,7 +351,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -427,7 +427,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -519,7 +519,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -611,7 +611,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -711,7 +711,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-front50/dependencies.lock
+++ b/keel-front50/dependencies.lock
@@ -49,13 +49,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -164,13 +164,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -279,13 +279,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -414,13 +414,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -529,13 +529,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.squareup.okhttp:okhttp-apache": {
             "firstLevelTransitive": [
@@ -648,13 +648,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -783,13 +783,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -918,13 +918,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -1061,13 +1061,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-intent-aws/dependencies.lock
+++ b/keel-intent-aws/dependencies.lock
@@ -69,13 +69,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -213,13 +213,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -357,13 +357,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -521,13 +521,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -665,13 +665,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -820,13 +820,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -992,13 +992,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1164,13 +1164,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1344,13 +1344,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-intent/dependencies.lock
+++ b/keel-intent/dependencies.lock
@@ -59,13 +59,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -192,13 +192,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -325,13 +325,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -478,13 +478,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -611,13 +611,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -755,13 +755,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -916,13 +916,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1077,13 +1077,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1246,13 +1246,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/config/IntentConfiguration.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/config/IntentConfiguration.kt
@@ -15,6 +15,8 @@
  */
 package com.netflix.spinnaker.config
 
+import com.netflix.spinnaker.keel.intent.SecurityGroupRule
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
@@ -24,4 +26,8 @@ import org.springframework.context.annotation.Configuration
   "com.netflix.spinnaker.keel.intent.processor",
   "com.netflix.spinnaker.keel.intent.processor.converter"
 ])
-open class IntentConfiguration
+open class IntentConfiguration {
+
+  @Bean open fun securityGroupSubTypeLocator() =
+    KeelSubTypeLocator(SecurityGroupRule::class.java, listOf("com.netflix.spinnaker.keel.intent"))
+}

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ParrotIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ParrotIntent.kt
@@ -39,6 +39,7 @@ class ParrotIntent
   @JsonIgnore override val defaultId = "$KIND:${spec.application}"
 }
 
+@JsonTypeName("parrot")
 data class ParrotSpec(
   val application: String,
   val description: String,

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/PipelineIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/PipelineIntent.kt
@@ -38,6 +38,7 @@ class PipelineIntent
   @JsonIgnore override val defaultId = "$KIND:${spec.application}:${spec.slug}"
 }
 
+@JsonTypeName("pipeline")
 data class PipelineSpec(
   override val application: String,
   // Used for idempotency of id

--- a/keel-orca/dependencies.lock
+++ b/keel-orca/dependencies.lock
@@ -55,13 +55,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -183,13 +183,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -311,13 +311,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -459,13 +459,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -587,13 +587,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -719,13 +719,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -867,13 +867,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1015,13 +1015,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1171,13 +1171,13 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-redis/dependencies.lock
+++ b/keel-redis/dependencies.lock
@@ -43,14 +43,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -123,14 +123,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -203,14 +203,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -303,14 +303,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -383,14 +383,14 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "net.logstash.logback:logstash-logback-encoder": {
@@ -476,18 +476,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -590,18 +590,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -704,18 +704,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -826,18 +826,18 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis-test": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {

--- a/keel-retrofit/dependencies.lock
+++ b/keel-retrofit/dependencies.lock
@@ -43,10 +43,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -139,10 +139,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -235,10 +235,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -351,10 +351,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -447,10 +447,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.squareup.okhttp:okhttp-apache": {
@@ -547,10 +547,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -663,10 +663,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -779,10 +779,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {
@@ -903,10 +903,10 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
-            "locked": "1.113.0",
+            "locked": "1.113.1",
             "requested": "+"
         },
         "com.nhaarman:mockito-kotlin": {

--- a/keel-scheduler/dependencies.lock
+++ b/keel-scheduler/dependencies.lock
@@ -58,20 +58,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -197,20 +197,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -336,20 +336,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -495,20 +495,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -634,20 +634,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -784,20 +784,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -951,20 +951,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1118,20 +1118,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1293,20 +1293,20 @@
             "project": true
         },
         "com.netflix.spinnaker.keiko:keiko-redis-spring": {
-            "locked": "2.0.0",
+            "locked": "2.1.1",
             "requested": "2.+"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/config/SchedulerConfiguration.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/config/SchedulerConfiguration.kt
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.config
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.q.migration.FqnTypeInfoSerializationMigrator
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -28,14 +27,13 @@ import org.springframework.context.annotation.Configuration
 @EnableConfigurationProperties(ScheduleConvergeHandlerProperties::class, ObjectMapperSubtypeProperties::class)
 open class SchedulerConfiguration {
 
-  @Autowired open fun redisQueueObjectMapper(redisQueueObjectMapper: ObjectMapper,
-                                             objectMapperSubtypeProperties: ObjectMapperSubtypeProperties) {
-    redisQueueObjectMapper.apply {
-      SpringObjectMapperConfigurer(objectMapperSubtypeProperties.apply {
-        messagePackages = messagePackages.union(listOf(
-          "com.netflix.spinnaker.keel.scheduler"
-        )).toList()
-      }).registerSubtypes(this)
+  @Autowired open fun objectMapperSubtypeProperties(properties: ObjectMapperSubtypeProperties,
+                                                    keelSubTypes: List<KeelSubTypeLocator>) {
+    properties.apply {
+      messagePackages = messagePackages.union(listOf(
+        "com.netflix.spinnaker.keel.scheduler"
+      )).toList()
+      extraSubtypes = keelSubTypes.map { it.cls.name to it.packages }.toMap() + extraSubtypes
     }
   }
 

--- a/keel-test/dependencies.lock
+++ b/keel-test/dependencies.lock
@@ -47,7 +47,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -123,7 +123,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -199,7 +199,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -295,7 +295,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -371,7 +371,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -447,7 +447,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -539,7 +539,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -631,7 +631,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
@@ -731,7 +731,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",

--- a/keel-web/dependencies.lock
+++ b/keel-web/dependencies.lock
@@ -99,31 +99,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -309,31 +309,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -519,31 +519,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -749,31 +749,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -959,31 +959,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1173,31 +1173,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1403,31 +1403,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1633,31 +1633,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [
@@ -1871,31 +1871,31 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-scheduler"
             ],
-            "locked": "2.0.0"
+            "locked": "2.1.1"
         },
         "com.netflix.spinnaker.kork:kork-core": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.kork:kork-web": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
-            "locked": "1.113.0"
+            "locked": "1.113.1"
         },
         "com.netflix.spinnaker.moniker:moniker": {
             "firstLevelTransitive": [


### PR DESCRIPTION
The upgrade from Keiko 1.x -> 2.x messed up how we handle object mapper subtypes. Originally, keiko didn't care about the subtype information that the rest of Keel uses for saving messages, but now we have to register to both the Keiko ObjectMapper as well as Keel's. I'm not super stoked on having two different ObjectMappers--I'll consolidate in a separate task--I just want things to not be broken.

Additionally, Keiko 2.x introduced a new `SpringObjectMapperConfigurer` for `NamedType` serialization. I'll be lifting that out into Kork so Keel can use that, rather than having two classpath scanning cycles at startup.

cc @emjburns 