### PR TITLE
fix(artifact): parse artifact correctly

### DIFF
--- a/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
+++ b/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   implementation(project(":keel-orca"))
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("com.netflix.spinnaker.kork:kork-security")
+  implementation("com.netflix.frigga:frigga")
 
   testImplementation(project(":keel-test"))
   testImplementation("dev.minutest:minutest")


### PR DESCRIPTION
The artifact name is not necessarily the app name. For example, the "appVersion" tags for keel are of the form `keel-0.231.0-h146.a7234bf` but my super great sample app has "appVersion" tags the form `deb-sample-app-server-0.0.1~rc.103-h104.72b8e24`. This PR uses frigga to parse the package name so that we correctly get `keel` as well as `deb-sample-app-server`.