### PR TITLE
feat(controller): artifact controller that can receive spinnaker artifacts

### DIFF
--- a/keel-api/keel-api.gradle
+++ b/keel-api/keel-api.gradle
@@ -20,6 +20,7 @@ dependencies {
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-joda"
   implementation "org.springframework.boot:spring-boot-starter-actuator"
   implementation "org.springframework.boot:spring-boot-starter-web"
+  implementation spinnaker.dependency("korkArtifacts")
 
   testImplementation "io.strikt:strikt-core:$striktVersion"
   testImplementation project(":keel-spring-test-support")

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -1,0 +1,36 @@
+package com.netflix.spinnaker.keel.rest
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(path = ["/artifacts"])
+class ArtifactController(
+  private val publisher: ApplicationEventPublisher
+) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  @PostMapping(
+    consumes = [MediaType.APPLICATION_JSON_VALUE]
+  )
+  fun submitArtifact(@RequestBody echoArtifactEvent: EchoArtifactEvent) {
+    log.debug("Received artifact events for ${echoArtifactEvent.payload.artifacts.map { it.reference }}")
+    publisher.publishEvent(echoArtifactEvent.payload)
+  }
+}
+
+data class EchoArtifactEvent(
+  val payload: ArtifactEvent,
+  val eventName: String
+)
+
+data class ArtifactEvent(
+  val artifacts: List<Artifact>,
+  val details: Map<String, Any>?
+)


### PR DESCRIPTION
`details` is an echo thing: https://github.com/spinnaker/echo/blob/master/echo-model/src/main/java/com/netflix/spinnaker/echo/model/Metadata.java

@robfletcher do you think that the information in `Metadata` would be useful in keel, or not needed? The other option is to just accept a list of artifacts w/o additional data.