### PR TITLE
feat(*): Add intent validation on upsert

### DIFF
--- a/keel-clouddriver/dependencies.lock
+++ b/keel-clouddriver/dependencies.lock
@@ -79,6 +79,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -180,6 +186,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -280,6 +292,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -402,6 +420,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -502,6 +526,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -622,6 +652,12 @@
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
             "requested": "1.9.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -756,6 +792,12 @@
             "locked": "1.9.0",
             "requested": "1.9.+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -888,6 +930,12 @@
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
             "requested": "1.9.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1029,6 +1077,12 @@
         "com.squareup.retrofit:retrofit-mock": {
             "locked": "1.9.0",
             "requested": "1.9.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-core/dependencies.lock
+++ b/keel-core/dependencies.lock
@@ -24,6 +24,10 @@
             "locked": "1.124.0",
             "requested": "+"
         },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "locked": "4.11",
             "requested": "4.+"
@@ -62,6 +66,10 @@
             "locked": "1.124.0",
             "requested": "+"
         },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "locked": "4.11",
             "requested": "4.+"
@@ -99,6 +107,10 @@
         "com.netflix.spinnaker.kork:kork-core": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "locked": "4.11",
@@ -158,6 +170,10 @@
             "locked": "1.124.0",
             "requested": "+"
         },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "locked": "4.11",
             "requested": "4.+"
@@ -195,6 +211,10 @@
         "com.netflix.spinnaker.kork:kork-core": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "locked": "4.11",
@@ -271,6 +291,13 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -370,6 +397,13 @@
             "locked": "1.5.0",
             "requested": "+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -467,6 +501,13 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -573,6 +614,13 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final",
+            "requested": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-core/keel-core.gradle
+++ b/keel-core/keel-core.gradle
@@ -18,6 +18,7 @@ dependencies {
   compile "org.slf4j:slf4j-api:1.7.+"
   compile "com.netflix.spinnaker.kork:kork-core:+"
   compile "net.logstash.logback:logstash-logback-encoder:4.+"
+  compile "javax.validation:validation-api:1.1.0.Final"
 
   compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
   compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/Intent.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel
 import com.fasterxml.jackson.annotation.*
 import com.github.jonpeterson.jackson.module.versioning.JsonSerializeToVersion
 import com.netflix.spectator.api.BasicTag
+import com.netflix.spinnaker.keel.annotation.IntentConstraint
 import com.netflix.spinnaker.keel.attribute.Attribute
 import com.netflix.spinnaker.keel.policy.Policy
 import kotlin.reflect.KClass
@@ -32,6 +33,7 @@ import kotlin.reflect.KClass
  * @param policies User-defined behavioral policies specific to the intent.
  * @param cas An optional ID-granular pessimistic lock.
  */
+@IntentConstraint
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 abstract class Intent<out S : IntentSpec>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/IntentConstraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/annotation/IntentConstraint.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.annotation
+
+import com.netflix.spinnaker.keel.validation.IntentValidator
+import javax.validation.Constraint
+
+
+@Constraint(validatedBy = [IntentValidator::class])
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class IntentConstraint(
+  val message: String = "Stored Intent requires an incremented CAS value"
+)
+
+//@Target(AnnotationTarget.TYPE)
+//@Retention(AnnotationRetention.RUNTIME)
+//annotation class List(vararg val value: IntentConstraint)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validation/IntentValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validation/IntentValidator.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.validation
+
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentRepository
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.annotation.IntentConstraint
+import org.springframework.stereotype.Component
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+@Component
+class IntentValidator(
+  private val intentRepository: IntentRepository
+) : ConstraintValidator<IntentConstraint, Intent<IntentSpec>> {
+
+  override fun isValid(value: Intent<IntentSpec>, context: ConstraintValidatorContext): Boolean {
+    // TODO rz - Should update the validator to not run when in dry-run mode?
+    val storedIntent = intentRepository.getIntent(value.id())
+
+    return ValidateIntentCommand(
+      storedIntent = storedIntent,
+      intent = value,
+      context = context
+    ).run {
+      // TODO rz - Add the other validation things
+      casVersion(this)
+    }
+  }
+
+  private fun casVersion(command: ValidateIntentCommand): Boolean {
+    return command.storedIntent
+      ?.let { storedIntent ->
+        if (storedIntent.cas == null) {
+          return@let true
+        }
+        val requiredCasValue = storedIntent.cas + 1
+
+        if (command.intent.cas == null) {
+          command.context.buildConstraintViolationWithTemplate("No Intent CAS value set, but a value of " +
+            "$requiredCasValue is required")
+            .addPropertyNode("cas")
+            .addConstraintViolation()
+          return@let false
+        }
+        if (command.intent.cas != requiredCasValue) {
+          command.context.buildConstraintViolationWithTemplate("Provided Intent CAS value '${command.intent.cas}' " +
+            "does not match expected $requiredCasValue value")
+            .addPropertyNode("cas")
+            .addConstraintViolation()
+          return@let false
+        }
+
+        return@let true
+      }
+      ?: true
+  }
+
+  override fun initialize(constraintAnnotation: IntentConstraint) {}
+}
+
+private data class ValidateIntentCommand(
+  val storedIntent: Intent<IntentSpec>?,
+  val intent: Intent<IntentSpec>,
+  val context: ConstraintValidatorContext
+)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validation/IntentValidatorTest.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validation/IntentValidatorTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.validation
+
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentRepository
+import com.netflix.spinnaker.keel.IntentStatus
+import com.netflix.spinnaker.keel.test.GenericTestIntentSpec
+import com.netflix.spinnaker.keel.test.TestIntent
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.whenever
+import org.junit.jupiter.api.Test
+import javax.validation.ConstraintValidatorContext
+
+object IntentValidatorTest {
+
+  @Test
+  fun `cas version should not be validated if not present in stored intent`() {
+    val intentRepository = mock<IntentRepository>()
+    whenever(intentRepository.getIntent(any())).thenReturn(TestIntent(
+      GenericTestIntentSpec("hello"),
+      mutableMapOf(),
+      mutableListOf(),
+      listOf()
+    ))
+
+    val constraintContext = mock<ConstraintValidatorContext>()
+    val subject = IntentValidator(intentRepository)
+
+    val intent = TestIntent(
+      GenericTestIntentSpec("hello"),
+      mutableMapOf(),
+      mutableListOf(),
+      listOf()
+    )
+
+    val result = subject.isValid(intent, constraintContext)
+
+    assert(result)
+  }
+
+  @Test
+  fun `cas version should be validated if provided in stored intent`() {
+    val intentRepository = mock<IntentRepository>()
+    whenever(intentRepository.getIntent(any())).thenReturn(CasIntent(4L))
+
+    val constraintContext = mock<ConstraintValidatorContext>()
+    val constraintBuilder = mock<ConstraintValidatorContext.ConstraintViolationBuilder>()
+    val nodeBuilder = mock<ConstraintValidatorContext.ConstraintViolationBuilder.NodeBuilderCustomizableContext>()
+    whenever(constraintContext.buildConstraintViolationWithTemplate(any())).thenReturn(constraintBuilder)
+    whenever(constraintBuilder.addPropertyNode(any())).thenReturn(nodeBuilder)
+    whenever(nodeBuilder.addConstraintViolation()).thenReturn(constraintContext)
+
+    val subject = IntentValidator(intentRepository)
+
+    subject.isValid(CasIntent(null), constraintContext).also { result ->
+      assert(!result, { "null cas version should be invalid" })
+    }
+    subject.isValid(CasIntent(4L), constraintContext).also { result ->
+      assert(!result, { "equal cas version should not be valid" })
+    }
+    subject.isValid(CasIntent(6L), constraintContext).also { result ->
+      assert(!result, { "jumping cas version should not be valid" })
+    }
+    subject.isValid(CasIntent(5L), constraintContext).also { result ->
+      assert(result, { "incremented cas version should be valid" })
+    }
+  }
+}
+
+private class CasIntent(
+  cas: Long?
+) : Intent<GenericTestIntentSpec>(
+  schema = "0",
+  kind = "CasIntent",
+  spec = GenericTestIntentSpec("hello"),
+  status = IntentStatus.ACTIVE,
+  labels = mutableMapOf(),
+  attributes = mutableListOf(),
+  policies = listOf(),
+  cas = cas
+) {
+  override val id = "cas"
+}

--- a/keel-echo/dependencies.lock
+++ b/keel-echo/dependencies.lock
@@ -75,6 +75,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -172,6 +178,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -268,6 +280,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -386,6 +404,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -482,6 +506,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -594,6 +624,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -720,6 +756,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -844,6 +886,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -977,6 +1025,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-eureka/dependencies.lock
+++ b/keel-eureka/dependencies.lock
@@ -39,6 +39,12 @@
             ],
             "locked": "1.124.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -99,6 +105,12 @@
             ],
             "locked": "1.124.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -158,6 +170,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.124.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -239,6 +257,12 @@
             ],
             "locked": "1.124.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -298,6 +322,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.124.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -366,6 +396,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -447,6 +483,12 @@
             "locked": "1.5.0",
             "requested": "+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -526,6 +568,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -614,6 +662,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-front50/dependencies.lock
+++ b/keel-front50/dependencies.lock
@@ -75,6 +75,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -172,6 +178,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -268,6 +280,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -386,6 +404,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -482,6 +506,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -587,6 +617,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -705,6 +741,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -821,6 +863,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -946,6 +994,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-intent-aws/dependencies.lock
+++ b/keel-intent-aws/dependencies.lock
@@ -105,6 +105,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -235,6 +241,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -364,6 +376,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -515,6 +533,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -644,6 +668,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -789,6 +819,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -948,6 +984,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -1105,6 +1147,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1271,6 +1319,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-intent/dependencies.lock
+++ b/keel-intent/dependencies.lock
@@ -91,6 +91,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -206,6 +212,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -320,6 +332,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -456,6 +474,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -570,6 +594,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -700,6 +730,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -844,6 +880,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -986,6 +1028,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1137,6 +1185,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-orca/dependencies.lock
+++ b/keel-orca/dependencies.lock
@@ -87,6 +87,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -197,6 +203,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -306,6 +318,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -437,6 +455,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -546,6 +570,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -664,6 +694,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -795,6 +831,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -924,6 +966,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1062,6 +1110,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-redis/dependencies.lock
+++ b/keel-redis/dependencies.lock
@@ -40,12 +40,18 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -108,12 +114,18 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -176,12 +188,18 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -264,12 +282,18 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -332,12 +356,18 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "locked": "1.124.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -413,7 +443,7 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
@@ -427,6 +457,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -515,7 +551,7 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
@@ -529,6 +565,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -617,7 +659,7 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
@@ -631,6 +673,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -727,7 +775,7 @@
             "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-dynomite": {
-            "locked": "1.123.0",
+            "locked": "1.124.0",
             "requested": "+"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
@@ -741,6 +789,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-retrofit/dependencies.lock
+++ b/keel-retrofit/dependencies.lock
@@ -59,6 +59,12 @@
             "locked": "1.9.0",
             "requested": "1.+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -139,6 +145,12 @@
             "locked": "1.9.0",
             "requested": "1.+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -218,6 +230,12 @@
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
             "requested": "1.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -319,6 +337,12 @@
             "locked": "1.9.0",
             "requested": "1.+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -398,6 +422,12 @@
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
             "requested": "1.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -486,6 +516,12 @@
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
             "requested": "1.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -587,6 +623,12 @@
             "locked": "1.9.0",
             "requested": "1.+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -686,6 +728,12 @@
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
             "requested": "1.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -794,6 +842,12 @@
         "com.squareup.retrofit:retrofit": {
             "locked": "1.9.0",
             "requested": "1.+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-scheduler/dependencies.lock
+++ b/keel-scheduler/dependencies.lock
@@ -97,6 +97,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -218,6 +224,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -338,6 +350,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -480,6 +498,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -600,6 +624,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -736,6 +766,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -886,6 +922,12 @@
             ],
             "locked": "1.9.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -1034,6 +1076,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1191,6 +1239,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-test/dependencies.lock
+++ b/keel-test/dependencies.lock
@@ -43,6 +43,12 @@
             ],
             "locked": "1.124.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -107,6 +113,12 @@
             ],
             "locked": "1.124.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -170,6 +182,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.124.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -255,6 +273,12 @@
             ],
             "locked": "1.124.0"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -318,6 +342,12 @@
                 "com.netflix.spinnaker.keel:keel-core"
             ],
             "locked": "1.124.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -386,6 +416,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -467,6 +503,12 @@
             "locked": "1.5.0",
             "requested": "+"
         },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
+        },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-core"
@@ -546,6 +588,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -634,6 +682,12 @@
         "com.nhaarman:mockito-kotlin": {
             "locked": "1.5.0",
             "requested": "+"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-web/dependencies.lock
+++ b/keel-web/dependencies.lock
@@ -111,7 +111,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -154,6 +154,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -309,7 +315,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -352,6 +358,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -507,7 +519,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -550,6 +562,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -725,7 +743,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -768,6 +786,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -923,7 +947,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -966,6 +990,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1125,7 +1155,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -1172,6 +1202,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1343,7 +1379,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -1390,6 +1426,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1561,7 +1603,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -1608,6 +1650,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [
@@ -1787,7 +1835,7 @@
             "firstLevelTransitive": [
                 "com.netflix.spinnaker.keel:keel-redis"
             ],
-            "locked": "1.123.0"
+            "locked": "1.124.0"
         },
         "com.netflix.spinnaker.kork:kork-jedis": {
             "firstLevelTransitive": [
@@ -1834,6 +1882,12 @@
                 "com.netflix.spinnaker.keel:keel-retrofit"
             ],
             "locked": "1.9.0"
+        },
+        "javax.validation:validation-api": {
+            "firstLevelTransitive": [
+                "com.netflix.spinnaker.keel:keel-core"
+            ],
+            "locked": "1.1.0.Final"
         },
         "net.logstash.logback:logstash-logback-encoder": {
             "firstLevelTransitive": [

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/controllers/v1/IntentController.kt
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import javax.validation.Valid
 import javax.ws.rs.QueryParam
 
 @RestController
@@ -55,12 +56,7 @@ class IntentController
 
   @RequestMapping(value = [""], method = [(RequestMethod.POST)])
   @ResponseStatus(HttpStatus.ACCEPTED)
-  fun upsertIntent(@RequestBody req: UpsertIntentRequest): Any {
-    // TODO rz - validate intents
-    // TODO rz - calculate graph
-
-    // TODO rz - add "notes" API property for history/audit
-
+  fun upsertIntent(@Valid @RequestBody req: UpsertIntentRequest): Any {
     if (req.dryRun) {
       return req.intents.map { dryRunIntentLauncher.launch(it) }
     }


### PR DESCRIPTION
Currently just addressing Intent's CAS version. I think this will do fine, but I am sort of concerned about performing validation on dry-run intents since it'll require talking to Front50 to validate the CAS. I think I might wind up adding a new dry run endpoint that Gate can hit directly, rather than going through Orca, which will perform a looser subset of validation.