### PR TITLE
Only run the resource check scheduler on a single instance at a time

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/sync/LockTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/sync/LockTests.kt
@@ -1,0 +1,60 @@
+package com.netflix.spinnaker.keel.sync
+
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+import java.time.Clock
+import java.time.Duration
+
+abstract class LockTests<T : Lock> : JUnit5Minutests {
+  protected abstract fun subject(clock: Clock): T
+  protected open fun flush() {}
+  private val clock = MutableClock()
+  private val duration = Duration.ofSeconds(30)
+
+  fun tests() = rootContext<Lock> {
+    fixture { subject(clock) }
+
+    after {
+      flush()
+    }
+
+    context("no pre-existing lock") {
+      test("can acquire the lock") {
+        expectThat(tryAcquire("lock1", duration)).isTrue()
+      }
+    }
+
+    context("a pre-existing lock that has expired") {
+      before {
+        tryAcquire("lock1", duration)
+        clock.incrementBy(duration * 2)
+      }
+
+      test("can acquire the lock") {
+        expectThat(tryAcquire("lock1", duration)).isTrue()
+      }
+    }
+
+    context("a pre-existing lock that has not expired") {
+      before {
+        tryAcquire("lock1", duration)
+        clock.incrementBy(duration / 2)
+      }
+
+      test("cannot acquire the lock") {
+        expectThat(tryAcquire("lock1", duration)).isFalse()
+      }
+
+      test("can acquire a different lock") {
+        expectThat(tryAcquire("lock2", duration)).isTrue()
+      }
+    }
+  }
+}
+
+private operator fun Duration.div(divisor: Long) = dividedBy(divisor)
+private operator fun Duration.times(multiplier: Long) = multipliedBy(multiplier)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -77,6 +77,9 @@ interface ResourceRepository {
    */
   fun lastKnownState(uid: UID): ResourceStateHistoryEntry
 
+  /**
+   * Retrieves the state history of the resource represented by [uid].
+   */
   fun stateHistory(uid: UID): List<ResourceStateHistoryEntry>
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/sync/Lock.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/sync/Lock.kt
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.keel.sync
+
+import java.time.Duration
+
+interface Lock {
+  fun tryAcquire(name: String, duration: Duration): Boolean
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/sync/NoOpLock.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/sync/NoOpLock.kt
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.keel.sync
+
+import java.time.Duration
+
+/**
+ * Appropriate for use locally or when running single instances. Always grants the lock.
+ */
+object NoOpLock : Lock {
+  override fun tryAcquire(name: String, duration: Duration) = true
+}

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/annealing/ResourceCheckScheduler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/annealing/ResourceCheckScheduler.kt
@@ -3,15 +3,18 @@ package com.netflix.spinnaker.keel.annealing
 import com.netflix.spinnaker.keel.activation.ApplicationDown
 import com.netflix.spinnaker.keel.activation.ApplicationUp
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.sync.Lock
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 class ResourceCheckScheduler(
   private val resourceRepository: ResourceRepository,
-  private val resourceCheckQueue: ResourceCheckQueue
+  private val resourceCheckQueue: ResourceCheckQueue,
+  private val lock: Lock
 ) {
 
   private var enabled = false
@@ -30,16 +33,25 @@ class ResourceCheckScheduler(
 
   @Scheduled(fixedDelayString = "\${keel.resource.monitoring.frequency.ms:60000}")
   fun checkManagedResources() {
-    if (enabled) {
-      log.debug("Starting scheduled validation…")
-      resourceRepository.allResources { (_, name, _, apiVersion, kind) ->
-        resourceCheckQueue.scheduleCheck(name, apiVersion, kind)
+    when {
+      !enabled ->
+        log.debug("Scheduled validation disabled")
+      !lock.tryAcquire(LOCK_NAME, LOCK_DURATION) ->
+        log.debug("Failed to acquire lock - another instance is checking resources")
+      else -> {
+        log.debug("Starting scheduled validation…")
+        resourceRepository.allResources { (_, name, _, apiVersion, kind) ->
+          resourceCheckQueue.scheduleCheck(name, apiVersion, kind)
+        }
+        log.debug("Scheduled validation complete")
       }
-      log.debug("Scheduled validation complete")
-    } else {
-      log.debug("Scheduled validation disabled")
     }
   }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  companion object {
+    const val LOCK_NAME = "resource-check"
+    val LOCK_DURATION: Duration = Duration.ofSeconds(60)
+  }
 }

--- a/keel-plugin/src/test/kotlin/com/netflix/spinnaker/keel/annealing/ResourceCheckSchedulerTests.kt
+++ b/keel-plugin/src/test/kotlin/com/netflix/spinnaker/keel/annealing/ResourceCheckSchedulerTests.kt
@@ -43,7 +43,7 @@ internal object ResourceCheckSchedulerTests : JUnit5Minutests {
 
   fun tests() = rootContext<ResourceCheckScheduler> {
     fixture {
-      ResourceCheckScheduler(resourceRepository, resourceCheckQueue, lock)
+      ResourceCheckScheduler(resourceRepository, resourceCheckQueue, lock, 60_000)
     }
 
     before {

--- a/keel-plugin/src/test/kotlin/com/netflix/spinnaker/keel/annealing/ResourceCheckSchedulerTests.kt
+++ b/keel-plugin/src/test/kotlin/com/netflix/spinnaker/keel/annealing/ResourceCheckSchedulerTests.kt
@@ -1,0 +1,98 @@
+package com.netflix.spinnaker.keel.annealing
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceMetadata
+import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.randomUID
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.sync.Lock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+internal object ResourceCheckSchedulerTests : JUnit5Minutests {
+
+  private val resourceRepository: ResourceRepository = InMemoryResourceRepository()
+  private val resourceCheckQueue: ResourceCheckQueue = mockk(relaxUnitFun = true)
+  private val lock: Lock = mockk()
+  private val resources = listOf(
+    Resource(
+      apiVersion = SPINNAKER_API_V1.subApi("ec2"),
+      kind = "security-group",
+      metadata = ResourceMetadata(
+        name = ResourceName("ec2:security-group:prod:ap-south-1:keel-sg"),
+        uid = randomUID()
+      ),
+      spec = "doesn't matter"
+    ),
+    Resource(
+      apiVersion = SPINNAKER_API_V1.subApi("ec2"),
+      kind = "cluster",
+      metadata = ResourceMetadata(
+        name = ResourceName("ec2:cluster:prod:ap-south-1:keel"),
+        uid = randomUID()
+      ),
+      spec = "doesn't matter"
+    )
+  )
+
+  fun tests() = rootContext<ResourceCheckScheduler> {
+    fixture {
+      ResourceCheckScheduler(resourceRepository, resourceCheckQueue, lock)
+    }
+
+    before {
+      resources.forEach(resourceRepository::store)
+    }
+
+    context("scheduler is disabled") {
+      test("nothing happens") {
+        checkManagedResources()
+
+        verify { resourceCheckQueue wasNot Called }
+      }
+    }
+
+    context("scheduler is enabled") {
+      before {
+        onApplicationUp()
+      }
+
+      after {
+        onApplicationDown()
+      }
+
+      context("unable to acquire lock") {
+        before {
+          every { lock.tryAcquire(any(), any()) } returns false
+        }
+
+        test("nothing happens") {
+          checkManagedResources()
+
+          verify { resourceCheckQueue wasNot Called }
+        }
+      }
+
+      context("able to acquire lock") {
+        before {
+          every { lock.tryAcquire(any(), any()) } returns true
+        }
+
+        test("checks for all resources are scheduled") {
+          checkManagedResources()
+
+          resources.forEach {
+            verify { resourceCheckQueue.scheduleCheck(it) }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/keel-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisConfiguration.kt
+++ b/keel-redis/src/main/kotlin/com/netflix/spinnaker/config/RedisConfiguration.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.ResourceVersionTracker
+import com.netflix.spinnaker.keel.redis.RedisLock
 import com.netflix.spinnaker.keel.redis.RedisResourceRepository
 import com.netflix.spinnaker.keel.redis.RedisResourceVersionTracker
 import com.netflix.spinnaker.kork.dynomite.DynomiteClientConfiguration
@@ -40,4 +41,7 @@ class RedisConfiguration {
   @Bean
   fun resourceVersionTracker(redisClientSelector: RedisClientSelector): ResourceVersionTracker =
     RedisResourceVersionTracker(redisClientSelector.primary("default"))
+
+  @Bean
+  fun lock(redisClientSelector: RedisClientSelector, clock: Clock) = RedisLock(redisClientSelector.primary("default"), clock)
 }

--- a/keel-redis/src/main/kotlin/com/netflix/spinnaker/keel/redis/RedisLock.kt
+++ b/keel-redis/src/main/kotlin/com/netflix/spinnaker/keel/redis/RedisLock.kt
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.keel.redis
+
+import com.netflix.spinnaker.keel.sync.Lock
+import com.netflix.spinnaker.kork.jedis.RedisClientDelegate
+import java.time.Clock
+import java.time.Duration
+
+class RedisLock(
+  private val redisClient: RedisClientDelegate,
+  private val clock: Clock
+) : Lock {
+  override fun tryAcquire(name: String, duration: Duration): Boolean =
+    redisClient.withCommandsClient<Boolean> { redis ->
+      redis.set("lock:$name", "🔒", "NX", "PX", duration.toMillis()) == "OK"
+    }
+}

--- a/keel-redis/src/test/kotlin/com/netflix/spinnaker/keel/redis/RedisLockTests.kt
+++ b/keel-redis/src/test/kotlin/com/netflix/spinnaker/keel/redis/RedisLockTests.kt
@@ -1,0 +1,36 @@
+package com.netflix.spinnaker.keel.redis
+
+import com.netflix.spinnaker.keel.sync.LockTests
+import com.netflix.spinnaker.kork.jedis.EmbeddedRedis
+import com.netflix.spinnaker.kork.jedis.JedisClientDelegate
+import org.junit.jupiter.api.AfterAll
+import redis.clients.jedis.Jedis
+import java.time.Clock
+import java.time.Duration
+
+internal object RedisLockTests : LockTests<RedisLock>() {
+
+  private val embeddedRedis = EmbeddedRedis.embed()
+  private val redisClient = JedisClientDelegate(embeddedRedis.pool)
+
+  override fun flush() {
+    redisClient.withCommandsClient { redis -> (redis as Jedis).flushAll() }
+  }
+
+  override fun simulateTimePassing(name: String, duration: Duration) {
+    redisClient.withCommandsClient { redis ->
+      val ttl = redis.pttl("lock:$name") - duration.toMillis()
+      redis.pexpire("lock:$name", Math.max(0L, ttl))
+    }
+  }
+
+  override fun subject(clock: Clock): RedisLock {
+    return RedisLock(redisClient, clock)
+  }
+
+  @JvmStatic
+  @AfterAll
+  fun shutdown() {
+    embeddedRedis.destroy()
+  }
+}

--- a/keel-redis/src/test/kotlin/com/netflix/spinnaker/keel/redis/spring/SpringStartupTests.kt
+++ b/keel-redis/src/test/kotlin/com/netflix/spinnaker/keel/redis/spring/SpringStartupTests.kt
@@ -3,8 +3,10 @@ package com.netflix.spinnaker.keel.redis.spring
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.ResourceVersionTracker
+import com.netflix.spinnaker.keel.redis.RedisLock
 import com.netflix.spinnaker.keel.redis.RedisResourceRepository
 import com.netflix.spinnaker.keel.redis.RedisResourceVersionTracker
+import com.netflix.spinnaker.keel.sync.Lock
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -31,6 +33,9 @@ internal class SpringStartupTests {
   @Autowired
   lateinit var resourceVersionTracker: ResourceVersionTracker
 
+  @Autowired
+  lateinit var lock: Lock
+
   @Test
   fun `uses RedisResourceRepository`() {
     expectThat(resourceRepository).isA<RedisResourceRepository>()
@@ -39,5 +44,10 @@ internal class SpringStartupTests {
   @Test
   fun `uses RedisResourceVersionTracker`() {
     expectThat(resourceVersionTracker).isA<RedisResourceVersionTracker>()
+  }
+
+  @Test
+  fun `uses RedisLock`() {
+    expectThat(lock).isA<RedisLock>()
   }
 }

--- a/keel-sql/keel-sql.gradle
+++ b/keel-sql/keel-sql.gradle
@@ -12,6 +12,9 @@ dependencies {
 
   runtimeOnly "mysql:mysql-connector-java:+"
 
+  testImplementation "io.strikt:strikt-core:$striktVersion"
+  testImplementation project(":keel-spring-test-support")
   testImplementation project(":keel-core-test")
+  testImplementation project(":keel-api")
   testImplementation "com.h2database:h2:+"
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.info.InstanceIdSupplier
+import com.netflix.spinnaker.keel.sql.SqlLock
 import com.netflix.spinnaker.keel.sql.SqlResourceRepository
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
 import org.jooq.DSLContext
@@ -23,4 +24,11 @@ class SqlConfiguration {
     instanceIdSupplier: InstanceIdSupplier
   ) =
     SqlResourceRepository(jooq, objectMapper, clock, instanceIdSupplier)
+
+  @Bean
+  fun lock(
+    jooq: DSLContext,
+    clock: Clock
+  ) =
+    SqlLock(jooq, clock)
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/Jooq.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/Jooq.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.sql
+
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+
+internal fun <R> DSLContext.inTransaction(fn: DSLContext.() -> R): R =
+  transactionResult { tx ->
+    DSL.using(tx).run(fn)
+  }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLock.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLock.kt
@@ -1,0 +1,51 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.sync.Lock
+import org.jooq.DSLContext
+import org.jooq.Field
+import org.jooq.Record
+import org.jooq.Table
+import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.table
+import org.slf4j.LoggerFactory
+import java.sql.Timestamp
+import java.time.Clock
+import java.time.Duration
+
+class SqlLock(
+  private val jooq: DSLContext,
+  private val clock: Clock
+) : Lock {
+  override fun tryAcquire(name: String, duration: Duration): Boolean =
+    jooq.inTransaction {
+      val now = clock.instant()
+      val limit = now.let(Timestamp::from)
+      val expires = now.plus(duration).let(Timestamp::from)
+      selectOne()
+        .from(LOCK)
+        .where(NAME.eq(name))
+        .forUpdate()
+        .fetch()
+        .intoResultSet()
+        .let {
+          if (it.next()) {
+            update(LOCK)
+              .set(EXPIRES, expires)
+              .where(NAME.eq(name), EXPIRES.lt(limit))
+              .execute() > 0
+          } else {
+            insertInto(LOCK, NAME, EXPIRES)
+              .values(name, expires)
+              .execute() > 0
+          }
+        }
+    }
+
+  companion object {
+    val LOCK: Table<Record> = table("lock")
+    val NAME: Field<Any> = field("name")
+    val EXPIRES: Field<Any> = field("expires")
+  }
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -19,7 +19,6 @@ import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import org.jooq.impl.DSL.field
-import org.jooq.impl.DSL.using
 import org.slf4j.LoggerFactory
 import java.sql.ResultSet
 import java.sql.Timestamp
@@ -234,12 +233,6 @@ class SqlResourceRepository(
   companion object {
     private val RESOURCE = DSL.table("resource")
     private val RESOURCE_STATE = DSL.table("resource_state")
-  }
-
-  private fun DSLContext.inTransaction(fn: DSLContext.() -> Unit) {
-    transaction { tx ->
-      using(tx).apply(fn)
-    }
   }
 
   private fun <T : Any> ResultSet.toResource(specType: Class<T>): Resource<T> =

--- a/keel-sql/src/main/resources/db/changelog-master.yml
+++ b/keel-sql/src/main/resources/db/changelog-master.yml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
       file: changelog/20190313-add-instance-to-resource-status.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20190320-create-lock-table.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/db/changelog/20190320-create-lock-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20190320-create-lock-table.yml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-instance-column-to-resource-state-table
+      author: fletch
+      changes:
+        - createTable:
+            tableName: lock
+            columns:
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: expires
+                  type: timestamp
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropTable:
+            tableName: lock

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/H2Database.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/H2Database.kt
@@ -1,0 +1,86 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import liquibase.Liquibase
+import liquibase.database.DatabaseFactory
+import liquibase.database.jvm.JdbcConnection
+import liquibase.exception.DatabaseException
+import liquibase.exception.LiquibaseException
+import liquibase.resource.ClassLoaderResourceAccessor
+import org.h2.engine.Mode
+import org.h2.engine.Mode.ModeEnum.MySQL
+import org.jooq.DSLContext
+import org.jooq.SQLDialect.H2
+import org.jooq.Schema
+import org.jooq.conf.RenderNameStyle.AS_IS
+import org.jooq.impl.DataSourceConnectionProvider
+import org.jooq.impl.DefaultConfiguration
+import org.jooq.impl.DefaultDSLContext
+import org.slf4j.LoggerFactory
+import java.sql.DriverManager
+import java.sql.SQLException
+
+internal fun initDatabase(jdbcUrl: String): DSLContext {
+  // Initialize the MySQL compatibility mode in H2 to _not_ insert default values to not null
+  // columns. This is what MySQL does on multi-row inserts but not single row inserts.
+  Mode.getInstance(MySQL.name).convertInsertNullToZero = false
+
+  val dataSource = HikariDataSource(
+    HikariConfig().also {
+      it.jdbcUrl = jdbcUrl
+      it.maximumPoolSize = 5
+    }
+  )
+
+  val config = DefaultConfiguration().also {
+    it.set(DataSourceConnectionProvider(dataSource))
+    it.setSQLDialect(H2)
+    it.settings().withRenderNameStyle(AS_IS)
+  }
+
+  try {
+    Liquibase(
+      "db/changelog-master.yml",
+      ClassLoaderResourceAccessor(),
+      DatabaseFactory
+        .getInstance()
+        .findCorrectDatabaseImplementation(JdbcConnection(dataSource.connection))
+    )
+      .update("test")
+  } catch (e: DatabaseException) {
+    log.error("Caught exception running liquibase: {}", e.message)
+    throw DatabaseInitializationFailed(e)
+  } catch (e: SQLException) {
+    log.error("Caught exception running liquibase: {}", e.message)
+    throw DatabaseInitializationFailed(e)
+  } catch (e: LiquibaseException) {
+    log.error("Caught exception running liquibase: {}", e.message)
+    throw DatabaseInitializationFailed(e)
+  }
+
+  return DefaultDSLContext(config)
+}
+
+internal class DatabaseInitializationFailed(cause: Throwable) : RuntimeException(cause)
+
+internal fun DSLContext.flushAll(schema: String = "PUBLIC") =
+  meta()
+    .schemas
+    .filter { it.name == schema }
+    .flatMap(Schema::getTables)
+    .forEach {
+      truncate(it).execute()
+    }
+
+/**
+ * Force in-memory database to shutdown so if further tests re-initialize it Liquibase won't shit
+ * the bed.
+ */
+internal fun shutdown(jdbcUrl: String) {
+  DriverManager.getConnection(jdbcUrl).use {
+    it.createStatement().execute("SHUTDOWN")
+  }
+}
+
+private val log by lazy { LoggerFactory.getLogger(::initDatabase.javaClass) }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLockTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLockTests.kt
@@ -1,0 +1,23 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.sync.LockTests
+import org.junit.jupiter.api.AfterAll
+import java.time.Clock
+
+internal object SqlLockTests : LockTests<SqlLock>() {
+
+  private val jooq = initDatabase("jdbc:h2:mem:keel;MODE=MYSQL")
+
+  @JvmStatic
+  @AfterAll
+  fun shutdown() {
+    jooq.close()
+    shutdown("jdbc:h2:mem:keel")
+  }
+
+  override fun subject(clock: Clock): SqlLock = SqlLock(jooq, clock)
+
+  override fun flush() {
+    jooq.flushAll()
+  }
+}

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -3,32 +3,15 @@ package com.netflix.spinnaker.keel.sql
 import com.netflix.spinnaker.keel.info.InstanceIdSupplier
 import com.netflix.spinnaker.keel.persistence.ResourceRepositoryTests
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
-import com.zaxxer.hikari.HikariConfig
-import com.zaxxer.hikari.HikariDataSource
-import liquibase.Liquibase
-import liquibase.database.DatabaseFactory
-import liquibase.database.jvm.JdbcConnection
-import liquibase.exception.DatabaseException
-import liquibase.exception.LiquibaseException
-import liquibase.resource.ClassLoaderResourceAccessor
-import org.h2.engine.Mode
-import org.h2.engine.Mode.ModeEnum.MySQL
-import org.jooq.SQLDialect.H2
-import org.jooq.Schema
-import org.jooq.conf.RenderNameStyle.AS_IS
-import org.jooq.impl.DataSourceConnectionProvider
-import org.jooq.impl.DefaultConfiguration
-import org.jooq.impl.DefaultDSLContext
 import org.junit.jupiter.api.AfterAll
-import java.sql.SQLException
 import java.time.Clock
 
 internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
-  private val context = initDatabase("jdbc:h2:mem:keel;MODE=MYSQL")
+  private val jooq = initDatabase("jdbc:h2:mem:keel;MODE=MYSQL")
 
   override fun factory(clock: Clock): SqlResourceRepository {
     return SqlResourceRepository(
-      context,
+      jooq,
       configuredObjectMapper(),
       clock,
       object : InstanceIdSupplier {
@@ -38,59 +21,13 @@ internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResource
   }
 
   override fun flush() {
-    context
-      .meta()
-      .schemas
-      .filter { it.name == "PUBLIC" }
-      .flatMap(Schema::getTables)
-      .forEach {
-        context.truncate(it).execute()
-      }
+    jooq.flushAll()
   }
 
   @JvmStatic
   @AfterAll
   fun shutdown() {
-    context.close()
-  }
-
-  private fun initDatabase(jdbcUrl: String): DefaultDSLContext {
-    // Initialize the MySQL compatibility mode in H2 to _not_ insert default values to not null
-    // columns. This is what MySQL does on multi-row inserts but not single row inserts.
-    Mode.getInstance(MySQL.name).convertInsertNullToZero = false
-
-    val dataSource = HikariDataSource(
-      HikariConfig().also {
-        it.jdbcUrl = jdbcUrl
-        it.maximumPoolSize = 5
-      }
-    )
-
-    val config = DefaultConfiguration().also {
-      it.set(DataSourceConnectionProvider(dataSource))
-      it.setSQLDialect(H2)
-      it.settings().withRenderNameStyle(AS_IS)
-    }
-
-    try {
-      Liquibase(
-        "db/changelog-master.yml",
-        ClassLoaderResourceAccessor(),
-        DatabaseFactory
-          .getInstance()
-          .findCorrectDatabaseImplementation(JdbcConnection(dataSource.connection))
-      )
-        .update("test")
-    } catch (e: DatabaseException) {
-      throw DatabaseInitializationFailed(e)
-    } catch (e: SQLException) {
-      throw DatabaseInitializationFailed(e)
-    } catch (e: LiquibaseException) {
-      throw DatabaseInitializationFailed(e)
-    }
-
-    return DefaultDSLContext(config)
+    jooq.close()
+    shutdown("jdbc:h2:mem:keel")
   }
 }
-
-private class DatabaseInitializationFailed(cause: Throwable) : RuntimeException(cause)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -1,0 +1,44 @@
+package com.netflix.spinnaker.keel.sql.spring
+
+import com.netflix.spinnaker.keel.KeelApplication
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.sql.SqlLock
+import com.netflix.spinnaker.keel.sql.SqlResourceRepository
+import com.netflix.spinnaker.keel.sync.Lock
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import strikt.api.expectThat
+import strikt.assertions.isA
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+  classes = [KeelApplication::class],
+  webEnvironment = MOCK,
+  properties = [
+    "sql.enabled=true",
+    "sql.connection-pools.default.jdbc-url=jdbc:h2:mem:keel;MODE=MYSQL",
+    "sql.migration.jdbc-url=jdbc:h2:mem:keel;MODE=MYSQL"
+  ]
+)
+internal class SpringStartupTests {
+
+  @Autowired
+  lateinit var resourceRepository: ResourceRepository
+
+  @Autowired
+  lateinit var lock: Lock
+
+  @Test
+  fun `uses RedisResourceRepository`() {
+    expectThat(resourceRepository).isA<SqlResourceRepository>()
+  }
+
+  @Test
+  fun `uses RedisLock`() {
+    expectThat(lock).isA<SqlLock>()
+  }
+}


### PR DESCRIPTION
I looked at the locking stuff in Kork and clouddriver-nflx and it's way more capable than what we need so I cooked up something super-simple.

This should just prevent multiple Keel instances from reading all the resources and scheduling checks at the same time.