### PR TITLE
fix(deliveryConfig): event for registering artifact

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
@@ -134,6 +134,7 @@ class ResourcePersister(
 
   private fun DeliveryArtifact.register() {
     if (!artifactRepository.isRegistered(name, type)) {
+      artifactRepository.register(this)
       publisher.publishEvent(ArtifactRegisteredEvent(this))
     }
   }

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.keel.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeleted
 import com.netflix.spinnaker.keel.events.ResourceUpdated
@@ -61,13 +62,13 @@ class ResourcePersister(
       }
 
   fun <T : ResourceSpec> upsert(resource: SubmittedResource<T>): Resource<T> =
-      resource.let {
-        if (it.id.isRegistered()) {
-          update(it.id, it)
-        } else {
-          create(it)
-        }
+    resource.let {
+      if (it.id.isRegistered()) {
+        update(it.id, it)
+      } else {
+        create(it)
       }
+    }
 
   fun <T : ResourceSpec> create(resource: SubmittedResource<T>): Resource<T> =
     handlerFor(resource)
@@ -81,9 +82,9 @@ class ResourcePersister(
   @Suppress("UNCHECKED_CAST")
   private fun <T : ResourceSpec> handlerFor(resource: SubmittedResource<T>) =
     handlers.supporting(
-        resource.apiVersion,
-        resource.kind
-      ) as ResolvableResourceHandler<T, *>
+      resource.apiVersion,
+      resource.kind
+    ) as ResolvableResourceHandler<T, *>
 
   fun <T : ResourceSpec> update(id: ResourceId, updated: SubmittedResource<T>): Resource<T> {
     log.debug("Updating $id")
@@ -133,7 +134,7 @@ class ResourcePersister(
 
   private fun DeliveryArtifact.register() {
     if (!artifactRepository.isRegistered(name, type)) {
-      artifactRepository.register(this)
+      publisher.publishEvent(ArtifactRegisteredEvent(this))
     }
   }
 

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -15,6 +15,7 @@ import com.netflix.spinnaker.keel.api.SubmittedMetadata
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.resources
+import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceUpdated
 import com.netflix.spinnaker.keel.persistence.get
@@ -40,7 +41,6 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
-import strikt.assertions.isTrue
 import strikt.assertions.startsWith
 import strikt.assertions.succeeded
 import java.time.Clock
@@ -229,7 +229,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
         }
 
         test("artifacts are persisted") {
-          expectThat(artifactRepository.isRegistered("keel", DEB)).isTrue()
+          verify { publisher.publishEvent(ArtifactRegisteredEvent(DeliveryArtifact("keel", DEB))) }
         }
 
         test("individual resources are persisted") {

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -41,6 +41,7 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
+import strikt.assertions.isTrue
 import strikt.assertions.startsWith
 import strikt.assertions.succeeded
 import java.time.Clock
@@ -229,6 +230,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
         }
 
         test("artifacts are persisted") {
+          expectThat(artifactRepository.isRegistered("keel", DEB)).isTrue()
           verify { publisher.publishEvent(ArtifactRegisteredEvent(DeliveryArtifact("keel", DEB))) }
         }
 

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListenerTests.kt
@@ -58,6 +58,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     context("the artifact is not something we're tracking") {
       before {
         every { repository.isRegistered(any(), any()) } returns false
+        every { repository.versions(any()) } returns listOf("0.227.0-h141.bd97556")
 
         listener.onArtifactEvent(event)
       }
@@ -71,9 +72,10 @@ internal class ArtifactListenerTests : JUnit5Minutests {
       }
     }
 
-    context("the artifact is registered") {
+    context("the artifact is registered with versions") {
       before {
         every { repository.isRegistered(artifact.name, artifact.type) } returns true
+        every { repository.versions(artifact) } returns listOf("0.227.0-h141.bd97556")
       }
 
       context("the version was already known") {
@@ -137,6 +139,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     context("artifact is already registered") {
       before {
         every { repository.isRegistered("fnord", DEB) } returns true
+        every { repository.versions(any()) } returns listOf("0.227.0-h141.bd97556")
         listener.onArtifactRegisteredEvent(event)
       }
 
@@ -153,6 +156,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
       context("there are versions of the artifact") {
         before {
           every { repository.store(any(), any()) } returns false
+          every { repository.versions(any()) } returns emptyList()
           coEvery { artifactService.getVersions("fnord") } returns
             listOf(
               "0.227.0-h141.bd97556",
@@ -174,6 +178,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
       context("there no versions of the artifact") {
         before {
           coEvery { artifactService.getVersions("fnord") } returns listOf()
+          coEvery { repository.versions(any()) } returns listOf()
 
           listener.onArtifactRegisteredEvent(event)
         }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -73,10 +73,10 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         subject.register(artifact1)
       }
 
-      test("re-registering the same artifact raises an exception") {
-        expectThrows<ArtifactAlreadyRegistered> {
-          subject.register(artifact1)
-        }
+      test("re-registering the same artifact does not raise an exception") {
+        subject.register(artifact1)
+
+        expectThat(subject.isRegistered(artifact1.name, artifact1.type)).isTrue()
       }
 
       context("no versions exist") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -3,18 +3,21 @@ package com.netflix.spinnaker.keel.persistence.memory
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class InMemoryArtifactRepository : ArtifactRepository {
   private val artifacts = mutableMapOf<DeliveryArtifact, MutableList<String>>()
   private val approvedVersions = mutableMapOf<Triple<DeliveryArtifact, DeliveryConfig, String>, String>()
   private val deployedVersions = mutableMapOf<Triple<DeliveryArtifact, DeliveryConfig, String>, MutableList<String>>()
+  private val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun register(artifact: DeliveryArtifact) {
     if (artifacts.containsKey(artifact)) {
-      throw ArtifactAlreadyRegistered(artifact)
+      log.warn("Duplicate artifact registered: {}", artifact)
+      return
     }
     artifacts[artifact] = mutableListOf()
   }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -5,7 +5,6 @@ import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.randomUID
-import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
@@ -33,7 +32,7 @@ class SqlArtifactRepository(
       .onDuplicateKeyIgnore()
       .execute()
       .also { count ->
-        if (count == 0) throw ArtifactAlreadyRegistered(artifact)
+        if (count == 0) log.warn("Duplicate artifact registered: {}", artifact)
       }
   }
 

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -143,27 +143,6 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
       }
     }
 
-    context("an artifact attached to the delivery config fails to persist") {
-      before {
-        every { artifactRepository.register(any()) } throws DataAccessException("o noes")
-
-        expectCatching { resourcePersister.upsert(submittedManifest) }
-          .failed()
-          .isA<DataAccessException>()
-      }
-
-      test("the delivery config is not persisted") {
-        expectCatching { deliveryConfigRepository.get("keel-manifest") }
-          .failed()
-          .isA<NoSuchDeliveryConfigName>()
-      }
-
-      test("the resources are not persisted") {
-        expectThat(resourceRepository.allResourceNames())
-          .isEmpty()
-      }
-    }
-
     context("the delivery config itself fails to persist") {
       before {
         every { deliveryConfigRepository.store(any()) } throws DataAccessException("o noes")
@@ -176,11 +155,6 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
       test("the resources are not persisted") {
         expectThat(resourceRepository.allResourceNames())
           .isEmpty()
-      }
-
-      test("the artifact not persisted") {
-        expectThat(artifactRepository.isRegistered("keel", DEB))
-          .isFalse()
       }
     }
   }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -143,6 +143,27 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
       }
     }
 
+    context("an artifact attached to the delivery config fails to persist") {
+      before {
+        every { artifactRepository.register(any()) } throws DataAccessException("o noes")
+
+        expectCatching { resourcePersister.upsert(submittedManifest) }
+          .failed()
+          .isA<DataAccessException>()
+      }
+
+      test("the delivery config is not persisted") {
+        expectCatching { deliveryConfigRepository.get("keel-manifest") }
+          .failed()
+          .isA<NoSuchDeliveryConfigName>()
+      }
+
+      test("the resources are not persisted") {
+        expectThat(resourceRepository.allResourceNames())
+          .isEmpty()
+      }
+    }
+
     context("the delivery config itself fails to persist") {
       before {
         every { deliveryConfigRepository.store(any()) } throws DataAccessException("o noes")
@@ -155,6 +176,11 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
       test("the resources are not persisted") {
         expectThat(resourceRepository.allResourceNames())
           .isEmpty()
+      }
+
+      test("the artifact not persisted") {
+        expectThat(artifactRepository.isRegistered("keel", DEB))
+          .isFalse()
       }
     }
   }


### PR DESCRIPTION
Publish an event for registering artifacts in the delivery config so that we automatically fetch the first version of them in [this function](https://github.com/spinnaker/keel/blob/e713b7281144aaa7a064cf4249804e2754131a08/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt#L47). This keeps the logic of registering in one place.