### PR TITLE
fix(dependencies): transitive dependency cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ subprojects {
   dependencies {
     implementation platform("org.springframework.boot:spring-boot-dependencies:$bootVersion")
     testImplementation platform("org.junit:junit-bom:${spinnaker.version('jupiter')}")
+    implementation "org.slf4j:slf4j-api"
   }
 
   configurations.all {

--- a/keel-clouddriver/keel-clouddriver.gradle
+++ b/keel-clouddriver/keel-clouddriver.gradle
@@ -7,8 +7,11 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
-  implementation "com.github.jonpeterson:jackson-module-model-versioning:1.2.2"
+  implementation "com.github.ben-manes.caffeine:caffeine"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+  implementation "org.springframework:spring-context"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation project(":keel-retrofit-test-support")
   testImplementation "com.squareup.retrofit2:retrofit-mock:${spinnaker.version('retrofit2')}"

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -32,13 +32,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 
 @Configuration
 @ConditionalOnProperty("clouddriver.enabled")
-@Import(RetrofitConfiguration::class)
 class ClouddriverConfiguration {
 
   @Bean

--- a/keel-deliveryconfig-plugin/keel-deliveryconfig-plugin.gradle
+++ b/keel-deliveryconfig-plugin/keel-deliveryconfig-plugin.gradle
@@ -7,6 +7,9 @@ dependencies {
   implementation project(":keel-plugin")
   implementation project(":keel-front50")
 
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+  implementation "org.springframework:spring-context"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
   testImplementation "io.strikt:strikt-core:$striktVersion"
   testImplementation "dev.minutest:minutest:$minutestVersion"
 }

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle
@@ -7,7 +7,9 @@ dependencies {
   implementation project(":keel-plugin")
   implementation project(":keel-clouddriver")
   implementation project(":keel-orca")
-  implementation "com.netflix.spinnaker.kork:kork-core:${spinnaker.version('kork')}"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+  implementation "org.springframework:spring-context"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation "io.strikt:strikt-core:$striktVersion"
   testImplementation "dev.minutest:minutest:$minutestVersion"

--- a/keel-front50/keel-front50.gradle
+++ b/keel-front50/keel-front50.gradle
@@ -7,8 +7,10 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "com.fasterxml.jackson.module:jackson-module-kotlin"
-  implementation "com.github.jonpeterson:jackson-module-model-versioning:1.2.2"
   implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+  implementation "org.springframework:spring-context"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   testImplementation project(":keel-retrofit-test-support")
   testImplementation "com.squareup.retrofit2:retrofit-mock:${spinnaker.version('retrofit2')}"

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Config.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/config/Front50Config.kt
@@ -11,13 +11,11 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 
 @Configuration
 @ConditionalOnProperty("front50.enabled")
-@Import(RetrofitConfiguration::class)
 class Front50Config {
   @Bean
   fun front50Endpoint(@Value("\${front50.baseUrl}") front50BaseUrl: String): HttpUrl =

--- a/keel-orca/keel-orca.gradle
+++ b/keel-orca/keel-orca.gradle
@@ -23,8 +23,10 @@ dependencies {
   implementation "com.fasterxml.jackson.core:jackson-databind"
   implementation "com.fasterxml.jackson.core:jackson-annotations"
   implementation "org.jetbrains.kotlin:kotlin-reflect"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
+  implementation "org.springframework:spring-context"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
 
   api "com.fasterxml.jackson.module:jackson-module-kotlin"
-  api "com.github.jonpeterson:jackson-module-model-versioning:1.2.2"
   api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/config/OrcaConfiguration.kt
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PRO
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.retrofit.KeelRetrofitConfiguration
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import org.springframework.beans.factory.annotation.Value
@@ -27,13 +26,11 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Import
 import retrofit2.Retrofit
 import retrofit2.converter.jackson.JacksonConverterFactory
 
 @Configuration
 @ConditionalOnProperty("orca.enabled")
-@Import(KeelRetrofitConfiguration::class)
 @ComponentScan("com.netflix.spinnaker.keel.orca")
 class OrcaConfiguration {
 

--- a/keel-plugin/keel-plugin.gradle
+++ b/keel-plugin/keel-plugin.gradle
@@ -5,8 +5,9 @@ apply from: "$rootDir/gradle/junit5.gradle"
 dependencies {
   api project(":keel-core")
   api "de.danielbechler:java-object-diff:0.95"
-  
-  implementation "com.netflix.spinnaker.kork:kork-core:${spinnaker.version('kork')}"
+
+  implementation "org.springframework:spring-context"
+  implementation "org.springframework.boot:spring-boot-autoconfigure"
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
 
   testImplementation "org.springframework.boot:spring-boot-starter-web"

--- a/keel-retrofit-test-support/keel-retrofit-test-support.gradle
+++ b/keel-retrofit-test-support/keel-retrofit-test-support.gradle
@@ -6,7 +6,6 @@ dependencies {
   api "com.fasterxml.jackson.core:jackson-databind"
   api "com.fasterxml.jackson.core:jackson-annotations"
   api "com.fasterxml.jackson.module:jackson-module-kotlin"
-  api "com.github.jonpeterson:jackson-module-model-versioning:1.2.2"
   api "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
   api project(":keel-core-test")
   implementation platform("org.junit:junit-bom:${spinnaker.version('jupiter')}")

--- a/keel-retrofit-test-support/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/model/ModelParsingTestSupport.kt
+++ b/keel-retrofit-test-support/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/model/ModelParsingTestSupport.kt
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.github.jonpeterson.jackson.module.versioning.VersioningModule
 import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
@@ -27,7 +26,6 @@ abstract class ModelParsingTestSupport<in S, out E>(serviceType: Class<S>) {
 
   private val mapper = ObjectMapper()
     .registerModule(KotlinModule())
-    .registerModule(VersioningModule())
     .registerModule(JavaTimeModule())
     .enable(INDENT_OUTPUT)
     .disable(FAIL_ON_UNKNOWN_PROPERTIES)

--- a/keel-retrofit/keel-retrofit.gradle
+++ b/keel-retrofit/keel-retrofit.gradle
@@ -19,9 +19,9 @@ apply plugin: "kotlin-spring"
 dependencies {
   api "com.squareup.retrofit2:retrofit:${spinnaker.version('retrofit2')}"
   api "com.squareup.retrofit2:converter-jackson:${spinnaker.version('retrofit2')}"
-  api("com.netflix.spinnaker.kork:kork-web:${spinnaker.version('kork')}")
   api "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:0.9.2"
-  api "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
 
+  implementation "com.netflix.spinnaker.kork:kork-web:${spinnaker.version('kork')}"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
   implementation "com.squareup.okhttp3:logging-interceptor:${spinnaker.version('okHttp3')}"
 }


### PR DESCRIPTION
We were picking up our spring-context/spring-boot-autoconfigure via keel-retrofit exporting
kork-web as an api level dependency. Moved some of keel-retrofit's dependencies to
implementation scope and added explicit dependencies where needed.

Switched use of Guava CacheBuilder to Caffeine CacheBuilder in ClouddriverInMemoryCache.
