### PR TITLE
rename resource name to resource id

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -53,7 +53,7 @@ class CheckScheduler(
       val job = launch {
         resourceRepository
           .launchForEachItem {
-            resourceActuator.checkResource(it.name, it.apiVersion, it.kind)
+            resourceActuator.checkResource(it.id, it.apiVersion, it.kind)
           }
       }
 

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -4,7 +4,7 @@ import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.uid
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCheckError
@@ -82,7 +82,7 @@ class ResourceActuator(
         else -> {
           log.info("Resource {} is valid", id)
           // TODO: not sure this logic belongs here
-          val lastEvent = resourceRepository.eventHistory(uid = resource.uid, limit = 1).first()
+          val lastEvent = resourceRepository.eventHistory(resource.id, limit = 1).first()
           if (lastEvent is ResourceDeltaDetected || lastEvent is ResourceActuationLaunched) {
             publisher.publishEvent(ResourceDeltaResolved(resource, current, clock))
           } else {

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -3,20 +3,20 @@ package com.netflix.spinnaker.keel.telemetry
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceName
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.id
 
 sealed class TelemetryEvent
 
 data class ResourceCheckSkipped(
   val apiVersion: ApiVersion,
   val kind: String,
-  val name: ResourceName
+  val id: ResourceId
 ) : TelemetryEvent() {
   constructor(resource: Resource<*>) : this(
     resource.apiVersion,
     resource.kind,
-    resource.name
+    resource.id
   )
 }
 

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -29,7 +29,7 @@ class TelemetryListener(
     spectator.counter(
       RESOURCE_CHECKED_COUNTER_ID,
       listOf(
-        BasicTag("resourceName", event.name),
+        BasicTag("resourceName", event.id),
         BasicTag("apiVersion", event.apiVersion.toString()),
         BasicTag("resourceKind", event.kind),
         BasicTag("resourceState", event.state.name),
@@ -43,7 +43,7 @@ class TelemetryListener(
     spectator.counter(
       RESOURCE_CHECK_SKIPPED_COUNTER_ID,
       listOf(
-        BasicTag("resourceName", event.name.value),
+        BasicTag("resourceName", event.id.value),
         BasicTag("apiVersion", event.apiVersion.toString()),
         BasicTag("resourceKind", event.kind)
       )
@@ -79,7 +79,7 @@ class TelemetryListener(
     spectator.counter(
       RESOURCE_ACTUATION_LAUNCHED_COUNTER_ID,
       listOf(
-        BasicTag("resourceName", event.name),
+        BasicTag("resourceName", event.id),
         BasicTag("apiVersion", event.apiVersion.toString()),
         BasicTag("resourceKind", event.kind),
         BasicTag("resourceApplication", event.application)

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -29,7 +29,7 @@ class TelemetryListener(
     spectator.counter(
       RESOURCE_CHECKED_COUNTER_ID,
       listOf(
-        BasicTag("resourceName", event.id),
+        BasicTag("resourceId", event.resourceId.value),
         BasicTag("apiVersion", event.apiVersion.toString()),
         BasicTag("resourceKind", event.kind),
         BasicTag("resourceState", event.state.name),
@@ -43,7 +43,7 @@ class TelemetryListener(
     spectator.counter(
       RESOURCE_CHECK_SKIPPED_COUNTER_ID,
       listOf(
-        BasicTag("resourceName", event.id.value),
+        BasicTag("resourceId", event.id.value),
         BasicTag("apiVersion", event.apiVersion.toString()),
         BasicTag("resourceKind", event.kind)
       )
@@ -79,7 +79,7 @@ class TelemetryListener(
     spectator.counter(
       RESOURCE_ACTUATION_LAUNCHED_COUNTER_ID,
       listOf(
-        BasicTag("resourceName", event.id),
+        BasicTag("resourceId", event.resourceId.value),
         BasicTag("apiVersion", event.apiVersion.toString()),
         BasicTag("resourceKind", event.kind),
         BasicTag("resourceApplication", event.application)

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.ResourceHeader
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
@@ -24,13 +23,11 @@ internal object CheckSchedulerTests : JUnit5Minutests {
   private val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
   private val resources = listOf(
     ResourceHeader(
-      uid = randomUID(),
       id = ResourceId("ec2:security-group:prod:ap-south-1:keel-sg"),
       apiVersion = SPINNAKER_API_V1.subApi("ec2"),
       kind = "security-group"
     ),
     ResourceHeader(
-      uid = randomUID(),
       id = ResourceId("ec2:cluster:prod:ap-south-1:keel"),
       apiVersion = SPINNAKER_API_V1.subApi("ec2"),
       kind = "cluster"

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.actuation
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
@@ -25,13 +25,13 @@ internal object CheckSchedulerTests : JUnit5Minutests {
   private val resources = listOf(
     ResourceHeader(
       uid = randomUID(),
-      name = ResourceName("ec2:security-group:prod:ap-south-1:keel-sg"),
+      id = ResourceId("ec2:security-group:prod:ap-south-1:keel-sg"),
       apiVersion = SPINNAKER_API_V1.subApi("ec2"),
       kind = "security-group"
     ),
     ResourceHeader(
       uid = randomUID(),
-      name = ResourceName("ec2:cluster:prod:ap-south-1:keel"),
+      id = ResourceId("ec2:cluster:prod:ap-south-1:keel"),
       apiVersion = SPINNAKER_API_V1.subApi("ec2"),
       kind = "cluster"
     )
@@ -77,7 +77,7 @@ internal object CheckSchedulerTests : JUnit5Minutests {
         resources.forEach { resource ->
           coVerify(timeout = 500) {
             with(resource) {
-              resourceActuator.checkResource(name, apiVersion, kind)
+              resourceActuator.checkResource(id, apiVersion, kind)
             }
           }
         }

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCheckError
@@ -75,16 +75,16 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
       context("the resource check is not vetoed") {
         before {
-          every { veto.check(resource.name) } returns VetoResponse(true)
+          every { veto.check(resource.id) } returns VetoResponse(true)
         }
 
         context("the plugin is already actuating this resource") {
           before {
-            coEvery { plugin1.actuationInProgress(resource.name) } returns true
+            coEvery { plugin1.actuationInProgress(resource.id) } returns true
 
             with(resource) {
               runBlocking {
-                subject.checkResource(name, apiVersion, kind)
+                subject.checkResource(id, apiVersion, kind)
               }
             }
           }
@@ -107,7 +107,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
         context("the plugin is not already actuating this resource") {
           before {
-            coEvery { plugin1.actuationInProgress(resource.name) } returns false
+            coEvery { plugin1.actuationInProgress(resource.id) } returns false
           }
 
           context("the current state matches the desired state") {
@@ -126,7 +126,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
                 with(resource) {
                   runBlocking {
-                    subject.checkResource(name, apiVersion, kind)
+                    subject.checkResource(id, apiVersion, kind)
                   }
                 }
               }
@@ -151,7 +151,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
               before {
                 with(resource) {
                   runBlocking {
-                    subject.checkResource(name, apiVersion, kind)
+                    subject.checkResource(id, apiVersion, kind)
                   }
                 }
               }
@@ -181,7 +181,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
               with(resource) {
                 runBlocking {
-                  subject.checkResource(name, apiVersion, kind)
+                  subject.checkResource(id, apiVersion, kind)
                 }
               }
             }
@@ -206,7 +206,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
               with(resource) {
                 runBlocking {
-                  subject.checkResource(name, apiVersion, kind)
+                  subject.checkResource(id, apiVersion, kind)
                 }
               }
             }
@@ -230,7 +230,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
               with(resource) {
                 runBlocking {
-                  subject.checkResource(name, apiVersion, kind)
+                  subject.checkResource(id, apiVersion, kind)
                 }
               }
             }
@@ -252,7 +252,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
               with(resource) {
                 runBlocking {
-                  subject.checkResource(name, apiVersion, kind)
+                  subject.checkResource(id, apiVersion, kind)
                 }
               }
             }
@@ -271,13 +271,13 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
       context("the resource check is vetoed") {
         before {
-          every { veto.check(resource.name) } returns VetoResponse(false)
+          every { veto.check(resource.id) } returns VetoResponse(false)
         }
 
         test("checking skipped") {
           with(resource) {
             runBlocking {
-              subject.checkResource(name, apiVersion, kind)
+              subject.checkResource(id, apiVersion, kind)
             }
           }
 

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.api.SubmittedEnvironment
 import com.netflix.spinnaker.keel.api.SubmittedMetadata
 import com.netflix.spinnaker.keel.api.SubmittedResource
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.resources
 import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceCreated
@@ -116,9 +116,9 @@ internal class ResourcePersisterTests : JUnit5Minutests {
           }
 
           test("stores the normalized resource") {
-            val persistedResource = resourceRepository.get<DummyResourceSpec>(resource.name)
+            val persistedResource = resourceRepository.get<DummyResourceSpec>(resource.id)
             expectThat(persistedResource) {
-              get { name }.isEqualTo(resource.name)
+              get { id }.isEqualTo(resource.id)
               get { spec.data }.isEqualTo("o hai")
             }
           }
@@ -139,11 +139,11 @@ internal class ResourcePersisterTests : JUnit5Minutests {
           context("after an update") {
             before {
               resourcesDueForCheck()
-              update(DummyResourceSpec(name = resource.spec.name, data = "kthxbye"))
+              update(DummyResourceSpec(id = resource.spec.id, data = "kthxbye"))
             }
 
             test("stores the updated resource") {
-              expectThat(resourceRepository.get<DummyResourceSpec>(resource.name))
+              expectThat(resourceRepository.get<DummyResourceSpec>(resource.id))
                 .get { spec.data }
                 .isEqualTo("kthxbye")
             }

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -15,7 +15,6 @@ import com.netflix.spinnaker.keel.api.SubmittedMetadata
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.resources
-import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceUpdated
 import com.netflix.spinnaker.keel.persistence.get
@@ -133,7 +132,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
             expectThat(resourcesDueForCheck())
               .hasSize(1)
               .first()
-              .get { uid }.isEqualTo(resource.uid)
+              .get { id }.isEqualTo(resource.id)
           }
 
           context("after an update") {
@@ -158,7 +157,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
               expectThat(resourcesDueForCheck())
                 .hasSize(1)
                 .first()
-                .get { uid }.isEqualTo(resource.uid)
+                .get { id }.isEqualTo(resource.id)
             }
           }
 
@@ -236,9 +235,9 @@ internal class ResourcePersisterTests : JUnit5Minutests {
         test("individual resources are persisted") {
           expectThat(resourceRepository.size()).isEqualTo(2)
 
-          deliveryConfig.resources.map { it.uid }.forEach { uid ->
+          deliveryConfig.resources.map { it.id }.forEach { id ->
             expectCatching {
-              resourceRepository.get<DummyResourceSpec>(uid)
+              resourceRepository.get<DummyResourceSpec>(id)
             }.succeeded()
           }
         }
@@ -307,7 +306,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
 
         test("resources are updated") {
           deliveryConfig.resources.forEach { resource ->
-            expectThat(resourceRepository.get<ResourceSpec>(resource.uid))
+            expectThat(resourceRepository.get<ResourceSpec>(resource.id))
               .get { spec }
               .isEqualTo(resource.spec)
               .isA<DummyResourceSpec>()

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
@@ -5,7 +5,6 @@ import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.Tag
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceValid
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -30,7 +29,6 @@ internal class TelemetryListenerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("ec2"),
     kind = "cluster",
     id = "ec2:cluster:prod:ap-south-1:keel-main",
-    uid = randomUID(),
     application = "fnord",
     timestamp = Instant.now()
   )
@@ -72,7 +70,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
             value().isEqualTo(event.kind)
           }
           any {
-            key().isEqualTo("resourceName")
+            key().isEqualTo("resourceId")
             value().isEqualTo(event.id)
           }
           any {

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
@@ -29,7 +29,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
   private val event = ResourceValid(
     apiVersion = SPINNAKER_API_V1.subApi("ec2"),
     kind = "cluster",
-    name = "ec2:cluster:prod:ap-south-1:keel-main",
+    id = "ec2:cluster:prod:ap-south-1:keel-main",
     uid = randomUID(),
     application = "fnord",
     timestamp = Instant.now()
@@ -73,7 +73,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
           }
           any {
             key().isEqualTo("resourceName")
-            value().isEqualTo(event.name)
+            value().isEqualTo(event.id)
           }
           any {
             key().isEqualTo("resourceApplication")

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -18,8 +18,8 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
-import com.netflix.spinnaker.keel.api.ResourceName
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
@@ -38,8 +38,8 @@ class AuthorizationSupport(
 
   fun userCanModifyResource(name: String): Boolean =
     try {
-      val resource = resourceRepository.get(ResourceName(name))
-      userCanModifySpec(resource.serviceAccount, resource.name)
+      val resource = resourceRepository.get(ResourceId(name))
+      userCanModifySpec(resource.serviceAccount, resource.id)
     } catch (e: NoSuchResourceException) {
       // If resource doesn't exist return true so a 404 is propagated from the controller.
       true

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.ResourceId
-import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
@@ -34,10 +33,8 @@ class EventController(
     @RequestParam("limit") limit: Int?
   ): List<ResourceEvent> {
     log.debug("Getting state history for: $id")
-    return resourceRepository.get(id).let { resource ->
-      resourceRepository
-        .eventHistory(resource.uid, limit ?: DEFAULT_MAX_EVENTS)
-    }
+    return resourceRepository
+      .eventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
   }
 
   // TODO: would be nice to make this common with ResourceController

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
@@ -26,15 +26,15 @@ class EventController(
   private val log by lazy { getLogger(javaClass) }
 
   @GetMapping(
-    path = ["/{name}"],
+    path = ["/{id}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
   fun eventHistory(
-    @PathVariable("name") name: ResourceName,
+    @PathVariable("id") id: ResourceId,
     @RequestParam("limit") limit: Int?
   ): List<ResourceEvent> {
-    log.debug("Getting state history for: $name")
-    return resourceRepository.get(name).let { resource ->
+    log.debug("Getting state history for: $id")
+    return resourceRepository.get(id).let { resource ->
       resourceRepository
         .eventHistory(resource.uid, limit ?: DEFAULT_MAX_EVENTS)
     }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
@@ -51,12 +51,12 @@ class ResourceController(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   @GetMapping(
-    path = ["/{name}"],
+    path = ["/{id}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  fun get(@PathVariable("name") name: ResourceName): Resource<*> {
-    log.debug("Getting: $name")
-    return resourceRepository.get(name)
+  fun get(@PathVariable("id") id: ResourceId): Resource<*> {
+    log.debug("Getting: $id")
+    return resourceRepository.get(id)
   }
 
   @PostMapping(
@@ -70,13 +70,13 @@ class ResourceController(
   }
 
   @DeleteMapping(
-    path = ["/{name}"],
+    path = ["/{id}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  @PreAuthorize("@authorizationSupport.userCanModifyResource(#name)")
-  fun delete(@PathVariable("name") name: ResourceName): Resource<*> {
-    log.debug("Deleting: $name")
-    return resourcePersister.delete(name)
+  @PreAuthorize("@authorizationSupport.userCanModifyResource(#id)")
+  fun delete(@PathVariable("id") id: ResourceId): Resource<*> {
+    log.debug("Deleting: $id")
+    return resourcePersister.delete(id)
   }
 
   @ExceptionHandler(NoSuchResourceException::class)

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCreated
@@ -63,7 +63,7 @@ internal class EventControllerTests : JUnit5Minutests {
 
   object Fixture {
     val resource: Resource<*> = resource()
-    val eventsUri: URI = URI.create("/resources/events/${resource.name}")
+    val eventsUri: URI = URI.create("/resources/events/${resource.id}")
   }
 
   fun tests() = rootContext<Fixture> {
@@ -71,7 +71,7 @@ internal class EventControllerTests : JUnit5Minutests {
 
     context("no resource exists") {
       test("event eventHistory endpoint responds with 404") {
-        val request = get("/resources/events/${resource.name}")
+        val request = get("/resources/events/${resource.id}")
           .accept(APPLICATION_JSON)
         mvc
           .perform(request)

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
-import com.netflix.spinnaker.keel.api.name
-import com.netflix.spinnaker.keel.persistence.NoSuchResourceName
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.persistence.NoSuchResourceId
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
@@ -179,7 +179,7 @@ internal class ResourceControllerTests {
 
   @Test
   fun `attempting to update an unknown resource results in a 404`() {
-    every { resourcePersister.upsert<DummyResourceSpec>(any()) } throws NoSuchResourceName(resource.name)
+    every { resourcePersister.upsert<DummyResourceSpec>(any()) } throws NoSuchResourceId(resource.id)
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
 
     val request = post("/resources")
@@ -226,7 +226,7 @@ internal class ResourceControllerTests {
   fun `can get a resource as YAML`() {
     resourceRepository.store(resource)
 
-    val request = get("/resources/${resource.name}")
+    val request = get("/resources/${resource.id}")
       .accept(APPLICATION_YAML)
     val result = mvc
       .perform(request)
@@ -240,20 +240,20 @@ internal class ResourceControllerTests {
 
   @Test
   fun `can delete a resource`() {
-    every { resourcePersister.delete(resource.name) } returns resource
-    every { authorizationSupport.userCanModifyResource(resource.name.toString()) } returns true
+    every { resourcePersister.delete(resource.id) } returns resource
+    every { authorizationSupport.userCanModifyResource(resource.id.toString()) } returns true
     resourceRepository.store(resource)
 
-    val request = delete("/resources/${resource.name}")
+    val request = delete("/resources/${resource.id}")
       .accept(APPLICATION_YAML)
     mvc
       .perform(request)
       .andExpect(status().isOk)
 
-    verify { resourcePersister.delete(resource.name) }
+    verify { resourcePersister.delete(resource.id) }
 
     // clean up after the test
-    resourceRepository.delete(resource.name)
+    resourceRepository.delete(resource.id)
   }
 
   @Test

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/api/ImageSpec.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/api/ImageSpec.kt
@@ -12,5 +12,5 @@ data class ImageSpec(
   override val application: String // the application an image is baked in
 ) : ResourceSpec {
   @JsonIgnore
-  override val name: String = artifactName
+  override val id: String = artifactName
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -8,10 +8,10 @@ import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.NoKnownArtifactVersions
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.bakery.api.ImageSpec
@@ -114,7 +114,7 @@ class ImageHandler(
           )
         ),
         trigger = OrchestrationTrigger(
-          correlationId = resource.name.toString(),
+          correlationId = resource.id.toString(),
           artifacts = listOf(artifact)
         )
       )
@@ -126,9 +126,9 @@ class ImageHandler(
     TODO("not implemented")
   }
 
-  override suspend fun actuationInProgress(name: ResourceName) =
+  override suspend fun actuationInProgress(id: ResourceId) =
     orcaService
-      .getCorrelatedExecutions(name.value)
+      .getCorrelatedExecutions(id.value)
       .isNotEmpty()
 
   private suspend fun findBaseAmi(baseImage: String, serviceAccount: String): String {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -8,8 +8,8 @@ import com.netflix.spinnaker.keel.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.resources
-import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.resource
@@ -74,11 +74,11 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
     }
 
     fun getEnvironment(resource: Resource<*>) = expectCatching {
-      repository.environmentFor(resource.uid)
+      repository.environmentFor(resource.id)
     }
 
     fun getDeliveryConfig(resource: Resource<*>) = expectCatching {
-      repository.deliveryConfigFor(resource.uid)
+      repository.deliveryConfigFor(resource.id)
     }
   }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryPeriodicallyCheckedTests.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.persistence
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.resource
 
@@ -12,14 +12,14 @@ abstract class ResourceRepositoryPeriodicallyCheckedTests<S : ResourceRepository
   override val createAndStore: Fixture<ResourceHeader, S>.(Int) -> Collection<ResourceHeader> = { count ->
     (1..count)
       .map { i ->
-        resource(name = "fnord-$i").also(subject::store)
+        resource(id = "fnord-$i").also(subject::store)
       }
       .map(::ResourceHeader)
   }
 
   override val updateOne: Fixture<ResourceHeader, S>.() -> ResourceHeader = {
     subject
-      .get<DummyResourceSpec>(ResourceName("test:whatever:fnord-1"))
+      .get<DummyResourceSpec>(ResourceId("test:whatever:fnord-1"))
       .let {
         it.copy(spec = it.spec.copy(data = randomString()))
       }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -16,8 +16,8 @@
 package com.netflix.spinnaker.keel.persistence
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceName
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
@@ -93,8 +93,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
       }
 
       test("deleting a non-existent resource throws an exception") {
-        expectThrows<NoSuchResourceName> {
-          subject.delete(ResourceName("whatever"))
+        expectThrows<NoSuchResourceId> {
+          subject.delete(ResourceId("whatever"))
         }
       }
     }
@@ -117,7 +117,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
       }
 
       test("it can be retrieved by name") {
-        val retrieved = subject.get<DummyResourceSpec>(resource.name)
+        val retrieved = subject.get<DummyResourceSpec>(resource.id)
         expectThat(retrieved).isEqualTo(resource)
       }
 
@@ -158,7 +158,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         }
 
         test("it replaces the original resource") {
-          expectThat(subject.get<DummyResourceSpec>(resource.name))
+          expectThat(subject.get<DummyResourceSpec>(resource.id))
             .get(Resource<*>::spec)
             .isEqualTo(updatedResource.spec)
         }
@@ -241,7 +241,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
 
       context("deleting the resource") {
         before {
-          subject.delete(resource.name)
+          subject.delete(resource.id)
         }
 
         test("the resource is no longer returned when listing all resources") {
@@ -252,7 +252,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
 
         test("the resource can no longer be retrieved by name") {
           expectThrows<NoSuchResourceException> {
-            subject.get<DummyResourceSpec>(resource.name)
+            subject.get<DummyResourceSpec>(resource.id)
           }
         }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -32,7 +32,7 @@ data class Resource<T : ResourceSpec>(
   init {
     require(kind.isNotEmpty()) { "resource kind must be defined" }
     require(metadata["uid"].isValidULID()) { "resource uid must be a valid ULID" }
-    require(metadata["name"].isValidName()) { "resource name must be a valid name" }
+    require(metadata["id"].isValidId()) { "resource id must be a valid id" }
     require(metadata["serviceAccount"].isValidServiceAccount()) { "serviceAccount must be a valid service account" }
     require(metadata["application"].isValidApplication()) { "application must be a valid application" }
   }
@@ -56,8 +56,8 @@ data class SubmittedResource<T : ResourceSpec>(
   val spec: T
 )
 
-val <T : ResourceSpec> SubmittedResource<T>.name: ResourceName
-  get() = "${apiVersion.prefix}:$kind:${spec.name}".let(::ResourceName)
+val <T : ResourceSpec> SubmittedResource<T>.id: ResourceId
+  get() = "${apiVersion.prefix}:$kind:${spec.id}".let(::ResourceId)
 
 /**
  * Required metadata to be submitted with a resource
@@ -69,8 +69,8 @@ data class SubmittedMetadata(
 val <T : ResourceSpec> Resource<T>.uid: UID
   get() = metadata.getValue("uid").toString().let(ULID::parseULID)
 
-val <T : ResourceSpec> Resource<T>.name: ResourceName
-  get() = metadata.getValue("name").toString().let(::ResourceName)
+val <T : ResourceSpec> Resource<T>.id: ResourceId
+  get() = metadata.getValue("id").toString().let(::ResourceId)
 
 val <T : ResourceSpec> Resource<T>.serviceAccount: String
   get() = metadata.getValue("serviceAccount").toString()
@@ -87,7 +87,7 @@ private fun Any?.isValidULID() =
     else -> false
   }
 
-private fun Any?.isValidName() =
+private fun Any?.isValidId() =
   when (this) {
     is String -> isNotBlank()
     else -> false

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
@@ -16,6 +16,6 @@
 package com.netflix.spinnaker.keel.api
 
 @Suppress("EXPERIMENTAL_FEATURE_WARNING")
-inline class ResourceName(val value: String) {
+inline class ResourceId(val value: String) {
   override fun toString(): String = value
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSpec.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSpec.kt
@@ -7,13 +7,13 @@ interface ResourceSpec {
 
   /**
    * The formal resource name. This is combined with the resource's API version prefix and kind to
-   * form the fully-qualified [ResourceName].
+   * form the fully-qualified [ResourceId].
    *
    * This can be a property that is part of the spec, or derived from other properties. If the
    * latter remember to annotate the overridden property with
    * [com.fasterxml.jackson.annotation.JsonIgnore].
    */
-  val name: String
+  val id: String
 
   /**
    * The Spinnaker application this resource belongs to.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -31,7 +31,7 @@ import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.UID
 import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceState.Diff
 import com.netflix.spinnaker.keel.events.ResourceState.Error
@@ -61,7 +61,7 @@ sealed class ResourceEvent {
   abstract val uid: UID
   abstract val apiVersion: ApiVersion
   abstract val kind: String
-  abstract val name: String
+  abstract val id: String
   abstract val application: String
   abstract val timestamp: Instant
 
@@ -89,7 +89,7 @@ data class ResourceCreated(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   override val timestamp: Instant
 ) : ResourceEvent() {
@@ -98,7 +98,7 @@ data class ResourceCreated(
     resource.uid,
     resource.apiVersion,
     resource.kind,
-    resource.name.value,
+    resource.id.value,
     resource.application,
     clock.instant()
   )
@@ -114,7 +114,7 @@ data class ResourceUpdated(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   val delta: Map<String, Any?>,
   override val timestamp: Instant
@@ -123,7 +123,7 @@ data class ResourceUpdated(
     resource.uid,
     resource.apiVersion,
     resource.kind,
-    resource.name.value,
+    resource.id.value,
     resource.application,
     delta,
     clock.instant()
@@ -134,7 +134,7 @@ data class ResourceDeleted(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   override val timestamp: Instant
 ) : ResourceEvent() {
@@ -142,7 +142,7 @@ data class ResourceDeleted(
     resource.uid,
     resource.apiVersion,
     resource.kind,
-    resource.name.value,
+    resource.id.value,
     resource.application,
     clock.instant()
   )
@@ -162,7 +162,7 @@ data class ResourceMissing(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   override val timestamp: Instant
 ) : ResourceCheckResult() {
@@ -173,7 +173,7 @@ data class ResourceMissing(
     resource.uid,
     resource.apiVersion,
     resource.kind,
-    resource.name.value,
+    resource.id.value,
     resource.application,
     clock.instant()
   )
@@ -188,7 +188,7 @@ data class ResourceDeltaDetected(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   val delta: Map<String, Any?>,
   override val timestamp: Instant
@@ -200,7 +200,7 @@ data class ResourceDeltaDetected(
     resource.uid,
     resource.apiVersion,
     resource.kind,
-    resource.name.value,
+    resource.id.value,
     resource.application,
     delta,
     clock.instant()
@@ -215,7 +215,7 @@ data class ResourceActuationLaunched(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   val plugin: String,
   val tasks: List<Task>,
@@ -226,7 +226,7 @@ data class ResourceActuationLaunched(
       resource.uid,
       resource.apiVersion,
       resource.kind,
-      resource.name.value,
+      resource.id.value,
       resource.application,
       plugin,
       tasks,
@@ -242,7 +242,7 @@ data class ResourceDeltaResolved(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   override val timestamp: Instant,
   val desired: Any,
@@ -256,7 +256,7 @@ data class ResourceDeltaResolved(
       resource.uid,
       resource.apiVersion,
       resource.kind,
-      resource.name.value,
+      resource.id.value,
       resource.application,
       clock.instant(),
       resource.spec,
@@ -268,7 +268,7 @@ data class ResourceValid(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   override val timestamp: Instant
 ) : ResourceCheckResult() {
@@ -283,7 +283,7 @@ data class ResourceValid(
       resource.uid,
       resource.apiVersion,
       resource.kind,
-      resource.name.value,
+      resource.id.value,
       resource.application,
       clock.instant()
     )
@@ -293,7 +293,7 @@ data class ResourceCheckError(
   override val uid: UID,
   override val apiVersion: ApiVersion,
   override val kind: String,
-  override val name: String,
+  override val id: String,
   override val application: String,
   override val timestamp: Instant,
   val exceptionType: Class<Throwable>,
@@ -306,7 +306,7 @@ data class ResourceCheckError(
     resource.uid,
     resource.apiVersion,
     resource.kind,
-    resource.name.value,
+    resource.id.value,
     resource.application,
     clock.instant(),
     exception.javaClass,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidResourceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidResourceException.kt
@@ -19,7 +19,7 @@
 package com.netflix.spinnaker.keel.exceptions
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 
 sealed class InvalidResourceException(
   message: String?,
@@ -31,5 +31,5 @@ class FailedNormalizationException(
   resource: Resource<*>,
   cause: Throwable
 ) : InvalidResourceException(
-  "Resource ${resource.name} failed normalization with error: $errorMessage. Resource: $resource", cause
+  "Resource ${resource.id} failed normalization with error: $errorMessage. Resource: $resource", cause
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.persistence
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
-import com.netflix.spinnaker.keel.api.UID
+import com.netflix.spinnaker.keel.api.ResourceId
 
 interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfig> {
 
@@ -10,9 +10,9 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
 
   fun get(name: String): DeliveryConfig
 
-  fun environmentFor(resourceUID: UID): Environment?
+  fun environmentFor(resourceId: ResourceId): Environment?
 
-  fun deliveryConfigFor(resourceUID: UID): DeliveryConfig?
+  fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig?
 }
 
 sealed class NoSuchDeliveryConfigException(message: String) : RuntimeException(message)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -18,22 +18,22 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.UID
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import java.time.Duration
 
 data class ResourceHeader(
   val uid: UID,
-  val name: ResourceName,
+  val id: ResourceId,
   val apiVersion: ApiVersion,
   val kind: String
 ) {
   constructor(resource: Resource<*>) : this(
     resource.uid,
-    resource.name,
+    resource.id,
     resource.apiVersion,
     resource.kind
   )
@@ -46,12 +46,12 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
   fun allResources(callback: (ResourceHeader) -> Unit)
 
   /**
-   * Retrieves a single resource by its unique [name].
+   * Retrieves a single resource by its unique [id].
    *
-   * @return The resource represented by [name] or `null` if [name] is unknown.
-   * @throws NoSuchResourceException if [name] does not map to a resource in the repository.
+   * @return The resource represented by [id] or `null` if [id] is unknown.
+   * @throws NoSuchResourceException if [id] does not map to a resource in the repository.
    */
-  fun get(name: ResourceName): Resource<out ResourceSpec>
+  fun get(id: ResourceId): Resource<out ResourceSpec>
 
   /**
    * Retrieves a single resource by its unique [uid].
@@ -76,9 +76,9 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
   fun store(resource: Resource<*>)
 
   /**
-   * Deletes the resource represented by [name].
+   * Deletes the resource represented by [id].
    */
-  fun delete(name: ResourceName)
+  fun delete(id: ResourceId)
 
   /**
    * Retrieves the history of state change events for the resource represented by [uid].
@@ -108,8 +108,8 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
 }
 
 @Suppress("UNCHECKED_CAST")
-inline fun <reified T : ResourceSpec> ResourceRepository.get(name: ResourceName): Resource<T> =
-  get(name).also { check(it.spec is T) } as Resource<T>
+inline fun <reified T : ResourceSpec> ResourceRepository.get(id: ResourceId): Resource<T> =
+  get(id).also { check(it.spec is T) } as Resource<T>
 
 @Suppress("UNCHECKED_CAST")
 inline fun <reified T : ResourceSpec> ResourceRepository.get(uid: UID): Resource<T> =
@@ -117,5 +117,5 @@ inline fun <reified T : ResourceSpec> ResourceRepository.get(uid: UID): Resource
 
 sealed class NoSuchResourceException(override val message: String?) : RuntimeException(message)
 
-class NoSuchResourceName(name: ResourceName) : NoSuchResourceException("No resource named $name exists in the repository")
+class NoSuchResourceId(id: ResourceId) : NoSuchResourceException("No resource with id $id exists in the repository")
 class NoSuchResourceUID(uid: UID) : NoSuchResourceException("No resource with uid $uid exists in the repository")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
@@ -2,9 +2,9 @@ package com.netflix.spinnaker.keel.persistence.memory
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
-import com.netflix.spinnaker.keel.api.UID
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.resources
-import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import java.time.Clock
@@ -28,16 +28,16 @@ class InMemoryDeliveryConfigRepository(
     }
   }
 
-  override fun environmentFor(resourceUID: UID): Environment? =
+  override fun environmentFor(resourceId: ResourceId): Environment? =
     configs
       .values
       .flatMap { it.environments }
-      .firstOrNull { it.resourceUids.contains(resourceUID) }
+      .firstOrNull { it.resourceIds.contains(resourceId) }
 
-  override fun deliveryConfigFor(resourceUID: UID): DeliveryConfig? =
+  override fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig? =
     configs
       .values
-      .firstOrNull { it.resourceUids.contains(resourceUID) }
+      .firstOrNull { it.resourceIds.contains(resourceId) }
 
   override fun itemsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig> {
     val cutoff = clock.instant().minus(minTimeSinceLastCheck)
@@ -57,9 +57,9 @@ class InMemoryDeliveryConfigRepository(
     configs.clear()
   }
 
-  private val Environment.resourceUids: Iterable<UID>
-    get() = resources.map { it.uid }
+  private val Environment.resourceIds: Iterable<ResourceId>
+    get() = resources.map { it.id }
 
-  private val DeliveryConfig.resourceUids: Iterable<UID>
-    get() = resources.map { it.uid }
+  private val DeliveryConfig.resourceIds: Iterable<ResourceId>
+    get() = resources.map { it.id }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
@@ -16,14 +16,14 @@
 package com.netflix.spinnaker.keel.persistence.memory
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.UID
 import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.uid
 import com.netflix.spinnaker.keel.events.ResourceEvent
-import com.netflix.spinnaker.keel.persistence.NoSuchResourceName
+import com.netflix.spinnaker.keel.persistence.NoSuchResourceId
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceUID
 import com.netflix.spinnaker.keel.persistence.ResourceHeader
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
@@ -46,10 +46,10 @@ class InMemoryResourceRepository(
   }
 
   @Suppress("UNCHECKED_CAST")
-  override fun get(name: ResourceName): Resource<out ResourceSpec> =
-    resources.values.find { it.name == name }?.let {
+  override fun get(id: ResourceId): Resource<out ResourceSpec> =
+    resources.values.find { it.id == id }?.let {
       get(it.uid)
-    } ?: throw NoSuchResourceName(name)
+    } ?: throw NoSuchResourceId(id)
 
   @Suppress("UNCHECKED_CAST")
   override fun get(uid: UID): Resource<out ResourceSpec> =
@@ -61,24 +61,24 @@ class InMemoryResourceRepository(
   override fun getByApplication(application: String): List<String> =
     resources
       .filterValues { it.application == application }
-      .map { it.value.name.toString() }
+      .map { it.value.id.toString() }
 
   override fun store(resource: Resource<*>) {
     resources[resource.uid] = resource
     lastCheckTimes[resource.uid] = EPOCH
   }
 
-  override fun delete(name: ResourceName) {
+  override fun delete(id: ResourceId) {
     resources
       .values
-      .filter { it.name == name }
+      .filter { it.id == id }
       .map { it.uid }
       .singleOrNull()
       ?.also {
         resources.remove(it)
         events.remove(it)
       }
-      ?: throw NoSuchResourceName(name)
+      ?: throw NoSuchResourceId(id)
   }
 
   override fun eventHistory(uid: UID, limit: Int): List<ResourceEvent> {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -33,7 +33,6 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
     get() = """
       {
         "type": "${createdEvent.javaClass.simpleName}",
-        "uid": "${createdEvent.uid}",
         "apiVersion": "${createdEvent.apiVersion}",
         "kind": "${createdEvent.kind}",
         "id": "${createdEvent.id}",
@@ -45,7 +44,6 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
   val Fixture.yaml: String
     get() = """
       --- !<${createdEvent.javaClass.simpleName}>
-      uid: "${createdEvent.uid}"
       apiVersion: "${createdEvent.apiVersion}"
       kind: "${createdEvent.kind}"
       id: "${createdEvent.id}"
@@ -64,7 +62,6 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
       test("can serialize a ResourceCreated event") {
         val json = mapper.valueToTree<ObjectNode>(createdEvent)
         expectThat(json)
-          .has("uid")
           .has("id")
           .has("apiVersion")
           .has("kind")
@@ -90,7 +87,6 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
       test("can serialize a ResourceCreated event") {
         val json = mapper.valueToTree<ObjectNode>(createdEvent)
         expectThat(json)
-          .has("uid")
           .has("id")
           .has("apiVersion")
           .has("kind")

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -36,7 +36,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
         "uid": "${createdEvent.uid}",
         "apiVersion": "${createdEvent.apiVersion}",
         "kind": "${createdEvent.kind}",
-        "name": "${createdEvent.name}",
+        "id": "${createdEvent.id}",
         "application": "${createdEvent.application}",
         "timestamp": "${createdEvent.timestamp}"
       }
@@ -48,7 +48,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
       uid: "${createdEvent.uid}"
       apiVersion: "${createdEvent.apiVersion}"
       kind: "${createdEvent.kind}"
-      name: "${createdEvent.name}"
+      id: "${createdEvent.id}"
       application: "${createdEvent.application}"
       timestamp: "${createdEvent.timestamp}"
     """.trimIndent()
@@ -65,7 +65,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
         val json = mapper.valueToTree<ObjectNode>(createdEvent)
         expectThat(json)
           .has("uid")
-          .has("name")
+          .has("id")
           .has("apiVersion")
           .has("kind")
           .has("application")
@@ -91,7 +91,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
         val json = mapper.valueToTree<ObjectNode>(createdEvent)
         expectThat(json)
           .has("uid")
-          .has("name")
+          .has("id")
           .has("apiVersion")
           .has("kind")
           .has("application")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancer.kt
@@ -27,7 +27,7 @@ data class ApplicationLoadBalancer(
   }
 
   @JsonIgnore
-  override val name: String = "${location.accountName}:${location.region}:${moniker.name}"
+  override val id: String = "${location.accountName}:${location.region}:${moniker.name}"
 
   data class Listener(
     val port: Int,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancer.kt
@@ -27,5 +27,5 @@ data class ClassicLoadBalancer(
   }
 
   @JsonIgnore
-  override val name: String = "${location.accountName}:${location.region}:${moniker.name}"
+  override val id: String = "${location.accountName}:${location.region}:${moniker.name}"
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -38,5 +38,5 @@ data class ClusterSpec(
   val tags: Map<String, String> = emptyMap()
 ) : Monikered, ResourceSpec {
   @JsonIgnore
-  override val name: String = "${location.accountName}:${location.region}:${moniker.name}"
+  override val id: String = "${location.accountName}:${location.region}:${moniker.name}"
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/cluster/Cluster.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/cluster/Cluster.kt
@@ -31,5 +31,5 @@ data class Cluster(
   val scaling: Scaling = Scaling(),
   val tags: Map<String, String> = emptyMap()
 ) : Monikered {
-  override val name = "${location.accountName}:${location.region}:${moniker.name}"
+  override val id = "${location.accountName}:${location.region}:${moniker.name}"
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/securityGroup/SecurityGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/securityGroup/SecurityGroup.kt
@@ -29,5 +29,5 @@ data class SecurityGroup(
   val description: String?,
   val inboundRules: Set<SecurityGroupRule> = emptySet()
 ) : Monikered {
-  override val name = "$accountName:$region:${moniker.name}"
+  override val id = "$accountName:$region:${moniker.name}"
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/actuation/ArtifactPromotionListener.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/actuation/ArtifactPromotionListener.kt
@@ -39,10 +39,10 @@ class ArtifactPromotionListener(
         "Found ${amis.size} images for image id $deployedImage when 1 was expected"
       }
       val appVersion = amis.first().appVersion
-      val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(event.uid)
-      val environment = deliveryConfigRepository.environmentFor(event.uid)
+      val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(event.resourceId)
+      val environment = deliveryConfigRepository.environmentFor(event.resourceId)
       if (deliveryConfig == null || environment == null) {
-        log.warn("Resource ${event.id} is not part of a delivery environment")
+        log.warn("Resource ${event.resourceId} is not part of a delivery environment")
       } else {
         artifactRepository.markAsSuccessfullyDeployedTo(
           deliveryConfig,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/actuation/ArtifactPromotionListener.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/actuation/ArtifactPromotionListener.kt
@@ -42,7 +42,7 @@ class ArtifactPromotionListener(
       val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(event.uid)
       val environment = deliveryConfigRepository.environmentFor(event.uid)
       if (deliveryConfig == null || environment == null) {
-        log.warn("Resource ${event.name} is not part of a delivery environment")
+        log.warn("Resource ${event.id} is not part of a delivery environment")
       } else {
         artifactRepository.markAsSuccessfullyDeployedTo(
           deliveryConfig,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -3,12 +3,12 @@ package com.netflix.spinnaker.keel.ec2.resource
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
 import com.netflix.spinnaker.keel.api.ec2.cluster.Location
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -69,7 +69,7 @@ class ApplicationLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toUpsertJob()),
-              OrchestrationTrigger(resource.name.toString())
+              OrchestrationTrigger(resource.id.toString())
             )
           )
       }
@@ -92,7 +92,7 @@ class ApplicationLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toDeleteJob()),
-              OrchestrationTrigger(resource.name.toString())
+              OrchestrationTrigger(resource.id.toString())
             )
           )
       }
@@ -100,8 +100,8 @@ class ApplicationLoadBalancerHandler(
     log.info("Started task ${taskRef.ref} to $description")
   }
 
-  override suspend fun actuationInProgress(name: ResourceName) =
-    orcaService.getCorrelatedExecutions(name.value).isNotEmpty()
+  override suspend fun actuationInProgress(id: ResourceId) =
+    orcaService.getCorrelatedExecutions(id.value).isNotEmpty()
 
   private suspend fun CloudDriverService.getApplicationLoadBalancer(spec: ApplicationLoadBalancer, serviceAccount: String):
     ApplicationLoadBalancer? =

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -3,13 +3,13 @@ package com.netflix.spinnaker.keel.ec2.resource
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerListener
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
 import com.netflix.spinnaker.keel.api.ec2.cluster.Location
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -70,7 +70,7 @@ class ClassicLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toUpsertJob()),
-              OrchestrationTrigger(resource.name.toString())
+              OrchestrationTrigger(resource.id.toString())
             )
           )
       }
@@ -93,7 +93,7 @@ class ClassicLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toDeleteJob()),
-              OrchestrationTrigger(resource.name.toString())
+              OrchestrationTrigger(resource.id.toString())
             )
           )
       }
@@ -101,8 +101,8 @@ class ClassicLoadBalancerHandler(
     log.info("Started task ${taskRef.ref} to $description")
   }
 
-  override suspend fun actuationInProgress(name: ResourceName) =
-    orcaService.getCorrelatedExecutions(name.value).isNotEmpty()
+  override suspend fun actuationInProgress(id: ResourceId) =
+    orcaService.getCorrelatedExecutions(id.value).isNotEmpty()
 
   private fun CloudDriverService.getClassicLoadBalancer(spec: ClassicLoadBalancer, serviceAccount: String): ClassicLoadBalancer? =
     runBlocking {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.ec2.resource
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.api.ec2.cluster.Health
 import com.netflix.spinnaker.keel.api.ec2.cluster.LaunchConfiguration
 import com.netflix.spinnaker.keel.api.ec2.cluster.Location
 import com.netflix.spinnaker.keel.api.ec2.cluster.Scaling
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -102,16 +102,16 @@ class ClusterHandler(
           spec.moniker.app,
           description,
           listOf(Job(job["type"].toString(), job)),
-          OrchestrationTrigger(resource.name.toString())
+          OrchestrationTrigger(resource.id.toString())
         ))
       .also { log.info("Started task {} to upsert cluster", it.ref) }
       // TODO: ugleee
       .let { listOf(Task(id = it.taskId, name = description)) }
   }
 
-  override suspend fun actuationInProgress(name: ResourceName) =
+  override suspend fun actuationInProgress(id: ResourceId) =
     orcaService
-      .getCorrelatedExecutions(name.value)
+      .getCorrelatedExecutions(id.value)
       .isNotEmpty()
 
   /**

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
@@ -11,7 +11,7 @@ import com.netflix.spinnaker.keel.api.ec2.image.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.IdImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.ImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.JenkinsImageProvider
-import com.netflix.spinnaker.keel.api.uid
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
@@ -35,8 +35,8 @@ class ImageResolver(
         return imageProvider.imageId
       }
       is ArtifactImageProvider -> {
-        val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.uid)
-        val environment = deliveryConfigRepository.environmentFor(resource.uid)
+        val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
+        val environment = deliveryConfigRepository.environmentFor(resource.id)
         val artifact = imageProvider.deliveryArtifact
         val account = dynamicConfigService.getConfig("images.default-account", "test")
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.keel.ec2.resource
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.securityGroup.CidrRule
 import com.netflix.spinnaker.keel.api.ec2.securityGroup.CrossAccountReferenceRule
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.keel.api.ec2.securityGroup.SecurityGroup
 import com.netflix.spinnaker.keel.api.ec2.securityGroup.SecurityGroupRule
 import com.netflix.spinnaker.keel.api.ec2.securityGroup.SecurityGroupRule.Protocol
 import com.netflix.spinnaker.keel.api.ec2.securityGroup.SelfReferenceRule
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -81,7 +81,7 @@ class SecurityGroupHandler(
             spec.moniker.app,
             description,
             listOf(spec.toCreateJob()),
-            OrchestrationTrigger(resource.name.toString())
+            OrchestrationTrigger(resource.id.toString())
           ))
     }
     log.info("Started task {} to create security group", taskRef.ref)
@@ -103,7 +103,7 @@ class SecurityGroupHandler(
             spec.moniker.app,
             description,
             listOf(spec.toUpdateJob()),
-            OrchestrationTrigger(resource.name.toString())
+            OrchestrationTrigger(resource.id.toString())
           ))
     }
     log.info("Started task {} to update security group", taskRef.ref)
@@ -120,15 +120,15 @@ class SecurityGroupHandler(
             spec.moniker.app,
             "Delete security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
             listOf(spec.toDeleteJob()),
-            OrchestrationTrigger(resource.name.toString())
+            OrchestrationTrigger(resource.id.toString())
           ))
     }
     log.info("Started task {} to upsert security group", taskRef.ref)
   }
 
-  override suspend fun actuationInProgress(name: ResourceName) =
+  override suspend fun actuationInProgress(id: ResourceId) =
     orcaService
-      .getCorrelatedExecutions(name.value)
+      .getCorrelatedExecutions(id.value)
       .isNotEmpty()
 
   private suspend fun CloudDriverService.getSecurityGroup(spec: SecurityGroup, serviceAccount: String): SecurityGroup? =
@@ -204,7 +204,7 @@ class SecurityGroupHandler(
         "application" to moniker.app,
         "credentials" to accountName,
         "cloudProvider" to CLOUD_PROVIDER,
-        "name" to name,
+        "name" to moniker.name,
         "regions" to listOf(region),
         "vpcId" to cloudDriverCache.networkBy(vpcName, accountName, region).id,
         "description" to description,
@@ -230,7 +230,7 @@ class SecurityGroupHandler(
         "application" to moniker.app,
         "credentials" to accountName,
         "cloudProvider" to CLOUD_PROVIDER,
-        "name" to name,
+        "name" to moniker.name,
         "regions" to listOf(region),
         "vpcId" to cloudDriverCache.networkBy(vpcName, accountName, region).id,
         "description" to description,
@@ -251,7 +251,7 @@ class SecurityGroupHandler(
         "application" to moniker.app,
         "credentials" to accountName,
         "cloudProvider" to CLOUD_PROVIDER,
-        "securityGroupName" to name,
+        "securityGroupName" to moniker.name,
         "regions" to listOf(region),
         "vpcId" to vpcName,
         "accountName" to accountName

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResolvableResourceHandler.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResolvableResourceHandler.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.SubmittedResource
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.events.Task
@@ -46,7 +46,7 @@ interface ResolvableResourceHandler<S : ResourceSpec, R : Any> : KeelPlugin {
    */
   fun normalize(resource: SubmittedResource<S>): Resource<S> {
     val metadata = mapOf(
-      "name" to resource.name.toString(),
+      "id" to resource.id.toString(),
       "uid" to randomUID().toString(),
       "serviceAccount" to resource.metadata.serviceAccount,
       "application" to resource.spec.application
@@ -71,7 +71,7 @@ interface ResolvableResourceHandler<S : ResourceSpec, R : Any> : KeelPlugin {
       .filter { it.handles(resource.apiVersion, resource.kind) }
       .filterIsInstance<ResourceNormalizer<S>>()
       .fold(resource) { r, normalizer ->
-        log.debug("Normalizing ${r.name} with ${normalizer.javaClass}")
+        log.debug("Normalizing ${r.id} with ${normalizer.javaClass}")
         normalizer.normalize(r)
       }
 
@@ -153,7 +153,7 @@ interface ResolvableResourceHandler<S : ResourceSpec, R : Any> : KeelPlugin {
   /**
    * @return `true` if this plugin is still busy running a previous actuation, `false` otherwise.
    */
-  suspend fun actuationInProgress(name: ResourceName): Boolean = false
+  suspend fun actuationInProgress(id: ResourceId): Boolean = false
 }
 
 /**

--- a/keel-sql/src/main/resources/db/changelog/20190904-rename-name-to-id.yml
+++ b/keel-sql/src/main/resources/db/changelog/20190904-rename-name-to-id.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: rename-name-to-id-drop-uid
+      author: fletch
+      changes:
+        - renameColumn:
+            tableName: resource
+            oldColumnName: name
+            newColumnName: id
+            columnDataType: varchar(255)
+      rollback:
+        - renameColumn:
+            tableName: resource
+            oldColumnName: id
+            newColumnName: name
+            columnDataType: varchar(255)

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -29,3 +29,6 @@ databaseChangeLog:
   - include:
       file: changelog/20190808-delivery-config-check-timestamp.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20190904-rename-name-to-id.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.keel.sql
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.persistence.ResourceHeader
 import com.netflix.spinnaker.keel.persistence.ResourceRepositoryPeriodicallyCheckedTests
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
@@ -74,8 +75,8 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
 
       test("metadata is persisted") {
         jooq
-          .select(field<String>("metadata"))
-          .from("resource")
+          .select(RESOURCE.METADATA)
+          .from(RESOURCE)
           .fetchOne()
           .let { (metadata) ->
             configuredObjectMapper().readValue<Map<String, Any?>>(metadata)
@@ -89,8 +90,8 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
 
       test("uid is stored consistently") {
         jooq
-          .select(field<String>("uid"), field<String>("metadata"))
-          .from("resource")
+          .select(RESOURCE.UID, RESOURCE.METADATA)
+          .from(RESOURCE)
           .fetchOne()
           .also { (uid, metadata) ->
             val metadataMap = configuredObjectMapper().readValue<Map<String, Any?>>(metadata)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -51,7 +51,7 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
     context("many threads are checking simultaneously") {
       before {
         repeat(1000) { i ->
-          val resource = resource(name = "fnord-$i")
+          val resource = resource(id = "fnord-$i")
           subject.store(resource)
         }
       }
@@ -83,7 +83,7 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
           .also { metadata ->
             expectThat(metadata)
               .containsKey("uid")
-              .containsKey("name")
+              .containsKey("id")
           }
       }
 

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -4,13 +4,13 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.api.SubmittedEnvironment
 import com.netflix.spinnaker.keel.api.SubmittedMetadata
 import com.netflix.spinnaker.keel.api.SubmittedResource
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
@@ -68,10 +68,10 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
   @Autowired
   lateinit var jooq: DSLContext
 
-  private fun ResourceRepository.allResourceNames(): List<ResourceName> =
-    mutableListOf<ResourceName>()
+  private fun ResourceRepository.allResourceNames(): List<ResourceId> =
+    mutableListOf<ResourceId>()
       .also { list ->
-        allResources { list.add(it.name) }
+        allResources { list.add(it.id) }
       }
 
   object Fixture {
@@ -117,7 +117,7 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
       before {
         every {
           resourceRepository.store(match {
-            it.name == ResourceName("test:whatever:prod")
+            it.id == ResourceId("test:whatever:prod")
           })
         } throws DataAccessException("o noes")
 

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandler.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandler.kt
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.name
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.ResourceDiff
@@ -119,7 +119,7 @@ class KeelTagHandler(
         desired.entityRef.application,
         description,
         listOf(Job(job["type"].toString(), job)),
-        OrchestrationTrigger(resource.name.toString())
+        OrchestrationTrigger(resource.id.toString())
       ))
     log.info("Started task {} to upsert entity tags", taskResponse.ref)
     return listOf(Task(id = taskResponse.taskId, name = description))
@@ -185,4 +185,4 @@ class KeelTagHandler(
     )
 }
 
-const val KEEL_TAG_NAME_PREFIX = "tag:keel-tag"
+const val KEEL_TAG_ID_PREFIX = "tag:keel-tag"

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpec.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpec.kt
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.keel.tagging
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.tags.EntityRef
 import com.netflix.spinnaker.keel.tags.EntityTag
@@ -34,19 +35,19 @@ import com.netflix.spinnaker.keel.tags.EntityTag
  * the [KEEL_TAG_NAMESPACE].
  */
 data class KeelTagSpec(
-  val keelId: String,
+  val keelId: ResourceId,
   val entityRef: EntityRef,
   val tagState: TagState
 ) : ResourceSpec {
   @JsonIgnore
-  override val id: String = keelId
+  override val id: String = keelId.value
 
   @JsonIgnore
   override val application: String = entityRef.application
 }
 
 data class TaggedResource(
-  val keelId: String,
+  val keelId: ResourceId,
   val entityRef: EntityRef,
   val relevantTag: EntityTag?
 )

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpec.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpec.kt
@@ -39,7 +39,7 @@ data class KeelTagSpec(
   val tagState: TagState
 ) : ResourceSpec {
   @JsonIgnore
-  override val name: String = keelId
+  override val id: String = keelId
 
   @JsonIgnore
   override val application: String = entityRef.application

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.keel.tagging
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -61,7 +62,7 @@ internal class KeelTagHandlerTests : JUnit5Minutests {
 
   val clock = MutableClock()
 
-  val keelId = "ec2:cluster:test:us-west-1:emburnstest-managed-reference"
+  val keelId = ResourceId("ec2:cluster:test:us-west-1:emburnstest-managed-reference")
   val entityRef = EntityRef(
     entityType = "servergroup",
     entityId = "emburnstest-managed-reference-v005",

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpecTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpecTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.tagging
 
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.tags.EntityRef
 import com.netflix.spinnaker.keel.tags.EntityTag
@@ -17,7 +18,7 @@ internal class KeelTagSpecTests : JUnit5Minutests {
     context("difference exists in whether tag is desired") {
       fixture {
         val resource = KeelTagSpec(
-          "ec2:cluster:mgmt:us-west-2:keel-prestaging",
+          ResourceId("ec2:cluster:mgmt:us-west-2:keel-prestaging"),
           EntityRef("cluster", "keel-prestaging", "keel", "us-west-2", "mgmt", "12345", "aws"),
           TagDesired(
             EntityTag(

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
@@ -79,7 +79,7 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("tag"),
     kind = "keel-tag",
     spec = KeelTagSpec(
-      keelId = clusterId.toString(),
+      keelId = clusterId,
       entityRef = EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "1234", "aws"),
       tagState = TagDesired(tag = EntityTag(
         value = TagValue(
@@ -98,7 +98,7 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("tag"),
     kind = "keel-tag",
     spec = KeelTagSpec(
-      clusterId.toString(),
+      clusterId,
       EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "1234", "aws"),
       TagNotDesired(clock.millis())
     )
@@ -199,7 +199,6 @@ internal class ResourceTaggerTests : JUnit5Minutests {
 
       test("we don't tag named images") {
         onCreateEvent(ResourceCreated(
-          uid = randomUID(),
           apiVersion = SPINNAKER_API_V1.subApi("bakery"),
           kind = "image",
           id = "bakery:image:keel",
@@ -215,7 +214,6 @@ internal class ResourceTaggerTests : JUnit5Minutests {
 
       test("we tag clbs") {
         onCreateEvent(ResourceCreated(
-          uid = randomUID(),
           apiVersion = SPINNAKER_API_V1.subApi("ec2"),
           kind = "classic-load-balancer",
           id = "ec2:classic-load-balancer:test:us-east-1:keel-managed",
@@ -227,7 +225,6 @@ internal class ResourceTaggerTests : JUnit5Minutests {
 
       test("we tag albs") {
         onCreateEvent(ResourceCreated(
-          uid = randomUID(),
           apiVersion = SPINNAKER_API_V1.subApi("ec2"),
           kind = "application-load-balancer",
           id = "ec2:application-load-balancer:test:us-east-1:keel-managed",
@@ -239,7 +236,6 @@ internal class ResourceTaggerTests : JUnit5Minutests {
 
       test("we tag security groups") {
         onCreateEvent(ResourceCreated(
-          uid = randomUID(),
           apiVersion = SPINNAKER_API_V1.subApi("ec2"),
           kind = "securityGroup",
           id = "ec2:securityGroup:test:us-west-2:keel-managed",
@@ -251,7 +247,6 @@ internal class ResourceTaggerTests : JUnit5Minutests {
 
       test("we tag clusters") {
         onCreateEvent(ResourceCreated(
-          uid = randomUID(),
           apiVersion = SPINNAKER_API_V1.subApi("ec2"),
           kind = "cluster",
           id = "ec2:cluster:test:us-west-2:keeldemo-test",

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -3,11 +3,10 @@ package com.netflix.spinnaker.keel.test
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Monikered
-import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
@@ -58,7 +57,6 @@ fun <T : ResourceSpec> resource(
     kind = kind,
     spec = spec,
     metadata = mapOf(
-      "uid" to randomUID(),
       "id" to "${apiVersion.prefix}:$kind:$id",
       "application" to application,
       "serviceAccount" to "keel@spinnaker"

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -20,16 +20,16 @@ val TEST_API = SPINNAKER_API_V1.subApi("test")
 fun resource(
   apiVersion: ApiVersion = TEST_API,
   kind: String = "whatever",
-  name: String = randomString(),
+  id: String = randomString(),
   application: String = "fnord"
 ): Resource<DummyResourceSpec> =
-  DummyResourceSpec(name = name, application = application)
+  DummyResourceSpec(id = id, application = application)
     .let { spec ->
       resource(
         apiVersion = apiVersion,
         kind = kind,
         spec = spec,
-        name = spec.name,
+        id = spec.id,
         application = application
       )
     }
@@ -42,7 +42,7 @@ fun <T : Monikered> resource(
   apiVersion = apiVersion,
   kind = kind,
   spec = spec,
-  name = spec.moniker.name,
+  id = spec.moniker.name,
   application = spec.application
 )
 
@@ -50,7 +50,7 @@ fun <T : ResourceSpec> resource(
   apiVersion: ApiVersion = TEST_API,
   kind: String = "whatever",
   spec: T,
-  name: String = spec.name,
+  id: String = spec.id,
   application: String = "fnord"
 ): Resource<T> =
   Resource(
@@ -59,23 +59,23 @@ fun <T : ResourceSpec> resource(
     spec = spec,
     metadata = mapOf(
       "uid" to randomUID(),
-      "name" to "${apiVersion.prefix}:$kind:$name",
+      "id" to "${apiVersion.prefix}:$kind:$id",
       "application" to application,
       "serviceAccount" to "keel@spinnaker"
     )
   )
 
 data class DummyResourceSpec(
-  override val name: String = randomString(),
+  override val id: String = randomString(),
   val data: String = randomString(),
   override val application: String = "fnord"
 ) : ResourceSpec
 
 data class DummyResource(
-  val name: String = randomString(),
+  val id: String = randomString(),
   val data: String = randomString()
 ) {
-  constructor(spec: DummyResourceSpec) : this(spec.name, spec.data)
+  constructor(spec: DummyResourceSpec) : this(spec.id, spec.data)
 }
 
 fun randomString(length: Int = 8) =

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
@@ -17,7 +17,7 @@
  */
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 
 /**
  * Implement this interface to create a veto that will be consulted
@@ -35,7 +35,7 @@ interface Veto {
   /**
    * Check whether the resource (identified by name) can be checked according to this veto
    */
-  fun check(name: ResourceName): VetoResponse
+  fun check(id: ResourceId): VetoResponse
 
   /**
    * The message format a veto accepts

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcer.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcer.kt
@@ -18,7 +18,7 @@
 
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import org.springframework.stereotype.Component
 
 /**
@@ -32,9 +32,9 @@ class VetoEnforcer(
   val vetos: List<Veto>
 ) {
 
-  fun canCheck(name: ResourceName): VetoResponse {
+  fun canCheck(id: ResourceId): VetoResponse {
     vetos.forEach { veto ->
-      val response = veto.check(name)
+      val response = veto.check(id)
       if (!response.allowed) {
         return response
       }

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.keel.veto.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.persistence.ApplicationVetoRepository
 import com.netflix.spinnaker.keel.veto.Veto
 import com.netflix.spinnaker.keel.veto.VetoResponse
@@ -31,8 +31,8 @@ class ApplicationVeto(
   val objectMapper: ObjectMapper
 ) : Veto {
 
-  override fun check(name: ResourceName): VetoResponse {
-    val appName = name.toString().split(":").last().split("-").first()
+  override fun check(id: ResourceId): VetoResponse {
+    val appName = id.toString().split(":").last().split("-").first()
     if (applicationVetoRepository.appVetoed(appName)) {
       return VetoResponse(allowed = false, message = "Application $appName has been opted out.")
     }

--- a/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/ApplicationVetoTests.kt
+++ b/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/ApplicationVetoTests.kt
@@ -17,7 +17,7 @@
  */
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryApplicationVetoRepository
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.veto.application.ApplicationVeto
@@ -31,7 +31,7 @@ import strikt.assertions.isTrue
 
 class ApplicationVetoTests : JUnit5Minutests {
   val appName = "keeldemo"
-  val resourceName = ResourceName("ec2:securityGroup:test:us-west-2:keeldemo-managed")
+  val resourceName = ResourceId("ec2:securityGroup:test:us-west-2:keeldemo-managed")
 
   internal
 

--- a/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcerTests.kt
+++ b/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcerTests.kt
@@ -17,7 +17,7 @@
  */
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ResourceName
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryApplicationVetoRepository
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.veto.application.ApplicationVeto
@@ -46,7 +46,7 @@ class VetoEnforcerTests : JUnit5Minutests {
       }
 
       test("no vetos means it's allowed") {
-        val response = subject.canCheck(ResourceName(appName))
+        val response = subject.canCheck(ResourceId(appName))
         expectThat(response.allowed).isTrue()
       }
 
@@ -58,7 +58,7 @@ class VetoEnforcerTests : JUnit5Minutests {
           )
         )
 
-        val response = subject.canCheck(ResourceName(appName))
+        val response = subject.canCheck(ResourceId(appName))
         expectThat(response.allowed).isFalse()
       }
     }


### PR DESCRIPTION
In discussion with @emjburns it's apparent we want the concept of a resource "name" to be user assignable (at least in part in order to use Kustomize). This PR renames the existing `name` metadata entry in resources to `id`. It's a consistent, hierarchical, system-assigned, but human readable identifier. 

I've also made that consistently the thing we use to identify resources rather than also maintaining a UID. We had some overloaded methods on `ResourceRepository`, for example, and were using `uid` to access resource history but `name` (now `id`) to access most everything else. This was annoying and inconsistent in a few places. `SqlResourceRepository` still assigns a UID that is used as the primary key on the tables, but it's no longer exposed via the `Resource` class (except through `metadata`). That's the same as `DeliveryConfig` and `Environment`. It was also easier than updating all the reference tables to use the `id` property instead which would be a much more complex schema migration and probably require us to dump all data out of the DB before pushing this change out.

Fixes #411