### PR TITLE
fix(intent): Refactor security group to only map to a single region

### DIFF
--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/SecurityGroupIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/SecurityGroupIntent.kt
@@ -35,9 +35,7 @@ class SecurityGroupIntent
   schema = CURRENT_SCHEMA,
   spec = spec
 ) {
-  // TODO rz - Region needs to be included in the id, but we also need a way to supercede other intents if a region is
-  // added or removed.
-  @JsonIgnore override val defaultId = "$KIND:${spec.cloudProvider}:${spec.accountName}:${spec.name}"
+  @JsonIgnore override val defaultId = "$KIND:${spec.cloudProvider}:${spec.accountName}:${spec.region}:${spec.name}"
 }
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
@@ -45,7 +43,7 @@ abstract class SecurityGroupSpec : ApplicationAwareIntentSpec() {
   abstract val name: String
   abstract val cloudProvider: String
   abstract val accountName: String
-  abstract val regions: Set<String>
+  abstract val region: String
   abstract val inboundRules: Set<SecurityGroupRule>
 }
 
@@ -55,7 +53,7 @@ data class AmazonSecurityGroupSpec(
   override val name: String,
   override val cloudProvider: String,
   override val accountName: String,
-  override val regions: Set<String>,
+  override val region: String,
   override val inboundRules: Set<SecurityGroupRule>,
   val outboundRules: Set<SecurityGroupRule>,
   // We don't care to support EC2 Classic, but for some reason clouddriver returns nulls (and isn't "default" vpcs)
@@ -110,7 +108,6 @@ data class CrossAccountReferenceSecurityGroupRule(
   override val protocol: String,
   override val name: String,
   val account: String,
-  val region: String, // TODO rz - remove; can only x-account to same region
   val vpcName: String
 ) : SecurityGroupRule(), PortRangeSupport
 

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/SpecConverter.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/converter/SpecConverter.kt
@@ -25,5 +25,3 @@ interface SpecConverter<I : IntentSpec, S : Any> {
   fun convertFromState(state: S): I?
   fun convertToJob(spec: I, changeSummary: ChangeSummary): List<Job>
 }
-
-const val COMPUTED_VALUE = "<computed>"

--- a/keel-intent/src/test/kotlin/com/netflix/spinnaker/keel/intent/SecurityGroupIntentTest.kt
+++ b/keel-intent/src/test/kotlin/com/netflix/spinnaker/keel/intent/SecurityGroupIntentTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.intent
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.should.shouldMatch
+import com.netflix.spinnaker.config.KeelConfiguration
+import com.netflix.spinnaker.config.KeelProperties
+import com.netflix.spinnaker.config.KeelSubTypeLocator
+import com.netflix.spinnaker.hamkrest.shouldEqual
+import org.junit.jupiter.api.Test
+
+object SecurityGroupIntentTest {
+
+  val mapper = KeelConfiguration()
+    .apply { properties = KeelProperties() }
+    .objectMapper(
+      ObjectMapper(),
+      listOf(KeelSubTypeLocator(SecurityGroupRule::class.java, listOf("com.netflix.spinnaker.keel.intent")))
+    )
+
+  @Test
+  fun `can serialize to expected JSON format`() {
+    val serialized = mapper.convertValue<Map<String, Any>>(sg)
+    val deserialized = mapper.readValue<Map<String, Any>>(json)
+
+    serialized shouldMatch equalTo(deserialized)
+  }
+
+  @Test
+  fun `can deserialize from expected JSON format`() {
+    mapper.readValue<SecurityGroupIntent>(json).apply {
+      spec shouldEqual sg.spec
+    }
+  }
+
+  val sg = SecurityGroupIntent(
+    AmazonSecurityGroupSpec(
+      application = "keel",
+      name = "keel",
+      cloudProvider = "aws",
+      accountName = "test",
+      region = "us-west-2",
+      inboundRules = setOf(
+        ReferenceSecurityGroupRule(
+          name = "keel",
+          protocol = "tcp",
+          portRanges = sortedSetOf(
+            SecurityGroupPortRange(6379, 6379),
+            SecurityGroupPortRange(7001, 7002)
+          )
+        )
+      ),
+      outboundRules = setOf(),
+      vpcName = "myVpc",
+      description = "Application security group for keel"
+    )
+  )
+
+  val json = """
+{
+  "kind": "SecurityGroup",
+  "spec": {
+    "kind": "aws",
+    "application": "keel",
+    "name": "keel",
+    "cloudProvider": "aws",
+    "accountName": "test",
+    "region": "us-west-2",
+    "inboundRules": [
+      {
+        "kind": "ref",
+        "name": "keel",
+        "protocol": "tcp",
+        "portRanges": [
+          {
+            "startPort": 6379,
+            "endPort": 6379
+          },
+          {
+            "startPort": 7001,
+            "endPort": 7002
+          }
+        ]
+      }
+    ],
+    "outboundRules": [],
+    "vpcName": "myVpc",
+    "description": "Application security group for keel"
+  },
+  "status": "ACTIVE",
+  "labels": {},
+  "attributes": [],
+  "policies": [],
+  "id": "SecurityGroup:aws:test:us-west-2:keel",
+  "schema": "0"
+}
+"""
+
+}

--- a/keel-intent/src/test/kotlin/com/netflix/spinnaker/keel/intent/processor/SecurityGroupIntentProcessorTest.kt
+++ b/keel-intent/src/test/kotlin/com/netflix/spinnaker/keel/intent/processor/SecurityGroupIntentProcessorTest.kt
@@ -29,10 +29,8 @@ import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.dryrun.ChangeType
 import com.netflix.spinnaker.keel.intent.AmazonSecurityGroupSpec
 import com.netflix.spinnaker.keel.intent.ApplicationIntent
-import com.netflix.spinnaker.keel.intent.BaseApplicationSpec
 import com.netflix.spinnaker.keel.intent.ReferenceSecurityGroupRule
 import com.netflix.spinnaker.keel.intent.SecurityGroupIntent
-import com.netflix.spinnaker.keel.intent.SecurityGroupSpec
 import com.netflix.spinnaker.keel.intent.processor.converter.SecurityGroupConverter
 import com.netflix.spinnaker.keel.tracing.TraceRepository
 import com.nhaarman.mockito_kotlin.any
@@ -73,8 +71,8 @@ object SecurityGroupIntentProcessorTest {
 
   @Test
   fun `should support SecurityGroupIntents`() {
-    subject.supports(ApplicationIntent(mock<BaseApplicationSpec>())) shouldMatch equalTo(false)
-    subject.supports(SecurityGroupIntent(mock<SecurityGroupSpec>())) shouldMatch equalTo(true)
+    subject.supports(ApplicationIntent(mock())) shouldMatch equalTo(false)
+    subject.supports(SecurityGroupIntent(mock())) shouldMatch equalTo(true)
   }
 
   @Test
@@ -95,7 +93,7 @@ object SecurityGroupIntentProcessorTest {
       name = "keel",
       cloudProvider = "aws",
       accountName = "test",
-      regions = setOf("us-west-2"),
+      region = "us-west-2",
       inboundRules = emptySet(),
       outboundRules = emptySet(),
       vpcName = "vpcName",
@@ -138,7 +136,7 @@ object SecurityGroupIntentProcessorTest {
       name = "keel",
       cloudProvider = "aws",
       accountName = "test",
-      regions = setOf("us-west-2"),
+      region = "us-west-2",
       inboundRules = emptySet(),
       outboundRules = emptySet(),
       vpcName = "vpcName",
@@ -180,7 +178,7 @@ object SecurityGroupIntentProcessorTest {
       name = "keel",
       cloudProvider = "aws",
       accountName = "test",
-      regions = setOf("us-west-2"),
+      region = "us-west-2",
       inboundRules = setOf(ReferenceSecurityGroupRule(sortedSetOf(), "tcp", "gate")),
       outboundRules = emptySet(),
       vpcName = "vpcName",


### PR DESCRIPTION
Refactoring the sg intent to be only a single region. This will allow people to have the same sg in different regions with different rules, etc.