### PR TITLE
fix(tags): add account, correct loadbalancer tag lookup

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/tags/EntityTag.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/tags/EntityTag.kt
@@ -47,11 +47,12 @@ data class EntityRef(
   val entityId: String,
   val application: String,
   val region: String,
-  val account: String, // must be account number
+  val account: String, // account name
+  val accountId: String, // account number
   val cloudProvider: String
 ) {
   fun generateId(): String {
-    return "$cloudProvider:$entityType:$entityId:$account:$region"
+    return "$cloudProvider:$entityType:$entityId:$accountId:$region"
   }
 }
 

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandler.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandler.kt
@@ -68,8 +68,7 @@ class KeelTagHandler(
         val desiredTag = (resource.spec.tagState as TagDesired).tag
         return TaggedResource(resource.spec.keelId, resource.spec.entityRef, desiredTag)
       }
-      else -> {
-        // TagNotDesired
+      is TagNotDesired -> {
         return TaggedResource(resource.spec.keelId, resource.spec.entityRef, null)
       }
     }

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -67,6 +67,11 @@ class ResourceTagger(
     "ec2" to "aws"
   )
 
+  private val entityTypeTransforms = mapOf(
+    "classic-load-balancer" to "loadbalancer",
+    "application-load-balancer" to "loadbalancer"
+  )
+
   private val taggableResources = listOf(
     "cluster",
     "securityGroup",
@@ -187,11 +192,12 @@ class ResourceTagger(
     }
 
     return EntityRef(
-      entityType = resourceType,
+      entityType = entityTypeTransforms.getOrDefault(resourceType, resourceType),
       entityId = resourceId,
       application = resourceId.substringBefore("-"),
       region = region,
-      account = accountId,
+      account = account,
+      accountId = accountId,
       cloudProvider = transforms.getOrDefault(pluginGroup, pluginGroup)
     )
   }

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
@@ -69,8 +69,9 @@ internal class KeelTagHandlerTests : JUnit5Minutests {
     entityId = "emburnstest-managed-reference-v005",
     application = "emburnstest",
     region = "us-west-1",
-    cloudProvider = "aws",
-    account = "test"
+    account = "test",
+    accountId = "1234",
+    cloudProvider = "aws"
   )
 
   val managedByKeelTag = EntityTag(

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpecTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpecTests.kt
@@ -18,7 +18,7 @@ internal class KeelTagSpecTests : JUnit5Minutests {
       fixture {
         val resource = KeelTagSpec(
           "ec2:cluster:mgmt:us-west-2:keel-prestaging",
-          EntityRef("cluster", "keel-prestaging", "keel", "us-west-2", "mgmt", "aws"),
+          EntityRef("cluster", "keel-prestaging", "keel", "us-west-2", "mgmt", "12345", "aws"),
           TagDesired(
             EntityTag(
               value = TagValue(

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
@@ -87,7 +87,7 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     kind = "keel-tag",
     spec = KeelTagSpec(
       clusterName.toString(),
-      EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "aws"),
+      EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "1234", "aws"),
       TagDesired(tag = EntityTag(
         value = TagValue(
           message = KEEL_TAG_MESSAGE,
@@ -111,7 +111,7 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     kind = "keel-tag",
     spec = KeelTagSpec(
       clusterName.toString(),
-      EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "aws"),
+      EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "1234", "aws"),
       TagNotDesired(clock.millis())
     )
   )


### PR DESCRIPTION
Entity tags should pass `account` (with account name) as well as `accountId` (account number) in the account ref. Otherwise, clouddriver sets `account = accountId` and the UI isn't super happy.

Also, transform `*-load-balancer` to `loadbalancer` (what clouddriver expects for load balancer entity tags) so that we can look them up successfully. 