### PR TITLE
feat(cluster): cluster converge with unhealthy instances

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -130,8 +130,17 @@ class ClusterHandler(
       "delayBeforeDisableSec" to 0,
       "delayBeforeScaleDownSec" to 0,
       "maxRemainingAsgs" to 2,
+      // the 2hr default timeout sort-of? makes sense in an imperative
+      // pipeline world where maybe within 2 hours the environment around
+      // the instances will fix itself and the stage will succeed. Since
+      // we are telling the red/black strategy to roll back on failure,
+      // this will leave us in a position where we will instead keep
+      // reattempting to clone the server group because the rollback
+      // on failure of instances to come up will leave us in a non
+      // converged state...
+      "stageTimeoutMs" to Duration.ofMinutes(30).toMillis(),
       "rollback" to mapOf(
-        "onFailure" to false
+        "onFailure" to true
       ),
       "scaleDown" to false,
       // </things to do with the strategy>


### PR DESCRIPTION
Changes the cluster task to use the rollback on failure flag, and times out the stage faster (30mins instead of 2hrs).

Rollback on failure only applies to instances failing to come up healthy, this change attempts to leave the cluster in
a previous-known-good but also needs-to-reconverge state so that we will get retries on deployment via keel attempting
to converge the cluster repeatedly.