### PR TITLE
fix(artifact): add RELEASE status to artifacts/images

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -10,5 +10,5 @@ enum class ArtifactType {
 }
 
 enum class ArtifactStatus {
-  FINAL, CANDIDATE, SNAPSHOT
+  RELEASE, FINAL, CANDIDATE, SNAPSHOT
 }


### PR DESCRIPTION
Turns out some folks use the `FINAL` status, but others use `RELEASE`.

Is this actually as easy as adding a value to an enum? Or am I missing something/everything?

I didn't touch the tests that use various values out of `ArtifactStatus`, because it appears they are all testing support for correctly differentiating between two different statuses (e.g. filtering or choosing between status1 and status2) — not anything that would be impacted by adding one more value to the list. Hopefully that's true.