### PR TITLE
feat(auth): add required service account for all resources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,6 +70,10 @@ subprojects {
       }
     }
   }
+
+  configurations.all {
+    exclude("javax.servlet","servlet-api")
+  }
 }
 
 defaultTasks(":keel-api:run")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 #Fri Jun 07 13:17:07 PDT 2019
 enablePublishing=false
+fiatVersion=1.1.0
 korkVersion=5.6.2
 kapt.use.worker.api=true

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -68,7 +68,8 @@ internal class ResourceActuatorTests : JUnit5Minutests {
         kind = "foo",
         metadata = mapOf(
           "name" to "resource1",
-          "uid" to randomUID()
+          "uid" to randomUID(),
+          "serviceAccount" to "keel@spinnaker"
         ),
         spec = DummyResourceSpec("whatever")
       )

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceName
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.SubmittedMetadata
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.name
 import com.netflix.spinnaker.keel.api.uid
@@ -52,6 +53,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
     @Suppress("UNCHECKED_CAST")
     fun update(updatedSpec: Any) {
       resource = subject.update(resource.name, SubmittedResource(
+        metadata = SubmittedMetadata("keel@spinnaker"),
         apiVersion = resource.apiVersion,
         kind = resource.kind,
         spec = updatedSpec
@@ -77,6 +79,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
       context("creation") {
         before {
           create(SubmittedResource(
+            metadata = SubmittedMetadata("keel@spinnaker"),
             apiVersion = SPINNAKER_API_V1.subApi("test"),
             kind = "whatever",
             spec = DummyResourceSpec("o hai")

--- a/keel-api/keel-api.gradle.kts
+++ b/keel-api/keel-api.gradle.kts
@@ -17,9 +17,13 @@ dependencies {
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("com.netflix.spinnaker.kork:kork-core")
+  implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.boot:spring-boot-starter-web")
   implementation("org.springframework.security:spring-security-config")
+
+  implementation("com.netflix.spinnaker.fiat:fiat-api:${property("fiatVersion")}")
+  implementation("com.netflix.spinnaker.fiat:fiat-core:${property("fiatVersion")}")
 
   testImplementation("io.strikt:strikt-jackson")
   testImplementation(project(":keel-core-test"))

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.fiat.shared.EnableFiatAutoConfig
+import com.netflix.spinnaker.filters.AuthenticatedRequestFilter
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.ResourceVersionTracker
@@ -12,15 +14,14 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import de.huxhorn.sulky.ulid.ULID
 import org.springframework.beans.factory.config.ConfigurableBeanFactory.SCOPE_PROTOTYPE
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Scope
-import org.springframework.core.Ordered.HIGHEST_PRECEDENCE
-import org.springframework.core.annotation.Order
-import org.springframework.security.config.annotation.web.builders.HttpSecurity
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.core.Ordered
 import java.time.Clock
 
+@EnableFiatAutoConfig
 @Configuration
 class DefaultConfiguration {
   @Bean
@@ -52,9 +53,9 @@ class DefaultConfiguration {
   fun noResourcePlugins(): List<ResolvableResourceHandler<*, *>> = emptyList()
 
   @Bean
-  fun csrfDisable() = @Order(HIGHEST_PRECEDENCE) object : WebSecurityConfigurerAdapter() {
-    override fun configure(http: HttpSecurity) {
-      http.csrf().disable()
-    }
+  fun authenticatedRequestFilter(): FilterRegistrationBean<AuthenticatedRequestFilter> {
+    val frb = FilterRegistrationBean(AuthenticatedRequestFilter(true))
+    frb.order = Ordered.HIGHEST_PRECEDENCE
+    return frb
   }
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.rest
+
+import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
+import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.serviceAccount
+import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+
+@Component
+class AuthorizationSupport(
+  private val permissionEvaluator: FiatPermissionEvaluator,
+  private val resourceRepository: ResourceRepository
+) {
+  fun userCanModifyResource(name: String): Boolean {
+    try {
+      val resource = resourceRepository.get(ResourceName(name), Any::class.java)
+      return userCanModifySpec(resource.serviceAccount)
+    } catch (e: NoSuchResourceException) {
+      // todo eb: should we say "unauthorized" if the resource doesn't exist?
+      // or, should we let someone see that it doesn't exist, because no action would happen?
+      return false
+    }
+  }
+
+  fun userCanModifySpec(serviceAccount: String): Boolean {
+    val auth = SecurityContextHolder.getContext().authentication
+    return userCanAccessServiceAccount(auth, serviceAccount)
+  }
+
+  fun userCanAccessServiceAccount(auth: Authentication, serviceAccount: String): Boolean =
+    permissionEvaluator.hasPermission(auth, serviceAccount, "SERVICE_ACCOUNT", "ignored-svcAcct-auth")
+}

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -36,9 +36,8 @@ class AuthorizationSupport(
       val resource = resourceRepository.get(ResourceName(name), Any::class.java)
       return userCanModifySpec(resource.serviceAccount)
     } catch (e: NoSuchResourceException) {
-      // todo eb: should we say "unauthorized" if the resource doesn't exist?
-      // or, should we let someone see that it doesn't exist, because no action would happen?
-      return false
+      // If resource doesn't exist return true so a 404 is propagated from the controller.
+      return true
     }
   }
 

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -32,6 +32,7 @@ import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
@@ -57,7 +58,9 @@ class ResourceController(
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
   @ResponseStatus(CREATED)
-  fun create(@RequestBody submittedResource: SubmittedResource<Any>): Resource<out Any> {
+  @PreAuthorize("@authorizationSupport.userCanModifySpec(#submittedResource.metadata.serviceAccount)")
+  fun create(@RequestBody submittedResource: SubmittedResource<Any>): Resource<out Any>
+  {
     log.debug("Creating: $submittedResource")
     return resourcePersister.create(submittedResource)
   }
@@ -76,6 +79,7 @@ class ResourceController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
+  @PreAuthorize("@authorizationSupport.userCanModifySpec(#resource.metadata.serviceAccount)")
   fun update(@PathVariable("name") name: ResourceName, @RequestBody resource: SubmittedResource<Any>): Resource<out Any> {
     log.debug("Updating: $resource")
     return resourcePersister.update(name, resource)
@@ -85,6 +89,7 @@ class ResourceController(
     path = ["/{name}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
+  @PreAuthorize("@authorizationSupport.userCanModifyResource(#name)")
   fun delete(@PathVariable("name") name: ResourceName): Resource<*> {
     log.debug("Deleting: $name")
     return resourcePersister.delete(name)

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -74,7 +74,8 @@ internal class EventControllerTests : JUnit5Minutests {
       kind = "securityGroup",
       metadata = mapOf(
         "name" to "ec2:securityGroup:test:ap-south-1:keel",
-        "uid" to randomUID()
+        "uid" to randomUID(),
+        "serviceAccount" to "keel@spinnaker"
       ),
       spec = "mockingThis"
     )

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.name
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceName
+import com.netflix.spinnaker.keel.persistence.get
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.redis.spring.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
@@ -54,6 +55,9 @@ internal class ResourceControllerTests {
   lateinit var resourceRepository: InMemoryResourceRepository
 
   @MockkBean
+  lateinit var authorizationSupport: AuthorizationSupport
+
+  @MockkBean
   lateinit var resourcePersister: ResourcePersister
 
   var resource = Resource(
@@ -61,7 +65,8 @@ internal class ResourceControllerTests {
     kind = "securityGroup",
     metadata = mapOf(
       "name" to "ec2:securityGroup:test:us-west-2:keel",
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     spec = "mockingThis"
   )
@@ -74,6 +79,7 @@ internal class ResourceControllerTests {
   @Test
   fun `can create a resource as YAML`() {
     every { resourcePersister.create(any()) } returns resource
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
     val request = post("/resources")
       .accept(APPLICATION_YAML)
@@ -81,6 +87,8 @@ internal class ResourceControllerTests {
       .content(
         """---
           |apiVersion: test.spinnaker.netflix.com/v1
+          |metadata:
+          |  serviceAccount: keel@spinnaker
           |kind: whatever
           |spec: o hai"""
           .trimMargin()
@@ -95,6 +103,7 @@ internal class ResourceControllerTests {
   @Test
   fun `can create a resource as JSON`() {
     every { resourcePersister.create(any()) } returns resource
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
     val request = post("/resources")
       .accept(APPLICATION_JSON)
@@ -103,6 +112,9 @@ internal class ResourceControllerTests {
         """{
           |  "apiVersion": "test.spinnaker.netflix.com/v1",
           |  "kind": "whatever",
+          |  "metadata": {
+          |  "serviceAccount": "keel@spinnaker"
+          |  },
           |  "spec": "o hai"
           |}"""
           .trimMargin()
@@ -116,6 +128,7 @@ internal class ResourceControllerTests {
 
   @Test
   fun `can update a resource`() {
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
     every { resourcePersister.update(resource.name, any()) } returns resource
 
     val request = put("/resources/${resource.name}")
@@ -124,6 +137,8 @@ internal class ResourceControllerTests {
       .content(
         """---
           |apiVersion: test.spinnaker.netflix.com/v1
+          |metadata:
+          |  serviceAccount: keel@spinnaker
           |kind: whatever
           |spec: kthxbye"""
           .trimMargin()
@@ -138,6 +153,7 @@ internal class ResourceControllerTests {
   @Test
   fun `attempting to update an unknown resource results in a 404`() {
     every { resourcePersister.update(resource.name, any()) } throws NoSuchResourceName(resource.name)
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
     val request = put("/resources/${resource.name}")
       .accept(APPLICATION_YAML)
@@ -145,6 +161,8 @@ internal class ResourceControllerTests {
       .content(
         """---
           |apiVersion: test.spinnaker.netflix.com/v1
+          |metadata:
+          |  serviceAccount: keel@spinnaker
           |kind: whatever
           |spec: kthxbye"""
           .trimMargin()
@@ -156,6 +174,8 @@ internal class ResourceControllerTests {
 
   @Test
   fun `an invalid request body results in an HTTP 400`() {
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
+
     val request = post("/resources")
       .accept(APPLICATION_YAML)
       .contentType(APPLICATION_YAML)
@@ -164,6 +184,7 @@ internal class ResourceControllerTests {
           |apiVersion: test.spinnaker.netflix.com/v1
           |kind: whatever
           |metadata:
+          |  serviceAccount: keel@spinnaker
           |  name: i-should-not-be-naming-my-resources-that-is-keels-job
           |spec: o hai"""
           .trimMargin()
@@ -192,7 +213,7 @@ internal class ResourceControllerTests {
   @Test
   fun `can delete a resource`() {
     every { resourcePersister.delete(resource.name) } returns resource
-
+    every { authorizationSupport.userCanModifyResource(resource.name.toString()) } returns true
     resourceRepository.store(resource)
 
     val request = delete("/resources/${resource.name}")
@@ -209,6 +230,7 @@ internal class ResourceControllerTests {
 
   @Test
   fun `unknown resource name results in a 404`() {
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
     val request = get("/resources/i-do-not-exist")
       .accept(APPLICATION_YAML)
     mvc

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -127,6 +127,29 @@ internal class ResourceControllerTests {
   }
 
   @Test
+  fun `can't create a resource when unauthorized`() {
+    every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns false
+
+    val request = post("/resources")
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
+      .content(
+        """{
+          |  "apiVersion": "test.spinnaker.netflix.com/v1",
+          |  "kind": "whatever",
+          |  "metadata": {
+          |  "serviceAccount": "keel@spinnaker"
+          |  },
+          |  "spec": "o hai"
+          |}"""
+          .trimMargin()
+      )
+    mvc
+      .perform(request)
+      .andExpect(status().isForbidden)
+  }
+
+  @Test
   fun `can update a resource`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
     every { resourcePersister.update(resource.name, any()) } returns resource

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -59,7 +59,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
       kind = handler.supportedKind.first.singular,
       metadata = mapOf(
         "uid" to randomUID(),
-        "name" to "bakery:image:keel"
+        "name" to "bakery:image:keel",
+        "serviceAccount" to "keel@spinnaker"
       ),
       spec = ImageSpec(
         artifactName = "keel",

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -98,7 +98,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         apiVersion = SPINNAKER_API_V1,
         metadata = mapOf(
           "name" to "ec2:security-group:test:us-west-2:fnord",
-          "uid" to randomUID().toString()
+          "uid" to randomUID().toString(),
+          "serviceAccount" to "keel@spinnaker"
         ) + randomData(),
         kind = "security-group",
         spec = randomData()
@@ -131,7 +132,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         val anotherResource = Resource(
           metadata = mapOf(
             "name" to "ec2:security-group:test:us-east-1:fnord",
-            "uid" to randomUID()
+            "uid" to randomUID(),
+            "serviceAccount" to "keel@spinnaker"
           ) + randomData(),
           apiVersion = SPINNAKER_API_V1,
           kind = "security-group",
@@ -257,7 +259,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
             apiVersion = SPINNAKER_API_V1,
             metadata = mapOf(
               "name" to "ec2:security-group:test:us-west-2:fnord-$it",
-              "uid" to randomUID()
+              "uid" to randomUID(),
+              "serviceAccount" to "keel@spinnaker"
             ) + randomData(),
             kind = "security-group",
             spec = randomData()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -30,6 +30,7 @@ data class Resource<T : Any>(
     require(kind.isNotEmpty()) { "resource kind must be defined" }
     require(metadata["uid"].isValidULID()) { "resource uid must be a valid ULID" }
     require(metadata["name"].isValidName()) { "resource name must be a valid name" }
+    require(metadata["serviceAccount"].isValidServiceAccount()) { "serviceAccount must be a valid email" }
   }
 
   constructor(resource: SubmittedResource<T>, metadata: Map<String, Any?>) :
@@ -38,12 +39,19 @@ data class Resource<T : Any>(
 
 /**
  * External representation of a resource that would be submitted to the API
- * It doesn't need to contain metadata
  */
 data class SubmittedResource<T : Any>(
+  val metadata: SubmittedMetadata,
   val apiVersion: ApiVersion,
   val kind: String,
   val spec: T
+)
+
+/**
+ * Required metadata to be submitted with a resource
+ */
+data class SubmittedMetadata(
+  val serviceAccount: String
 )
 
 val <T : Any> Resource<T>.uid: UID
@@ -51,6 +59,9 @@ val <T : Any> Resource<T>.uid: UID
 
 val <T : Any> Resource<T>.name: ResourceName
   get() = metadata.getValue("name").toString().let(::ResourceName)
+
+val <T : Any> Resource<T>.serviceAccount: String
+  get() = metadata.getValue("serviceAccount").toString()
 
 private fun Any?.isValidULID() =
   when (this) {
@@ -64,5 +75,11 @@ private fun Any?.isValidULID() =
 private fun Any?.isValidName() =
   when (this) {
     is String -> isNotBlank()
+    else -> false
+  }
+
+private fun Any?.isValidServiceAccount() =
+  when (this) {
+    is String -> isNotBlank() && contains("@")
     else -> false
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -30,7 +30,7 @@ data class Resource<T : Any>(
     require(kind.isNotEmpty()) { "resource kind must be defined" }
     require(metadata["uid"].isValidULID()) { "resource uid must be a valid ULID" }
     require(metadata["name"].isValidName()) { "resource name must be a valid name" }
-    require(metadata["serviceAccount"].isValidServiceAccount()) { "serviceAccount must be a valid email" }
+    require(metadata["serviceAccount"].isValidServiceAccount()) { "serviceAccount must be a valid service account" }
   }
 
   constructor(resource: SubmittedResource<T>, metadata: Map<String, Any?>) :
@@ -80,6 +80,6 @@ private fun Any?.isValidName() =
 
 private fun Any?.isValidServiceAccount() =
   when (this) {
-    is String -> isNotBlank() && contains("@")
+    is String -> isNotBlank()
     else -> false
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -35,6 +35,7 @@ import com.netflix.spinnaker.keel.api.uid
 import java.time.Clock
 import java.time.Instant
 
+// todo emjburns: use the common class in kork, but refactor so you can also set the time in those.
 @JsonTypeInfo(
   use = Id.NAME,
   property = "type",

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
@@ -19,6 +19,7 @@ internal class ResourceMetadataTests : JUnit5Minutests {
         mapOf(
           "name" to "my-new-cron-object",
           "uid" to "1423255B460011E7AF6A28D244",
+          "serviceAccount" to "keel@spinnaker",
           "clusterName" to "",
           "creationTimestamp" to "2017-05-31T12:56:35Z",
           "deletionGracePeriodSeconds" to null,
@@ -33,6 +34,7 @@ internal class ResourceMetadataTests : JUnit5Minutests {
           """---
           |name: "my-new-cron-object"
           |uid: "1423255B460011E7AF6A28D244"
+          |serviceAccount: "keel@spinnaker"
           |clusterName: ""
           |creationTimestamp: "2017-05-31T12:56:35Z"
           |deletionGracePeriodSeconds: null
@@ -54,6 +56,7 @@ internal class ResourceMetadataTests : JUnit5Minutests {
         |namespace: default
         |selfLink: /apis/stable.example.com/v1/namespaces/default/crontabs/my-new-cron-object
         |uid: 1423255b460011e7af6a28d244
+        |serviceAccount: "keel@spinnaker"
       """.trimMargin()
       }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -61,7 +61,8 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
           kind = "ec2:whatever",
           metadata = mapOf(
             "uid" to randomUID(),
-            "name" to "ec2:prod:ap-south-1:a-thing"
+            "name" to "ec2:prod:ap-south-1:a-thing",
+            "serviceAccount" to "keel@spinnaker"
           ),
           spec = randomData()
         )

--- a/keel-deliveryconfig-plugin/src/test/kotlin/com/netflix/spinnaker/keel/deliveryconfig/resource/DeliveryConfigHandlerTests.kt
+++ b/keel-deliveryconfig-plugin/src/test/kotlin/com/netflix/spinnaker/keel/deliveryconfig/resource/DeliveryConfigHandlerTests.kt
@@ -27,7 +27,8 @@ internal class DeliveryConfigHandlerTests : JUnit5Minutests {
     "deliveryconfig",
     mapOf(
       "name" to "foo",
-      "uid" to idGenerator.nextValue()
+      "uid" to idGenerator.nextValue(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     spec
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTest.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTest.kt
@@ -73,7 +73,8 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
     "application-load-balancer",
     mapOf(
       "name" to "my-alb",
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     spec
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -78,7 +78,8 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
     "classic-load-balancer",
     mapOf(
       "name" to "my-clb",
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     spec
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -98,7 +98,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     "cluster",
     mapOf(
       "name" to "my-cluster",
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     spec
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -504,7 +504,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
         "name" to with(securityGroup) {
           "ec2.SecurityGroup:${moniker.app}:$accountName:$region:${moniker.name}"
         },
-        "uid" to randomUID()
+        "uid" to randomUID(),
+        "serviceAccount" to "keel@spinnaker"
       ),
       kind = "ec2.SecurityGroup",
       spec = securityGroup

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResolvableResourceHandler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResolvableResourceHandler.kt
@@ -62,7 +62,8 @@ interface ResolvableResourceHandler<S : Any, R : Any> : KeelPlugin {
     }
     val metadata = mapOf(
       "name" to generateName(spec).toString(),
-      "uid" to randomUID().toString()
+      "uid" to randomUID().toString(),
+      "serviceAccount" to resource.metadata.serviceAccount
     )
     val hydratedResource = Resource(
       apiVersion = resource.apiVersion,

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -65,7 +65,8 @@ internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResource
             apiVersion = SPINNAKER_API_V1,
             metadata = mapOf(
               "name" to "ec2:security-group:test:us-west-2:fnord-$it",
-              "uid" to randomUID()
+              "uid" to randomUID(),
+              "serviceAccount" to "keel@spinnaker"
             ) + randomData(),
             kind = "security-group",
             spec = randomData()
@@ -90,7 +91,8 @@ internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResource
           apiVersion = SPINNAKER_API_V1,
           metadata = mapOf(
             "name" to "ec2:security-group:test:us-west-2:fnord",
-            "uid" to randomUID()
+            "uid" to randomUID(),
+            "serviceAccount" to "keel@spinnaker"
           ) + randomData(),
           kind = "security-group",
           spec = randomData()

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.keel.tagging
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
 import com.netflix.spinnaker.keel.api.ResourceName
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.SubmittedMetadata
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
@@ -151,6 +152,7 @@ class ResourceTagger(
 
   private fun KeelTagSpec.toSubmittedResource() =
     SubmittedResource(
+      metadata = SubmittedMetadata("keel@spinnaker.io"),
       apiVersion = SPINNAKER_API_V1.subApi("tag"),
       kind = "keel-tag",
       spec = this

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
@@ -108,7 +108,8 @@ internal class KeelTagHandlerTests : JUnit5Minutests {
     "keel-tag",
     mapOf(
       "name" to keelId,
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     specWithTag
   )

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
@@ -72,7 +72,8 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("ec2"),
     metadata = mapOf(
       "name" to clusterName.toString(),
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     kind = "cluster",
     spec = mapOf("fake" to "data")
@@ -82,7 +83,8 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("tag"),
     metadata = mapOf(
       "name" to clusterTagName.toString(),
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     kind = "keel-tag",
     spec = KeelTagSpec(
@@ -106,7 +108,8 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("tag"),
     metadata = mapOf(
       "name" to clusterTagName.toString(),
-      "uid" to randomUID()
+      "uid" to randomUID(),
+      "serviceAccount" to "keel@spinnaker"
     ),
     kind = "keel-tag",
     spec = KeelTagSpec(
@@ -159,7 +162,8 @@ internal class ResourceTaggerTests : JUnit5Minutests {
           arg(1),
           mapOf(
             "name" to clusterTagName.value,
-            "uid" to randomUID()
+            "uid" to randomUID(),
+            "serviceAccount" to "keel@spinnaker"
           )
         )
       }

--- a/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/api/SimpleVetoPluginTests.kt
+++ b/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/api/SimpleVetoPluginTests.kt
@@ -31,7 +31,8 @@ internal object SimpleVetoPluginTests : JUnit5Minutests {
           kind = "ec2.SecurityGroup",
           metadata = mapOf(
             "name" to "ec2.SecurityGroup:keel:prod:us-east-1:keel",
-            "uid" to randomUID()
+            "uid" to randomUID(),
+            "serviceAccount" to "keel@spinnaker"
           ),
           spec = randomData()
         )


### PR DESCRIPTION
* Adding fiat to keel.
* Adding a required new field when submitting resources, `metadata`, which must contain a `securityAccount`. Is this good? Give me opinions. I'm not sure if this should be required.
* Checking when you create/update/delete if you (`X-SPINNAKER-USER`) have access to the service account you specify.
* Adding this service account to the normal metadata for all resources.

TODO: use that service account for actuation. 