### PR TITLE
Resize ASG if only diff is capacity

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ kapt.use.worker.api=true
 bootVersion=1.5.19.RELEASE
 kotlinVersion=1.3.21
 coroutinesVersion=1.1.1
+javersVersion=5.2.0
 minutestVersion=1.0.0
 spinnakerVersion=4.1.2
 striktVersion=0.17.2

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
@@ -10,6 +10,7 @@ data class ClusterActiveServerGroup(
   val targetGroups: Set<String>,
   val loadBalancers: Set<String>,
   val capacity: ServerGroupCapacity,
+  val cloudProvider: String,
   val securityGroups: Set<String>,
   val accountName: String,
   val moniker: Moniker

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ClusterActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ClusterActiveServerGroupTest.kt
@@ -20,6 +20,7 @@ object ClusterActiveServerGroupTest : BaseModelParsingTest<ClusterActiveServerGr
 
   override val expected = ClusterActiveServerGroup(
     name = "fletch_test-v000",
+    cloudProvider = "aws",
     accountName = "test",
     targetGroups = emptySet(),
     region = "eu-west-1",

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.runBlocking
+import org.javers.core.diff.Diff
 import org.slf4j.LoggerFactory
 import retrofit2.HttpException
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroup as RiverSecurityGroup
@@ -52,7 +53,7 @@ class SecurityGroupHandler(
   override fun current(resource: Resource<SecurityGroup>): SecurityGroup? =
     cloudDriverService.getSecurityGroup(resource.spec)
 
-  override fun upsert(resource: Resource<SecurityGroup>) {
+  override fun upsert(resource: Resource<SecurityGroup>, diff: Diff?) {
     val taskRef = runBlocking {
       resource.spec.let { spec ->
         orcaService

--- a/keel-file-plugin/src/main/kotlin/com/netflix/spinnaker/keel/file/FileHandler.kt
+++ b/keel-file-plugin/src/main/kotlin/com/netflix/spinnaker/keel/file/FileHandler.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.file.Message
 import com.netflix.spinnaker.keel.plugin.ResourceConflict
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import org.javers.core.diff.Diff
 import org.slf4j.LoggerFactory
 import java.io.File
 import javax.annotation.PostConstruct
@@ -58,7 +59,7 @@ class FileHandler(private val directory: File) : ResourceHandler<Message> {
     }
   }
 
-  override fun upsert(resource: Resource<Message>) {
+  override fun upsert(resource: Resource<Message>, diff: Diff?) {
     log.info("Upsert resource {}", resource)
     resource.file.writer().use {
       it.append(resource.spec.text)

--- a/keel-plugin/keel-plugin.gradle
+++ b/keel-plugin/keel-plugin.gradle
@@ -4,13 +4,14 @@ apply from: "$rootDir/gradle/junit5.gradle"
 
 dependencies {
   api project(":keel-core")
+  api "org.javers:javers-core:$javersVersion"
+
   implementation "com.netflix.spinnaker.kork:kork-core:${spinnaker.version('kork')}"
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
   implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda"
-  implementation "org.javers:javers-core:5.1.3"
 
   testImplementation "org.springframework.boot:spring-boot-starter-web"
   testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceHandler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceHandler.kt
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.keel.plugin
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
+import org.javers.core.diff.Diff
+import org.javers.core.diff.DiffBuilder
 
 interface ResourceHandler<T : Any> : KeelPlugin {
 
@@ -45,7 +47,7 @@ interface ResourceHandler<T : Any> : KeelPlugin {
    * Otherwise just implement [upsert].
    */
   fun create(resource: Resource<T>) {
-    upsert(resource)
+    upsert(resource, null)
   }
 
   /**
@@ -56,8 +58,8 @@ interface ResourceHandler<T : Any> : KeelPlugin {
    * Implement this method and [create] if you need to handle create and update in different ways.
    * Otherwise just implement [upsert].
    */
-  fun update(resource: Resource<T>) {
-    upsert(resource)
+  fun update(resource: Resource<T>, diff: Diff = DiffBuilder.empty()) {
+    upsert(resource, diff)
   }
 
   /**
@@ -66,7 +68,7 @@ interface ResourceHandler<T : Any> : KeelPlugin {
    * You don't need to implement this method if you are implementing [create] and [update]
    * individually.
    */
-  fun upsert(resource: Resource<T>) {
+  fun upsert(resource: Resource<T>, diff: Diff? = null) {
     TODO("Not implemented")
   }
 

--- a/keel-plugin/src/test/kotlin/com/netflix/spinnaker/keel/plugin/monitoring/ResourceStateMonitorTests.kt
+++ b/keel-plugin/src/test/kotlin/com/netflix/spinnaker/keel/plugin/monitoring/ResourceStateMonitorTests.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.reset
@@ -67,7 +68,7 @@ internal object ResourceStateMonitorTests : JUnit5Minutests {
 
         test("the resource is not updated") {
           verify(plugin1, never()).create(any())
-          verify(plugin1, never()).update(any())
+          verify(plugin1, never()).update(any(), any())
           verify(plugin1, never()).delete(any())
         }
 
@@ -95,8 +96,8 @@ internal object ResourceStateMonitorTests : JUnit5Minutests {
           validateManagedResources()
         }
 
-        test("the resource is created") {
-          verify(plugin1).update(resource)
+        test("the resource is updated") {
+          verify(plugin1).update(eq(resource), any())
         }
       }
     }


### PR DESCRIPTION
I built this on top of #201 so you can ignore the first commit for now. It will get rebased out.

I'd like to do some tweaking of the use of the diff library as the method I'm using is designed for comparing new & old versions of the same object. In our case that's not quite valid as either one could be newer (either desired state changed, or actual resource in the cloud changed out of band).

This is a proof-of-concept though so I haven't really tried to be too clean here. I like that the check for what changed is strongly typed rather than just grepping strings or something.