### PR TITLE
fix(imageName): replace ~ with _

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
@@ -1,5 +1,8 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.NoImageFound
 import com.netflix.spinnaker.keel.api.NoImageFoundForRegion
 import com.netflix.spinnaker.keel.api.NoImageSatisfiesConstraints
@@ -37,18 +40,7 @@ class ImageResolver(
         val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.uid)
         val environment = deliveryConfigRepository.environmentFor(resource.uid)
         val artifact = imageProvider.deliveryArtifact
-        var artifactName = if (deliveryConfig != null && environment != null) {
-          artifactRepository.latestVersionApprovedIn(
-            deliveryConfig,
-            artifact,
-            environment.name
-          ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
-        } else {
-          artifact.name
-        }
-
-        // image names have _ instead of ~
-        artifactName = artifactName.replace("~", "_")
+        val artifactName = determineArtifactName(artifact, deliveryConfig, environment)
 
         val account = dynamicConfigService.getConfig("images.default-account", "test")
         val namedImage = imageService
@@ -77,6 +69,27 @@ class ImageResolver(
         throw UnsupportedStrategy(imageProvider::class.simpleName.orEmpty(), ImageProvider::class.simpleName.orEmpty())
       }
     }
+  }
+
+  /**
+   * Supplies a specific version if a [deliveryConfig] and [environment] are provided,
+   * otherwise just returns the package name.
+   *
+   * Formats the name to comply with AMI naming conventions.
+   */
+  private fun determineArtifactName(artifact: DeliveryArtifact, deliveryConfig: DeliveryConfig?, environment: Environment?): String {
+    val name = if (deliveryConfig != null && environment != null) {
+      artifactRepository.latestVersionApprovedIn(
+        deliveryConfig,
+        artifact,
+        environment.name
+      ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
+    } else {
+      artifact.name
+    }
+
+    // image names have _ instead of ~
+    return name.replace("~", "_")
   }
 
   private inline fun <reified T> DynamicConfigService.getConfig(configName: String, defaultValue: T) =

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
@@ -37,7 +37,7 @@ class ImageResolver(
         val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.uid)
         val environment = deliveryConfigRepository.environmentFor(resource.uid)
         val artifact = imageProvider.deliveryArtifact
-        val artifactName = if (deliveryConfig != null && environment != null) {
+        var artifactName = if (deliveryConfig != null && environment != null) {
           artifactRepository.latestVersionApprovedIn(
             deliveryConfig,
             artifact,
@@ -46,6 +46,10 @@ class ImageResolver(
         } else {
           artifact.name
         }
+
+        // image names have _ instead of ~
+        artifactName = artifactName.replace("~", "_")
+
         val account = dynamicConfigService.getConfig("images.default-account", "test")
         val namedImage = imageService
           .getLatestNamedImage(artifactName, account, region) ?: throw NoImageFound(artifactName)


### PR DESCRIPTION
Artifact versions have ~ in them for dev artifacts, like `keeldemo-0.0.1~dev.1-h2.da2282b`. The corresponding image names replace ~ with an _. This PR replaces any ~s in the artifact version it finds so it can appropriately find the right image.