### PR TITLE
New coroutines support in Retrofit core lib

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,9 @@ subprojects {
 
     repositories {
       jcenter()
+      if (property("korkVersion").toString().endsWith("-SNAPSHOT")) {
+        mavenLocal()
+      }
     }
 
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 #Fri Jun 07 13:17:07 PDT 2019
 enablePublishing=false
-korkVersion=5.4.9
+korkVersion=5.5.0
 kapt.use.worker.api=true

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -47,7 +47,7 @@ internal class AuthPropagationTests : JUnit5Minutests {
 
     fun listNetworks() {
       _listNetworksResults = runBlocking {
-        cloudDriverService.listNetworks().await()
+        cloudDriverService.listNetworks()
       }
     }
   }

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.integration
 
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.KeelApplication
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
@@ -82,7 +81,6 @@ private class TestConfiguration {
       .Builder()
       .baseUrl(server.url("/"))
       .client(retrofitClient)
-      .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .build()
       .create(DummyRetrofitService::class.java)
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -111,7 +111,6 @@ class ImageHandler(
         )
       )
     )
-      .await()
     return listOf(TaskRef(taskRef.ref)) // TODO: wow, this is ugly
   }
 
@@ -122,12 +121,10 @@ class ImageHandler(
   override suspend fun actuationInProgress(name: ResourceName) =
     orcaService
       .getCorrelatedExecutions(name.value)
-      .await()
       .isNotEmpty()
 
   private suspend fun findBaseAmi(baseImage: String): String {
     return cloudDriver.namedImages(baseImage, "test")
-      .await()
       .lastOrNull()
       ?.let { namedImage ->
         val tags = namedImage

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -95,7 +95,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
           } returns "xenialbase-x86_64-201904291721-ebs"
 
-          every { theCloudDriver.namedImages("xenialbase-x86_64-201904291721-ebs", "test") } returns CompletableDeferred(
+          coEvery { theCloudDriver.namedImages("xenialbase-x86_64-201904291721-ebs", "test") } returns
             listOf(
               NamedImage(
                 imageName = "xenialbase-x86_64-201904291721-ebs",
@@ -142,9 +142,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
                 )
               )
             )
-          )
 
-          every { theCloudDriver.namedImages(image.appVersion, "test") } returns CompletableDeferred(
+          coEvery { theCloudDriver.namedImages(image.appVersion, "test") } returns
             listOf(
               NamedImage(
                 imageName = "keel-0.161.0-h63.24d0843-x86_64-20190422190426-xenial-hvm-sriov-ebs",
@@ -175,7 +174,6 @@ internal class ImageHandlerTests : JUnit5Minutests {
                 )
               )
             )
-          )
 
           coEvery { imageService.getLatestImage("keel", "keel-0.161.0-h63.24d0843", "test") } returns image
         }
@@ -225,9 +223,9 @@ internal class ImageHandlerTests : JUnit5Minutests {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
           } returns "xenialbase-x86_64-201904291721-ebs"
 
-          every {
+          coEvery {
             theCloudDriver.namedImages("xenialbase-x86_64-201904291721-ebs", "test")
-          } returns CompletableDeferred(emptyList())
+          } returns emptyList()
         }
 
         test("an exception is thrown") {
@@ -263,7 +261,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
       test("artifact is attached to the trigger") {
         val request = slot<OrchestrationRequest>()
-        every { orcaService.orchestrate(capture(request)) } returns randomTaskRef()
+        coEvery { orcaService.orchestrate(capture(request)) } returns randomTaskRef()
 
         runBlocking {
           handler.upsert(resource, ResourceDiff(null, image))
@@ -275,5 +273,5 @@ internal class ImageHandlerTests : JUnit5Minutests {
     }
   }
 
-  private fun randomTaskRef() = CompletableDeferred(TaskRefResponse(randomUUID().toString()))
+  private fun randomTaskRef() = TaskRefResponse(randomUUID().toString())
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -17,7 +17,6 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ImageService
@@ -51,7 +50,6 @@ class ClouddriverConfiguration {
     CloudDriverService =
     Retrofit.Builder()
       .addConverterFactory(JacksonConverterFactory.create(objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES)))
-      .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .baseUrl(clouddriverEndpoint)
       .client(retrofitClient)
       .build()

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroup
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
-import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -31,63 +30,63 @@ import retrofit2.http.Query
 interface CloudDriverService {
 
   @GET("/securityGroups/{account}/{type}/{region}/{securityGroupName}")
-  fun getSecurityGroup(
+  suspend fun getSecurityGroup(
     @Path("account") account: String,
     @Path("type") type: String,
     @Path("securityGroupName") securityGroupName: String,
     @Path("region") region: String,
     @Query("vpcId") vpcId: String? = null
-  ): Deferred<SecurityGroup>
+  ): SecurityGroup
 
   @GET("/securityGroups/{account}/{provider}")
-  fun getSecurityGroupSummaries(
+  suspend fun getSecurityGroupSummaries(
     @Path("account") account: String,
     @Path("provider") provider: String,
     @Query("region") region: String
-  ): Deferred<Collection<SecurityGroupSummary>>
+  ): Collection<SecurityGroupSummary>
 
   @GET("/networks")
-  fun listNetworks(): Deferred<Map<String, Set<Network>>>
+  suspend fun listNetworks(): Map<String, Set<Network>>
 
   @GET("/networks/{cloudProvider}")
-  fun listNetworksByCloudProvider(@Path("cloudProvider") cloudProvider: String): Deferred<Set<Network>>
+  suspend fun listNetworksByCloudProvider(@Path("cloudProvider") cloudProvider: String): Set<Network>
 
   @GET("/subnets/{cloudProvider}")
-  fun listSubnets(@Path("cloudProvider") cloudProvider: String): Deferred<Set<Subnet>>
+  suspend fun listSubnets(@Path("cloudProvider") cloudProvider: String): Set<Subnet>
 
   @GET("/credentials")
-  fun listCredentials(): Deferred<Set<Credential>>
+  suspend fun listCredentials(): Set<Credential>
 
   @GET("/credentials/{account}")
-  fun getCredential(@Path("account") account: String): Deferred<Credential>
+  suspend fun getCredential(@Path("account") account: String): Credential
 
   @GET("/{provider}/loadBalancers/{account}/{region}/{name}")
-  fun getClassicLoadBalancer(
+  suspend fun getClassicLoadBalancer(
     @Path("provider") provider: String,
     @Path("account") account: String,
     @Path("region") region: String,
     @Path("name") name: String
-  ): Deferred<List<ClassicLoadBalancerModel>>
+  ): List<ClassicLoadBalancerModel>
 
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{region}/serverGroups/target/current_asg_dynamic?onlyEnabled=true")
-  fun activeServerGroup(
+  suspend fun activeServerGroup(
     @Path("app") app: String,
     @Path("account") account: String,
     @Path("cluster") cluster: String,
     @Path("region") region: String,
     @Path("cloudProvider") cloudProvider: String
-  ): Deferred<ClusterActiveServerGroup>
+  ): ClusterActiveServerGroup
 
   @GET("/aws/images/find")
-  fun namedImages(
+  suspend fun namedImages(
     @Query("q") imageName: String,
     @Query("account") account: String?,
     @Query("region") region: String? = null
-  ): Deferred<List<NamedImage>>
+  ): List<NamedImage>
 
   @GET("/images/find")
-  fun images(
+  suspend fun images(
     @Query("provider") provider: String,
     @Query("q") name: String
-  ): Deferred<List<NamedImage>>
+  ): List<NamedImage>
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -33,7 +33,6 @@ class ImageService(
    */
   suspend fun getLatestImage(artifactName: String, version: String, account: String): Image? {
     return cloudDriverService.namedImages(version, account)
-      .await()
       .sortedWith(NamedImageComparator)
       .lastOrNull()
       ?.let { namedImage ->
@@ -61,14 +60,12 @@ class ImageService(
    */
   suspend fun getLatestNamedImage(packageName: String, account: String): NamedImage? {
     return cloudDriverService.namedImages(packageName, account)
-      .await()
       .sortedWith(NamedImageComparator)
       .lastOrNull()
   }
 
   suspend fun getNamedImageFromJenkinsInfo(packageName: String, account: String, buildHost: String, buildName: String, buildNumber: String): NamedImage? {
     return cloudDriverService.namedImages(packageName, account)
-      .await()
       .sortedWith(NamedImageComparator)
       .lastOrNull { namedImage ->
         val allTags = getAllTags(namedImage)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
@@ -58,7 +58,7 @@ class MemoryCloudDriverCache(
   private fun credentialBy(name: String): Credential =
     credentials.getOrNotFound(name, "Credentials with name $name not found") {
       cloudDriver
-        .getCredential(name).await()
+        .getCredential(name)
     }
 
   override fun securityGroupById(account: String, region: String, id: String): SecurityGroupSummary =
@@ -71,7 +71,6 @@ class MemoryCloudDriverCache(
       // TODO-AJ should be able to swap this out for a call to `/search`
       cloudDriver
         .getSecurityGroupSummaries(account, credential.type, region)
-        .await()
         .firstOrNull { it.id == id }
     }
 
@@ -85,15 +84,13 @@ class MemoryCloudDriverCache(
       // TODO-AJ should be able to swap this out for a call to `/search`
       cloudDriver
         .getSecurityGroupSummaries(account, credential.type, region)
-        .await()
         .firstOrNull { it.name == name }
     }
 
   override fun networkBy(id: String): Network =
     networks.getOrNotFound(id, "VPC network with id $id not found") {
       cloudDriver
-        .listNetworks()
-        .await()["aws"]
+        .listNetworks()["aws"]
         ?.firstOrNull { it.id == id }
     }
 
@@ -102,8 +99,7 @@ class MemoryCloudDriverCache(
   override fun networkBy(name: String?, account: String, region: String): Network =
     networks.getOrNotFound("$name:$account:$region", "VPC network named $name not found in $region") {
       cloudDriver
-        .listNetworks()
-        .await()["aws"]
+        .listNetworks()["aws"]
         ?.firstOrNull { it.name == name && it.account == account && it.region == region }
     }
 
@@ -112,7 +108,6 @@ class MemoryCloudDriverCache(
       runBlocking {
         cloudDriver
           .listSubnets("aws")
-          .await()
           .filter { it.account == account && it.vpcId == vpcId && it.region == region }
           .map { it.availabilityZone }
           .toSet()
@@ -123,7 +118,6 @@ class MemoryCloudDriverCache(
     subnets.getOrNotFound(subnetId, "Subnet with id $subnetId not found") {
       cloudDriver
         .listSubnets("aws")
-        .await()
         .find { it.id == subnetId }
     }
 

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTest.kt
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImageComparator
 import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
@@ -108,7 +107,7 @@ object ImageServiceTest {
   fun `get latest image returns actual latest image`() {
     coEvery {
       cloudDriver.namedImages("my-package-0.0.1_rc.98-h99", "test")
-    } returns CompletableDeferred(listOf(image2, image3, image1))
+    } returns listOf(image2, image3, image1)
 
     runBlocking {
       val image = subject.getLatestImage("my-package", "my-package-0.0.1_rc.98-h99", "test")
@@ -121,7 +120,7 @@ object ImageServiceTest {
   fun `get latest named image returns actual latest image`() {
     coEvery {
       cloudDriver.namedImages("my-package", "test")
-    } returns CompletableDeferred(listOf(image2, image3, image1))
+    } returns listOf(image2, image3, image1)
 
     runBlocking {
       val image = subject.getLatestNamedImage("my-package", "test")
@@ -134,7 +133,7 @@ object ImageServiceTest {
   fun `no image provided if image not found for latest from artifact`() {
     coEvery {
       cloudDriver.namedImages("my-package", "test")
-    } returns CompletableDeferred(emptyList())
+    } returns emptyList()
 
     runBlocking {
       val image = subject.getLatestNamedImage("my-package", "test")
@@ -146,7 +145,7 @@ object ImageServiceTest {
   fun `get named image from jenkins info works`() {
     coEvery {
       cloudDriver.namedImages("my-package", "test")
-    } returns CompletableDeferred(listOf(image2, image3, image1))
+    } returns listOf(image2, image3, image1)
 
     runBlocking {
       val image = subject.getNamedImageFromJenkinsInfo(

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
@@ -4,9 +4,8 @@ import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
-import io.mockk.every
+import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.CompletableDeferred
 import org.junit.jupiter.api.Test
 import strikt.api.catching
 import strikt.api.expectThat
@@ -49,12 +48,12 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `security groups are looked up from CloudDriver when accessed by id`() {
-    every {
+    coEvery {
       cloudDriver.getSecurityGroupSummaries("prod", "aws", "us-east-1")
-    } returns CompletableDeferred(securityGroupSummaries)
-    every {
+    } returns securityGroupSummaries
+    coEvery {
       cloudDriver.getCredential("prod")
-    } returns CompletableDeferred(Credential("prod", "aws"))
+    } returns Credential("prod", "aws")
 
     subject.securityGroupById("prod", "us-east-1", "sg-2").let { securityGroupSummary ->
       expectThat(securityGroupSummary) {
@@ -66,12 +65,12 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `security groups are looked up from CloudDriver when accessed by name`() {
-    every {
+    coEvery {
       cloudDriver.getSecurityGroupSummaries("prod", "aws", "us-east-1")
-    } returns CompletableDeferred(securityGroupSummaries)
-    every {
+    } returns securityGroupSummaries
+    coEvery {
       cloudDriver.getCredential("prod")
-    } returns CompletableDeferred(Credential("prod", "aws"))
+    } returns Credential("prod", "aws")
 
     subject.securityGroupByName("prod", "us-east-1", "bar").let { securityGroupSummary ->
       expectThat(securityGroupSummary) {
@@ -83,9 +82,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `an invalid security group id throws an exception`() {
-    every {
+    coEvery {
       cloudDriver.getSecurityGroupSummaries("prod", "aws", "us-east-1")
-    } returns CompletableDeferred(securityGroupSummaries)
+    } returns securityGroupSummaries
 
     expectThat(catching {
       subject.securityGroupById("prod", "us-east-1", "sg-4")
@@ -95,9 +94,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `VPC networks are looked up by id from CloudDriver`() {
-    every {
+    coEvery {
       cloudDriver.listNetworks()
-    } returns CompletableDeferred(mapOf("aws" to vpcs))
+    } returns mapOf("aws" to vpcs)
 
     subject.networkBy("vpc-2").let { vpc ->
       expectThat(vpc) {
@@ -110,9 +109,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `an invalid VPC id throws an exception`() {
-    every {
+    coEvery {
       cloudDriver.listNetworks()
-    } returns CompletableDeferred(mapOf("aws" to vpcs))
+    } returns mapOf("aws" to vpcs)
 
     expectThat(catching { subject.networkBy("vpc-5") })
       .throws<ResourceNotFound>()
@@ -120,9 +119,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `VPC networks are looked up by name and region from CloudDriver`() {
-    every {
+    coEvery {
       cloudDriver.listNetworks()
-    } returns CompletableDeferred(mapOf("aws" to vpcs))
+    } returns mapOf("aws" to vpcs)
 
     subject.networkBy("vpcName", "test", "us-west-2").let { vpc ->
       expectThat(vpc.id).isEqualTo("vpc-2")
@@ -131,9 +130,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `an invalid VPC name and region throws an exception`() {
-    every {
+    coEvery {
       cloudDriver.listNetworks()
-    } returns CompletableDeferred(mapOf("aws" to vpcs))
+    } returns mapOf("aws" to vpcs)
 
     expectThat(catching {
       subject.networkBy("invalid", "prod", "us-west-2")
@@ -143,9 +142,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `availability zones are looked up by account, VPC id and region from CloudDriver`() {
-    every {
+    coEvery {
       cloudDriver.listSubnets("aws")
-    } returns CompletableDeferred(subnets)
+    } returns subnets
 
     subject.availabilityZonesBy("test", "vpc-2", "us-west-2").let { zones ->
       expectThat(zones)
@@ -155,9 +154,9 @@ object MemoryCloudDriverCacheTest {
 
   @Test
   fun `an invalid account, VPC id and region returns an empty set`() {
-    every {
+    coEvery {
       cloudDriver.listNetworks()
-    } returns CompletableDeferred(mapOf("aws" to vpcs))
+    } returns mapOf("aws" to vpcs)
 
     expectThat(
       subject.availabilityZonesBy("test", "vpc-2", "ew-west-1")

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroupTest.kt
@@ -3,15 +3,13 @@ package com.netflix.spinnaker.keel.clouddriver.model
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.retrofit.model.ModelParsingTestSupport
-import kotlinx.coroutines.Deferred
 
 object ClusterActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, ClusterActiveServerGroup>(CloudDriverService::class.java) {
 
   override val json = javaClass.getResource("/cluster.json")
 
-  override val call: CloudDriverService.() -> Deferred<ClusterActiveServerGroup?> = {
-    activeServerGroup("keel", "mgmttest", "keel-test", "eu-west-1", "aws")
-  }
+  override suspend fun CloudDriverService.call(): ClusterActiveServerGroup? =
+    this.activeServerGroup("keel", "mgmttest", "keel-test", "eu-west-1", "aws")
 
   override val expected = ClusterActiveServerGroup(
     name = "fletch_test-v000",

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroupTest.kt
@@ -3,14 +3,12 @@ package com.netflix.spinnaker.keel.clouddriver.model
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.retrofit.model.ModelParsingTestSupport
-import kotlinx.coroutines.Deferred
 
 object SecurityGroupTest : ModelParsingTestSupport<CloudDriverService, SecurityGroup>(CloudDriverService::class.java) {
   override val json = javaClass.getResource("/vpc-sg.json")
 
-  override val call: CloudDriverService.() -> Deferred<SecurityGroup?> = {
+  override suspend fun CloudDriverService.call(): SecurityGroup? =
     getSecurityGroup("account", "type", "name", "region")
-  }
 
   override val expected = SecurityGroup(
     type = "aws",

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -74,7 +74,6 @@ class ClassicLoadBalancerHandler(
               OrchestrationTrigger(resource.metadata.name.toString())
             )
           )
-          .await()
       }
 
     log.info("Started task ${taskRef.ref} to create classicLoadBalancer ${resource.spec.moniker.name} in " +
@@ -95,7 +94,6 @@ class ClassicLoadBalancerHandler(
               OrchestrationTrigger(resource.metadata.name.toString())
             )
           )
-          .await()
       }
 
     log.info("Started task ${taskRef.ref} to delete classicLoadBalancer ${resource.spec.moniker.name} in " +
@@ -103,7 +101,7 @@ class ClassicLoadBalancerHandler(
   }
 
   override suspend fun actuationInProgress(name: ResourceName) =
-    orcaService.getCorrelatedExecutions(name.value).await().isNotEmpty()
+    orcaService.getCorrelatedExecutions(name.value).isNotEmpty()
 
   private fun CloudDriverService.getClassicLoadBalancer(spec: ClassicLoadBalancer): ClassicLoadBalancer? =
     runBlocking {
@@ -114,7 +112,6 @@ class ClassicLoadBalancerHandler(
           spec.location.region,
           spec.moniker.name
         )
-          .await()
           .firstOrNull()
           ?.let { lb ->
             val securityGroupNames = lb.securityGroups.map {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -151,7 +151,6 @@ class ClusterHandler(
         listOf(Job(job["type"].toString(), job)),
         OrchestrationTrigger(resource.metadata.name.toString())
       ))
-      .await()
       .also { log.info("Started task {} to upsert cluster", it.ref) }
       // TODO: ugleee
       .let { listOf(TaskRef(it.ref)) }
@@ -160,7 +159,6 @@ class ClusterHandler(
   override suspend fun actuationInProgress(name: ResourceName) =
     orcaService
       .getCorrelatedExecutions(name.value)
-      .await()
       .isNotEmpty()
 
   /**
@@ -285,7 +283,6 @@ class ClusterHandler(
         spec.location.region,
         CLOUD_PROVIDER
       )
-        .await()
     } catch (e: HttpException) {
       if (e.isNotFound) {
         null
@@ -303,7 +300,6 @@ class ClusterHandler(
         spec.location.region,
         CLOUD_PROVIDER
       )
-        .await()
         .run {
           Cluster(
             moniker = Moniker(app = moniker.app, stack = moniker.stack, detail = moniker.detail),

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/NamedImageHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/NamedImageHandler.kt
@@ -44,7 +44,7 @@ class NamedImageHandler(
     )
 
   private suspend fun NamedImage.currentState(): ImageResult? =
-    cloudDriverService.namedImages(name, account).await().sortedByDescending {
+    cloudDriverService.namedImages(name, account).sortedByDescending {
       it.attributes["creationDate"]?.toString() ?: "0000-00-00T00:00:00.000Z"
     }.firstOrNull()?.let {
       objectMapper.convertValue<ImageResult>(it)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -81,7 +81,6 @@ class SecurityGroupHandler(
           listOf(spec.toCreateJob()),
           OrchestrationTrigger(resource.metadata.name.toString())
         ))
-        .await()
     }
     log.info("Started task {} to create security group", taskRef.ref)
     return listOf(TaskRef(taskRef.ref))
@@ -100,7 +99,6 @@ class SecurityGroupHandler(
           listOf(spec.toUpdateJob()),
           OrchestrationTrigger(resource.metadata.name.toString())
         ))
-        .await()
     }
     log.info("Started task {} to update security group", taskRef.ref)
     return listOf(TaskRef(taskRef.ref))
@@ -116,7 +114,6 @@ class SecurityGroupHandler(
           listOf(spec.toDeleteJob()),
           OrchestrationTrigger(resource.metadata.name.toString())
         ))
-        .await()
     }
     log.info("Started task {} to upsert security group", taskRef.ref)
   }
@@ -124,7 +121,6 @@ class SecurityGroupHandler(
   override suspend fun actuationInProgress(name: ResourceName) =
     orcaService
       .getCorrelatedExecutions(name.value)
-      .await()
       .isNotEmpty()
 
   private suspend fun CloudDriverService.getSecurityGroup(spec: SecurityGroup): SecurityGroup? =
@@ -136,7 +132,6 @@ class SecurityGroupHandler(
         spec.region,
         spec.vpcName?.let { cloudDriverCache.networkBy(it, spec.accountName, spec.region).id }
       )
-        .await()
         .let { response ->
           SecurityGroup(
             Moniker(app = response.moniker.app, stack = response.moniker.stack, detail = response.moniker.detail),

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerModelHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerModelHandlerTests.kt
@@ -26,12 +26,12 @@ import de.danielbechler.diff.ObjectDifferBuilder
 import de.danielbechler.diff.node.DiffNode
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.get
@@ -148,8 +148,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpc.account, vpc.region, sg3.name) } returns sg3
       }
 
-      every { orcaService.orchestrate(any()) } returns
-        CompletableDeferred(TaskRefResponse("/tasks/${UUID.randomUUID()}"))
+      coEvery { orcaService.orchestrate(any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
     }
 
     after {
@@ -158,8 +157,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
 
     context("the CLB does not exist") {
       before {
-        every { cloudDriverService.getClassicLoadBalancer(any(), any(), any(), any()) } returns
-          CompletableDeferred(emptyList())
+        coEvery { cloudDriverService.getClassicLoadBalancer(any(), any(), any(), any()) } returns emptyList()
       }
 
       test("the current model is null") {
@@ -177,7 +175,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
         }
 
         val slot = slot<OrchestrationRequest>()
-        verify { orcaService.orchestrate(capture(slot)) }
+        coVerify { orcaService.orchestrate(capture(slot)) }
 
         expectThat(slot.captured.job.first()) {
           get("type").isEqualTo("upsertLoadBalancer")
@@ -196,7 +194,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
         }
 
         val slot = slot<OrchestrationRequest>()
-        verify { orcaService.orchestrate(capture(slot)) }
+        coVerify { orcaService.orchestrate(capture(slot)) }
 
         expectThat(slot.captured.job.first()) {
           get("securityGroups").isEqualTo(setOf("nondefault-elb"))
@@ -206,8 +204,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
 
     context("deployed CLB with a default security group") {
       before {
-        every { cloudDriverService.getClassicLoadBalancer(any(), any(), any(), any()) } returns
-          CompletableDeferred(listOf(model))
+        coEvery { cloudDriverService.getClassicLoadBalancer(any(), any(), any(), any()) } returns listOf(model)
       }
 
       test("computed diff removes the default security group if the spec only specifies another") {
@@ -229,7 +226,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
         }
 
         val slot = slot<OrchestrationRequest>()
-        verify { orcaService.orchestrate(capture(slot)) }
+        coVerify { orcaService.orchestrate(capture(slot)) }
       }
     }
   }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -46,12 +46,12 @@ import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import strikt.api.Assertion
 import strikt.api.expectThat
@@ -227,8 +227,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
       .forEach { (methodName, handlerMethod) ->
         context("$methodName a security group with no ingress rules") {
           before {
-            every { orcaService.orchestrate(any()) } answers {
-              CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
+            coEvery { orcaService.orchestrate(any()) } answers {
+              TaskRefResponse("/tasks/${randomUUID()}")
             }
 
             runBlocking {
@@ -242,7 +242,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
           test("it upserts the security group via Orca") {
             val slot = slot<OrchestrationRequest>()
-            verify { orcaService.orchestrate(capture(slot)) }
+            coVerify { orcaService.orchestrate(capture(slot)) }
             expectThat(slot.captured) {
               application.isEqualTo(securityGroup.moniker.app)
               job
@@ -277,8 +277,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
               every { cloudDriverCache.networkBy(it.name, it.account, it.region) } returns it
             }
 
-            every { orcaService.orchestrate(any()) } answers {
-              CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
+            coEvery { orcaService.orchestrate(any()) } answers {
+              TaskRefResponse("/tasks/${randomUUID()}")
             }
 
             runBlocking {
@@ -292,7 +292,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
           test("it upserts the security group via Orca") {
             val slot = slot<OrchestrationRequest>()
-            verify { orcaService.orchestrate(capture(slot)) }
+            coVerify { orcaService.orchestrate(capture(slot)) }
             expectThat(slot.captured) {
               application.isEqualTo(securityGroup.moniker.app)
               job.hasSize(1)
@@ -327,8 +327,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           }
 
           before {
-            every { orcaService.orchestrate(any()) } answers {
-              CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
+            coEvery { orcaService.orchestrate(any()) } answers {
+              TaskRefResponse("/tasks/${randomUUID()}")
             }
 
             runBlocking {
@@ -342,7 +342,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
           test("it upserts the security group via Orca") {
             val slot = slot<OrchestrationRequest>()
-            verify { orcaService.orchestrate(capture(slot)) }
+            coVerify { orcaService.orchestrate(capture(slot)) }
             expectThat(slot.captured) {
               application.isEqualTo(securityGroup.moniker.app)
               job.hasSize(1)
@@ -377,8 +377,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
       }
 
       before {
-        every { orcaService.orchestrate(any()) } answers {
-          CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
+        coEvery { orcaService.orchestrate(any()) } answers {
+          TaskRefResponse("/tasks/${randomUUID()}")
         }
 
         runBlocking {
@@ -392,7 +392,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
       test("it does not try to create the self-referencing rule") {
         val slot = slot<OrchestrationRequest>()
-        verify { orcaService.orchestrate(capture(slot)) }
+        coVerify { orcaService.orchestrate(capture(slot)) }
         expectThat(slot.captured) {
           application.isEqualTo(securityGroup.moniker.app)
           job.hasSize(1)
@@ -417,8 +417,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
       }
 
       before {
-        every { orcaService.orchestrate(any()) } answers {
-          CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
+        coEvery { orcaService.orchestrate(any()) } answers {
+          TaskRefResponse("/tasks/${randomUUID()}")
         }
 
         runBlocking {
@@ -432,7 +432,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
       test("it includes self-referencing rule in the Orca task") {
         val slot = slot<OrchestrationRequest>()
-        verify { orcaService.orchestrate(capture(slot)) }
+        coVerify { orcaService.orchestrate(capture(slot)) }
         expectThat(slot.captured) {
           application.isEqualTo(securityGroup.moniker.app)
           job.hasSize(1)
@@ -448,8 +448,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
     context("deleting a security group") {
       before {
-        every { orcaService.orchestrate(any()) } answers {
-          CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
+        coEvery { orcaService.orchestrate(any()) } answers {
+          TaskRefResponse("/tasks/${randomUUID()}")
         }
 
         runBlocking {
@@ -463,7 +463,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
       test("it deletes the security group via Orca") {
         val slot = slot<OrchestrationRequest>()
-        verify { orcaService.orchestrate(capture(slot)) }
+        coVerify { orcaService.orchestrate(capture(slot)) }
         expectThat(slot.captured) {
           application.isEqualTo(securityGroup.moniker.app)
           job
@@ -478,15 +478,15 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
   private fun CurrentFixture.cloudDriverSecurityGroupReturns() {
     with(cloudDriverResponse) {
-      every {
+      coEvery {
         cloudDriverService.getSecurityGroup(accountName, CLOUD_PROVIDER, name, region, vpcId)
-      } returns CompletableDeferred(this)
+      } returns this
     }
   }
 
   private fun CurrentFixture.cloudDriverSecurityGroupNotFound() {
     with(cloudDriverResponse) {
-      every {
+      coEvery {
         cloudDriverService.getSecurityGroup(accountName, CLOUD_PROVIDER, name, region, vpcId)
       } throws RETROFIT_NOT_FOUND
     }

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Config.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Config.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.front50.Front50Service
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -30,7 +29,6 @@ class Front50Config {
   ): Front50Service =
     Retrofit.Builder()
       .addConverterFactory(JacksonConverterFactory.create(objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES)))
-      .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .baseUrl(front50Endpoint)
       .client(retrofitClient)
       .build()

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.front50
 
 import com.netflix.spinnaker.keel.front50.model.Delivery
-import kotlinx.coroutines.Deferred
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -12,14 +11,14 @@ import retrofit2.http.Path
 interface Front50Service {
 
   @GET("/deliveries/{id}")
-  fun deliveryById(@Path("id") id: String): Deferred<Delivery>
+  suspend fun deliveryById(@Path("id") id: String): Delivery
 
   @POST("/deliveries")
-  fun createDelivery(@Body delivery: Delivery): Deferred<Delivery>
+  suspend fun createDelivery(@Body delivery: Delivery): Delivery
 
   @PUT("/deliveries/{id}")
-  fun upsertDelivery(@Path("id") id: String, @Body delivery: Delivery): Deferred<Delivery>
+  suspend fun upsertDelivery(@Path("id") id: String, @Body delivery: Delivery): Delivery
 
   @DELETE("/applications/{application}/deliveries/{id}")
-  fun deleteDelivery(@Path("application") application: String, @Path("id") id: String): Deferred<Unit>
+  suspend fun deleteDelivery(@Path("application") application: String, @Path("id") id: String)
 }

--- a/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/model/DeliveryTest.kt
+++ b/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/model/DeliveryTest.kt
@@ -2,15 +2,13 @@ package com.netflix.spinnaker.keel.front50.model
 
 import com.netflix.spinnaker.keel.front50.Front50Service
 import com.netflix.spinnaker.keel.retrofit.model.ModelParsingTestSupport
-import kotlinx.coroutines.Deferred
 
 object DeliveryTest : ModelParsingTestSupport<Front50Service, Delivery>(Front50Service::class.java) {
 
   override val json = javaClass.getResource("/delivery.json")
 
-  override val call: Front50Service.() -> Deferred<Delivery?> = {
+  override suspend fun Front50Service.call(): Delivery? =
     deliveryById("foo")
-  }
 
   override val expected = Delivery(
     id = "foo",

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.igor.ArtifactService
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -29,7 +28,6 @@ class IgorConfiguration {
   ): ArtifactService =
     Retrofit.Builder()
       .addConverterFactory(JacksonConverterFactory.create(objectMapper))
-      .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .baseUrl(igorEndpoint)
       .client(retrofitClient)
       .build()

--- a/keel-mahe/src/main/kotlin/com/netflix/spinnaker/config/MaheConfiguration.kt
+++ b/keel-mahe/src/main/kotlin/com/netflix/spinnaker/config/MaheConfiguration.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.mahe.DynamicPropertyService
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -29,7 +28,6 @@ class MaheConfiguration {
   ): DynamicPropertyService =
     Retrofit.Builder()
       .addConverterFactory(JacksonConverterFactory.create(objectMapper))
-      .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .baseUrl(maheEndpoint)
       .client(retrofitClient)
       .build()

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
@@ -17,7 +17,6 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.orca.OrcaService
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
@@ -48,7 +47,6 @@ class OrcaConfiguration {
       .baseUrl(orcaEndpoint)
       .client(retrofitClient)
       .addConverterFactory(JacksonConverterFactory.create(objectMapper.disable(FAIL_ON_UNKNOWN_PROPERTIES)))
-      .addCallAdapterFactory(CoroutineCallAdapterFactory())
       .build()
       .create(OrcaService::class.java)
 }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -16,7 +16,6 @@
 package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
-import kotlinx.coroutines.Deferred
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
@@ -30,13 +29,13 @@ interface OrcaService {
 
   @POST("/ops")
   @Headers("Content-Type: application/context+json")
-  fun orchestrate(@Body request: OrchestrationRequest): Deferred<TaskRefResponse>
+  suspend fun orchestrate(@Body request: OrchestrationRequest): TaskRefResponse
 
   @GET("/tasks/{id}")
-  fun getTask(@Path("id") id: String): Deferred<TaskDetailResponse>
+  suspend fun getTask(@Path("id") id: String): TaskDetailResponse
 
   @GET("/executions/correlated/{correlationId}")
-  fun getCorrelatedExecutions(@Path("correlationId") correlationId: String): Deferred<List<String>>
+  suspend fun getCorrelatedExecutions(@Path("correlationId") correlationId: String): List<String>
 }
 
 data class TaskRefResponse(

--- a/keel-retrofit/keel-retrofit.gradle.kts
+++ b/keel-retrofit/keel-retrofit.gradle.kts
@@ -21,10 +21,9 @@ plugins {
 dependencies {
   api("com.squareup.retrofit2:retrofit")
   api("com.squareup.retrofit2:converter-jackson")
-  api("com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2")
+  api("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 
   implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("com.netflix.spinnaker.kork:kork-security")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("com.squareup.okhttp3:logging-interceptor")
 }


### PR DESCRIPTION
The new coroutine support in Retrofit differs a bit from the call adapter we've been using. Instead of returning `Deferred<*>` the interface methods are just defined as `suspend`.