### PR TITLE
fix(tags): hack to get tags showwing for server groups

### DIFF
--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -71,8 +71,13 @@ class ResourceTagger(
 
   private val entityTypeTransforms = mapOf(
     "classic-load-balancer" to "loadbalancer",
-    "application-load-balancer" to "loadbalancer"
+    "application-load-balancer" to "loadbalancer",
+    "server-group" to "cluster" // this is a hack
   )
+  // we need tags to show up on a server group when we're managing a server group, but our definition of the
+  // resource doesn't have the version number because it's auto generated
+  // mapping server-group -> cluster is a hack to get the UI bits showing up, but this needs to be
+  // re though because it falls apart when one region is managed by keel and one region is not.
 
   private val taggableResources = listOf(
     "server-group",


### PR DESCRIPTION
We need entity tags to show up on the resource, but it's non-trivial to correctly tag the server group because we don't have the version number.

I think this area needs a little (or a lot) more thought - likely in the `KeelTagHandler` for how to actually tag server groups vs just the cluster.

For now though this should be ok for a server group defined in only one region.