### PR TITLE
feat(deliveryConfig): actuating on dynamic image

### DIFF
--- a/keel-api/keel-api.gradle
+++ b/keel-api/keel-api.gradle
@@ -8,7 +8,6 @@ dependencies {
   api project(":keel-plugin")
   api project(":keel-eureka")
 
-  implementation project(":keel-eureka")
   implementation project(":keel-ec2-plugin")
   implementation project(":keel-deliveryconfig-plugin")
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel.clouddriver
 import com.netflix.spinnaker.keel.clouddriver.model.ClusterActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.LoadBalancer
+import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroup
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
@@ -77,4 +78,10 @@ interface CloudDriverService {
     @Path("region") region: String,
     @Path("cloudProvider") cloudProvider: String
   ): Deferred<ClusterActiveServerGroup>
+
+  @GET("/aws/images/find")
+  fun namedImages(
+    @Query("q") imageName: String,
+    @Query("account") account: String?,
+    @Query("region") region: String? = null): Deferred<List<NamedImage>>
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
@@ -19,7 +19,7 @@ data class ClusterActiveServerGroup(
 data class LaunchConfig(
   val ramdiskId: String?,
   val ebsOptimized: Boolean,
-  val imageId: String,
+  val imageId: String?,
   val instanceType: String,
   val keyName: String,
   val iamInstanceProfile: String,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Credential.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Credential.kt
@@ -15,7 +15,18 @@
  */
 package com.netflix.spinnaker.keel.clouddriver.model
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonCreator
+
 data class Credential(
   val name: String,
-  val type: String
-)
+  val type: String,
+  @get:JsonAnyGetter val attributes: Map<String, Any?> = emptyMap()
+) {
+  @JsonCreator
+  constructor(data: Map<String, Any?>) : this(
+    name = data.getValue("name") as String,
+    type = data.getValue("type") as String,
+    attributes = data - "name" - "type"
+  )
+}

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+data class NamedImage(
+  val imageName: String,
+  val attributes: Map<String, Any?>,
+  val tagsByImageId: Map<String, Map<String, String?>?>,
+  val accounts: Set<String>,
+  val amis: Map<String, List<String>?>)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -91,7 +91,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         metadata = ResourceMetadata(
           name = ResourceName("SecurityGroup:ec2:test:us-west-2:fnord"),
           resourceVersion = 1234L,
-          uid = randomUID()
+          uid = randomUID(),
+          data = randomData()
         ),
         kind = "ec2:SecurityGroup",
         spec = randomData()
@@ -130,7 +131,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
           metadata = ResourceMetadata(
             name = ResourceName("SecurityGroup:ec2:test:us-east-1:fnord"),
             resourceVersion = 1234L,
-            uid = randomUID()
+            uid = randomUID(),
+            data = randomData()
           ),
           apiVersion = SPINNAKER_API_V1,
           kind = "ec2:SecurityGroup",

--- a/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/config/DeliveryConfigConfig.kt
+++ b/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/config/DeliveryConfigConfig.kt
@@ -1,9 +1,11 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.annealing.ResourcePersister
 import com.netflix.spinnaker.keel.deliveryconfig.resource.DeliveryConfigHandler
-import com.netflix.spinnaker.keel.front50.Front50Service
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import org.springframework.beans.factory.ObjectFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -15,12 +17,13 @@ class DeliveryConfigConfig {
 
   @Bean
   fun deliveryConfigHandler(
-    front50Service: Front50Service,
     objectMapper: ObjectMapper,
-    normalizers: List<ResourceNormalizer<*>>
+    normalizers: List<ResourceNormalizer<*>>,
+    resourceRepository: ObjectFactory<ResourceRepository>,
+    resourcePersister: ObjectFactory<ResourcePersister>
   ) = DeliveryConfigHandler(
-      front50Service,
       objectMapper,
-      normalizers
-  )
+      normalizers,
+      resourcePersister,
+      resourceRepository)
 }

--- a/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/deliveryconfig/DeliveryConfig.kt
+++ b/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/deliveryconfig/DeliveryConfig.kt
@@ -6,5 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 @JsonInclude(NON_NULL)
 data class DeliveryConfig(
   val name: String,
-  val application: String
+  val application: String,
+  val deliveryArtifacts: List<Map<String, Any>> = emptyList(),
+  val deliveryEnvironments: List<DeliveryEnvironment> = emptyList()
 )

--- a/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/deliveryconfig/DeliveryEnvironment.kt
+++ b/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/deliveryconfig/DeliveryEnvironment.kt
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.keel.api.deliveryconfig
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
+import com.netflix.spinnaker.keel.api.ApiVersion
+import com.netflix.spinnaker.keel.api.ResourceMetadata
+
+data class DeliveryEnvironment(
+  val name: String,
+  val packageRef: ChildResource,
+  val targets: List<ChildResource>
+)
+
+@JsonInclude(NON_NULL)
+data class ChildResource(
+  val apiVersion: ApiVersion,
+  val kind: String,
+  val spec: Map<String, Any?>,
+  val metadata: Map<String, Any?>?
+) {
+  @get:JsonIgnore
+  val resourceMetadata : ResourceMetadata?
+    get() = metadata?.let { ResourceMetadata(it) }
+}

--- a/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/keel/deliveryconfig/resource/DeliveryConfigHandler.kt
+++ b/keel-deliveryconfig-plugin/src/main/kotlin/com/netflix/spinnaker/keel/deliveryconfig/resource/DeliveryConfigHandler.kt
@@ -1,26 +1,33 @@
 package com.netflix.spinnaker.keel.deliveryconfig.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.keel.annealing.ResourcePersister
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceName
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.SubmittedResource
+import com.netflix.spinnaker.keel.api.deliveryconfig.ChildResource
 import com.netflix.spinnaker.keel.api.deliveryconfig.DeliveryConfig
-import com.netflix.spinnaker.keel.front50.Front50Service
-import com.netflix.spinnaker.keel.front50.model.Delivery
+import com.netflix.spinnaker.keel.api.deliveryconfig.DeliveryEnvironment
+import com.netflix.spinnaker.keel.events.ResourceCreated
+import com.netflix.spinnaker.keel.events.ResourceUpdated
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.get
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
-import com.netflix.spinnaker.keel.retrofit.isNotFound
-import de.danielbechler.diff.node.DiffNode
 import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import retrofit2.HttpException
+import org.springframework.beans.factory.ObjectFactory
 
 class DeliveryConfigHandler(
-  private val front50Service: Front50Service,
   override val objectMapper: ObjectMapper,
-  override val normalizers: List<ResourceNormalizer<*>>
+  override val normalizers: List<ResourceNormalizer<*>>,
+  private val resourcePersisterProvider: ObjectFactory<ResourcePersister>,
+  private val resourceRepositoryProvider: ObjectFactory<ResourceRepository>
 ) : ResourceHandler<DeliveryConfig> {
   override val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -35,39 +42,98 @@ class DeliveryConfigHandler(
     "deliveryConfig:${spec.name}"
   )
 
-  override fun current(resource: Resource<DeliveryConfig>): DeliveryConfig? =
-    runBlocking {
-      log.debug("Fetching delivery ${resource.spec.name} from front50")
-      try {
-        val delivery = front50Service.deliveryById(resource.spec.name).await()
-        log.debug("Fetched $delivery")
-        DeliveryConfig(delivery.id, delivery.application)
-      } catch (e: HttpException) {
-        if (!e.isNotFound) {
-          log.error("Fetching delivery from front50 failed", e)
-          throw e
-        }
-        null
-      }
+  private val resourcePersister: ResourcePersister by lazy { resourcePersisterProvider.getObject() }
+  private val resourceRepository: ResourceRepository by lazy { resourceRepositoryProvider.getObject() }
+
+  private val DeliveryConfig.isResolved : Boolean
+    get() = this.deliveryEnvironments.all { env ->
+      env.packageRef.resourceMetadata != null
+        && env.targets.all { it.resourceMetadata != null}
     }
 
+  override fun current(resource: Resource<DeliveryConfig>): DeliveryConfig? =
+    if (resource.spec.isResolved) {
+      runBlocking {
+        val cfg = resource.spec.copy(
+          deliveryEnvironments = resource.spec.deliveryEnvironments.map { it.refreshFromRepository() })
+        cfg
+      }
+    } else {
+      null
+    }
 
   override fun delete(resource: Resource<DeliveryConfig>) {
+    TODO("Not implemented")
+  }
+
+  override fun upsert(resource: Resource<DeliveryConfig>, resourceDiff: ResourceDiff<DeliveryConfig>?) {
     runBlocking {
-      log.debug("deleting delivery ${resource.spec.name} in application ${resource.spec.application}")
-      front50Service.deleteDelivery(resource.spec.application, resource.spec.name).await()
-      log.debug("deleted delivery ${resource.spec.name} in application ${resource.spec.application}")
+      resourceRepository.store(resource.copy(spec = resource.spec.copy(
+        deliveryEnvironments = resource.spec.deliveryEnvironments.map { env ->
+          env.packageRef.getOrCreateResource().let { pkg ->
+            env.copy(
+              packageRef = pkg,
+              targets = env.targets.map { t ->
+                t.getOrCreateResource().updateMetadata(mapOf("packageResource" to pkg))
+              }
+            )
+          }
+        }
+      )))
     }
   }
 
-  override fun upsert(resource: Resource<DeliveryConfig>, diff: DiffNode?) {
-    runBlocking {
-      log.debug("Upserting deliveryconfig $resource")
-      val delivery = front50Service
-        .upsertDelivery(resource.spec.name, Delivery(id = resource.spec.name, application = resource.spec.application))
-        .await()
-      log.debug("Upserted delivery $delivery")
+  private fun DeliveryEnvironment.refreshFromRepository() =
+    this.copy(
+      packageRef = this.packageRef.refreshFromRepository(),
+      targets = this.targets.map { t -> t.refreshFromRepository() }
+    )
+
+  private fun ChildResource.refreshFromRepository() =
+    this.resourceMetadata?.let { meta ->
+      resourceRepository.get<Map<String, Any?>>(meta.name).let { res ->
+        this.copy(
+          metadata = objectMapper.convertValue(res.metadata),
+          spec = res.spec)
+      }
+    } ?: this
+
+  private fun ChildResource.getOrCreateResource(): ChildResource =
+    when (val resourceName = this.resourceMetadata?.name) {
+      null -> this.createNew()
+      else -> resourceName.getExisting()
     }
-  }
+
+  private fun ChildResource.createNew() =
+    resourcePersister
+      .handle(ResourceCreated(this.asSubmittedResource()))
+      .asBaseSubResource()
+
+
+  private fun ResourceName.getExisting() =
+    resourceRepository
+      .get<Any>(this)
+      .asBaseSubResource()
+
+  private fun ChildResource.updateMetadata(extraMetadata: Map<String, Any?>) =
+    resourcePersister
+      .handle(ResourceUpdated(
+        objectMapper.convertValue(
+          this.copy(
+            metadata = this.metadata?.let { it + extraMetadata }
+          )))).asBaseSubResource()
+
+  private fun ChildResource.asSubmittedResource() =
+    objectMapper.convertValue<SubmittedResource<Any>>(
+      this.copy(metadata = null)
+    )
+
+  private fun Resource<*>.asBaseSubResource() =
+    ChildResource(
+      apiVersion = this.apiVersion,
+      kind = this.kind,
+      metadata = objectMapper.convertValue(this.metadata),
+      spec = objectMapper.convertValue(this.spec)
+    )
 
 }

--- a/keel-deliveryconfig-plugin/src/test/kotlin/com/netflix/spinnaker/keel/deliveryconfig/resource/DeliveryConfigHandlerTests.kt
+++ b/keel-deliveryconfig-plugin/src/test/kotlin/com/netflix/spinnaker/keel/deliveryconfig/resource/DeliveryConfigHandlerTests.kt
@@ -2,27 +2,23 @@ package com.netflix.spinnaker.keel.deliveryconfig.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.netflix.spinnaker.keel.annealing.ResourcePersister
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceMetadata
 import com.netflix.spinnaker.keel.api.ResourceName
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.deliveryconfig.DeliveryConfig
-import com.netflix.spinnaker.keel.front50.Front50Service
-import com.netflix.spinnaker.keel.front50.model.Delivery
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import de.huxhorn.sulky.ulid.ULID
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
-import kotlinx.coroutines.CompletableDeferred
 import okhttp3.MediaType
 import okhttp3.ResponseBody
+import org.springframework.beans.factory.ObjectFactory
 import retrofit2.HttpException
 import retrofit2.Response.error
-import strikt.api.expectThat
-import strikt.assertions.isNull
 
 internal class DeliveryConfigHandlerTests : JUnit5Minutests {
 
@@ -38,8 +34,10 @@ internal class DeliveryConfigHandlerTests : JUnit5Minutests {
     ),
     spec
   )
-  private val front50Service = mockk<Front50Service>()
   private val objectMapper = ObjectMapper().registerKotlinModule()
+  private val resourcePersister = mockk<ResourcePersister>()
+  private val resourceRepository = mockk<ResourceRepository>()
+
   private val RETROFIT_NOT_FOUND = HttpException(
     error<Any>(404, ResponseBody.create(MediaType.parse("application/json"), ""))
   )
@@ -48,23 +46,9 @@ internal class DeliveryConfigHandlerTests : JUnit5Minutests {
 
   fun tests() = rootContext<DeliveryConfigHandler> {
     fixture {
-      DeliveryConfigHandler(front50Service, objectMapper, normalizers)
+      DeliveryConfigHandler(objectMapper, normalizers, ObjectFactory { resourcePersister }, ObjectFactory { resourceRepository })
     }
 
-    context("the deliveryconfig does not exist") {
-      before {
-        every { front50Service.deliveryById(any()) } throws RETROFIT_NOT_FOUND
-        every { front50Service.upsertDelivery("foo", Delivery(spec.name, spec.application)) } returns CompletableDeferred(Delivery(spec.name, spec.application))
-      }
-
-      test("the current model is null") {
-        expectThat(current(resource)).isNull()
-      }
-
-      test("upserting a deliveryconfig persists to front50") {
-        upsert(resource)
-        verify { front50Service.upsertDelivery(spec.name, Delivery(spec.name, spec.application)) }
-      }
-    }
+    //TODO(cfieber) - some tests would be good
   }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -20,9 +20,12 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
+import com.netflix.spinnaker.keel.ec2.resource.NamedImageHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
+import org.springframework.beans.factory.ObjectFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -64,5 +67,19 @@ class EC2Config {
       orcaService,
       objectMapper,
       normalizers
+    )
+
+  @Bean
+  fun imageHandler(
+    cloudDriverService: CloudDriverService,
+    objectMapper: ObjectMapper,
+    normalizers: List<ResourceNormalizer<*>>,
+    resourceRepository: ObjectFactory<ResourceRepository>
+  ): NamedImageHandler =
+    NamedImageHandler(
+      cloudDriverService,
+      objectMapper,
+      normalizers,
+      resourceRepository
     )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Cluster.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Cluster.kt
@@ -40,7 +40,7 @@ data class Cluster(
   )
 
   data class LaunchConfiguration(
-    val imageId: String,
+    val imageId: String?,
     val instanceType: String,
     val ebsOptimized: Boolean,
     val iamRole: String,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/NamedImage.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/NamedImage.kt
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.keel.api.ec2
+
+
+data class NamedImage(
+  val account: String,
+  val name: String,
+  val currentImage: ImageResult?)
+
+data class ImageResult(
+  val imageName: String,
+  val attributes: Map<String, Any?>?,
+  val tagsByImageId: Map<String, Map<String, String?>?>?,
+  val accounts: Set<String>?,
+  val amis: Map<String, List<String>?>)
+
+

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -1,12 +1,24 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceName
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.ec2.*
-import com.netflix.spinnaker.keel.api.ec2.Cluster.*
+import com.netflix.spinnaker.keel.api.ec2.Capacity
+import com.netflix.spinnaker.keel.api.ec2.Cluster
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Dependencies
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Health
+import com.netflix.spinnaker.keel.api.ec2.Cluster.LaunchConfiguration
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Location
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Moniker
+import com.netflix.spinnaker.keel.api.ec2.Cluster.Scaling
+import com.netflix.spinnaker.keel.api.ec2.HealthCheckType
+import com.netflix.spinnaker.keel.api.ec2.Metric
+import com.netflix.spinnaker.keel.api.ec2.NamedImage
+import com.netflix.spinnaker.keel.api.ec2.ScalingProcess
+import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.ClusterActiveServerGroup
@@ -18,9 +30,11 @@ import com.netflix.spinnaker.keel.model.OrchestrationTrigger
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.ResourceConflict
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import de.danielbechler.diff.node.DiffNode
+import de.danielbechler.diff.path.NodePath
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -51,6 +65,10 @@ class ClusterHandler(
     "clusters"
   ) to Cluster::class.java
 
+  private val imageIdSuppliers = setOf(
+    NamedImageImageIdSupplier(objectMapper)
+  )
+
   override fun generateName(spec: Cluster) = ResourceName(
     "ec2:cluster:${spec.location.accountName}:${spec.location.region}:${spec.moniker.cluster}"
   )
@@ -60,34 +78,103 @@ class ClusterHandler(
       cloudDriverService.getCluster(resource.spec)
     }
 
-  override fun upsert(resource: Resource<Cluster>, diff: DiffNode?) {
-    val taskRef = runBlocking {
+  private fun Resource<Cluster>.imageIdFromMetadata(): String? =
+    packageResource()?.let { pkg ->
+      imageIdSuppliers.find { it.supports(pkg) }?.imageIdForCluster(pkg, this.spec)
+    }
+
+  interface ImageIdSupplier {
+    fun supports(r: Resource<*>): Boolean
+    fun imageIdForCluster(r: Resource<*>, c: Cluster): String?
+  }
+
+  class NamedImageImageIdSupplier(private val objectMapper: ObjectMapper) : ImageIdSupplier {
+    override fun supports(r: Resource<*>) =
+      r.apiVersion == SPINNAKER_API_V1.subApi("ec2") && r.kind == "namedImage"
+
+    override fun imageIdForCluster(r: Resource<*>, c: Cluster): String? =
+      objectMapper
+        .convertValue<NamedImage>(r.spec)
+        .currentImage
+        ?.amis
+        ?.get(c.location.region)
+        ?.firstOrNull()
+  }
+
+  private fun Resource<Cluster>.packageResource(): Resource<Map<String, Any?>>? =
+    this.metadata.data["packageResource"]?.let { p ->
+      objectMapper.convertValue(p)
+    }
+
+  private fun ResourceDiff<Cluster>?.shouldDeploy(imageId: String?) =
+    imageId != null
+      && (this == null
+      || !this.isImageOnly()
+      || this.source.launchConfiguration.imageId != imageId)
+
+  private suspend fun Resource<Cluster>.maybeCreateServerGroupWithDynamicImage(resourceDiff: ResourceDiff<Cluster>?): Map<String, Any?> {
+    val imageId = this.imageIdFromMetadata()
+    return if (resourceDiff.shouldDeploy(imageId)) {
+      this.spec.createServerGroupJob() + mapOf("amiName" to imageId!!)
+    } else {
+      emptyMap()
+    }
+  }
+
+  override fun upsert(resource: Resource<Cluster>, resourceDiff: ResourceDiff<Cluster>?) {
+    runBlocking {
       val spec = resource.spec
       val job = when {
-        diff.isCapacityOnly() -> spec.resizeServerGroupJob()
-        else -> spec.createServerGroupJob()
+        resourceDiff.isCapacityOnly() -> spec.resizeServerGroupJob()
+        spec.hasStaticImage -> spec.createServerGroupJob()
+        !resourceDiff.isImageOnly() -> emptyMap()
+        else -> resource.maybeCreateServerGroupWithDynamicImage(resourceDiff)
       }
 
-      log.info("Upserting cluster using task: {}", job)
+      if (job.isNotEmpty()) {
+        log.info("Upserting cluster using task: {}", job)
 
-      orcaService
-        .orchestrate(OrchestrationRequest(
-          "Upsert cluster ${spec.moniker.cluster} in ${spec.location.accountName}/${spec.location.region}",
-          spec.moniker.application,
-          "Upsert cluster ${spec.moniker.cluster} in ${spec.location.accountName}/${spec.location.region}",
-          listOf(Job(job["type"].toString(), job)),
-          OrchestrationTrigger(resource.metadata.name.toString())
-        ))
-        .await()
+        orcaService
+          .orchestrate(OrchestrationRequest(
+            "Upsert cluster ${spec.moniker.cluster} in ${spec.location.accountName}/${spec.location.region}",
+            spec.moniker.application,
+            "Upsert cluster ${spec.moniker.cluster} in ${spec.location.accountName}/${spec.location.region}",
+            listOf(Job(job["type"].toString(), job)),
+            OrchestrationTrigger(resource.metadata.name.toString())
+          ))
+          .await()
+      } else {
+        null
+      }
+    }?.also {
+      log.info("Started task {} to upsert cluster", it.ref)
     }
-    log.info("Started task {} to upsert cluster", taskRef.ref)
   }
 
   /**
    * @return `true` if the only changes in the diff are to capacity.
    */
-  private fun DiffNode?.isCapacityOnly(): Boolean =
-    this != null && affectedRootPropertyTypes.all { it == Capacity::class.java }
+  private fun ResourceDiff<Cluster>?.isCapacityOnly(): Boolean =
+    this != null && diff.affectedRootPropertyTypes.all { it == Capacity::class.java }
+
+  private fun ResourceDiff<Cluster>?.isImageOnly(): Boolean =
+    this != null && this.diff.imageChanged && this.diff.nodePaths.size == 1
+
+  private val imageIdPath = NodePath.with("launchConfiguration", "imageId")
+
+  private val DiffNode.imageChanged: Boolean
+    get() = this.nodePaths.contains(imageIdPath)
+
+  private val DiffNode.nodePaths: Set<NodePath>
+    get() {
+      val paths = mutableSetOf<NodePath>()
+      visitChildren { node, _ ->
+        if (!node.hasChildren()) {
+          paths.add(node.path)
+        }
+      }
+      return paths
+    }
 
   private val DiffNode.affectedRootPropertyTypes: List<Class<*>>
     get() {
@@ -98,6 +185,9 @@ class ClusterHandler(
       }
       return types
     }
+
+  private val Cluster.hasStaticImage: Boolean
+    get() = this.launchConfiguration.imageId != null
 
   private suspend fun Cluster.createServerGroupJob(): Map<String, Any?> =
     mutableMapOf(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/NamedImageHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/NamedImageHandler.kt
@@ -1,0 +1,69 @@
+package com.netflix.spinnaker.keel.ec2.resource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.ec2.ImageResult
+import com.netflix.spinnaker.keel.api.ec2.NamedImage
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
+import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
+import kotlinx.coroutines.runBlocking
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.ObjectFactory
+
+class NamedImageHandler(
+  private val cloudDriverService: CloudDriverService,
+  override val objectMapper: ObjectMapper,
+  override val normalizers: List<ResourceNormalizer<*>>,
+  private val resourceRepositoryProvider: ObjectFactory<ResourceRepository>
+) : ResourceHandler<NamedImage> {
+
+  private val resourceRepository: ResourceRepository by lazy { resourceRepositoryProvider.getObject() }
+  override val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
+  override val apiVersion = SPINNAKER_API_V1.subApi("ec2")
+  override val supportedKind = ResourceKind(
+    apiVersion.group,
+    "namedImage",
+    "namedImages"
+  ) to NamedImage::class.java
+
+  override fun generateName(spec: NamedImage) = ResourceName(
+    "ec2:image:${spec.account}:${spec.name}"
+  )
+
+  override fun current(resource: Resource<NamedImage>): NamedImage? =
+    resource.spec.copy(
+      currentImage = resource.spec.currentState()
+    )
+
+  private fun NamedImage.currentState(): ImageResult? =
+    runBlocking {
+      cloudDriverService.namedImages(name, account).await().sortedByDescending {
+        it.attributes["creationDate"]?.toString() ?: "0000-00-00T00:00:00.000Z"
+      }.firstOrNull()?.let {
+        objectMapper.convertValue<ImageResult>(it)
+      }
+    }
+
+
+  override fun upsert(resource: Resource<NamedImage>, resourceDiff: ResourceDiff<NamedImage>?) {
+    runBlocking {
+      resourceDiff?.also {
+        resourceRepository.store(resource.copy(
+          spec = resourceDiff.source
+        ))
+      }
+    }
+  }
+
+  override fun delete(resource: Resource<NamedImage>) {
+    TODO("not implemented")
+  }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -30,9 +30,9 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.OrchestrationTrigger
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.retrofit.isNotFound
-import de.danielbechler.diff.node.DiffNode
 import kotlinx.coroutines.runBlocking
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -79,7 +79,7 @@ class SecurityGroupHandler(
     log.info("Started task {} to create security group", taskRef.ref)
   }
 
-  override fun update(resource: Resource<SecurityGroup>, diff: DiffNode) {
+  override fun update(resource: Resource<SecurityGroup>, resourceDiff: ResourceDiff<SecurityGroup>) {
     val taskRef = runBlocking {
       resource.spec.let { spec ->
         orcaService

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import de.danielbechler.diff.ObjectDifferBuilder
 import dev.minutest.junit.JUnit5Minutests
@@ -206,7 +207,8 @@ internal object ClusterHandlerTests : JUnit5Minutests {
 
       context("the diff is only in capacity") {
 
-        val diff = differ.compare(resource.spec.withDoubleCapacity(), resource.spec)
+        val modified = resource.spec.withDoubleCapacity()
+        val diff = ResourceDiff(modified, differ.compare(modified, resource.spec))
 
         test("annealing resizes the current server group") {
           upsert(resource, diff)
@@ -230,7 +232,8 @@ internal object ClusterHandlerTests : JUnit5Minutests {
 
       context("the diff is something other than just capacity") {
 
-        val diff = differ.compare(resource.spec.withDoubleCapacity().withDifferentInstanceType(), resource.spec)
+        val modified = resource.spec.withDoubleCapacity().withDifferentInstanceType()
+        val diff = ResourceDiff(modified, differ.compare(modified, resource.spec))
 
         test("annealing clones the current server group") {
           upsert(resource, diff)

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import de.danielbechler.diff.node.DiffNode
@@ -196,7 +197,7 @@ internal object SecurityGroupHandlerTests : JUnit5Minutests {
 
     sequenceOf(
       "create" to SecurityGroupHandler::create,
-      "update" to SecurityGroupHandler::update.partially3(DiffNode.newRootNode())
+      "update" to SecurityGroupHandler::update.partially3(ResourceDiff(UpsertFixture().resource.spec))
     )
       .forEach { (methodName, handlerMethod) ->
         context("$methodName a security group with no ingress rules") {
@@ -387,7 +388,7 @@ internal object SecurityGroupHandlerTests : JUnit5Minutests {
           CompletableDeferred(TaskRefResponse("/tasks/${randomUUID()}"))
         }
 
-        handler.update(resource)
+        handler.update(resource, ResourceDiff(resource.spec))
       }
 
       after {

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/annealing/ResourceActuator.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/annealing/ResourceActuator.kt
@@ -4,11 +4,12 @@ import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceName
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
-import com.netflix.spinnaker.keel.persistence.ResourceState.Diff
+import com.netflix.spinnaker.keel.persistence.ResourceState.Diff as Different
 import com.netflix.spinnaker.keel.persistence.ResourceState.Missing
 import com.netflix.spinnaker.keel.persistence.ResourceState.Ok
 import com.netflix.spinnaker.keel.plugin.ResourceConflict
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.plugin.ResourceHandler.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.supporting
 import de.danielbechler.diff.ObjectDifferBuilder
 import de.danielbechler.diff.node.DiffNode
@@ -47,8 +48,8 @@ class ResourceActuator(
             }
             log.warn("Resource {} is invalid", resource.metadata.name)
             log.info("Resource {} delta: {}", resource.metadata.name, builder.toString())
-            resourceRepository.updateState(resource.metadata.uid, Diff)
-            plugin.update(resource, diff)
+            resourceRepository.updateState(resource.metadata.uid, Different)
+            plugin.update(resource, ResourceDiff(current, diff))
           } else {
             log.info("Resource {} is valid", resource.metadata.name)
             resourceRepository.updateState(resource.metadata.uid, Ok)
@@ -79,8 +80,8 @@ class ResourceActuator(
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun <T : Any> ResourceHandler<T>.update(resource: Resource<*>, diff: DiffNode) {
-    update(resource as Resource<T>, diff)
+  private fun <T : Any> ResourceHandler<T>.update(resource: Resource<*>, resourceDiff: ResourceHandler.ResourceDiff<*>) {
+    update(resource as Resource<T>, resourceDiff as ResourceDiff<T>)
   }
   // end type coercing extensions
 

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceHandler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceHandler.kt
@@ -22,6 +22,14 @@ import de.danielbechler.diff.node.DiffNode
 import org.slf4j.Logger
 
 interface ResourceHandler<T : Any> : KeelPlugin {
+  data class ResourceDiff<T : Any>(
+    val source: T,
+    val diff: DiffNode
+  ) {
+    constructor(source : T) : this(source, DiffNode.newRootNode())
+  }
+
+
   val log: Logger
 
   val apiVersion: ApiVersion
@@ -124,8 +132,8 @@ interface ResourceHandler<T : Any> : KeelPlugin {
    * Implement this method and [create] if you need to handle create and update in different ways.
    * Otherwise just implement [upsert].
    */
-  fun update(resource: Resource<T>, diff: DiffNode = DiffNode.newRootNode()) {
-    upsert(resource, diff)
+  fun update(resource: Resource<T>, resourceDiff: ResourceDiff<T> = ResourceDiff(resource.spec)) {
+    upsert(resource, resourceDiff)
   }
 
   /**
@@ -134,7 +142,7 @@ interface ResourceHandler<T : Any> : KeelPlugin {
    * You don't need to implement this method if you are implementing [create] and [update]
    * individually.
    */
-  fun upsert(resource: Resource<T>, diff: DiffNode? = null) {
+  fun upsert(resource: Resource<T>, resourceDiff: ResourceDiff<T>? = null) {
     TODO("Not implemented")
   }
 

--- a/keel-sql/src/main/resources/db/changelog-master.yml
+++ b/keel-sql/src/main/resources/db/changelog-master.yml
@@ -8,3 +8,6 @@ databaseChangeLog:
   - include:
       file: changelog/20190320-create-lock-table.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20190321-persist-metadata.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/db/changelog/20190321-persist-metadata.yml
+++ b/keel-sql/src/main/resources/db/changelog/20190321-persist-metadata.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-metadata-to-resource
+      author: cfieber
+      changes:
+        - addColumn:
+            tableName: resource
+            columns:
+              - column:
+                  name: metadata
+                  type: longtext
+                  beforeColumn: spec
+                  value: "{}"
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: resource
+            columnName: metadata


### PR DESCRIPTION
this "works" in that it will detect a newer image and trigger annealing
of a cluster, however it needs a solid overhaul to handle resource
references, hence the pretty much zero tests currently

this orphans the front50 module currently, but I didn't remove it as
I suspect we may still want that at some point