### PR TITLE
Added appVersion to resolved cluster model

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
@@ -1,11 +1,13 @@
 package com.netflix.spinnaker.keel.clouddriver.model
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.netflix.spinnaker.keel.model.Moniker
 
 data class ClusterActiveServerGroup(
   val name: String,
   val region: String,
   val zones: Set<String>,
+  val image: ClusterImage,
   val launchConfig: LaunchConfig,
   val asg: AutoScalingGroup,
   val vpcId: String,
@@ -17,6 +19,25 @@ data class ClusterActiveServerGroup(
   val accountName: String,
   val moniker: Moniker
 )
+
+data class ClusterImage(
+  val imageId: String,
+  val appVersion: String
+) {
+  @JsonCreator
+  constructor(
+    imageId: String,
+    tags: List<Map<String, Any?>>
+  ) : this(
+    imageId,
+    tags.first {
+      it["key"] == "appversion"
+    }
+      ["value"]
+      .toString()
+      .substringBefore("/")
+  )
+}
 
 data class LaunchConfig(
   val ramdiskId: String?,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroup.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.clouddriver.model
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.netflix.spinnaker.keel.model.Moniker
-import java.lang.RuntimeException
 
 data class ClusterActiveServerGroup(
   val name: String,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Image.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Image.kt
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.keel.clouddriver.model
 
 /**
- * The resolved representation of an [ImageSpec].
+ * The resolved representation of an AMI.
  */
 data class Image(
   val baseAmiVersion: String,

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ClusterActiveServerGroupTest.kt
@@ -18,6 +18,10 @@ object ClusterActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService
     targetGroups = emptySet(),
     region = "eu-west-1",
     zones = setOf("eu-west-1b", "eu-west-1c", "eu-west-1a"),
+    image = ClusterImage(
+      imageId = "ami-05a878bfa321e03b4",
+      appVersion = "mimirdemo-3.16.0-h205.121d4ac"
+    ),
     launchConfig = LaunchConfig(
       ramdiskId = "",
       ebsOptimized = false,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/InvalidPayload.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/InvalidPayload.kt
@@ -17,8 +17,6 @@
  */
 package com.netflix.spinnaker.keel.api
 
-import java.lang.RuntimeException
-
 class UnsupportedStrategy(requestedStrategy: String, validStrategy: String) : RuntimeException("Strategy $requestedStrategy is not supported for $validStrategy")
 
 class InvalidPayload(strategy: String) : RuntimeException("Payload is not valid for $strategy")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -50,6 +50,7 @@ class EC2Config {
   ): ImageResolver =
     ImageResolver(
       dynamicConfigService,
+      cloudDriverService,
       deliveryConfigRepository,
       artifactRepository,
       imageService

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/cluster/LaunchConfiguration.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/cluster/LaunchConfiguration.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.keel.api.ec2.cluster
 
 data class LaunchConfiguration(
   val imageId: String,
+  val appVersion: String,
   val instanceType: String,
   val ebsOptimized: Boolean,
   val iamRole: String,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/cluster/LaunchConfigurationSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/cluster/LaunchConfigurationSpec.kt
@@ -28,9 +28,10 @@ data class LaunchConfigurationSpec(
   val instanceMonitoring: Boolean = false,
   val ramdiskId: String? = null
 ) {
-  fun generateLaunchConfiguration(imageId: String): LaunchConfiguration {
-    return LaunchConfiguration(
+  fun generateLaunchConfiguration(imageId: String, appVersion: String) =
+    LaunchConfiguration(
       imageId = imageId,
+      appVersion = appVersion,
       instanceType = instanceType,
       ebsOptimized = ebsOptimized,
       iamRole = iamRole,
@@ -38,5 +39,4 @@ data class LaunchConfigurationSpec(
       instanceMonitoring = instanceMonitoring,
       ramdiskId = ramdiskId
     )
-  }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -68,11 +68,11 @@ class ClusterHandler(
 
   override suspend fun desired(resource: Resource<ClusterSpec>): Cluster =
     with(resource.spec) {
-      val imageId = imageResolver.resolveImageId(resource)
+      val (imageId, appVersion) = imageResolver.resolveImageId(resource)
       Cluster(
         moniker = moniker,
         location = location,
-        launchConfiguration = launchConfiguration.generateLaunchConfiguration(imageId),
+        launchConfiguration = launchConfiguration.generateLaunchConfiguration(imageId, appVersion),
         capacity = capacity,
         dependencies = dependencies,
         health = health,
@@ -273,13 +273,14 @@ class ClusterHandler(
             ),
             launchConfiguration = launchConfig.run {
               LaunchConfiguration(
-                imageId,
-                instanceType,
-                ebsOptimized,
-                iamInstanceProfile,
-                keyName,
-                instanceMonitoring.enabled,
-                ramdiskId.orNull()
+                imageId = imageId,
+                appVersion = "",
+                instanceType = instanceType,
+                ebsOptimized = ebsOptimized,
+                iamRole = iamInstanceProfile,
+                keyPair = keyName,
+                instanceMonitoring = instanceMonitoring.enabled,
+                ramdiskId = ramdiskId.orNull()
               )
             },
             capacity = capacity.let { Capacity(it.min, it.max, it.desired) },

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
@@ -12,7 +12,10 @@ import com.netflix.spinnaker.keel.api.ec2.image.IdImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.ImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.JenkinsImageProvider
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.clouddriver.ImageService
+import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -20,6 +23,7 @@ import org.slf4j.LoggerFactory
 
 class ImageResolver(
   private val dynamicConfigService: DynamicConfigService,
+  private val cloudDriverService: CloudDriverService,
   private val deliveryConfigRepository: DeliveryConfigRepository,
   private val artifactRepository: ArtifactRepository,
   private val imageService: ImageService
@@ -28,66 +32,84 @@ class ImageResolver(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   // TODO: we may (probably will) want to make the parameter type more generic
-  suspend fun resolveImageId(resource: Resource<ClusterSpec>): String {
-    val region = resource.spec.location.region
+  suspend fun resolveImageId(resource: Resource<ClusterSpec>): Pair<String, String> =
     when (val imageProvider = resource.spec.launchConfiguration.imageProvider) {
       is IdImageProvider -> {
-        return imageProvider.imageId
+        resolveFromImageId(resource, imageProvider)
       }
       is ArtifactImageProvider -> {
-        val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
-        val environment = deliveryConfigRepository.environmentFor(resource.id)
-        val artifact = imageProvider.deliveryArtifact
-        val account = dynamicConfigService.getConfig("images.default-account", "test")
-
-        return if (deliveryConfig != null && environment != null) {
-          val artifactVersion = artifactRepository.latestVersionApprovedIn(
-            deliveryConfig,
-            artifact,
-            environment.name
-          ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
-          val image = imageService.getLatestNamedImage(
-            appVersion = AppVersion.parseName(artifactVersion),
-            account = account,
-            region = region
-          ) ?: throw NoImageFound(artifactVersion)
-
-          image.amis[region]?.first()
-            ?.also {
-              log.info("Image found for {}: {}", artifactVersion, image)
-            } ?: throw NoImageFoundForRegion(artifactVersion, region)
-        } else {
-          val image = imageService.getLatestNamedImage(
-            packageName = artifact.name,
-            account = account,
-            region = region
-          ) ?: throw NoImageFound(artifact.name)
-
-          image.amis[region]?.first()
-            ?.also {
-              log.info("Image found for {}: {}", artifact.name, image)
-            }
-            ?: throw NoImageFoundForRegion(artifact.name, region)
-        }
+        resolveFromArtifact(resource, imageProvider)
       }
       is JenkinsImageProvider -> {
-        val namedImage = imageService.getNamedImageFromJenkinsInfo(
-          imageProvider.packageName,
-          dynamicConfigService.getConfig("images.default-account", "test"),
-          imageProvider.buildHost,
-          imageProvider.buildName,
-          imageProvider.buildNumber
-        ) ?: throw NoImageFound(imageProvider.packageName)
-
-        log.info("Image found for {}: {}", imageProvider.packageName, namedImage)
-        val amis = namedImage.amis[region]
-          ?: throw NoImageFoundForRegion(imageProvider.packageName, region)
-        return amis.first() // todo eb: when are there multiple?
+        resolveFromJenkinsJob(resource, imageProvider)
       }
       else -> {
         throw UnsupportedStrategy(imageProvider::class.simpleName.orEmpty(), ImageProvider::class.simpleName.orEmpty())
       }
     }
+
+  private suspend fun resolveFromImageId(resource: Resource<ClusterSpec>, imageProvider: IdImageProvider): Pair<String, String> {
+    val images = cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, imageProvider.imageId, null, null)
+    check(images.size == 1) {
+      "Expected a single image for AMI id ${imageProvider.imageId} but found ${images.size}"
+    }
+    return imageProvider.imageId to images.first().appVersion
+  }
+
+  private suspend fun resolveFromArtifact(resource: Resource<ClusterSpec>, imageProvider: ArtifactImageProvider): Pair<String, String> {
+    val region = resource.spec.location.region
+    val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
+    val environment = deliveryConfigRepository.environmentFor(resource.id)
+    val artifact = imageProvider.deliveryArtifact
+    val account = dynamicConfigService.getConfig("images.default-account", "test")
+
+    return if (deliveryConfig != null && environment != null) {
+      val artifactVersion = artifactRepository.latestVersionApprovedIn(
+        deliveryConfig,
+        artifact,
+        environment.name
+      ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
+      val image = imageService.getLatestNamedImage(
+        appVersion = AppVersion.parseName(artifactVersion),
+        account = account,
+        region = region
+      ) ?: throw NoImageFound(artifactVersion)
+
+      val imageId = image.amis[region]?.first()
+        ?.also {
+          log.info("Image found for {}: {}", artifactVersion, image)
+        } ?: throw NoImageFoundForRegion(artifactVersion, region)
+      imageId to artifactVersion
+    } else {
+      val image = imageService.getLatestNamedImage(
+        packageName = artifact.name,
+        account = account,
+        region = region
+      ) ?: throw NoImageFound(artifact.name)
+
+      val imageId = (image.amis[region]?.first()
+        ?.also {
+          log.info("Image found for {}: {}", artifact.name, image)
+        }
+        ?: throw NoImageFoundForRegion(artifact.name, region))
+      imageId to image.appVersion
+    }
+  }
+
+  private suspend fun resolveFromJenkinsJob(resource: Resource<ClusterSpec>, imageProvider: JenkinsImageProvider): Pair<String, String> {
+    val region = resource.spec.location.region
+    val namedImage = imageService.getNamedImageFromJenkinsInfo(
+      imageProvider.packageName,
+      dynamicConfigService.getConfig("images.default-account", "test"),
+      imageProvider.buildHost,
+      imageProvider.buildName,
+      imageProvider.buildNumber
+    ) ?: throw NoImageFound(imageProvider.packageName)
+
+    log.info("Image found for {}: {}", imageProvider.packageName, namedImage)
+    val amis = namedImage.amis[region]
+      ?: throw NoImageFoundForRegion(imageProvider.packageName, region)
+    return amis.first() to namedImage.appVersion // todo eb: when are there multiple?
   }
 
   private inline fun <reified T> DynamicConfigService.getConfig(configName: String, defaultValue: T) =

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterTests.kt
@@ -36,6 +36,7 @@ internal object ClusterTests : JUnit5Minutests {
             |  subnet: internal (vpc0)
             |launchConfiguration:
             |  imageId: ami-01fdaa2821a7ea01e
+            |  appVersion: mimirdemo-3.18.0-h207.e06f231
             |  instanceType: m5.large
             |  ebsOptimized: true
             |  instanceMonitoring: false

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/actuation/ArtifactPromotionListenerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/actuation/ArtifactPromotionListenerTests.kt
@@ -14,7 +14,6 @@ import com.netflix.spinnaker.keel.api.ec2.cluster.Location
 import com.netflix.spinnaker.keel.api.ec2.image.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.image.IdImageProvider
 import com.netflix.spinnaker.keel.api.ec2.securityGroup.SecurityGroup
-import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.model.Moniker
@@ -24,7 +23,6 @@ import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.Called
-import io.mockk.coEvery
 import io.mockk.mockk
 import io.mockk.verify
 
@@ -50,10 +48,7 @@ internal class ArtifactPromotionListenerTests : JUnit5Minutests {
 
     private val deliveryConfigRepository = InMemoryDeliveryConfigRepository()
     val artifactRepository = mockk<ArtifactRepository>(relaxUnitFun = true)
-    private val cloudDriverService = mockk<CloudDriverService>() {
-      coEvery { namedImages(imageId, "test", "ap-south-1") } returns listOf(ami)
-    }
-    private val subject = ArtifactPromotionListener(deliveryConfigRepository, artifactRepository, cloudDriverService)
+    private val subject = ArtifactPromotionListener(deliveryConfigRepository, artifactRepository)
 
     val artifact = DeliveryArtifact(
       name = "fnord",
@@ -113,6 +108,7 @@ internal class ArtifactPromotionListenerTests : JUnit5Minutests {
       location,
       LaunchConfiguration(
         imageId,
+        appVersion,
         launchConfiguration.instanceType,
         launchConfiguration.ebsOptimized,
         launchConfiguration.iamRole,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -18,6 +18,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.AutoScalingGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ClusterActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.ClusterImage
 import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
 import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
 import com.netflix.spinnaker.keel.clouddriver.model.Network
@@ -86,7 +87,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val cluster = Cluster(
     moniker = spec.moniker,
     location = spec.location,
-    launchConfiguration = spec.launchConfiguration.generateLaunchConfiguration("i-123543254134"),
+    launchConfiguration = spec.launchConfiguration.generateLaunchConfiguration("i-123543254134", "keel-0.252.0-h168.35fe253/SPINNAKER-rocket-package-keel/168"),
     capacity = spec.capacity,
     dependencies = spec.dependencies
   )
@@ -100,6 +101,10 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     "keel-test-v069",
     spec.location.region,
     spec.location.availabilityZones,
+    ClusterImage(
+      (spec.launchConfiguration.imageProvider as IdImageProvider).imageId,
+      "keel-0.252.0-h168.35fe253"
+    ),
     LaunchConfig(
       spec.launchConfiguration.ramdiskId,
       spec.launchConfiguration.ebsOptimized,
@@ -204,10 +209,9 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       derivedContext<Cluster?>("fetching the current cluster state") {
         deriveFixture {
-          val current = runBlocking {
+          runBlocking {
             current(resource)
           }
-          current
         }
 
         test("the current model is converted to a cluster") {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.ClusterImage
 import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
 import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
 import com.netflix.spinnaker.keel.clouddriver.model.Network
+import com.netflix.spinnaker.keel.clouddriver.model.RequiredTagMissing
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCapacity
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
@@ -33,6 +34,7 @@ import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.plugin.CannotResolveCurrentState
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -45,8 +47,12 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.assertions.cause
+import strikt.assertions.failed
 import strikt.assertions.get
+import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
@@ -199,6 +205,25 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         expectThat(slot.captured.job.first()) {
           get("type").isEqualTo("createServerGroup")
         }
+      }
+    }
+
+    context("the currently deployed image is missing its appversion tag") {
+      before {
+        coEvery { cloudDriverService.activeServerGroup() } throws RequiredTagMissing(
+          "appversion",
+          activeServerGroupResponse.image.imageId
+        )
+      }
+
+      test("resolving the current model results in an exception") {
+        expectCatching {
+          current(resource)
+        }
+          .failed()
+          .isA<CannotResolveCurrentState>()
+          .cause
+          .isA<RequiredTagMissing>()
       }
     }
 

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/CannotResolveCurrentState.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/CannotResolveCurrentState.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.plugin
 
 import com.netflix.spinnaker.keel.api.ResourceId
-import java.lang.RuntimeException
 
 class CannotResolveCurrentState(
   resourceId: ResourceId,

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/CannotResolveCurrentState.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/CannotResolveCurrentState.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.plugin
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import java.lang.RuntimeException
+
+class CannotResolveCurrentState(
+  resourceId: ResourceId,
+  cause: Throwable
+) : RuntimeException("Unable to resolve current state of $resourceId", cause)


### PR DESCRIPTION
This should provide some more informative context in the resource history. It also enables the `ArtifactPromotionListener` to mark a version as deployed without needing to run an AMI lookup on the CloudDriver.