### PR TITLE
refactor(web): Schedule immediate convergence instead of blocking on upsert

### DIFF
--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/ScheduleService.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/ScheduleService.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.scheduler
+
+import com.netflix.spinnaker.config.ScheduleConvergeHandlerProperties
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.q.Queue
+import org.springframework.stereotype.Component
+import java.time.Clock
+
+@Component
+class ScheduleService(
+  private val queue: Queue,
+  private val scheduleConvergenceHandlerProperties: ScheduleConvergeHandlerProperties,
+  private val clock: Clock
+) {
+
+  fun converge(intent: Intent<IntentSpec>) {
+    queue.push(ConvergeIntent(
+      intent,
+      clock.instant().plusMillis(scheduleConvergenceHandlerProperties.stalenessTtl).toEpochMilli(),
+      clock.instant().plusMillis(scheduleConvergenceHandlerProperties.timeoutTtl).toEpochMilli()
+    ))
+  }
+}

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/SchedulerAgent.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/SchedulerAgent.kt
@@ -29,7 +29,7 @@ import javax.annotation.PostConstruct
  */
 @Component
 @ConditionalOnExpression("\${scheduler.enabled:true}")
-class QueueBackedSchedulerAgent(
+class SchedulerAgent(
   private val queue: Queue,
   @Value("\${scheduler.retry.onStart.ms:30000}") private val ensureSchedulerFrequency: Long
 ) {

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ScheduleConvergeHandler.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ScheduleConvergeHandler.kt
@@ -17,30 +17,25 @@ package com.netflix.spinnaker.keel.scheduler.handler
 
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.config.ScheduleConvergeHandlerProperties
 import com.netflix.spinnaker.keel.IntentRepository
 import com.netflix.spinnaker.keel.IntentStatus
 import com.netflix.spinnaker.keel.filter.Filter
-import com.netflix.spinnaker.keel.scheduler.ConvergeIntent
 import com.netflix.spinnaker.keel.scheduler.ScheduleConvergence
+import com.netflix.spinnaker.keel.scheduler.ScheduleService
 import com.netflix.spinnaker.q.MessageHandler
 import com.netflix.spinnaker.q.Queue
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import java.time.Clock
 
 @Component
 class ScheduleConvergeHandler
 @Autowired constructor(
   override val queue: Queue,
-  private val properties: ScheduleConvergeHandlerProperties,
+  private val scheduleService: ScheduleService,
   private val intentRepository: IntentRepository,
   private val filters: List<Filter>,
-  private val registry: Registry,
-  private val clock: Clock,
-  private val applicationEventPublisher: ApplicationEventPublisher
+  private val registry: Registry
 ) : MessageHandler<ScheduleConvergence> {
 
   private val log = LoggerFactory.getLogger(javaClass)
@@ -56,11 +51,7 @@ class ScheduleConvergeHandler
         .filter { intent -> filters.all { it.filter(intent) } }
         .also { log.info("Scheduling ${it.size} active intents after filters") }
         .forEach {
-          queue.push(ConvergeIntent(
-            it,
-            clock.instant().plusMillis(properties.stalenessTtl).toEpochMilli(),
-            clock.instant().plusMillis(properties.timeoutTtl).toEpochMilli()
-          ))
+          scheduleService.converge(it)
         }
       registry.counter(invocations.withTag("result", "success")).increment()
     } catch (e: Exception) {

--- a/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ScheduleConvergeHandlerTest.kt
+++ b/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ScheduleConvergeHandlerTest.kt
@@ -20,16 +20,12 @@ import com.netflix.spinnaker.config.ScheduleConvergeHandlerProperties
 import com.netflix.spinnaker.keel.IntentRepository
 import com.netflix.spinnaker.keel.scheduler.ConvergeIntent
 import com.netflix.spinnaker.keel.scheduler.ScheduleConvergence
-import com.netflix.spinnaker.keel.test.TestIntent
+import com.netflix.spinnaker.keel.scheduler.ScheduleService
 import com.netflix.spinnaker.keel.test.GenericTestIntentSpec
+import com.netflix.spinnaker.keel.test.TestIntent
 import com.netflix.spinnaker.q.Queue
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.Test
-import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -41,9 +37,9 @@ object ScheduleConvergeHandlerTest {
   val intentRepository = mock<IntentRepository>()
   val registry = NoopRegistry()
   val clock = Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault())
-  val applicationEventPublisher = mock<ApplicationEventPublisher>()
+  val scheduleService = ScheduleService(queue, properties, clock)
 
-  val subject = ScheduleConvergeHandler(queue, properties, intentRepository, emptyList(), registry, clock, applicationEventPublisher)
+  val subject = ScheduleConvergeHandler(queue, scheduleService, intentRepository, emptyList(), registry)
 
   @Test
   fun `should push converge messages for each active intent`() {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.config.KeelProperties
 import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.dryrun.DryRunIntentLauncher
 import com.netflix.spinnaker.keel.model.UpsertIntentRequest
-import com.netflix.spinnaker.keel.orca.OrcaIntentLauncher
+import com.netflix.spinnaker.keel.scheduler.ScheduleService
 import com.netflix.spinnaker.keel.tracing.TraceRepository
 import net.logstash.logback.argument.StructuredArguments
 import org.slf4j.LoggerFactory
@@ -33,7 +33,7 @@ import javax.ws.rs.QueryParam
 class IntentController
 @Autowired constructor(
   private val dryRunIntentLauncher: DryRunIntentLauncher,
-  private val orcaIntentLauncher: OrcaIntentLauncher,
+  private val scheduleService: ScheduleService,
   private val intentRepository: IntentRepository,
   private val intentActivityRepository: IntentActivityRepository,
   private val traceRepository: TraceRepository,
@@ -71,8 +71,8 @@ class IntentController
       intentRepository.upsertIntent(intent)
 
       if (keelProperties.immediatelyRunIntents) {
-        log.info("Immediately launching intent {}", StructuredArguments.value("intent", intent.id))
-        orcaIntentLauncher.launch(intent)
+        log.info("Immediately scheduling intent {}", StructuredArguments.value("intent", intent.id))
+        scheduleService.converge(intent)
       }
 
       intentList.add(UpsertIntentResponse(intent.id, intent.status))


### PR DESCRIPTION
We don't actually do anything with the results of the converge during upsert, so there's no reason to perform the convergence in a request thread. Instead, this change will schedule convergence immediately and distribute the work onto the queue.