### PR TITLE
feat(create): if resource exists, second create is an update

### DIFF
--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -284,6 +284,12 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 private fun <T : Iterable<E>, E> Assertion.Builder<T>.second(): Assertion.Builder<E> =
   get("second element %s") { toList()[1] }
 
-internal data class DummyResource(val state: String)
+internal data class DummyResource(
+  val state: String,
+  val data: String = "some data"
+)
 
-internal data class DummyResourceSpec(val state: String)
+internal data class DummyResourceSpec(
+  val state: String,
+  val data: String = "some data"
+)

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -47,12 +47,12 @@ internal class ResourcePersisterTests : JUnit5Minutests {
 
     @Suppress("UNCHECKED_CAST")
     fun create(submittedResource: SubmittedResource<Any>) {
-      resource = subject.create(submittedResource) as Resource<DummyResourceSpec>
+      resource = subject.upsert(submittedResource) as Resource<DummyResourceSpec>
     }
 
     @Suppress("UNCHECKED_CAST")
     fun update(updatedSpec: Any) {
-      resource = subject.update(resource.name, SubmittedResource(
+      resource = subject.upsert(SubmittedResource(
         metadata = SubmittedMetadata("keel@spinnaker"),
         apiVersion = resource.apiVersion,
         kind = resource.kind,
@@ -111,12 +111,17 @@ internal class ResourcePersisterTests : JUnit5Minutests {
         context("after an update") {
           before {
             resourcesDueForCheck()
-            update(DummyResourceSpec("kthxbye"))
+            subject.upsert(SubmittedResource(
+              metadata = SubmittedMetadata("keel@spinnaker"),
+              apiVersion = resource.apiVersion,
+              kind = resource.kind,
+              spec = DummyResourceSpec("o hai", "kthxbye")
+            ))
           }
 
           test("stores the updated resource") {
             expectThat(repository.get<DummyResourceSpec>(resource.name))
-              .get { spec.state }
+              .get { spec.data }
               .isEqualTo("kthxbye")
           }
 
@@ -149,29 +154,6 @@ internal class ResourcePersisterTests : JUnit5Minutests {
           test("does not check the resource again") {
             expectThat(resourcesDueForCheck())
               .isEmpty()
-          }
-        }
-
-        context("a second create is sent") {
-          before {
-            create(SubmittedResource(
-              apiVersion = SPINNAKER_API_V1.subApi("test"),
-              kind = "whatever",
-              spec = DummyResourceSpec("o hai")
-            ))
-
-            subject.update(resource.name, SubmittedResource(
-              apiVersion = resource.apiVersion,
-              kind = resource.kind,
-              spec = DummyResourceSpec("o bai")
-            ))
-          }
-
-          test("a second create becomes an update") {
-            expectThat(eventHistory())
-              .hasSize(2)
-              .first()
-              .isA<ResourceUpdated>()
           }
         }
       }

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -151,6 +151,29 @@ internal class ResourcePersisterTests : JUnit5Minutests {
               .isEmpty()
           }
         }
+
+        context("a second create is sent") {
+          before {
+            create(SubmittedResource(
+              apiVersion = SPINNAKER_API_V1.subApi("test"),
+              kind = "whatever",
+              spec = DummyResourceSpec("o hai")
+            ))
+
+            subject.update(resource.name, SubmittedResource(
+              apiVersion = resource.apiVersion,
+              kind = resource.kind,
+              spec = DummyResourceSpec("o bai")
+            ))
+          }
+
+          test("a second create becomes an update") {
+            expectThat(eventHistory())
+              .hasSize(2)
+              .first()
+              .isA<ResourceUpdated>()
+          }
+        }
       }
     }
   }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.keel.persistence.get
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus.BAD_REQUEST
-import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -37,7 +36,6 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -53,18 +51,6 @@ class ResourceController(
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
-  @PostMapping(
-    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  @ResponseStatus(CREATED)
-  @PreAuthorize("@authorizationSupport.userCanModifySpec(#submittedResource.metadata.serviceAccount)")
-  fun create(@RequestBody submittedResource: SubmittedResource<Any>): Resource<out Any>
-  {
-    log.debug("Creating: $submittedResource")
-    return resourcePersister.create(submittedResource)
-  }
-
   @GetMapping(
     path = ["/{name}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
@@ -75,14 +61,13 @@ class ResourceController(
   }
 
   @PutMapping(
-    path = ["/{name}"],
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
   @PreAuthorize("@authorizationSupport.userCanModifySpec(#resource.metadata.serviceAccount)")
-  fun update(@PathVariable("name") name: ResourceName, @RequestBody resource: SubmittedResource<Any>): Resource<out Any> {
-    log.debug("Updating: $resource")
-    return resourcePersister.update(name, resource)
+  fun upsert(@RequestBody resource: SubmittedResource<Any>): Resource<out Any> {
+    log.debug("Upserting: $resource")
+    return resourcePersister.upsert(resource)
   }
 
   @DeleteMapping(

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -36,7 +36,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
@@ -60,7 +60,7 @@ class ResourceController(
     return resourceRepository.get(name)
   }
 
-  @PutMapping(
+  @PostMapping(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -27,7 +27,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import strikt.api.Assertion
 import strikt.api.DescribeableBuilder
@@ -79,7 +79,7 @@ internal class ResourceControllerTests {
     every { resourcePersister.upsert(any()) } returns resource
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
-    val request = put("/resources")
+    val request = post("/resources")
       .accept(APPLICATION_YAML)
       .contentType(APPLICATION_YAML)
       .content(
@@ -103,7 +103,7 @@ internal class ResourceControllerTests {
     every { resourcePersister.upsert(any()) } returns resource
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
-    val request = put("/resources")
+    val request = post("/resources")
       .accept(APPLICATION_JSON)
       .contentType(APPLICATION_JSON)
       .content(
@@ -128,7 +128,7 @@ internal class ResourceControllerTests {
   fun `can't create a resource when unauthorized`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns false
 
-    val request = put("/resources")
+    val request = post("/resources")
       .accept(APPLICATION_JSON)
       .contentType(APPLICATION_JSON)
       .content(
@@ -152,7 +152,7 @@ internal class ResourceControllerTests {
     every { resourcePersister.upsert(any()) } returns resource
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
-    val request = put("/resources")
+    val request = post("/resources")
       .accept(APPLICATION_YAML)
       .contentType(APPLICATION_YAML)
       .content(
@@ -176,7 +176,7 @@ internal class ResourceControllerTests {
     every { resourcePersister.upsert(any()) } throws NoSuchResourceName(resource.name)
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
 
-    val request = put("/resources")
+    val request = post("/resources")
       .accept(APPLICATION_YAML)
       .contentType(APPLICATION_YAML)
       .content(
@@ -196,7 +196,7 @@ internal class ResourceControllerTests {
   @Test
   fun `an invalid request body results in an HTTP 400`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker") } returns true
-    val request = put("/resources")
+    val request = post("/resources")
       .accept(APPLICATION_YAML)
       .contentType(APPLICATION_YAML)
       .content(


### PR DESCRIPTION
This will make sure that we don't get mismatching uids