### PR TITLE
Use actual MySQL instead of H2 for SQL tests

### DIFF
--- a/keel-sql/keel-sql.gradle
+++ b/keel-sql/keel-sql.gradle
@@ -10,11 +10,11 @@ dependencies {
   implementation "com.zaxxer:HikariCP:$hikariVersion"
   implementation "org.liquibase:liquibase-core:$liquibaseVersion"
 
-  runtimeOnly "mysql:mysql-connector-java:+"
+  runtimeOnly "mysql:mysql-connector-java:8.0.15"
 
   testImplementation "io.strikt:strikt-core:$striktVersion"
   testImplementation project(":keel-spring-test-support")
   testImplementation project(":keel-core-test")
   testImplementation project(":keel-api")
-  testImplementation "com.h2database:h2:+"
+  testImplementation "org.testcontainers:mysql:1.10.7"
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLock.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLock.kt
@@ -22,19 +22,19 @@ class SqlLock(
       val limit = now.let(Timestamp::from)
       val expires = now.plus(duration).let(Timestamp::from)
       selectOne()
-        .from(LOCK)
+        .from(CLUSTER_LOCK)
         .where(NAME.eq(name))
         .forUpdate()
         .fetch()
         .intoResultSet()
         .let {
           if (it.next()) {
-            update(LOCK)
+            update(CLUSTER_LOCK)
               .set(EXPIRES, expires)
               .where(NAME.eq(name), EXPIRES.lt(limit))
               .execute() > 0
           } else {
-            insertInto(LOCK, NAME, EXPIRES)
+            insertInto(CLUSTER_LOCK, NAME, EXPIRES)
               .values(name, expires)
               .execute() > 0
           }
@@ -42,7 +42,7 @@ class SqlLock(
     }
 
   companion object {
-    val LOCK: Table<Record> = table("lock")
+    val CLUSTER_LOCK: Table<Record> = table("cluster_lock")
     val NAME: Field<Any> = field("name")
     val EXPIRES: Field<Any> = field("expires")
   }

--- a/keel-sql/src/main/resources/db/changelog/20190320-create-lock-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20190320-create-lock-table.yml
@@ -4,7 +4,7 @@ databaseChangeLog:
       author: fletch
       changes:
         - createTable:
-            tableName: lock
+            tableName: cluster_lock
             columns:
               - column:
                   name: name
@@ -17,6 +17,10 @@ databaseChangeLog:
                   type: timestamp
                   constraints:
                     nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"
       rollback:
         - dropTable:
             tableName: lock

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLockTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLockTests.kt
@@ -1,18 +1,21 @@
 package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.sync.LockTests
+import org.jooq.SQLDialect.MYSQL_5_7
 import org.junit.jupiter.api.AfterAll
 import java.time.Clock
 
 internal object SqlLockTests : LockTests<SqlLock>() {
 
-  private val jooq = initDatabase("jdbc:h2:mem:keel;MODE=MYSQL")
+  private val jooq = initDatabase(
+    "jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
+    MYSQL_5_7
+  )
 
   @JvmStatic
   @AfterAll
   fun shutdown() {
     jooq.close()
-    shutdown("jdbc:h2:mem:keel")
   }
 
   override fun subject(clock: Clock): SqlLock = SqlLock(jooq, clock)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -3,11 +3,15 @@ package com.netflix.spinnaker.keel.sql
 import com.netflix.spinnaker.keel.info.InstanceIdSupplier
 import com.netflix.spinnaker.keel.persistence.ResourceRepositoryTests
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import org.jooq.SQLDialect.MYSQL_5_7
 import org.junit.jupiter.api.AfterAll
 import java.time.Clock
 
 internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
-  private val jooq = initDatabase("jdbc:h2:mem:keel;MODE=MYSQL")
+  private val jooq = initDatabase(
+    "jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
+    MYSQL_5_7
+  )
 
   override fun factory(clock: Clock): SqlResourceRepository {
     return SqlResourceRepository(
@@ -28,6 +32,5 @@ internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResource
   @AfterAll
   fun shutdown() {
     jooq.close()
-    shutdown("jdbc:h2:mem:keel")
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -20,8 +20,9 @@ import strikt.assertions.isA
   webEnvironment = MOCK,
   properties = [
     "sql.enabled=true",
-    "sql.connection-pools.default.jdbc-url=jdbc:h2:mem:keel;MODE=MYSQL",
-    "sql.migration.jdbc-url=jdbc:h2:mem:keel;MODE=MYSQL"
+    "sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
+    "sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
+    "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
   ]
 )
 internal class SpringStartupTests {


### PR DESCRIPTION
Would love any thoughts on this. I ran into a compatibility issue the other day that got me looking at alternatives to using H2 in MySQL "compatibility" mode. This is using `testcontainers` but is considerably faster than the test I wrote for SQS that was using a very large docker image.