### PR TITLE
Use a data class for ResourceId

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
@@ -15,7 +15,13 @@
  */
 package com.netflix.spinnaker.keel.api
 
-@Suppress("EXPERIMENTAL_FEATURE_WARNING")
-inline class ResourceId(val value: String) {
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import com.netflix.spinnaker.keel.serialization.ResourceIdDeserializer
+
+@JsonSerialize(using = ToStringSerializer::class)
+@JsonDeserialize(using = ResourceIdDeserializer::class)
+data class ResourceId(val value: String) {
   override fun toString(): String = value
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ResourceIdDeserializer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ResourceIdDeserializer.kt
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.keel.serialization
+
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer
+import com.netflix.spinnaker.keel.api.ResourceId
+
+class ResourceIdDeserializer : FromStringDeserializer<ResourceId>(ResourceId::class.java) {
+  override fun _deserialize(value: String, ctxt: DeserializationContext) =
+    ResourceId(value)
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/InstanceType.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/InstanceType.kt
@@ -1,4 +1,0 @@
-package com.netflix.spinnaker.keel.api.ec2
-
-@Suppress("EXPERIMENTAL_FEATURE_WARNING")
-inline class InstanceType(val value: String)

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpec.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpec.kt
@@ -35,12 +35,12 @@ import com.netflix.spinnaker.keel.tags.EntityTag
  * the [KEEL_TAG_NAMESPACE].
  */
 data class KeelTagSpec(
-  val keelId: String,
+  val keelId: ResourceId,
   val entityRef: EntityRef,
   val tagState: TagState
 ) : ResourceSpec {
   @JsonIgnore
-  override val id: String = keelId
+  override val id: String = keelId.value
 
   @JsonIgnore
   override val application: String = entityRef.application

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -97,7 +97,7 @@ class ResourceTagger(
       log.debug("Persisting no tag desired for resource {} because it is no longer managed", event.resourceId)
       val entityRef = event.resourceId.toEntityRef()
       val spec = KeelTagSpec(
-        keelId = event.resourceId.value,
+        keelId = event.resourceId,
         entityRef = entityRef,
         tagState = TagNotDesired(startTime = clock.millis())
       )
@@ -163,7 +163,7 @@ class ResourceTagger(
 
   private fun ResourceId.generateKeelTagSpec() =
     KeelTagSpec(
-      value,
+      this,
       toEntityRef(),
       generateTagDesired()
     )

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandlerTests.kt
@@ -85,7 +85,7 @@ internal class KeelTagHandlerTests : JUnit5Minutests {
   )
 
   val specWithTag = KeelTagSpec(
-    keelId = keelId.value,
+    keelId = keelId,
     entityRef = entityRef,
     tagState = TagDesired(
       tag = managedByKeelTag

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpecTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagSpecTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.tagging
 
+import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.tags.EntityRef
 import com.netflix.spinnaker.keel.tags.EntityTag
@@ -17,7 +18,7 @@ internal class KeelTagSpecTests : JUnit5Minutests {
     context("difference exists in whether tag is desired") {
       fixture {
         val resource = KeelTagSpec(
-          "ec2:cluster:mgmt:us-west-2:keel-prestaging",
+          ResourceId("ec2:cluster:mgmt:us-west-2:keel-prestaging"),
           EntityRef("cluster", "keel-prestaging", "keel", "us-west-2", "mgmt", "12345", "aws"),
           TagDesired(
             EntityTag(

--- a/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
+++ b/keel-tagging-plugin/src/test/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTaggerTests.kt
@@ -79,7 +79,7 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("tag"),
     kind = "keel-tag",
     spec = KeelTagSpec(
-      keelId = clusterId.value,
+      keelId = clusterId,
       entityRef = EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "1234", "aws"),
       tagState = TagDesired(tag = EntityTag(
         value = TagValue(
@@ -98,7 +98,7 @@ internal class ResourceTaggerTests : JUnit5Minutests {
     apiVersion = SPINNAKER_API_V1.subApi("tag"),
     kind = "keel-tag",
     spec = KeelTagSpec(
-      clusterId.value,
+      clusterId,
       EntityRef("cluster", "keel", "keel", "ap-south-1", "test", "1234", "aws"),
       TagNotDesired(clock.millis())
     )


### PR DESCRIPTION
Jackson can't handle `inline class` and I keep forgetting. I don't think the advantages are worth the hassle.