### PR TITLE
feat(artifact): mark artifact deployed if already out

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -24,7 +24,7 @@ class CheckScheduler(
   private val deliveryConfigRepository: DeliveryConfigRepository,
   private val resourceActuator: ResourceActuator,
   private val environmentPromotionChecker: EnvironmentPromotionChecker,
-  @Value("\${keel.resource-check.min-age-minutes:1}") private val resourceCheckMinAgeMinutes: Long,
+  @Value("\${keel.resource-check.min-age-duration:60s}") private val resourceCheckMinAgeDuration: Duration,
   @Value("\${keel.resource-check.batch-size:1}") private val resourceCheckBatchSize: Int,
   private val publisher: ApplicationEventPublisher
 ) : CoroutineScope {
@@ -85,7 +85,7 @@ class CheckScheduler(
   }
 
   private fun <T : Any> PeriodicallyCheckedRepository<T>.launchForEachItem(block: suspend CoroutineScope.(T) -> Unit) {
-    itemsDueForCheck(Duration.ofMinutes(resourceCheckMinAgeMinutes), resourceCheckBatchSize)
+    itemsDueForCheck(resourceCheckMinAgeDuration, resourceCheckBatchSize)
       .forEach {
         launch { block(it) }
       }

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
@@ -13,6 +13,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
+import java.time.Duration
 
 internal object CheckSchedulerTests : JUnit5Minutests {
 
@@ -41,7 +42,7 @@ internal object CheckSchedulerTests : JUnit5Minutests {
         deliveryConfigRepository = deliveryConfigRepository,
         resourceActuator = resourceActuator,
         environmentPromotionChecker = environmentPromotionChecker,
-        resourceCheckMinAgeMinutes = 5,
+        resourceCheckMinAgeDuration = Duration.ofMinutes(5),
         resourceCheckBatchSize = 2,
         publisher = publisher
       )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.time.Clock
@@ -62,7 +63,8 @@ class EC2Config {
     imageResolver: ImageResolver,
     clock: Clock,
     objectMapper: ObjectMapper,
-    normalizers: List<ResourceNormalizer<*>>
+    normalizers: List<ResourceNormalizer<*>>,
+    publisher: ApplicationEventPublisher
   ): ClusterHandler =
     ClusterHandler(
       cloudDriverService,
@@ -70,6 +72,7 @@ class EC2Config {
       orcaService,
       imageResolver,
       clock,
+      publisher,
       objectMapper,
       normalizers
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ArtifactAlreadyDeployedEvent.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ArtifactAlreadyDeployedEvent.kt
@@ -1,0 +1,28 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.ec2.image
+
+/**
+ * An event fired while we check a cluster that lets us know
+ * what version of software is running in that cluster
+ */
+data class ArtifactAlreadyDeployedEvent(
+  val resourceId: String,
+  val imageId: String,
+  val provider: String = "aws"
+)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/CurrentlyDeployedImageApprover.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/CurrentlyDeployedImageApprover.kt
@@ -1,0 +1,76 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.ec2.image
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.serviceAccount
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.appVersion
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class CurrentlyDeployedImageApprover(
+  private val cloudDriverService: CloudDriverService,
+  private val artifactRepository: ArtifactRepository,
+  private val resourceRepository: ResourceRepository,
+  private val deliveryConfigRepository: DeliveryConfigRepository
+) {
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  @EventListener(ArtifactAlreadyDeployedEvent::class)
+  fun artifactAlreadyDeployedEventHandler(event: ArtifactAlreadyDeployedEvent) =
+    runBlocking {
+      val resourceId = ResourceId(event.resourceId)
+      val resource = resourceRepository.get(resourceId)
+      val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resourceId)
+      val env = deliveryConfigRepository.environmentFor(resourceId)
+
+      if (resource.spec is ClusterSpec && deliveryConfig != null && env != null) {
+        val spec = resource.spec as ClusterSpec // needed because kotlin can't cast it automatically
+        if (spec.launchConfiguration.imageProvider is ArtifactImageProvider) {
+          val artifact = spec.launchConfiguration.imageProvider.deliveryArtifact
+          val image = cloudDriverService.namedImages(resource.serviceAccount, event.imageId, null).first()
+          val appversion = image.appVersion
+
+          val wasSuccessfullyDeployed = artifactRepository.wasSuccessfullyDeployedTo(
+            deliveryConfig = deliveryConfig,
+            artifact = artifact,
+            version = appversion,
+            targetEnvironment = env.name
+          )
+          // should only mark as successfully deployed if it's already approved for the environment
+          if (!wasSuccessfullyDeployed) {
+            log.info("Approving {} for {} in {} because it is already deployed", appversion, env.name, deliveryConfig.name)
+            artifactRepository.markAsSuccessfullyDeployedTo(
+              deliveryConfig = deliveryConfig,
+              artifact = artifact,
+              version = appversion,
+              targetEnvironment = env.name
+            )
+          }
+        }
+      }
+    }
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/image/CurrentlyDeployedImageApproverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/image/CurrentlyDeployedImageApproverTests.kt
@@ -1,0 +1,190 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.ec2.image
+
+import com.netflix.spinnaker.keel.api.ArtifactType
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.ec2.cluster.LaunchConfigurationSpec
+import com.netflix.spinnaker.keel.api.ec2.cluster.Location
+import com.netflix.spinnaker.keel.api.ec2.image.ArtifactAlreadyDeployedEvent
+import com.netflix.spinnaker.keel.api.ec2.image.ArtifactImageProvider
+import com.netflix.spinnaker.keel.api.ec2.image.CurrentlyDeployedImageApprover
+import com.netflix.spinnaker.keel.api.ec2.image.IdImageProvider
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
+import com.netflix.spinnaker.keel.ec2.actuation.ArtifactPromotionListenerTests
+import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.Called
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+internal class CurrentlyDeployedImageApproverTests : JUnit5Minutests {
+
+  object Fixture {
+    const val appVersion = "fnord-0.214.0-h127.4a44d09"
+    const val imageId = "ami-0662ddfa402bb25d9"
+    val ami = NamedImage(
+      "$appVersion-x86_64-20190730165302-xenial-hvm-sriov-ebs",
+      mapOf(
+        "virtualizationType" to "hvm",
+        "creationDate" to "2019-07-30T16:57:37.000Z"
+      ),
+      mapOf(
+        imageId to mapOf(
+          "appversion" to "$appVersion/JENKINS-rocket-package-fnord/127"
+        )
+      ),
+      setOf("test"),
+      mapOf("ap-south-1" to listOf(imageId))
+    )
+
+    val artifact = DeliveryArtifact(
+      name = "fnord",
+      type = ArtifactType.DEB
+    )
+
+    val nonArtifactCluster = resource(
+      apiVersion = SPINNAKER_API_V1.subApi("ec2"),
+      kind = "cluster",
+      spec = ClusterSpec(
+        moniker = Moniker("fnord", "api"),
+        location = Location("test", "ap-south-1", "internal (vpc0)", setOf("ap-south1-a", "ap-south1-b", "ap-south1-c")),
+        launchConfiguration = LaunchConfigurationSpec(
+          imageProvider = IdImageProvider(imageId = imageId),
+          instanceType = "m4.2xlarge",
+          ebsOptimized = true,
+          iamRole = "fnordInstanceProfile",
+          keyPair = "fnordKeyPair"
+        )
+      )
+    )
+
+    val artifactCluster = resource(
+      apiVersion = SPINNAKER_API_V1.subApi("ec2"),
+      kind = "cluster",
+      spec = ClusterSpec(
+        moniker = Moniker("fnord", "api"),
+        location = Location("test", "ap-south-1", "internal (vpc0)", setOf("ap-south1-a", "ap-south1-b", "ap-south1-c")),
+        launchConfiguration = LaunchConfigurationSpec(
+          imageProvider = ArtifactImageProvider(deliveryArtifact = artifact),
+          instanceType = "m4.2xlarge",
+          ebsOptimized = true,
+          iamRole = "fnordInstanceProfile",
+          keyPair = "fnordKeyPair"
+        )
+      )
+    )
+
+    val testEnv = Environment(name = "test", resources = setOf(artifactCluster))
+
+    val deliveryConfig = DeliveryConfig(
+      name = "manifest",
+      application = "fnord",
+      artifacts = setOf(artifact),
+      environments = setOf(testEnv)
+    )
+
+    val deliveryConfigRepository = InMemoryDeliveryConfigRepository()
+    val resourceRepository = InMemoryResourceRepository()
+    val artifactRepository = mockk<ArtifactRepository>(relaxUnitFun = true)
+    val cloudDriverService = mockk<CloudDriverService> {
+      coEvery { namedImages(ArtifactPromotionListenerTests.Fixture.imageId, "test", "ap-south-1") } returns listOf(ArtifactPromotionListenerTests.Fixture.ami)
+    }
+
+    val subject = CurrentlyDeployedImageApprover(
+      cloudDriverService = cloudDriverService,
+      artifactRepository = artifactRepository,
+      resourceRepository = resourceRepository,
+      deliveryConfigRepository = deliveryConfigRepository
+    )
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture }
+
+    after {
+      deliveryConfigRepository.dropAll()
+      resourceRepository.dropAll()
+      clearAllMocks()
+    }
+
+    context("cluster does not have an artifact image provider") {
+      before {
+        deliveryConfigRepository.store(deliveryConfig)
+        resourceRepository.store(nonArtifactCluster)
+        val event = ArtifactAlreadyDeployedEvent(nonArtifactCluster.id.toString(), imageId)
+        subject.artifactAlreadyDeployedEventHandler(event)
+      }
+
+      test("nothing happens") {
+        verify { artifactRepository wasNot Called }
+      }
+    }
+
+    context("cluster has artifact image provider and didn't deploy the version") {
+
+      before {
+        deliveryConfigRepository.store(deliveryConfig)
+        resourceRepository.store(artifactCluster)
+
+        every { artifactRepository.latestVersionApprovedIn(deliveryConfig, artifact, testEnv.name) } returns appVersion
+        every { artifactRepository.wasSuccessfullyDeployedTo(deliveryConfig, artifact, appVersion, testEnv.name) } returns false
+        coEvery { cloudDriverService.namedImages(any(), imageId, null) } returns listOf(ami)
+
+        val event = ArtifactAlreadyDeployedEvent(artifactCluster.id.toString(), imageId)
+        subject.artifactAlreadyDeployedEventHandler(event)
+      }
+
+      test("running version is the latest version") {
+        verify { artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, appVersion, testEnv.name) }
+      }
+    }
+
+    context("cluster has artifact image provider and did deploy the version") {
+      before {
+        deliveryConfigRepository.store(deliveryConfig)
+        resourceRepository.store(artifactCluster)
+
+        every { artifactRepository.latestVersionApprovedIn(deliveryConfig, artifact, testEnv.name) } returns appVersion
+        every { artifactRepository.wasSuccessfullyDeployedTo(deliveryConfig, artifact, appVersion, testEnv.name) } returns true
+        coEvery { cloudDriverService.namedImages(any(), imageId, null) } returns listOf(ami)
+
+        val event = ArtifactAlreadyDeployedEvent(artifactCluster.id.toString(), imageId)
+        subject.artifactAlreadyDeployedEventHandler(event)
+      }
+
+      test("running version is the latest version") {
+        verify(exactly = 0) { artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, appVersion, testEnv.name) }
+      }
+    }
+  }
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -43,6 +43,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
+import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.get
 import strikt.assertions.isEqualTo
@@ -135,6 +136,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val imageResolver = mockk<ImageResolver>()
   val objectMapper = ObjectMapper().registerKotlinModule()
   val normalizers = emptyList<ResourceNormalizer<Cluster>>()
+  val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
 
   fun tests() = rootContext<ClusterHandler> {
     fixture {
@@ -144,6 +146,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         orcaService,
         imageResolver,
         Clock.systemDefaultZone(),
+        publisher,
         objectMapper,
         normalizers
       )


### PR DESCRIPTION
Current state:
- for artifacts to "progress" through environments, keel has to deploy them (it's not enough that they're already running in that environment)
- this is annoying for testing and annoying for someone switching to declarative

This pr:
- emits an event with the ami deployed to a cluster every time we get the current state of the cluster
- a new listener reacts to those events and checks if the version running has been approved for that env but not deployed
- if so, the listener marks that version as successfully deployed in the environment. 

I also change `keel.resource-check.min-age-minutes` to `keel.resource-check.min-age-duration` (where duration is something like `60s` or `1m`) because that makes it easier to quicken up the checks locally and I'm impatient. 