### PR TITLE
Handle default security groups

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/Main.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/Main.kt
@@ -27,11 +27,13 @@ import com.netflix.spinnaker.kork.PlatformComponents
 import de.huxhorn.sulky.ulid.ULID
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Scope
 import org.springframework.scheduling.annotation.EnableAsync
 import java.time.Clock
 import javax.annotation.PostConstruct
@@ -66,6 +68,8 @@ class KeelApplication {
   fun idGenerator(): ULID = ULID()
 
   @Bean
+  // prototype as we want to customize config for some uses
+  @Scope(SCOPE_PROTOTYPE)
   fun objectMapper(): ObjectMapper = configuredObjectMapper()
 
   @Bean

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.config
 
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
@@ -56,7 +57,7 @@ class ClouddriverConfiguration {
     retrofitClient: OkHttpClient)
     : CloudDriverService =
     Retrofit.Builder()
-      .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+      .addConverterFactory(JacksonConverterFactory.create(objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES)))
       .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .baseUrl(clouddriverEndpoint)
       .client(retrofitClient)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.serialization
 
-import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_WITH_ZONE_ID
@@ -31,7 +30,6 @@ private fun ObjectMapper.configureMe() =
     .registerULIDModule()
     .registerModule(JavaTimeModule())
     .configureSaneDateTimeRepresentation()
-    .disable(FAIL_ON_UNKNOWN_PROPERTIES)
 
 private fun ObjectMapper.registerULIDModule() =
   registerModule(SimpleModule().apply {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import de.huxhorn.sulky.ulid.ULID
 import java.text.SimpleDateFormat
@@ -19,29 +18,33 @@ import java.util.*
  * Factory method for [ObjectMapper]s configured how we like 'em.
  */
 fun configuredObjectMapper(): ObjectMapper =
-  jacksonObjectMapper()
-    .registerModule(JavaTimeModule())
-    .registerULIDModule()
-    .enable(WRITE_DATES_AS_TIMESTAMPS)
-    .enable(WRITE_DATES_WITH_ZONE_ID)
-    .enable(WRITE_DATE_KEYS_AS_TIMESTAMPS)
-    .disable(FAIL_ON_UNKNOWN_PROPERTIES)
-    .apply {
-      dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").apply {
-        timeZone = TimeZone.getDefault()
-      }
-    }
+  ObjectMapper().configureMe()
 
 /**
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
 fun configuredYamlMapper(): ObjectMapper =
-  YAMLMapper()
-    .registerKotlinModule()
+  YAMLMapper().configureMe()
+
+private fun ObjectMapper.configureMe() =
+  registerKotlinModule()
     .registerULIDModule()
+    .registerModule(JavaTimeModule())
+    .configureSaneDateTimeRepresentation()
+    .disable(FAIL_ON_UNKNOWN_PROPERTIES)
 
 private fun ObjectMapper.registerULIDModule() =
   registerModule(SimpleModule().apply {
     addSerializer(ULID.Value::class.java, ToStringSerializer())
     addDeserializer(ULID.Value::class.java, ULIDDeserializer())
   })
+
+private fun ObjectMapper.configureSaneDateTimeRepresentation() =
+  enable(WRITE_DATES_AS_TIMESTAMPS)
+    .enable(WRITE_DATES_WITH_ZONE_ID)
+    .enable(WRITE_DATE_KEYS_AS_TIMESTAMPS)
+    .apply {
+      dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").apply {
+        timeZone = TimeZone.getDefault()
+      }
+    }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Cluster.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Cluster.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType.EC2
@@ -22,6 +23,7 @@ data class Cluster(
     val stack: String? = null,
     val detail: String? = null
   ) {
+    @get:JsonIgnore
     val cluster: String
       get() = when {
         stack == null && detail == null -> application

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -72,6 +72,7 @@ class ClusterHandler(
         resource.copy(spec = it) as Resource<Cluster>
       }
 
+  // TODO: Netflix-specific, migrate to keel-nflx. See https://github.com/spinnaker/keel/issues/225
   private fun Cluster.withDefaultSecurityGroups(): Cluster =
     copy(
       dependencies = dependencies.copy(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterValidationTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterValidationTests.kt
@@ -1,0 +1,88 @@
+package com.netflix.spinnaker.keel.ec2.resource
+
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceMetadata
+import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.ec2.Cluster
+import com.netflix.spinnaker.keel.api.ec2.Cluster.LaunchConfiguration
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Location
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Moniker
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.nhaarman.mockito_kotlin.mock
+import de.huxhorn.sulky.ulid.ULID
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.contains
+import java.time.Clock
+
+internal object ClusterValidationTests : JUnit5Minutests {
+
+  val objectMapper = configuredObjectMapper()
+  val idGenerator = ULID()
+
+  data class Fixture(
+    val cluster: Cluster = Cluster(
+      moniker = Moniker(
+        application = "fnord",
+        stack = "test"
+      ),
+      location = Location(
+        accountName = "test",
+        region = "ap-south-1",
+        subnet = "internal (vpc0)",
+        availabilityZones = setOf("ap-south-1a", "ap-south-1b", "ap-south-1c")
+      ),
+      launchConfiguration = LaunchConfiguration(
+        "some-image-id",
+        "m4.large",
+        true,
+        "fnordInstanceProfile",
+        "fnordKeyPair"
+      )
+    )
+  ) {
+    val resource: Resource<Any> = Resource(
+      apiVersion = SPINNAKER_API_V1,
+      kind = "cluster",
+      metadata = ResourceMetadata(
+        name = ResourceName("undefined"),
+        uid = idGenerator.nextValue()
+      ),
+      spec = objectMapper.convertValue<Map<String, Any?>>(cluster)
+    )
+    val handler: ClusterHandler = ClusterHandler(
+      mock(), mock(), mock(), Clock.systemDefaultZone(), objectMapper, idGenerator
+    )
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("a cluster spec with no security groups") {
+      test("validation assigns default security groups") {
+        val validatedResource = handler.validate(resource)
+
+        expectThat(validatedResource.spec.dependencies.securityGroupNames)
+          .contains(cluster.moniker.application, "nf-infrastructure", "nf-datacenter")
+      }
+    }
+
+    context("a cluster spec with some other security groups") {
+      deriveFixture {
+        copy(cluster = cluster.copy(dependencies = cluster.dependencies.copy(securityGroupNames = setOf("foo", "bar", "baz"))))
+      }
+
+      test("validation adds default security groups") {
+        val validatedResource = handler.validate(resource)
+
+        expectThat(validatedResource.spec.dependencies.securityGroupNames)
+          .contains(cluster.moniker.application, "nf-infrastructure", "nf-datacenter")
+          .contains(cluster.dependencies.securityGroupNames)
+      }
+    }
+  }
+
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterValidationTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterValidationTests.kt
@@ -16,6 +16,7 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectThat
 import strikt.assertions.contains
+import strikt.assertions.doesNotContain
 import java.time.Clock
 
 internal object ClusterValidationTests : JUnit5Minutests {
@@ -79,8 +80,9 @@ internal object ClusterValidationTests : JUnit5Minutests {
         val validatedResource = handler.validate(resource)
 
         expectThat(validatedResource.spec.dependencies.securityGroupNames)
-          .contains(cluster.moniker.application, "nf-infrastructure", "nf-datacenter")
+          .contains("nf-infrastructure", "nf-datacenter")
           .contains(cluster.dependencies.securityGroupNames)
+          .doesNotContain(cluster.moniker.application)
       }
     }
   }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.config
 
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.orca.OrcaService
@@ -49,7 +50,7 @@ class OrcaConfiguration {
     Retrofit.Builder()
       .baseUrl(orcaEndpoint)
       .client(retrofitClient)
-      .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+      .addConverterFactory(JacksonConverterFactory.create(objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES)))
       .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .build()
       .create(OrcaService::class.java)

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceHandler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceHandler.kt
@@ -75,9 +75,10 @@ interface ResourceHandler<T : Any> : KeelPlugin {
    * set default values.
    */
   @Suppress("UNCHECKED_CAST")
-  fun validate(resource: Resource<Any>): Resource<T> = resource.copy(
-    spec = objectMapper.convertValue(resource.spec, supportedKind.second)
-  ) as Resource<T>
+  fun validate(resource: Resource<Any>): Resource<T> =
+    resource.copy(
+      spec = objectMapper.convertValue(resource.spec, supportedKind.second)
+    ) as Resource<T>
 
 
   /**


### PR DESCRIPTION
We should _always_ assign `nf-infrastructure` and `nf-datacenter`, and--if there are no other security group names--an application specific security group.

Closes #213