### PR TITLE
represent a cluster's server groups as a Map not a Set

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiffTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiffTests.kt
@@ -24,11 +24,6 @@ import dev.minutest.rootContext
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
-/**
- * Diffing should work between objects of the same parent, but different sub classes.
- *
- * https://github.com/spinnaker/keel/issues/317
- */
 internal class ResourceDiffTests : JUnit5Minutests {
   private data class Container(val prop: Parent)
 
@@ -46,21 +41,34 @@ internal class ResourceDiffTests : JUnit5Minutests {
     val anotherProp: String
   ) : Parent
 
-  fun tests() = rootContext {
-    context("delta is the type of a polymorphic property") {
-      test("the delta is detected") {
+  fun tests() = rootContext<ResourceDiff<Any>> {
+    /**
+     * Diffing should work between objects of the same parent, but different sub classes.
+     *
+     * https://github.com/spinnaker/keel/issues/317
+     */
+    context("delta in the type of a polymorphic property") {
+      fixture {
         val obj1 = Container(Child1("common", "myprop"))
         val obj2 = Container(Child2("common", "anotherProp"))
-        val resourceDiff = ResourceDiff(obj1, obj2)
-        expectThat(resourceDiff.diff.state).isEqualTo(CHANGED)
+        ResourceDiff(obj1, obj2)
+      }
+
+      test("the delta is detected") {
+        expectThat(diff.state).isEqualTo(CHANGED)
       }
     }
 
     context("two different types of empty map") {
-      val obj1 = emptyMap<Any, Any>()
-      val obj2 = LinkedHashMap<Any, Any>()
-      val resourceDiff = ResourceDiff(obj1, obj2)
-      expectThat(resourceDiff.diff.state).isEqualTo(UNTOUCHED)
+      fixture {
+        val obj1 = emptyMap<Any, Any>()
+        val obj2 = LinkedHashMap<Any, Any>()
+        ResourceDiff(obj1, obj2)
+      }
+
+      test("no delta is detected") {
+        expectThat(diff.state).isEqualTo(UNTOUCHED)
+      }
     }
   }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -12,8 +12,8 @@ import java.time.Duration
 /**
  * Transforms a [ClusterSpec] into a concrete model of server group desired states.
  */
-fun ClusterSpec.resolve(resolvedImages: ResolvedImages): Set<ServerGroup> {
-  return locations.regions.map {
+fun ClusterSpec.resolve(resolvedImages: ResolvedImages): Set<ServerGroup> =
+  locations.regions.map {
     ServerGroup(
       name = moniker.name,
       location = Location(
@@ -35,7 +35,6 @@ fun ClusterSpec.resolve(resolvedImages: ResolvedImages): Set<ServerGroup> {
     )
   }
     .toSet()
-}
 
 private fun ClusterSpec.resolveLaunchConfiguration(region: String, appVersion: String, imageId: String): LaunchConfiguration =
   LaunchConfiguration(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -44,3 +44,6 @@ data class ServerGroup(
 
 val ServerGroup.moniker: Moniker
   get() = parseMoniker(name)
+
+fun Iterable<ServerGroup>.byRegion(): Map<String, ServerGroup> =
+  associateBy { it.location.region }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroupDiffTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroupDiffTests.kt
@@ -1,0 +1,108 @@
+package com.netflix.spinnaker.keel.api.ec2
+
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import de.danielbechler.diff.node.DiffNode
+import de.danielbechler.diff.node.DiffNode.State.ADDED
+import de.danielbechler.diff.node.DiffNode.State.CHANGED
+import de.danielbechler.diff.node.DiffNode.State.UNTOUCHED
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
+import org.apache.commons.lang3.RandomStringUtils.randomNumeric
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+internal class ServerGroupDiffTests : JUnit5Minutests {
+
+  data class Fixture(
+    val desired: Map<String, ServerGroup>,
+    val current: Map<String, ServerGroup>? = null
+  )
+
+  val Fixture.diff: ResourceDiff<Map<String, ServerGroup>>
+    get() = ResourceDiff(desired, current)
+
+  val Fixture.state: DiffNode.State
+    get() = diff.diff.state
+
+  fun Map<String, ServerGroup>.withSequenceNumbers(): Map<String, ServerGroup> =
+    mapValues { (_, serverGroup) ->
+      serverGroup.copy(name = "${serverGroup.name}-v${randomNumeric(3)}")
+    }
+
+  fun Fixture.withMatchingCurrentClusters(): Fixture =
+    Fixture(
+      desired,
+      desired.withSequenceNumbers()
+    )
+
+  fun Fixture.withOneClusterOutOfDate(diffRegion: String): Fixture =
+    Fixture(
+      desired,
+      desired.mapValues { (region, serverGroup) ->
+        if (region == diffRegion) {
+          serverGroup.copy(launchConfiguration = serverGroup.launchConfiguration.copy(
+            imageId = "ami-${randomAlphanumeric(7)}",
+            appVersion = "fnord-0.0.9.h22.${randomNumeric(6)}"
+          ))
+        } else {
+          serverGroup
+        }
+      }
+        .withSequenceNumbers()
+    )
+
+  fun tests() = rootContext<Fixture> {
+    context("desire server groups in 2 regions") {
+      fixture {
+        Fixture(
+          desired = setOf("ap-south-1", "me-south-1").associateWith { region ->
+            ServerGroup(
+              name = "fnord-main",
+              location = Location(
+                accountName = "prod",
+                region = region,
+                subnet = "internal",
+                availabilityZones = setOf("a", "b", "c").map { "$region$it" }.toSet()
+              ),
+              launchConfiguration = LaunchConfiguration(
+                imageId = "ami-${randomAlphanumeric(7)}",
+                appVersion = "fnord-1.0.0.h23.${randomNumeric(6)}",
+                instanceType = "r5.4xlarge",
+                ebsOptimized = true,
+                iamRole = "fnordInstanceRole",
+                keyPair = "fnordKeyPair"
+              )
+            )
+          }
+        )
+      }
+
+      context("currently none exist") {
+        test("there is a diff") {
+          expectThat(state).isEqualTo(ADDED)
+        }
+      }
+
+      context("both server groups match") {
+        deriveFixture {
+          withMatchingCurrentClusters()
+        }
+
+        test("there is no diff") {
+          expectThat(state).isEqualTo(UNTOUCHED)
+        }
+      }
+
+      context("one server group differs") {
+        deriveFixture {
+          withOneClusterOutOfDate("me-south-1")
+        }
+
+        test("there is no diff") {
+          expectThat(state).isEqualTo(CHANGED)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Diff doesn't work as nicely when comparing a `Set<ServerGroup>` as it does with a `Map<String, ServerGroup>`. In particular ignored fields still register as a diff, which causes false deltas in this case.