### PR TITLE
chore(*): Remove capability to user-define intent ids

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
@@ -15,11 +15,7 @@
  */
 package com.netflix.spinnaker.keel
 
-import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonGetter
-import com.fasterxml.jackson.annotation.JsonIgnore
-import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.*
 import com.github.jonpeterson.jackson.module.versioning.JsonSerializeToVersion
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spinnaker.keel.attribute.Attribute
@@ -35,9 +31,6 @@ import kotlin.reflect.KClass
  * @param attributes User-land specific metadata and extension data.
  * @param policies User-defined behavioral policies specific to the intent.
  * @param cas An optional ID-granular pessimistic lock.
- * @param namespace Used to logically group intents together; guarantees user- defined ids are unique within buckets.
- * Required if ID override is set.
- * @param idOverride A user-defined ID override for an individual intent. Must not conflict with default id.
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -50,15 +43,12 @@ abstract class Intent<out S : IntentSpec>
   val labels: MutableMap<String, String> = mutableMapOf(),
   val attributes: List<Attribute<*>> = listOf(),
   val policies: List<Policy<*>> = listOf(),
-  val cas: Long? = null,
-  val namespace: String? = null,
-  val idOverride: String? = null
+  val cas: Long? = null
 ) {
 
-  abstract val defaultId: String
+  abstract val id: String
 
-  @JsonGetter
-  fun id(): String = idOverride.takeUnless { it.isNullOrBlank() || namespace.isNullOrBlank() } ?: defaultId
+  @JsonGetter fun id() = id
 
   @JsonIgnore
   fun getMetricTags() = listOf(BasicTag("kind", kind), BasicTag("schema", schema))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/filter/ExecutionWindowFilter.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/filter/ExecutionWindowFilter.kt
@@ -57,7 +57,7 @@ class ExecutionWindowFilter
     }
 
     val executionWindow = intent.getAttribute(ExecutionWindowAttribute::class)!!
-    log.info("Calculating scheduled time for {}; $executionWindow", value("intent", intent.id()))
+    log.info("Calculating scheduled time for {}; $executionWindow", value("intent", intent.id))
 
     val now = Date.from(clock.instant())
     val scheduledTime: Date
@@ -69,7 +69,7 @@ class ExecutionWindowFilter
       return config.allowExecutionOnFailure
     }
 
-    log.debug("Calculated schedule time for {}: $scheduledTime", value("intent", intent.id()))
+    log.debug("Calculated schedule time for {}: $scheduledTime", value("intent", intent.id))
 
     return now >= scheduledTime
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryIntentRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryIntentRepository.kt
@@ -38,7 +38,7 @@ class MemoryIntentRepository(
 
   override fun upsertIntent(intent: Intent<IntentSpec>): Intent<IntentSpec> {
     applicationEventPublisher.publishEvent(BeforeIntentUpsertEvent(intent))
-    intents.put(intent.id(), intent)
+    intents.put(intent.id, intent)
     applicationEventPublisher.publishEvent(AfterIntentUpsertEvent(intent))
     return intent
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryTraceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/memory/MemoryTraceRepository.kt
@@ -31,10 +31,10 @@ class MemoryTraceRepository : TraceRepository {
   }
 
   override fun record(trace: Trace) {
-    if (!traces.containsKey(trace.intent.id())) {
-      traces[trace.intent.id()] = mutableListOf()
+    if (!traces.containsKey(trace.intent.id)) {
+      traces[trace.intent.id] = mutableListOf()
     }
-    traces[trace.intent.id()]?.add(trace)
+    traces[trace.intent.id]?.add(trace)
   }
 
   override fun getForIntent(intentId: String) = traces[intentId]?.toList() ?: listOf()

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/dryrun/DryRunIntentLauncherTest.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/dryrun/DryRunIntentLauncherTest.kt
@@ -82,7 +82,7 @@ object DryRunIntentLauncherTest {
     kind: String,
     spec: TestIntentSpec
   ) : Intent<TestIntentSpec>(schema, kind, spec, ACTIVE) {
-    override val defaultId = ""
+    override val id = ""
   }
 
   private data class TestIntentSpec(val id: String) : IntentSpec

--- a/keel-echo/src/main/kotlin/com/netflix/spinnaker/keel/echo/EventNotificationListener.kt
+++ b/keel-echo/src/main/kotlin/com/netflix/spinnaker/keel/echo/EventNotificationListener.kt
@@ -43,7 +43,7 @@ class EventNotificationListener(
             log.info(
               "Sending {} notifications for intent (intent: {})",
               value("kind", sub.key),
-              value("intent", event.intent.id())
+              value("intent", event.intent.id)
             )
 
             sub.value.forEach { notification ->
@@ -59,7 +59,7 @@ class EventNotificationListener(
                   additionalContext = notification.getAdditionalContext().toMutableMap().let {
                     it.putAll(mapOf(
                       "eventKind" to event.kind.toValue(),
-                      "intentId" to event.intent.id()
+                      "intentId" to event.intent.id
                     ))
                     it
                   }
@@ -68,7 +68,7 @@ class EventNotificationListener(
               } catch (cause: Exception) {
                 log.error(
                   "Failed creating notification for intent (intent: {}, type: {})",
-                  value("intent", event.intent.id()),
+                  value("intent", event.intent.id),
                   value("kind", sub.key),
                   cause
                 )

--- a/keel-intent-aws/src/main/kotlin/com/netflix/spinnaker/keel/intent/aws/securitygroup/AmazonSecurityGroupIntent.kt
+++ b/keel-intent-aws/src/main/kotlin/com/netflix/spinnaker/keel/intent/aws/securitygroup/AmazonSecurityGroupIntent.kt
@@ -34,7 +34,7 @@ class AmazonSecurityGroupIntent
   schema = CURRENT_SCHEMA,
   spec = spec
 ) {
-  @JsonIgnore override val defaultId = spec.intentId()
+  @JsonIgnore override val id = spec.intentId()
 
   @JsonIgnore fun parentId(): String? {
     if (spec is AmazonSecurityGroupRootSpec) {

--- a/keel-intent-aws/src/main/kotlin/com/netflix/spinnaker/keel/intent/aws/securitygroup/AmazonSecurityGroupIntentProcessor.kt
+++ b/keel-intent-aws/src/main/kotlin/com/netflix/spinnaker/keel/intent/aws/securitygroup/AmazonSecurityGroupIntentProcessor.kt
@@ -56,7 +56,7 @@ class AmazonSecurityGroupIntentProcessor(
   override fun supports(intent: Intent<IntentSpec>) = intent is AmazonSecurityGroupIntent
 
   override fun converge(intent: AmazonSecurityGroupIntent): ConvergeResult {
-    val changeSummary = ChangeSummary(intent.id())
+    val changeSummary = ChangeSummary(intent.id)
     val currentState = loader.load(intent.spec)
 
     traceRepository.record(Trace(
@@ -77,14 +77,14 @@ class AmazonSecurityGroupIntentProcessor(
       }
 
       val transientSpec = converter.convertFromState(currentState)
-        ?: throw DeclarativeException("Spec converted from current state was null for intent: ${intent.id()}")
+        ?: throw DeclarativeException("Spec converted from current state was null for intent: ${intent.id}")
 
       rootIntent = AmazonSecurityGroupIntent(transientSpec)
     }
 
     val desiredRootIntent = mergeRootIntent(rootIntent, intent)
 
-    if (currentStateUpToDate(intent.id(), currentState, desiredRootIntent.spec, changeSummary)) {
+    if (currentStateUpToDate(intent.id, currentState, desiredRootIntent.spec, changeSummary)) {
       changeSummary.addMessage(ConvergeReason.UNCHANGED.reason)
       return ConvergeResult(listOf(), changeSummary)
     }
@@ -104,7 +104,7 @@ class AmazonSecurityGroupIntentProcessor(
         application = intent.spec.application,
         description = "Converging on desired security group state",
         job = converter.convertToJob(desiredRootIntent.spec, changeSummary),
-        trigger = OrchestrationTrigger(intent.id())
+        trigger = OrchestrationTrigger(intent.id)
       )
     ), changeSummary)
   }
@@ -112,11 +112,9 @@ class AmazonSecurityGroupIntentProcessor(
   /**
    * Finds all intents that have a RuleSpec with a parent ID matching the root intent, and merges the intents into
    * the root intent for the duration of the convergence.
-   *
-   * TODO rz - Should figure out a way to flag the individual security group rules that are affected by child intents.
    */
   private fun mergeRootIntent(rootIntent: AmazonSecurityGroupIntent, thisIntent: AmazonSecurityGroupIntent): AmazonSecurityGroupIntent {
-    val childRules = getChildRules(rootIntent.id())
+    val childRules = getChildRules(rootIntent.id)
 
     rootIntent.spec.inboundRules.addAll(childRules.map { it.spec.inboundRules }.flatten())
     if (thisIntent.spec is AmazonSecurityGroupRuleSpec) {

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ApplicationIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ApplicationIntent.kt
@@ -37,7 +37,7 @@ class ApplicationIntent
   schema = CURRENT_SCHEMA,
   spec = spec
 ) {
-  @JsonIgnore override val defaultId = "$KIND:${spec.name}"
+  @JsonIgnore override val id = "$KIND:${spec.name}"
 }
 
 // Using an abstract class here so that we can override the spec with Netflix-specific values and continue to use the

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/LoadBalancerIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/LoadBalancerIntent.kt
@@ -19,7 +19,7 @@ class LoadBalancerIntent(spec: LoadBalancerSpec) : Intent<LoadBalancerSpec>(
   schema = CURRENT_SCHEMA,
   spec = spec
 ) {
-  @JsonIgnore override val defaultId = "$KIND:${spec.cloudProvider()}:${spec.accountName}:${spec.name}"
+  @JsonIgnore override val id = "$KIND:${spec.cloudProvider()}:${spec.accountName}:${spec.name}"
 }
 
 @JsonTypeInfo(use = NAME, include = PROPERTY, property = KIND_PROPERTY)

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ParrotIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/ParrotIntent.kt
@@ -36,7 +36,7 @@ class ParrotIntent
   schema = CURRENT_SCHEMA,
   spec = spec
 ) {
-  @JsonIgnore override val defaultId = "$KIND:${spec.application}"
+  @JsonIgnore override val id = "$KIND:${spec.application}"
 }
 
 @JsonTypeName("parrot")

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/PipelineIntent.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/PipelineIntent.kt
@@ -35,7 +35,7 @@ class PipelineIntent
   schema = CURRENT_SCHEMA,
   spec = spec
 ) {
-  @JsonIgnore override val defaultId = "$KIND:${spec.application}:${spec.name}"
+  @JsonIgnore override val id = "$KIND:${spec.application}:${spec.name}"
 }
 
 @JsonTypeName("pipeline")

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ApplicationIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ApplicationIntentProcessor.kt
@@ -16,11 +16,7 @@
 package com.netflix.spinnaker.keel.intent.processor
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.keel.ConvergeReason
-import com.netflix.spinnaker.keel.ConvergeResult
-import com.netflix.spinnaker.keel.Intent
-import com.netflix.spinnaker.keel.IntentProcessor
-import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.dryrun.ChangeType
 import com.netflix.spinnaker.keel.front50.Front50Service
@@ -54,11 +50,11 @@ class ApplicationIntentProcessor
   override fun supports(intent: Intent<IntentSpec>) = intent is ApplicationIntent
 
   override fun converge(intent: ApplicationIntent): ConvergeResult {
-    val changeSummary = ChangeSummary(intent.id())
+    val changeSummary = ChangeSummary(intent.id)
 
     val currentState = getApplication(intent.spec.name)
 
-    if (currentStateUpToDate(intent.id(), currentState, intent.spec, changeSummary)) {
+    if (currentStateUpToDate(intent.id, currentState, intent.spec, changeSummary)) {
       changeSummary.addMessage(ConvergeReason.UNCHANGED.reason)
       return ConvergeResult(listOf(), changeSummary)
     }
@@ -83,7 +79,7 @@ class ApplicationIntentProcessor
             )
           )
         ),
-        trigger = OrchestrationTrigger(intent.id())
+        trigger = OrchestrationTrigger(intent.id)
       )
     ),
       changeSummary

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ParrotIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/ParrotIntentProcessor.kt
@@ -38,7 +38,7 @@ class ParrotIntentProcessor
   override fun supports(intent: Intent<IntentSpec>) = intent is ParrotIntent
 
   override fun converge(intent: ParrotIntent): ConvergeResult {
-    val changeSummary = ChangeSummary(intent.id())
+    val changeSummary = ChangeSummary(intent.id)
     changeSummary.addMessage("Squawk!")
     traceRepository.record(Trace(mapOf(), intent))
     return ConvergeResult(listOf(
@@ -49,7 +49,7 @@ class ParrotIntentProcessor
         job = listOf(
           Job("wait", mutableMapOf("waitTime" to intent.spec.waitTime))
         ),
-        trigger = OrchestrationTrigger(intent.id())
+        trigger = OrchestrationTrigger(intent.id)
       )
     ), changeSummary)
   }

--- a/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/PipelineIntentProcessor.kt
+++ b/keel-intent/src/main/kotlin/com/netflix/spinnaker/keel/intent/processor/PipelineIntentProcessor.kt
@@ -16,11 +16,7 @@
 package com.netflix.spinnaker.keel.intent.processor
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.keel.ConvergeReason
-import com.netflix.spinnaker.keel.ConvergeResult
-import com.netflix.spinnaker.keel.Intent
-import com.netflix.spinnaker.keel.IntentProcessor
-import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.dryrun.ChangeType
 import com.netflix.spinnaker.keel.front50.Front50Service
@@ -49,11 +45,11 @@ class PipelineIntentProcessor(
   override fun supports(intent: Intent<IntentSpec>) = intent is PipelineIntent
 
   override fun converge(intent: PipelineIntent): ConvergeResult {
-    val changeSummary = ChangeSummary(intent.id())
+    val changeSummary = ChangeSummary(intent.id)
 
     val currentState = getPipelineConfig(intent.spec.application, intent.spec.name)
 
-    if (currentStateUpToDate(intent.id(), currentState, intent.spec, changeSummary)) {
+    if (currentStateUpToDate(intent.id, currentState, intent.spec, changeSummary)) {
       changeSummary.addMessage(ConvergeReason.UNCHANGED.reason)
       return ConvergeResult(listOf(), changeSummary)
     }
@@ -77,7 +73,7 @@ class PipelineIntentProcessor(
         application = intent.spec.application,
         description = "Converging on desired pipeline state",
         job = pipelineConverter.convertToJob(intent.spec, changeSummary),
-        trigger = OrchestrationTrigger(intent.id())
+        trigger = OrchestrationTrigger(intent.id)
       )
     ), changeSummary)
   }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
@@ -17,13 +17,7 @@ package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.keel.Intent
-import com.netflix.spinnaker.keel.IntentActivityRepository
-import com.netflix.spinnaker.keel.IntentConvergenceRecord
-import com.netflix.spinnaker.keel.IntentLauncher
-import com.netflix.spinnaker.keel.IntentProcessor
-import com.netflix.spinnaker.keel.IntentSpec
-import com.netflix.spinnaker.keel.LaunchedIntentResult
+import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -61,7 +55,7 @@ open class OrcaIntentLauncher
       }
 
       intentActivityRepository.logConvergence(IntentConvergenceRecord(
-        intentId = intent.id(),
+        intentId = intent.id,
         changeType = result.changeSummary.type,
         orchestrations = orchestrationIds,
         messages = result.changeSummary.message,

--- a/keel-redis/src/main/kotlin/com/netflix/spinnaker/keel/redis/RedisTraceRepository.kt
+++ b/keel-redis/src/main/kotlin/com/netflix/spinnaker/keel/redis/RedisTraceRepository.kt
@@ -53,7 +53,7 @@ class RedisTraceRepository
           "startingState" to objectMapper.writeValueAsString(trace.startingState)
         ))
         c.zadd(traceIndexKey(), createTs.toDouble(), traceKey)
-        c.zadd(intentTracesKey(trace.intent.id()), createTs.toDouble(), traceKey)
+        c.zadd(intentTracesKey(trace.intent.id), createTs.toDouble(), traceKey)
       }
     }
   }

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandler.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandler.kt
@@ -20,11 +20,7 @@ import com.netflix.spinnaker.keel.Intent
 import com.netflix.spinnaker.keel.IntentActivityRepository
 import com.netflix.spinnaker.keel.IntentRepository
 import com.netflix.spinnaker.keel.IntentSpec
-import com.netflix.spinnaker.keel.event.BeforeIntentConvergeEvent
-import com.netflix.spinnaker.keel.event.IntentConvergeFailureEvent
-import com.netflix.spinnaker.keel.event.IntentConvergeNotFoundEvent
-import com.netflix.spinnaker.keel.event.IntentConvergeSuccessEvent
-import com.netflix.spinnaker.keel.event.IntentConvergeTimeoutEvent
+import com.netflix.spinnaker.keel.event.*
 import com.netflix.spinnaker.keel.orca.OrcaIntentLauncher
 import com.netflix.spinnaker.keel.scheduler.ConvergeIntent
 import com.netflix.spinnaker.q.MessageHandler
@@ -59,7 +55,7 @@ class ConvergeIntentHandler
 
   override fun handle(message: ConvergeIntent) {
     if (clock.millis() > message.timeoutTtl) {
-      log.warn("Intent timed out, canceling converge for {}", value("intent", message.intent.id()))
+      log.warn("Intent timed out, canceling converge for {}", value("intent", message.intent.id))
       applicationEventPublisher.publishEvent(IntentConvergeTimeoutEvent(message.intent))
 
       registry.counter(canceledId.withTags("kind", message.intent.kind, "reason", CANCELLATION_REASON_TIMEOUT))
@@ -68,8 +64,8 @@ class ConvergeIntentHandler
 
     val intent = getIntent(message)
     if (intent == null) {
-      log.warn("Intent no longer exists, canceling converge for {}", value("intent", message.intent.id()))
-      applicationEventPublisher.publishEvent(IntentConvergeNotFoundEvent(message.intent.id()))
+      log.warn("Intent no longer exists, canceling converge for {}", value("intent", message.intent.id))
+      applicationEventPublisher.publishEvent(IntentConvergeNotFoundEvent(message.intent.id))
 
       registry.counter(canceledId.withTags("kind", message.intent.kind, "reason", CANCELLATION_REASON_NOT_FOUND))
       return
@@ -81,7 +77,7 @@ class ConvergeIntentHandler
       orcaIntentLauncher.launch(intent)
         .takeIf { it.orchestrationIds.isNotEmpty() }
         ?.also { result ->
-          intentActivityRepository.addOrchestrations(intent.id(), result.orchestrationIds)
+          intentActivityRepository.addOrchestrations(intent.id, result.orchestrationIds)
           applicationEventPublisher.publishEvent(IntentConvergeSuccessEvent(intent, result.orchestrationIds))
 
           // TODO rz - MonitorOrchestrations is deprecated. Reconsider if we want to totally remove it.
@@ -89,7 +85,7 @@ class ConvergeIntentHandler
         }
       registry.counter(invocationsId.withTags(message.intent.getMetricTags("result", "success")))
     } catch (t: Throwable) {
-      log.error("Failed launching intent: ${intent.id()}", t)
+      log.error("Failed launching intent: ${intent.id}", t)
       applicationEventPublisher.publishEvent(
         IntentConvergeFailureEvent(intent, t.message ?: "Could not determine reason", t)
       )
@@ -102,10 +98,10 @@ class ConvergeIntentHandler
       return message.intent
     }
 
-    log.debug("Refreshing intent state for {}", value("intent", message.intent.id()))
+    log.debug("Refreshing intent state for {}", value("intent", message.intent.id))
     registry.counter(refreshesId.withTags(message.intent.getMetricTags())).increment()
 
-    return intentRepository.getIntent(message.intent.id())
+    return intentRepository.getIntent(message.intent.id)
   }
 
   override val messageType = ConvergeIntent::class.java

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/TestIntent.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/TestIntent.kt
@@ -37,7 +37,7 @@ class TestIntent
   attributes: List<Attribute<Any>> = listOf(),
   policies: List<Policy<PolicySpec>> = listOf()
 ) : Intent<TestIntentSpec>("1", "Test", spec, IntentStatus.ACTIVE, labels, attributes, policies) {
-  @JsonIgnore override val defaultId = "test:${spec.id}"
+  @JsonIgnore override val id = "test:${spec.id}"
 }
 
 // Using minimal class for ease in testing

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
@@ -16,11 +16,7 @@
 package com.netflix.spinnaker.keel.controllers.v1
 
 import com.netflix.spinnaker.config.KeelProperties
-import com.netflix.spinnaker.keel.Intent
-import com.netflix.spinnaker.keel.IntentActivityRepository
-import com.netflix.spinnaker.keel.IntentRepository
-import com.netflix.spinnaker.keel.IntentSpec
-import com.netflix.spinnaker.keel.IntentStatus
+import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.dryrun.DryRunIntentLauncher
 import com.netflix.spinnaker.keel.model.UpsertIntentRequest
 import com.netflix.spinnaker.keel.orca.OrcaIntentLauncher
@@ -29,13 +25,7 @@ import net.logstash.logback.argument.StructuredArguments
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestMethod
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.ResponseStatus
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import javax.ws.rs.QueryParam
 
 @RestController
@@ -81,11 +71,11 @@ class IntentController
       intentRepository.upsertIntent(intent)
 
       if (keelProperties.immediatelyRunIntents) {
-        log.info("Immediately launching intent {}", StructuredArguments.value("intent", intent.id()))
+        log.info("Immediately launching intent {}", StructuredArguments.value("intent", intent.id))
         orcaIntentLauncher.launch(intent)
       }
 
-      intentList.add(UpsertIntentResponse(intent.id(), intent.status))
+      intentList.add(UpsertIntentResponse(intent.id, intent.status))
     }
 
     return intentList


### PR DESCRIPTION
User-defined IDs was providing very little value at the cost of unnecessary confusion.