### PR TITLE
Fix coroutine compatibility in Mahe & Igor services

### DIFF
--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.integration
 
 import com.netflix.spinnaker.keel.KeelApplication
-import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import okhttp3.Interceptor
@@ -40,7 +39,7 @@ internal class SchedulingResilienceTests {
     val latch = CountDownLatch(1)
     GlobalScope.launch {
       try {
-        service.greet().await()
+        service.greet()
       } finally {
         latch.countDown()
       }
@@ -62,7 +61,7 @@ fun Assertion.Builder<CountDownLatch>.countsDownWithin(timeoutSeconds: Long): As
 
 internal interface DummyRetrofitService {
   @GET("/")
-  fun greet(): Deferred<ResponseBody>
+  suspend fun greet(): ResponseBody
 }
 
 private class TestConfiguration {

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
@@ -25,7 +25,6 @@ class BaseImageCache(
   internal suspend fun refresh() {
     maheService
       .getProperties("bakery")
-      .await()
       .propertiesList
       .find { it.key == "bakery.api.base_label_map" }
       ?.let {

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -107,7 +107,7 @@ class ImageHandler(
         ),
         trigger = OrchestrationTrigger(
           correlationId = resource.metadata.name.toString(),
-          artifacts = listOf(artifact.await())
+          artifacts = listOf(artifact)
         )
       )
     )

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCacheTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCacheTests.kt
@@ -10,9 +10,8 @@ import com.netflix.spinnaker.keel.mahe.api.PropertyResponse
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.every
+import io.mockk.coEvery
 import io.mockk.mockk
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.api.expectThrows
@@ -37,7 +36,7 @@ internal class BaseImageCacheTests : JUnit5Minutests {
 
     context("refreshing the cache") {
       before {
-        every { maheService.getProperties("bakery") } returns CompletableDeferred(PropertyResponse(
+        coEvery { maheService.getProperties("bakery") } returns PropertyResponse(
           propertiesList = setOf(
             DynamicProperty(
               propertyId = "bakery.api.base_label_map|bakery|test||||",
@@ -82,7 +81,7 @@ internal class BaseImageCacheTests : JUnit5Minutests {
                 |}""".trimMargin()
             )
           )
-        ))
+        )
 
         runBlocking {
           subject.refresh()

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -30,7 +30,6 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.api.expectThrows
@@ -236,7 +235,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
     context("baking a new AMI") {
       before {
-        every { igorService.getArtifact("keel", "0.161.0-h63.24d0843") } returns CompletableDeferred(
+        coEvery { igorService.getArtifact("keel", "0.161.0-h63.24d0843") } returns
           Artifact(
             "DEB",
             false,
@@ -253,7 +252,6 @@ internal class ImageHandlerTests : JUnit5Minutests {
             "https://spinnaker.builds.test.netflix.net/job/SPINNAKER-rocket-package-keel/62",
             null
           )
-        )
       }
 
       test("bake configuration is based on resource spec") {

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -40,9 +40,9 @@ class ImageService(
           .tagsByImageId
           .values
           .first { it?.containsKey("base_ami_version") ?: false && it?.containsKey("appversion") ?: false }
-        if (tags == null) {
+        return if (tags == null) {
           log.debug("Image not found for {} version {}", artifactName, version)
-          return null
+          null
         } else {
           val image = Image(
             tags.getValue("base_ami_version")!!,
@@ -50,7 +50,7 @@ class ImageService(
             namedImage.amis.keys
           )
           log.debug("Latest image for {} version {} is {}", artifactName, version, image)
-          return image
+          image
         }
       }
   }
@@ -75,10 +75,10 @@ class ImageService(
 
   private fun getAllTags(image: NamedImage): Map<String, String> {
     val allTags = HashMap<String, String>()
-    image.tagsByImageId.forEach { amiId, tags ->
+    image.tagsByImageId.forEach { (_, tags) ->
       tags?.forEach { k, v ->
         if (v != null) {
-          allTags.put(k, v)
+          allTags[k] = v
         }
       }
     }
@@ -90,7 +90,7 @@ class ImageService(
       return false
     }
 
-    val appversion = tags["appversion"]!!.split("/")
+    val appversion = tags["appversion"]?.split("/") ?: error("appversion tag is missing")
 
     if (appversion.size != 3) {
       return false

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerModelHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerModelHandlerTests.kt
@@ -222,7 +222,7 @@ internal class ClassicLoadBalancerModelHandlerTests : JUnit5Minutests {
         expectThat(diff.diff.getChild("securityGroupNames").state).isEqualTo(DiffNode.State.CHANGED)
 
         runBlocking {
-          upsert(normalize(newResource as Resource<Any>), diff as ResourceDiff<ClassicLoadBalancer>)
+          upsert(normalize(newResource as Resource<Any>), diff)
         }
 
         val slot = slot<OrchestrationRequest>()

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ArtifactService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ArtifactService.kt
@@ -1,15 +1,14 @@
 package com.netflix.spinnaker.igor
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
-import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface ArtifactService {
 
   @GET("/artifacts/rocket/{application}/{version}")
-  fun getArtifact(
+  suspend fun getArtifact(
     @Path("application") application: String,
     @Path("version") version: String
-  ): Deferred<Artifact>
+  ): Artifact
 }

--- a/keel-mahe/src/main/kotlin/com/netflix/spinnaker/keel/mahe/DynamicPropertyService.kt
+++ b/keel-mahe/src/main/kotlin/com/netflix/spinnaker/keel/mahe/DynamicPropertyService.kt
@@ -1,13 +1,12 @@
 package com.netflix.spinnaker.keel.mahe
 
 import com.netflix.spinnaker.keel.mahe.api.PropertyResponse
-import kotlinx.coroutines.Deferred
 import retrofit2.http.GET
 import retrofit2.http.Path
 
 interface DynamicPropertyService {
   @GET("/properties/app/{application}")
-  fun getProperties(
+  suspend fun getProperties(
     @Path("application") application: String
-  ): Deferred<PropertyResponse>
+  ): PropertyResponse
 }


### PR DESCRIPTION
Damn, missed a couple of services in recent switch over to new coroutine support in Retrofit 2.6.0