### PR TITLE
feat(image): provide image with jenkins information

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/Dates.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/Dates.kt
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.clouddriver
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class Dates {
+  companion object {
+    private val formats: List<DateTimeFormatter> = listOf(
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSS'Z'"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSSZ"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+      DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+      DateTimeFormatter.ofPattern("MM/dd/yyyy"),
+      DateTimeFormatter.ofPattern("MMMM d, yyyy h:mm a"),
+      DateTimeFormatter.ofPattern("MMMM d, yyyy"),
+      DateTimeFormatter.ofPattern("MMMM d, yyyy")
+    )
+
+    fun toLocalDateTime(date: String): LocalDateTime {
+      var exception: Exception? = null
+      formats.forEach { format ->
+        try {
+          return LocalDateTime.parse(date, format)
+        } catch (e: Exception) {
+          exception = e
+        }
+      }
+
+      throw exception!!
+    }
+  }
+}

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
@@ -1,5 +1,9 @@
 package com.netflix.spinnaker.keel.clouddriver.model
 
+import com.netflix.spinnaker.keel.clouddriver.Dates
+import java.time.LocalDateTime
+import java.time.ZoneId
+
 data class NamedImage(
   val imageName: String,
   val attributes: Map<String, Any?>,
@@ -7,3 +11,29 @@ data class NamedImage(
   val accounts: Set<String>,
   val amis: Map<String, List<String>?>
 )
+
+class NamedImageComparator {
+
+  companion object : Comparator<NamedImage> {
+
+    override fun compare(a: NamedImage, b: NamedImage): Int =
+      (a.creationMs - b.creationMs).toInt()
+  }
+}
+
+private val NamedImage.creationMs: Long
+  get() {
+    if (!attributes.containsKey("creationDate") || attributes["creationDate"] !is String) {
+      // if no creation date, we will assume it is very old.
+      return LocalDateTime.now()
+        .minusYears(3) // falling back to 3 years prior if creationDate is nil to support legacy resources
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()
+    }
+    val creationDate: String = this.attributes["creationDate"] as String
+    return Dates.toLocalDateTime(creationDate)
+      .atZone(ZoneId.systemDefault())
+      .toInstant()
+      .toEpochMilli()
+  }

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTest.kt
@@ -1,0 +1,163 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.clouddriver
+
+import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
+import com.netflix.spinnaker.keel.clouddriver.model.NamedImageComparator
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+
+object ImageServiceTest {
+  val cloudDriver = mockk<CloudDriverService>()
+  val subject = ImageService(cloudDriver)
+
+  val image1 = NamedImage(
+    imageName = "my-package-0.0.1_rc.97-h98",
+    attributes = mapOf(
+      "virtualizationType" to "hvm",
+      "creationDate" to "2018-10-25T13:08:58.000Z"
+    ),
+    tagsByImageId = mapOf(
+      "ami-001" to mapOf(
+        "build_host" to "https://jenkins/",
+        "appversion" to "my-package-0.0.1~rc.97-h98/JENKINS-job/98",
+        "creator" to "emburns@netflix.com",
+        "base_ami_version" to "nflx-base-5.292.0-h988",
+        "creation_time" to "2018-10-25 13:08:59 UTC"
+      )
+    ),
+    accounts = setOf("test"),
+    amis = mapOf(
+      "us-west-1" to listOf("ami-001")
+    )
+  )
+
+  val image2 = NamedImage(
+    imageName = "my-package-0.0.1_rc.98-h99",
+    attributes = mapOf(
+      "virtualizationType" to "hvm",
+      "creationDate" to "2018-10-28T13:09:13.000Z"
+    ),
+    tagsByImageId = mapOf(
+      "ami-002" to mapOf(
+        "build_host" to "https://jenkins/",
+        "appversion" to "my-package-0.0.1~rc.98-h99.4cb755c/JENKINS-job/99",
+        "creator" to "emburns@netflix.com",
+        "base_ami_version" to "nflx-base-5.292.0-h988",
+        "creation_time" to "2018-10-28 13:09:14 UTC"
+      )
+    ),
+    accounts = setOf("test"),
+    amis = mapOf(
+      "us-west-1" to listOf("ami-002")
+    )
+  )
+
+  val image3 = NamedImage(
+    imageName = "my-package-0.0.1_rc.99-h100",
+    attributes = mapOf(
+      "virtualizationType" to "hvm",
+      "creationDate" to "2018-10-31T13:09:54.000Z"
+    ),
+    tagsByImageId = mapOf(
+      "ami-003" to mapOf(
+        "build_host" to "https://jenkins/",
+        "appversion" to "my-package-0.0.1~rc.99-h100.8192e02/JENKINS-job/100",
+        "creator" to "emburns@netflix.com",
+        "base_ami_version" to "nflx-base-5.292.0-h988",
+        "creation_time" to "2018-10-31 13:09:55 UTC"
+      )
+    ),
+    accounts = setOf("test"),
+    amis = mapOf(
+      "us-west-1" to listOf("ami-003")
+    )
+  )
+
+  @Test
+  fun `namedImages are in cronological order`() {
+    val sortedImages = listOf(image2, image3, image1).sortedWith(NamedImageComparator)
+    expectThat(sortedImages.last()) {
+      get { imageName }.isEqualTo("my-package-0.0.1_rc.99-h100")
+    }
+  }
+
+  @Test
+  fun `get latest image returns actual latest image`() {
+    coEvery {
+      cloudDriver.namedImages("my-package-0.0.1_rc.98-h99", "test")
+    } returns CompletableDeferred(listOf(image2, image3, image1))
+
+    runBlocking {
+      val image = subject.getLatestImage("my-package", "my-package-0.0.1_rc.98-h99", "test")
+      expectThat(image).isNotNull()
+      expectThat(image?.appVersion).equals("my-package-0.0.1~rc.98-h99.4cb755c/JENKINS-job/99")
+    }
+  }
+
+  @Test
+  fun `get latest named image returns actual latest image`() {
+    coEvery {
+      cloudDriver.namedImages("my-package", "test")
+    } returns CompletableDeferred(listOf(image2, image3, image1))
+
+    runBlocking {
+      val image = subject.getLatestNamedImage("my-package", "test")
+      expectThat(image).isNotNull()
+      expectThat(image?.imageName).equals("my-package-0.0.1_rc.99-h100")
+    }
+  }
+
+  @Test
+  fun `no image provided if image not found for latest from artifact`() {
+    coEvery {
+      cloudDriver.namedImages("my-package", "test")
+    } returns CompletableDeferred(emptyList())
+
+    runBlocking {
+      val image = subject.getLatestNamedImage("my-package", "test")
+      expectThat(image).isNull()
+    }
+  }
+
+  @Test
+  fun `get named image from jenkins info works`() {
+    coEvery {
+      cloudDriver.namedImages("my-package", "test")
+    } returns CompletableDeferred(listOf(image2, image3, image1))
+
+    runBlocking {
+      val image = subject.getNamedImageFromJenkinsInfo(
+        packageName = "my-package",
+        account = "test",
+        buildHost = "https://jenkins/",
+        buildName = "JENKINS-job",
+        buildNumber = "98"
+      )
+      expectThat(image).isNotNull()
+      expectThat(image?.imageName).equals("my-package-0.0.1_rc.97-h98")
+    }
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/InvalidPayload.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/InvalidPayload.kt
@@ -22,4 +22,3 @@ import java.lang.RuntimeException
 class UnsupportedStrategy(requestedStrategy: String, validStrategy: String) : RuntimeException("Strategy $requestedStrategy is not supported for $validStrategy")
 
 class InvalidPayload(strategy: String) : RuntimeException("Payload is not valid for $strategy")
-

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/InvalidPayload.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/InvalidPayload.kt
@@ -20,3 +20,6 @@ package com.netflix.spinnaker.keel.api
 import java.lang.RuntimeException
 
 class UnsupportedStrategy(requestedStrategy: String, validStrategy: String) : RuntimeException("Strategy $requestedStrategy is not supported for $validStrategy")
+
+class InvalidPayload(strategy: String) : RuntimeException("Payload is not valid for $strategy")
+

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
   implementation(project(":keel-orca"))
   implementation(project(":keel-retrofit"))
   implementation("com.netflix.spinnaker.kork:kork-core")
+  implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import org.springframework.beans.factory.ObjectFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
@@ -42,6 +43,7 @@ class EC2Config {
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
     imageService: ImageService,
+    dynamicConfigService: DynamicConfigService,
     clock: Clock,
     objectMapper: ObjectMapper,
     normalizers: List<ResourceNormalizer<*>>
@@ -51,6 +53,7 @@ class EC2Config {
       cloudDriverCache,
       orcaService,
       imageService,
+      dynamicConfigService,
       clock,
       objectMapper,
       normalizers

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ImageProvider.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ImageProvider.kt
@@ -42,3 +42,14 @@ data class IdImageProvider(
 data class LatestFromPackageImageProvider(
   val deliveryArtifact: DeliveryArtifact
 ) : ImageProvider()
+
+/**
+ * Provides an image by reference to a jenkins master, job, and job number
+ */
+@JsonDeserialize(using = JsonDeserializer.None::class)
+data class JenkinsJobImageProvider(
+  val packageName: String,
+  val buildHost: String,
+  val buildName: String,
+  val buildNumber: String
+) : ImageProvider()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ImageProviderDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ImageProviderDeserializer.kt
@@ -17,6 +17,7 @@
  */
 package com.netflix.spinnaker.keel.api.ec2.image
 
+import com.netflix.spinnaker.keel.api.InvalidPayload
 import com.netflix.spinnaker.keel.serialization.PropertyNamePolymorphicDeserializer
 
 internal class ImageProviderDeserializer :
@@ -25,6 +26,7 @@ internal class ImageProviderDeserializer :
     when {
       "imageId" in fieldNames -> IdImageProvider::class.java
       "deliveryArtifact" in fieldNames -> LatestFromPackageImageProvider::class.java
-      else -> ImageProvider::class.java
+      "buildHost" in fieldNames -> JenkinsJobImageProvider::class.java
+      else -> throw InvalidPayload("ImageProvider")
     }
 }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -38,6 +38,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.plugin.ResourceDiff
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
+import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import de.danielbechler.diff.ObjectDifferBuilder
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -142,6 +143,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val cloudDriverCache = mockk<CloudDriverCache>()
   val orcaService = mockk<OrcaService>()
   val imageService = mockk<ImageService>()
+  val dynamicConfigService = mockk<DynamicConfigService>()
   val objectMapper = ObjectMapper().registerKotlinModule()
 
   val differ = ObjectDifferBuilder.buildDefault()
@@ -155,6 +157,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         cloudDriverCache,
         orcaService,
         imageService,
+        dynamicConfigService,
         Clock.systemDefaultZone(),
         objectMapper,
         normalizers


### PR DESCRIPTION
It's pretty easy to add another ImageProvider. Added a preliminary jenkins one here - it relies on our special netflix "appversion" tag and "build_host" tag that every image gets tagged with when it bakes.

Not loving the way you have to specify this detail (build_host is a full url), but this is good beginning functionality for testing these things out and working with some of our alpha adopters.

This looks like:

```
"launchConfiguration": {
  "imageProvider": {
    "packageName": "deb-sample-app-server",
    "buildHost": "https://my.jenkins.url/",
    "buildName": "MY-JENKINS-job-name",
    "buildNumber": "92"
  },
```