### PR TITLE
2-phase create for security groups with self-ref ingress

### DIFF
--- a/keel-ec2-plugin/keel-ec2-plugin.gradle
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle
@@ -12,4 +12,5 @@ dependencies {
   testImplementation "io.strikt:strikt-core:$striktVersion"
   testImplementation "dev.minutest:minutest:$minutestVersion"
   testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
+  testImplementation "org.funktionale:funktionale-partials:1.2"
 }


### PR DESCRIPTION
You can't include a self-referential ingress rule when creating a new security group as the referenced group must exist already. Instead I'm now filtering them out on create which means a delta will be detected later and the ingress added.

Fixes #235 