### PR TITLE
feat(artifact): optionally specify status in image and cluster

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.rest
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.events.ArtifactEvent
-import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
@@ -12,7 +11,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus.ACCEPTED
 import org.springframework.http.HttpStatus.CONFLICT
-import org.springframework.http.HttpStatus.CREATED
 import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -38,22 +36,7 @@ class ArtifactController(
   )
   @ResponseStatus(ACCEPTED)
   fun submitArtifact(@RequestBody echoArtifactEvent: EchoArtifactEvent) {
-    log.debug(
-      echoArtifactEvent.eventName,
-      echoArtifactEvent.payload.artifacts.map { it.name }
-    )
     publisher.publishEvent(echoArtifactEvent.payload)
-  }
-
-  // todo eb: do we need this endpoint anymore? we auto-register.
-  @PostMapping(
-    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  @ResponseStatus(CREATED)
-  fun register(@RequestBody artifact: DeliveryArtifact) {
-    log.debug("Registering {} artifact {}", artifact.type, artifact.name)
-    publisher.publishEvent(ArtifactRegisteredEvent(artifact))
   }
 
   @GetMapping(

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -39,13 +39,13 @@ class ArtifactController(
   @ResponseStatus(ACCEPTED)
   fun submitArtifact(@RequestBody echoArtifactEvent: EchoArtifactEvent) {
     log.debug(
-      "Received artifact events {} for {}",
       echoArtifactEvent.eventName,
       echoArtifactEvent.payload.artifacts.map { it.name }
     )
     publisher.publishEvent(echoArtifactEvent.payload)
   }
 
+  // todo eb: do we need this endpoint anymore? we auto-register.
   @PostMapping(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -17,7 +17,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -37,22 +36,6 @@ internal class ArtifactControllerTests {
   @AfterEach
   fun clearRepository() {
     artifactRepository.dropAll()
-  }
-
-  @Test
-  fun `can register a new artifact`() {
-    val request = post("/artifacts")
-      .accept(APPLICATION_YAML)
-      .contentType(APPLICATION_YAML)
-      .content(
-        """---
-          |name: fnord
-          |type: DEB
-        """.trimMargin()
-      )
-    mvc
-      .perform(request)
-      .andExpect(status().isCreated)
   }
 
   @Test

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.KeelApplication
+import com.netflix.spinnaker.keel.api.ArtifactStatus.FINAL
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
@@ -59,9 +60,9 @@ internal class ArtifactControllerTests {
     val artifact = DeliveryArtifact("fnord", DEB)
     with(artifactRepository) {
       register(artifact)
-      store(artifact, "fnord-1.0.0-41595c4")
-      store(artifact, "fnord-2.0.0-608bd90")
-      store(artifact, "fnord-2.1.0-18ed1dc")
+      store(artifact, "fnord-1.0.0-41595c4", FINAL)
+      store(artifact, "fnord-2.0.0-608bd90", FINAL)
+      store(artifact, "fnord-2.1.0-18ed1dc", FINAL)
     }
 
     val request = get("/artifacts/${artifact.name}/${artifact.type}")

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/api/ImageSpec.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/api/ImageSpec.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.bakery.api
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.ResourceSpec
 
 data class ImageSpec(
@@ -9,6 +10,7 @@ data class ImageSpec(
   val baseOs: String,
   val regions: Set<String>,
   val storeType: StoreType,
+  val artifactStatuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList(),
   override val application: String // the application an image is baked in
 ) : ResourceSpec {
   @JsonIgnore

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -8,3 +8,7 @@ data class DeliveryArtifact(
 enum class ArtifactType {
   DEB
 }
+
+enum class ArtifactStatus {
+  FINAL, CANDIDATE, SNAPSHOT
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ArtifactEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ArtifactEvent.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.events
 
+import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 
@@ -8,6 +9,10 @@ data class ArtifactEvent(
   val details: Map<String, Any>?
 )
 
+/**
+ * This event optionally takes [statuses] so that we can fetch the most relevant first artifact.
+ */
 data class ArtifactRegisteredEvent(
-  val artifact: DeliveryArtifact
+  val artifact: DeliveryArtifact,
+  val statuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.persistence
 
 import com.netflix.frigga.ami.AppVersion
 import com.netflix.rocket.semver.shaded.DebianVersionComparator
+import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
@@ -18,17 +19,26 @@ interface ArtifactRepository {
    * @return `true` if a new version is persisted, `false` if the specified version was already
    * known (in which case this method is a no-op).
    */
-  fun store(artifact: DeliveryArtifact, version: String): Boolean
-
-  fun versions(artifact: DeliveryArtifact): List<String>
+  fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus): Boolean
 
   /**
-   * @return the latest version of [artifact] approved for use in [targetEnvironment].
+   * @returns the versions we have for an artifact, optionally filtering by status if provided
+   */
+  fun versions(
+    artifact: DeliveryArtifact,
+    statuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
+  ): List<String>
+  // todo eb: if the list matches the default value, should we also include nulls? probably.
+
+  /**
+   * @return the latest version of [artifact] approved for use in [targetEnvironment],
+   * optionally filtering by status if provided.
    */
   fun latestVersionApprovedIn(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
-    targetEnvironment: String
+    targetEnvironment: String,
+    statuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
   ): String?
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -28,7 +28,6 @@ interface ArtifactRepository {
     artifact: DeliveryArtifact,
     statuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
   ): List<String>
-  // todo eb: if the list matches the default value, should we also include nulls? probably.
 
   /**
    * @return the latest version of [artifact] approved for use in [targetEnvironment],

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepositoryTests.kt
@@ -1,11 +1,30 @@
 package com.netflix.spinnaker.keel.persistence.memory
 
+import com.netflix.spinnaker.keel.api.ArtifactStatus.SNAPSHOT
 import com.netflix.spinnaker.keel.persistence.ArtifactRepositoryTests
+import java.time.Clock
 
 class InMemoryArtifactRepositoryTests : ArtifactRepositoryTests<InMemoryArtifactRepository>() {
   override fun factory() = InMemoryArtifactRepository()
 
   override fun InMemoryArtifactRepository.flush() {
     dropAll()
+  }
+
+  private val deliveryConfigRepository = InMemoryDeliveryConfigRepository(
+    Clock.systemDefaultZone())
+
+  override fun Fixture<InMemoryArtifactRepository>.persist() {
+    with(subject) {
+      register(artifact1)
+      setOf(version1, version2, version3).forEach {
+        store(artifact1, it, SNAPSHOT)
+      }
+      register(artifact2)
+      setOf(version1, version2, version3).forEach {
+        store(artifact2, it, SNAPSHOT)
+      }
+    }
+    deliveryConfigRepository.store(manifest)
   }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ImageProvider.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/image/ImageProvider.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.keel.api.ec2.image
 
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.ec2.jackson.ImageProviderDeserializer
 
@@ -41,7 +42,8 @@ data class IdImageProvider(
  */
 @JsonDeserialize(using = JsonDeserializer.None::class)
 data class ArtifactImageProvider(
-  val deliveryArtifact: DeliveryArtifact
+  val deliveryArtifact: DeliveryArtifact,
+  val artifactStatuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
 ) : ImageProvider()
 
 /**

--- a/keel-igor/keel-igor.gradle.kts
+++ b/keel-igor/keel-igor.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
   implementation(project(":keel-retrofit"))
+  implementation(project(":keel-core"))
   implementation("com.netflix.spinnaker.kork:kork-artifacts")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ArtifactService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ArtifactService.kt
@@ -1,8 +1,10 @@
 package com.netflix.spinnaker.igor
 
+import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface ArtifactService {
 
@@ -14,6 +16,7 @@ interface ArtifactService {
 
   @GET("/artifacts/rocket/{packageName}")
   suspend fun getVersions(
-    @Path("packageName") packageName: String
+    @Path("packageName") packageName: String,
+    @Query("releaseStatus") releaseStatus: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
   ): List<String> // sorted in descending order
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.sql
 
+import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
@@ -37,7 +38,7 @@ class SqlArtifactRepository(
       }
   }
 
-  override fun store(artifact: DeliveryArtifact, version: String): Boolean {
+  override fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus): Boolean {
     val uid = jooq.select(DELIVERY_ARTIFACT.UID)
       .from(DELIVERY_ARTIFACT)
       .where(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
@@ -48,6 +49,7 @@ class SqlArtifactRepository(
     return jooq.insertInto(DELIVERY_ARTIFACT_VERSION)
       .set(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID, uid.value1())
       .set(DELIVERY_ARTIFACT_VERSION.VERSION, version)
+      .set(DELIVERY_ARTIFACT_VERSION.STATUS, status.toString())
       .onDuplicateKeyIgnore()
       .execute() == 1
   }
@@ -60,35 +62,43 @@ class SqlArtifactRepository(
       .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
       .fetchOne() != null
 
-  override fun versions(artifact: DeliveryArtifact): List<String> =
-    if (isRegistered(artifact.name, artifact.type)) {
+  override fun versions(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>): List<String> {
+    val status = statuses.map { it.toString() }
+    return if (isRegistered(artifact.name, artifact.type)) {
       jooq
         .select(DELIVERY_ARTIFACT_VERSION.VERSION)
         .from(DELIVERY_ARTIFACT, DELIVERY_ARTIFACT_VERSION)
         .where(DELIVERY_ARTIFACT.UID.eq(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID))
         .and(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
         .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type.name))
+        .and(DELIVERY_ARTIFACT_VERSION.STATUS.`in`(*status.toTypedArray()))
         .fetch()
         .getValues(DELIVERY_ARTIFACT_VERSION.VERSION)
         .sortAppVersion()
     } else {
       throw NoSuchArtifactException(artifact)
     }
+  }
 
   override fun latestVersionApprovedIn(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
-    targetEnvironment: String
+    targetEnvironment: String,
+    statuses: List<ArtifactStatus>
   ): String? {
     val environment = deliveryConfig.environmentNamed(targetEnvironment)
-    return jooq
+    val approvedVersions = jooq
       .select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
       .from(ENVIRONMENT_ARTIFACT_VERSIONS)
       .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environment)))
       .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
       .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.APPROVED_AT.desc())
-      .limit(1)
-      .fetchOne(0, String::class.java)
+      .fetch()
+      .getValues(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
+    val versionsWithCorrectStatus = versions(artifact, statuses)
+
+    // return the latest version that has been approved with the correct status
+    return approvedVersions.intersect(versionsWithCorrectStatus).firstOrNull()
   }
 
   override fun approveVersionFor(

--- a/keel-sql/src/main/resources/db/changelog/20190913-add-status-to-artifact-version.yml
+++ b/keel-sql/src/main/resources/db/changelog/20190913-add-status-to-artifact-version.yml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: status-to-artifact-version
+      author: emjburns
+      changes:
+        - addColumn:
+            tableName: delivery_artifact_version
+            columns:
+              - column:
+                  name: status
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: delivery_artifact_version
+            columnName: status
+
+  - changeSet:
+      id: status-to-artifact-version-drop-index
+      author: emjburns
+      changes:
+        - dropIndex:
+            indexName: delivery_artifact_version_uid_idx
+            tableName: delivery_artifact_version
+      rollback:
+        - createIndex:
+            indexName: delivery_artifact_version_uid_idx
+            tableName: delivery_artifact_version
+            columns:
+              - column:
+                  name: delivery_artifact_uid
+  - changeSet:
+      id: status-to-artifact-version-create-better-index
+      author: emjburns
+      changes:
+        - createIndex:
+            indexName: delivery_artifact_version_uid_idx
+            tableName: delivery_artifact_version
+            columns:
+              - column:
+                  name: delivery_artifact_uid
+              - column:
+                  name: status
+      rollback:
+        - dropIndex:
+            indexName: delivery_artifact_version_uid_idx
+            tableName: delivery_artifact_version

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: changelog/20190917-rename-cluster-to-server-group.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20190913-add-status-to-artifact-version.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.sql
 
+import com.netflix.spinnaker.keel.api.ArtifactStatus.SNAPSHOT
 import com.netflix.spinnaker.keel.persistence.ArtifactRepositoryTests
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
@@ -25,11 +26,11 @@ class SqlArtifactRepositoryTests : ArtifactRepositoryTests<SqlArtifactRepository
     with(subject) {
       register(artifact1)
       setOf(version1, version2, version3).forEach {
-        store(artifact1, it)
+        store(artifact1, it, SNAPSHOT)
       }
       register(artifact2)
       setOf(version1, version2, version3).forEach {
-        store(artifact2, it)
+        store(artifact2, it, SNAPSHOT)
       }
     }
     deliveryConfigRepository.store(manifest)


### PR DESCRIPTION
If you only want to bake or deploy an artifact with a certain status, you should be able to do that. 

This PR allows you to optionally add a list of statuses (`FINAL`, `CANDIDATE`, or `SNAPSHOT`) to the `ImageSpec` and the `ArtifactImageProvider` section of the `ClusterSpec`.

I've verified that when you have resources in the database and you upgrade to this version everything serializes with the default value correctly. Until you get new artifacts in the database with status recorded you won't be able to deploy any new versions, but that's expected (we don't know the status of the old versions, so they don't meet the requirement of being `in` the default list of statuses.

