### PR TITLE
refactor(activity): Simplify intent activity, squash history into single log

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelConfiguration.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/KeelConfiguration.kt
@@ -60,7 +60,7 @@ open class KeelConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(IntentActivityRepository::class)
-  open fun memoryIntentActivityRepository(): IntentActivityRepository = MemoryIntentActivityRepository(properties)
+  open fun memoryIntentActivityRepository(): IntentActivityRepository = MemoryIntentActivityRepository()
 
   @Bean open fun clock(): Clock = Clock.systemDefaultZone()
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/event/IntentActivityListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/event/IntentActivityListener.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.event
+
+import com.netflix.spinnaker.keel.IntentActivityRepository
+import com.netflix.spinnaker.keel.IntentChangeAction.DELETE
+import com.netflix.spinnaker.keel.IntentChangeAction.UPSERT
+import com.netflix.spinnaker.keel.IntentChangeRecord
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class IntentActivityListener(
+  private val intentActivityRepository: IntentActivityRepository
+) {
+
+  @EventListener(AfterIntentUpsertEvent::class, AfterIntentDeleteEvent::class)
+  fun recordUpsert(event: IntentAwareEvent) {
+    // TODO rz - actor needs to be pulled out of AuthenticatedRequest
+    intentActivityRepository.record(IntentChangeRecord(
+      event.intent.id(),
+      action = if (event is AfterIntentUpsertEvent) UPSERT else DELETE,
+      actor = "TODO: unknown",
+      value = event.intent
+    ))
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/model/ListCriteria.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/model/ListCriteria.kt
@@ -13,17 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.config
+package com.netflix.spinnaker.keel.model
 
-import org.springframework.boot.context.properties.ConfigurationProperties
-
-@ConfigurationProperties("keel")
-class KeelProperties {
-  var prettyPrintJson: Boolean = false
-  var immediatelyRunIntents: Boolean = true
-  var maxConvergenceLogEntriesPerIntent: Int = 1000
-
-  var intentPackages: List<String> = listOf("com.netflix.spinnaker.keel.intent")
-  var intentSpecPackages: List<String> = listOf("com.netflix.spinnaker.keel.intent")
-  var attributePackages: List<String> = listOf("com.netflix.spinnaker.keel.attribute")
+// TODO validation
+interface ListCriteria {
+  val limit: Int
+  val offset: Int
 }
+
+data class PagingListCriteria(
+  override val limit: Int = 10,
+  override val offset: Int = 0
+) : ListCriteria

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaIntentLauncher.kt
@@ -21,21 +21,17 @@ import com.netflix.spinnaker.keel.*
 import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import net.logstash.logback.argument.StructuredArguments.value
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
-import java.time.Clock
 import java.util.concurrent.TimeUnit
 
 @Component(value = "orcaIntentLauncher")
-open class OrcaIntentLauncher
-@Autowired constructor(
+open class OrcaIntentLauncher(
   private val intentProcessors: List<IntentProcessor<*>>,
   private val orcaService: OrcaService,
   private val registry: Registry,
   private val applicationEventPublisher: ApplicationEventPublisher,
-  private val intentActivityRepository: IntentActivityRepository,
-  private val clock: Clock
+  private val intentActivityRepository: IntentActivityRepository
 ) : IntentLauncher<OrcaLaunchedIntentResult> {
 
   private val log = LoggerFactory.getLogger(javaClass)
@@ -61,14 +57,10 @@ open class OrcaIntentLauncher
         orcaService.orchestrate(it).ref
       }
 
-      intentActivityRepository.logConvergence(IntentConvergenceRecord(
+      intentActivityRepository.record(IntentConvergenceRecord(
         intentId = intent.id(),
-        changeType = result.changeSummary.type,
-        orchestrations = orchestrationIds,
-        messages = result.changeSummary.message,
-        diff = result.changeSummary.diff,
-        actor = "keel:scheduledConvergence",
-        timestampMillis = clock.millis()
+        actor = "keel:scheduledConverge",
+        result = result
       ))
 
       log.info(

--- a/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandler.kt
+++ b/keel-scheduler/src/main/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandler.kt
@@ -16,7 +16,10 @@
 package com.netflix.spinnaker.keel.scheduler.handler
 
 import com.netflix.spectator.api.Registry
-import com.netflix.spinnaker.keel.*
+import com.netflix.spinnaker.keel.Intent
+import com.netflix.spinnaker.keel.IntentRepository
+import com.netflix.spinnaker.keel.IntentSpec
+import com.netflix.spinnaker.keel.IntentStatus
 import com.netflix.spinnaker.keel.event.*
 import com.netflix.spinnaker.keel.orca.OrcaIntentLauncher
 import com.netflix.spinnaker.keel.scheduler.ConvergeIntent
@@ -37,7 +40,6 @@ class ConvergeIntentHandler
 @Autowired constructor(
   override val queue: Queue,
   private val intentRepository: IntentRepository,
-  private val intentActivityRepository: IntentActivityRepository,
   private val orcaIntentLauncher: OrcaIntentLauncher,
   private val clock: Clock,
   private val registry: Registry,
@@ -74,7 +76,6 @@ class ConvergeIntentHandler
       orcaIntentLauncher.launch(intent)
         .takeIf { it.orchestrationIds.isNotEmpty() }
         ?.also { result ->
-          intentActivityRepository.addOrchestrations(intent.id(), result.orchestrationIds)
           applicationEventPublisher.publishEvent(IntentConvergeSuccessEvent(intent, result.orchestrationIds))
 
           if (intent.status.shouldIsolate()) {

--- a/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandlerTest.kt
+++ b/keel-scheduler/src/test/kotlin/com/netflix/spinnaker/keel/scheduler/handler/ConvergeIntentHandlerTest.kt
@@ -16,22 +16,15 @@
 package com.netflix.spinnaker.keel.scheduler.handler
 
 import com.netflix.spectator.api.NoopRegistry
-import com.netflix.spinnaker.keel.IntentActivityRepository
 import com.netflix.spinnaker.keel.IntentRepository
 import com.netflix.spinnaker.keel.dryrun.ChangeSummary
 import com.netflix.spinnaker.keel.orca.OrcaIntentLauncher
 import com.netflix.spinnaker.keel.orca.OrcaLaunchedIntentResult
 import com.netflix.spinnaker.keel.scheduler.ConvergeIntent
-import com.netflix.spinnaker.keel.test.TestIntent
 import com.netflix.spinnaker.keel.test.GenericTestIntentSpec
+import com.netflix.spinnaker.keel.test.TestIntent
 import com.netflix.spinnaker.q.Queue
-import com.nhaarman.mockito_kotlin.doReturn
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.reset
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
@@ -43,17 +36,16 @@ object ConvergeIntentHandlerTest {
 
   val queue = mock<Queue>()
   val intentRepository = mock<IntentRepository>()
-  val intentActivityRepository = mock<IntentActivityRepository>()
   val orcaIntentLauncher = mock<OrcaIntentLauncher>()
   val clock = Clock.fixed(Instant.ofEpochSecond(500), ZoneId.systemDefault())
   val registry = NoopRegistry()
   val applicationEventPublisher = mock<ApplicationEventPublisher>()
 
-  val subject = ConvergeIntentHandler(queue, intentRepository, intentActivityRepository, orcaIntentLauncher, clock, registry, applicationEventPublisher)
+  val subject = ConvergeIntentHandler(queue, intentRepository, orcaIntentLauncher, clock, registry, applicationEventPublisher)
 
   @AfterEach
   fun cleanup() {
-    reset(queue, intentRepository, intentActivityRepository, orcaIntentLauncher, applicationEventPublisher)
+    reset(queue, intentRepository, orcaIntentLauncher, applicationEventPublisher)
   }
 
   @Test
@@ -96,7 +88,6 @@ object ConvergeIntentHandlerTest {
     subject.handle(message)
 
     verify(orcaIntentLauncher).launch(refreshedIntent)
-    verify(intentActivityRepository).addOrchestrations("test:1", listOf("one"))
-    verifyNoMoreInteractions(orcaIntentLauncher, intentActivityRepository)
+    verifyNoMoreInteractions(orcaIntentLauncher)
   }
 }


### PR DESCRIPTION
I didn't really like how `IntentActivityRepository` was built. Refactored to have a simpler interface, and putting all activity for an intent inside a single log. The read operations are also always paginated. I think I'll probably want to do a little more filtering on convergence events so the log isn't just filled up with `NO_CHANGE` convergence events. It'll probably make more sense to do a lookback on `NO_CHANGE` and validate that the last record was not also a `NO_CHANGE`.

This change will require you to flush the redis database (or at least the `log:*` keys). It is not backwards compat.