### PR TITLE
fix(imagehandler): exclude unnecessary image regions

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -72,7 +72,9 @@ class ImageHandler(
 
   override suspend fun current(resource: Resource<ImageSpec>): Image? =
     with(resource) {
-      imageService.getLatestImage(spec.artifactName, "test")
+      imageService.getLatestImage(spec.artifactName, "test")?.let {
+        it.copy(regions = it.regions.intersect(resource.spec.regions))
+      }
     }
 
   private fun DeliveryArtifact.findLatestVersion(): String =

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -196,6 +196,19 @@ internal class ImageHandlerTests : JUnit5Minutests {
           expectThrows<BaseAmiNotFound> { handler.desired(resource) }
         }
       }
+
+      context("the image already exists in more regions than desired") {
+        before {
+          coEvery {
+            imageService.getLatestImage("keel", "test")
+          } returns image.copy(regions = image.regions + "eu-west-1")
+        }
+        test("current should filter the undesireable regions out of the image") {
+          runBlocking {
+            expectThat(handler.current(resource)!!.regions).isEqualTo(resource.spec.regions)
+          }
+        }
+      }
     }
 
     context("baking a new AMI") {


### PR DESCRIPTION
If an image exists in more regions than desired, consider the
current state only to contain the regions in the desired state.