### PR TITLE
feat(history): task id and name, not ref

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -10,7 +10,7 @@ import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceMissing
 import com.netflix.spinnaker.keel.events.ResourceValid
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.plugin.supporting
@@ -121,14 +121,14 @@ class ResourceActuator(
   private suspend fun <S : Any, R : Any> ResolvableResourceHandler<S, R>.create(
     resource: Resource<*>,
     resourceDiff: ResourceDiff<*>
-  ): List<TaskRef> =
+  ): List<Task> =
     create(resource as Resource<S>, resourceDiff as ResourceDiff<R>)
 
   @Suppress("UNCHECKED_CAST")
   private suspend fun <S : Any, R : Any> ResolvableResourceHandler<S, R>.update(
     resource: Resource<*>,
     resourceDiff: ResourceDiff<*>
-  ): List<TaskRef> =
+  ): List<Task> =
     update(resource as Resource<S>, resourceDiff as ResourceDiff<R>)
   // end type coercing extensions
 }

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceMissing
 import com.netflix.spinnaker.keel.events.ResourceValid
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckError
@@ -179,7 +179,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
           before {
             coEvery { plugin1.desired(resource) } returns DummyResource(resource.spec.state)
             coEvery { plugin1.current(resource) } returns null
-            coEvery { plugin1.create(resource, any()) } returns listOf(TaskRef("/tasks/${randomUID()}"))
+            coEvery { plugin1.create(resource, any()) } returns listOf(Task(id = randomUID().toString(), name = "a task"))
 
             with(resource) {
               runBlocking {
@@ -204,7 +204,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
           before {
             coEvery { plugin1.desired(resource) } returns DummyResource(resource.spec.state)
             coEvery { plugin1.current(resource) } returns DummyResource("some other state that does not match")
-            coEvery { plugin1.update(resource, any()) } returns listOf(TaskRef("/tasks/${randomUID()}"))
+            coEvery { plugin1.update(resource, any()) } returns listOf(Task(id = randomUID().toString(), name = "a task"))
 
             with(resource) {
               runBlocking {

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -12,7 +12,7 @@ import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceEvent
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
@@ -107,7 +107,7 @@ internal class EventControllerTests : JUnit5Minutests {
           clock.incrementBy(Duration.ofMinutes(10))
           appendHistory(ResourceDeltaDetected(resource, emptyMap(), clock))
           clock.incrementBy(Duration.ofMinutes(10))
-          appendHistory(ResourceActuationLaunched(resource, "a-plugin", listOf(TaskRef(randomUID().toString())), clock))
+          appendHistory(ResourceActuationLaunched(resource, "a-plugin", listOf(Task(id = randomUID().toString(), name = "i did a thing")), clock))
           clock.incrementBy(Duration.ofMinutes(10))
           appendHistory(ResourceDeltaResolved(resource, resource.spec, clock))
           clock.incrementBy(Duration.ofMinutes(10))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -198,10 +198,10 @@ data class ResourceActuationLaunched(
   override val kind: String,
   override val name: String,
   val plugin: String,
-  val tasks: List<TaskRef>,
+  val tasks: List<Task>,
   override val timestamp: Instant
 ) : ResourceEvent() {
-  constructor(resource: Resource<*>, plugin: String, tasks: List<TaskRef>, clock: Clock = Companion.clock) :
+  constructor(resource: Resource<*>, plugin: String, tasks: List<Task>, clock: Clock = Companion.clock) :
     this(
       resource.uid,
       resource.apiVersion,
@@ -270,6 +270,11 @@ data class ResourceValid(
 data class TaskRef(val value: String) {
   override fun toString(): String = value
 }
+
+data class Task(
+  val id: String,
+  val name: String
+)
 
 class TaskRefDeserializer : StdDeserializer<TaskRef>(TaskRef::class.java) {
   override fun deserialize(parser: JsonParser, context: DeserializationContext): TaskRef =

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -14,7 +14,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -54,7 +54,7 @@ class ApplicationLoadBalancerHandler(
   override suspend fun upsert(
     resource: Resource<ApplicationLoadBalancer>,
     resourceDiff: ResourceDiff<ApplicationLoadBalancer>
-  ): List<TaskRef> {
+  ): List<Task> {
     val action = when {
       resourceDiff.current == null -> "Creating"
       else -> "Upserting"
@@ -80,7 +80,7 @@ class ApplicationLoadBalancerHandler(
       }
 
     log.info("Started task ${taskRef.ref} to $description")
-    return listOf(TaskRef(taskRef.ref))
+    return listOf(Task(id = taskRef.taskId, name = description))
   }
 
   override suspend fun delete(resource: Resource<ApplicationLoadBalancer>) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -15,7 +15,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -56,7 +56,7 @@ class ClassicLoadBalancerHandler(
   override suspend fun upsert(
     resource: Resource<ClassicLoadBalancer>,
     resourceDiff: ResourceDiff<ClassicLoadBalancer>
-  ): List<TaskRef> {
+  ): List<Task> {
     val action = when {
       resourceDiff.current == null -> "Creating"
       else -> "Upserting"
@@ -81,7 +81,7 @@ class ClassicLoadBalancerHandler(
       }
 
     log.info("Started task ${taskRef.ref} to $description")
-    return listOf(TaskRef(taskRef.ref))
+    return listOf(Task(id = taskRef.taskId, name = description))
   }
 
   override suspend fun delete(resource: Resource<ClassicLoadBalancer>) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/NamedImageHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/NamedImageHandler.kt
@@ -11,7 +11,7 @@ import com.netflix.spinnaker.keel.api.ec2.NamedImage
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.ResourceDiff
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
@@ -51,7 +51,7 @@ class NamedImageHandler(
       objectMapper.convertValue<ImageResult>(it)
     }
 
-  override suspend fun upsert(resource: Resource<NamedImage>, resourceDiff: ResourceDiff<NamedImage>): List<TaskRef> {
+  override suspend fun upsert(resource: Resource<NamedImage>, resourceDiff: ResourceDiff<NamedImage>): List<Task> {
     resourceDiff.current?.also {
       resourceRepository.store(resource.copy(spec = it))
     }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -34,7 +34,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -73,41 +73,45 @@ class SecurityGroupHandler(
   override suspend fun create(
     resource: Resource<SecurityGroup>,
     resourceDiff: ResourceDiff<SecurityGroup>
-  ): List<TaskRef> {
+  ): List<Task> {
+    val description: String
     val taskRef = resource.spec.let { spec ->
+      description = "Create security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}"
       orcaService
         .orchestrate(
           resource.serviceAccount,
           OrchestrationRequest(
-            "Create security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
+            description,
             spec.moniker.app,
-            "Create security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
+            description,
             listOf(spec.toCreateJob()),
             OrchestrationTrigger(resource.name.toString())
           ))
     }
     log.info("Started task {} to create security group", taskRef.ref)
-    return listOf(TaskRef(taskRef.ref))
+    return listOf(Task(id = taskRef.taskId, name = description))
   }
 
   override suspend fun update(
     resource: Resource<SecurityGroup>,
     resourceDiff: ResourceDiff<SecurityGroup>
-  ): List<TaskRef> {
+  ): List<Task> {
+    val description: String
     val taskRef = resource.spec.let { spec ->
+      description = "Update security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}"
       orcaService
         .orchestrate(
           resource.serviceAccount,
           OrchestrationRequest(
-            "Update security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
+            description,
             spec.moniker.app,
-            "Update security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
+            description,
             listOf(spec.toUpdateJob()),
             OrchestrationTrigger(resource.name.toString())
           ))
     }
     log.info("Started task {} to update security group", taskRef.ref)
-    return listOf(TaskRef(taskRef.ref))
+    return listOf(Task(id = taskRef.taskId, name = description))
   }
 
   override suspend fun delete(resource: Resource<SecurityGroup>) {

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResolvableResourceHandler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResolvableResourceHandler.kt
@@ -10,7 +10,7 @@ import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.name
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.diff.ResourceDiff
-import com.netflix.spinnaker.keel.events.TaskRef
+import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.exceptions.InvalidResourceFormatException
 import com.netflix.spinnaker.keel.exceptions.InvalidResourceStructureException
 import org.slf4j.Logger
@@ -138,7 +138,7 @@ interface ResolvableResourceHandler<S : Any, R : Any> : KeelPlugin {
   suspend fun create(
     resource: Resource<S>,
     resourceDiff: ResourceDiff<R>
-  ): List<TaskRef> =
+  ): List<Task> =
     upsert(resource, resourceDiff)
 
   /**
@@ -154,7 +154,7 @@ interface ResolvableResourceHandler<S : Any, R : Any> : KeelPlugin {
   suspend fun update(
     resource: Resource<S>,
     resourceDiff: ResourceDiff<R>
-  ): List<TaskRef> =
+  ): List<Task> =
     upsert(resource, resourceDiff)
 
   /**
@@ -168,7 +168,7 @@ interface ResolvableResourceHandler<S : Any, R : Any> : KeelPlugin {
   suspend fun upsert(
     resource: Resource<S>,
     resourceDiff: ResourceDiff<R>
-  ): List<TaskRef> {
+  ): List<Task> {
     TODO("Not implemented")
   }
 


### PR DESCRIPTION
When we launch tasks, save them in the history with an `id` and a `name` instead of the `ref`.