### PR TITLE
Handle multiple AMIs for appversion (different AMIs in each region)

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -59,10 +59,13 @@ class ImageService(
   }
 
   /**
-   * Get the latest named image for a package
+   * Get the latest named image for a package.
+   *
+   * @param region if supplied the latest image in this region is returned, if `null` the latest
+   * image regardless of region.
    */
-  suspend fun getLatestNamedImage(packageName: String, account: String): NamedImage? =
-    cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, "$packageName-", account)
+  suspend fun getLatestNamedImage(packageName: String, account: String, region: String? = null): NamedImage? =
+    cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, "$packageName-", account, region)
       .sortedWith(NamedImageComparator)
       .lastOrNull {
         AppVersion.parseName(it.appVersion).packageName == packageName

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -296,7 +296,8 @@ data class ResourceCheckError(
   override val name: String,
   override val application: String,
   override val timestamp: Instant,
-  val exception: Throwable
+  val exceptionType: Class<Throwable>,
+  val exceptionMessage: String?
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Error
@@ -308,7 +309,8 @@ data class ResourceCheckError(
     resource.name.value,
     resource.application,
     clock.instant(),
-    exception
+    exception.javaClass,
+    exception.message
   )
 }
 /**

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolverTests.kt
@@ -159,7 +159,7 @@ internal class ImageResolverTests : JUnit5Minutests {
       context("the resource is not in an environment") {
         before {
           coEvery {
-            imageService.getLatestNamedImage(artifact.name, any())
+            imageService.getLatestNamedImage(artifact.name, any(), resourceRegion)
           } answers {
             images.lastOrNull { it.appVersion.startsWith(firstArg<String>()) }
           }
@@ -184,7 +184,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-1.1.0", "test")
             coEvery {
-              imageService.getLatestNamedImage("${artifact.name}-1.1.0", any())
+              imageService.getLatestNamedImage("${artifact.name}-1.1.0", any(), resourceRegion)
             } answers {
               images.lastOrNull { it.appVersion.startsWith(firstArg<String>()) }
             }
@@ -212,7 +212,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-1.1.0", "test")
             coEvery {
-              imageService.getLatestNamedImage("${artifact.name}-1.1.0", any())
+              imageService.getLatestNamedImage("${artifact.name}-1.1.0", any(), resourceRegion)
             } returns null
           }
 
@@ -244,7 +244,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-1.1.0", "test")
             coEvery {
-              imageService.getLatestNamedImage("${artifact.name}-1.1.0", any())
+              imageService.getLatestNamedImage("${artifact.name}-1.1.0", any(), resourceRegion)
             } answers {
               images.lastOrNull { it.appVersion.startsWith(firstArg<String>()) }
             }


### PR DESCRIPTION
I know this should not strictly be necessary but it's pretty easy to make Keel resilient to this case