### PR TITLE
Make sure we're getting an AMI for the right package

### DIFF
--- a/keel-clouddriver/keel-clouddriver.gradle.kts
+++ b/keel-clouddriver/keel-clouddriver.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
+  implementation("com.netflix.frigga:frigga")
 
   testImplementation(project(":keel-retrofit-test-support"))
   testImplementation("com.squareup.retrofit2:retrofit-mock")

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -97,6 +97,27 @@ internal class ImageServiceTests {
     )
   )
 
+  val image4 = NamedImage(
+    imageName = "my-package-foo-0.0.1_rc.99-h100",
+    attributes = mapOf(
+      "virtualizationType" to "hvm",
+      "creationDate" to "2019-08-28T13:09:54.000Z"
+    ),
+    tagsByImageId = mapOf(
+      "ami-003" to mapOf(
+        "build_host" to "https://jenkins/",
+        "appversion" to "my-package-foo-0.0.1~rc.99-h100.8192e02/JENKINS-job/100",
+        "creator" to "emburns@netflix.com",
+        "base_ami_version" to "nflx-base-5.292.0-h988",
+        "creation_time" to "2018-10-31 13:09:55 UTC"
+      )
+    ),
+    accounts = setOf("test"),
+    amis = mapOf(
+      "us-west-1" to listOf("ami-004")
+    )
+  )
+
   val newestImage = listOf(image1, image2, image3)
     .maxBy { it.creationDate } ?: error("can't find latest image in fixture")
 
@@ -111,8 +132,8 @@ internal class ImageServiceTests {
   @Test
   fun `get latest image returns actual latest image`() {
     coEvery {
-      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package", "test")
-    } returns listOf(image2, image3, image1)
+      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package-", "test")
+    } returns listOf(image2, image4, image3, image1)
 
     runBlocking {
       val image = subject.getLatestImage("my-package", "test")
@@ -126,8 +147,8 @@ internal class ImageServiceTests {
   @Test
   fun `get latest named image returns actual latest image`() {
     coEvery {
-      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package", "test")
-    } returns listOf(image2, image3, image1)
+      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package-", "test")
+    } returns listOf(image2, image4, image3, image1)
 
     runBlocking {
       val image = subject.getLatestNamedImage("my-package", "test")
@@ -141,7 +162,7 @@ internal class ImageServiceTests {
   @Test
   fun `no image provided if image not found for latest from artifact`() {
     coEvery {
-      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package", "test")
+      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package-", "test")
     } returns emptyList()
 
     runBlocking {
@@ -154,8 +175,8 @@ internal class ImageServiceTests {
   @Test
   fun `get named image from jenkins info works`() {
     coEvery {
-      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package", "test")
-    } returns listOf(image2, image3, image1)
+      cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package-", "test")
+    } returns listOf(image2, image4, image3, image1)
 
     runBlocking {
       val image = subject.getNamedImageFromJenkinsInfo(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -49,7 +49,6 @@ class EC2Config {
   ): ImageResolver =
     ImageResolver(
       dynamicConfigService,
-      cloudDriverService,
       deliveryConfigRepository,
       artifactRepository,
       imageService

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
@@ -10,11 +10,8 @@ import com.netflix.spinnaker.keel.api.ec2.image.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.IdImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.ImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.JenkinsImageProvider
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.uid
-import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ImageService
-import com.netflix.spinnaker.keel.clouddriver.model.NamedImageComparator
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -22,7 +19,6 @@ import org.slf4j.LoggerFactory
 
 class ImageResolver(
   private val dynamicConfigService: DynamicConfigService,
-  private val cloudDriverService: CloudDriverService,
   private val deliveryConfigRepository: DeliveryConfigRepository,
   private val artifactRepository: ArtifactRepository,
   private val imageService: ImageService
@@ -50,10 +46,8 @@ class ImageResolver(
           artifact.name
         }
         val account = dynamicConfigService.getConfig("images.default-account", "test")
-        val namedImage = cloudDriverService
-          .namedImages(resource.serviceAccount, artifactName, account)
-          .sortedWith(NamedImageComparator)
-          .lastOrNull() ?: throw NoImageFound(artifactName)
+        val namedImage = imageService
+          .getLatestNamedImage(artifactName, account) ?: throw NoImageFound(artifactName)
 
         log.info("Image found for {}: {}", artifactName, namedImage)
 


### PR DESCRIPTION
Previously 2 packages starting with the same name could be mistaken for each other, resulting in Keel deploying the wrong thing.

Fixes #403