### PR TITLE
feat(securityGroup): multi-region resource definitions

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.Network
-import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroup
+import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.tags.EntityTags
@@ -43,7 +43,7 @@ interface CloudDriverService {
     @Path("securityGroupName") securityGroupName: String,
     @Path("region") region: String,
     @Query("vpcId") vpcId: String? = null
-  ): SecurityGroup
+  ): SecurityGroupModel
 
   @GET("/securityGroups/{account}/{provider}")
   suspend fun getSecurityGroupSummaries(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroupModel.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroupModel.kt
@@ -17,7 +17,7 @@ package com.netflix.spinnaker.keel.clouddriver.model
 
 import com.netflix.spinnaker.keel.model.Moniker
 
-data class SecurityGroup(
+data class SecurityGroupModel(
   val type: String,
   val id: String?,
   val name: String,

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/SecurityGroupTest.kt
@@ -4,7 +4,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.retrofit.model.ModelParsingTestSupport
 
-object SecurityGroupTest : ModelParsingTestSupport<CloudDriverService, SecurityGroup>(CloudDriverService::class.java) {
+object SecurityGroupTest : ModelParsingTestSupport<CloudDriverService, SecurityGroupModel>(CloudDriverService::class.java) {
   override val json = """
     |{
     |  "class": "com.netflix.spinnaker.clouddriver.aws.model.AmazonSecurityGroup",
@@ -38,10 +38,10 @@ object SecurityGroupTest : ModelParsingTestSupport<CloudDriverService, SecurityG
     |}
   """.trimMargin()
 
-  override suspend fun CloudDriverService.call(): SecurityGroup? =
+  override suspend fun CloudDriverService.call(): SecurityGroupModel? =
     getSecurityGroup("keel@spinnaker", "account", "type", "name", "region")
 
-  override val expected = SecurityGroup(
+  override val expected = SecurityGroupModel(
     type = "aws",
     id = "sg-bpkkjzva",
     name = "covfefe",

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroup.kt
@@ -1,33 +1,20 @@
-/*
- * Copyright 2018 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.netflix.spinnaker.keel.api.ec2
 
-import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.model.Moniker
-import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
+import de.danielbechler.diff.inclusion.Inclusion
 import de.danielbechler.diff.introspection.ObjectDiffProperty
 
 data class SecurityGroup(
-  override val moniker: Moniker,
-  val accountName: String,
-  val region: String,
+  val moniker: Moniker,
+  val location: Location,
   val vpcName: String?,
-  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
   val description: String?,
   val inboundRules: Set<SecurityGroupRule> = emptySet()
-) : Monikered {
-  override val id = "$accountName:$region:${moniker.name}"
+) {
+
+  data class Location(
+    val accountName: String,
+    val region: String
+  )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
@@ -41,7 +41,7 @@ data class ReferenceRule(
   val name: String,
   override val portRange: PortRange
 ) : SecurityGroupRule() {
-  constructor(protocol: Protocol, reference: SecurityGroup, portRange: PortRange) : this(
+  constructor(protocol: Protocol, reference: SecurityGroupSpec, portRange: PortRange) : this(
     protocol = protocol,
     name = reference.moniker.name,
     portRange = portRange
@@ -56,10 +56,10 @@ data class CrossAccountReferenceRule(
   val vpcName: String,
   override val portRange: PortRange
 ) : SecurityGroupRule() {
-  constructor(protocol: Protocol, reference: SecurityGroup, portRange: PortRange) : this(
+  constructor(protocol: Protocol, reference: SecurityGroupSpec, portRange: PortRange) : this(
     protocol = protocol,
     name = reference.moniker.name,
-    account = reference.accountName,
+    account = reference.locations.accountName,
     vpcName = reference.vpcName!!,
     portRange = portRange
   )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api.ec2
+
+import com.netflix.spinnaker.keel.api.MultiRegion
+import com.netflix.spinnaker.keel.model.Moniker
+import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
+import de.danielbechler.diff.introspection.ObjectDiffProperty
+
+data class SecurityGroupSpec(
+  override val moniker: Moniker,
+  val locations: Locations,
+  val vpcName: String?,
+  val description: String?,
+  val inboundRules: Set<SecurityGroupRule> = emptySet(),
+  val overrides: Map<String, SecurityGroupOverride> = emptyMap()
+) : MultiRegion {
+  override val id = "${locations.accountName}:${moniker.name}"
+
+  override val regionalIds = locations.regions.map { region ->
+    "${locations.accountName}:$region:${moniker.name}"
+  }.sorted()
+
+  data class Locations(
+    val accountName: String,
+    val regions: Set<String>
+  )
+}
+
+data class SecurityGroupOverride(
+  val vpcName: String? = null,
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  val description: String? = null,
+  val inboundRules: Set<SecurityGroupRule>? = null
+)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.api.ec2.CrossAccountReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.PortRange
 import com.netflix.spinnaker.keel.api.ec2.ReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroup
+import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol
 import com.netflix.spinnaker.keel.api.ec2.SelfReferenceRule
@@ -32,6 +33,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.events.Task
@@ -40,9 +42,11 @@ import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.OrchestrationTrigger
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.plugin.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.retrofit.isNotFound
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import retrofit2.HttpException
@@ -54,7 +58,7 @@ class SecurityGroupHandler(
   private val environmentResolver: EnvironmentResolver,
   override val objectMapper: ObjectMapper,
   override val normalizers: List<ResourceNormalizer<*>>
-) : ResourceHandler<SecurityGroup> {
+) : ResolvableResourceHandler<SecurityGroupSpec, Map<String, SecurityGroup>> {
   override val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
 
   override val apiVersion = SPINNAKER_API_V1.subApi("ec2")
@@ -62,157 +66,183 @@ class SecurityGroupHandler(
     apiVersion.group,
     "security-group",
     "security-groups"
-  ) to SecurityGroup::class.java
+  ) to SecurityGroupSpec::class.java
 
-  override suspend fun current(resource: Resource<SecurityGroup>): SecurityGroup? =
+  override suspend fun desired(resource: Resource<SecurityGroupSpec>): Map<String, SecurityGroup> =
+    with(resource.spec) {
+      locations.regions.associateWith { region ->
+        SecurityGroup(
+          moniker = Moniker(app = moniker.app, stack = moniker.stack, detail = moniker.detail),
+          location = SecurityGroup.Location(accountName = locations.accountName, region = region),
+          vpcName = overrides[region]?.vpcName ?: vpcName,
+          description = overrides[region]?.description ?: description,
+          inboundRules = overrides[region]?.inboundRules ?: inboundRules
+        )
+      }
+    }
+
+  override suspend fun current(resource: Resource<SecurityGroupSpec>): Map<String, SecurityGroup> =
     cloudDriverService.getSecurityGroup(resource.spec, resource.serviceAccount)
 
-  override suspend fun create(
-    resource: Resource<SecurityGroup>,
-    resourceDiff: ResourceDiff<SecurityGroup>
-  ): List<Task> {
+  override suspend fun upsert(
+    resource: Resource<SecurityGroupSpec>,
+    resourceDiff: ResourceDiff<Map<String, SecurityGroup>>
+  ): List<Task> =
+    coroutineScope {
+      resourceDiff
+        .toIndividualDiffs()
+        .filter { diff -> diff.hasChanges() }
+        .map { diff ->
+          val spec = diff.desired
+          val job: Job
+          val verb: Pair<String, String>
 
-    val notifications = environmentResolver.getNotificationsFor(resource.id)
+          when (diff.current) {
+            null -> {
+              job = spec.toCreateJob()
+              verb = Pair("Creating", "create")
+            }
+            else -> {
+              job = spec.toUpdateJob()
+              verb = Pair("Updating", "update")
+            }
+          }
 
-    val description: String
-    val taskRef = resource.spec.let { spec ->
-      description = "Create security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}"
-      orcaService
-        .orchestrate(
-          resource.serviceAccount,
-          OrchestrationRequest(
-            description,
-            spec.moniker.app,
-            description,
-            listOf(spec.toCreateJob()),
-            OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
-          ))
+          log.info("${verb.first} security group using task: $job")
+
+          val description = "${verb.first} security group ${spec.moniker.name} in " +
+            "${spec.location.accountName}/${spec.location.region}"
+          val notifications = environmentResolver.getNotificationsFor(resource.id)
+
+          async {
+            orcaService
+              .orchestrate(
+                resource.serviceAccount,
+                OrchestrationRequest(
+                  description,
+                  spec.moniker.app,
+                  description,
+                  listOf(job),
+                  OrchestrationTrigger("${resource.id}:${spec.location.region}", notifications = notifications)
+                ))
+              .let {
+                log.info("Started task {} to ${verb.second} security group", it.ref)
+                Task(id = it.taskId, name = description)
+              }
+          }
+        }
+        .map { it.await() }
     }
-    log.info("Started task {} to create security group", taskRef.ref)
-    return listOf(Task(id = taskRef.taskId, name = description))
+
+  override suspend fun delete(resource: Resource<SecurityGroupSpec>) {
+    TODO("not implemented")
   }
 
-  override suspend fun update(
-    resource: Resource<SecurityGroup>,
-    resourceDiff: ResourceDiff<SecurityGroup>
-  ): List<Task> {
-    val description: String
-    val taskRef = resource.spec.let { spec ->
-      description = "Update security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}"
-      val notifications = environmentResolver.getNotificationsFor(resource.id)
-      orcaService
-        .orchestrate(
-          resource.serviceAccount,
-          OrchestrationRequest(
-            description,
-            spec.moniker.app,
-            description,
-            listOf(spec.toUpdateJob()),
-            OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
-          ))
+  private fun ResourceDiff<Map<String, SecurityGroup>>.toIndividualDiffs() =
+    desired.map { (region, desire) ->
+      ResourceDiff(desire, current?.getOrDefault(region, null))
     }
-    log.info("Started task {} to update security group", taskRef.ref)
-    return listOf(Task(id = taskRef.taskId, name = description))
-  }
-
-  override suspend fun delete(resource: Resource<SecurityGroup>) {
-    val notifications = environmentResolver.getNotificationsFor(resource.id)
-    val taskRef = resource.spec.let { spec ->
-      orcaService
-        .orchestrate(
-          resource.serviceAccount,
-          OrchestrationRequest(
-            "Delete security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
-            spec.moniker.app,
-            "Delete security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
-            listOf(spec.toDeleteJob()),
-            OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
-          ))
-    }
-    log.info("Started task {} to upsert security group", taskRef.ref)
-  }
 
   override suspend fun actuationInProgress(id: ResourceId) =
     orcaService
       .getCorrelatedExecutions(id.value)
       .isNotEmpty()
 
-  private suspend fun CloudDriverService.getSecurityGroup(spec: SecurityGroup, serviceAccount: String): SecurityGroup? =
-    try {
-      getSecurityGroup(
-        serviceAccount,
-        spec.accountName,
-        CLOUD_PROVIDER,
-        spec.moniker.name,
-        spec.region,
-        spec.vpcName?.let { cloudDriverCache.networkBy(it, spec.accountName, spec.region).id }
-      )
-        .let { response ->
-          SecurityGroup(
-            Moniker(app = response.moniker.app, stack = response.moniker.stack, detail = response.moniker.detail),
-            response.accountName,
-            response.region,
-            response.vpcId?.let { cloudDriverCache.networkBy(it).name },
-            response.description,
-            response.inboundRules.flatMap { rule ->
-              val ingressGroup = rule.securityGroup
-              val ingressRange = rule.range
-              val protocol = Protocol.valueOf(rule.protocol!!.toUpperCase())
-              when {
-                ingressGroup != null -> rule.portRanges
-                  ?.map { PortRange(it.startPort!!, it.endPort!!) }
-                  ?.map { portRange ->
-                    when {
-                      ingressGroup.accountName != response.accountName || ingressGroup.vpcId != response.vpcId -> CrossAccountReferenceRule(
-                        protocol,
-                        ingressGroup.name,
-                        ingressGroup.accountName!!,
-                        cloudDriverCache.networkBy(ingressGroup.vpcId!!).name!!,
-                        portRange
-                      )
-                      ingressGroup.name != response.name -> ReferenceRule(
-                        protocol,
-                        ingressGroup.name,
-                        portRange
-                      )
-                      else -> SelfReferenceRule(
-                        protocol,
-                        portRange
-                      )
-                    }
-                  } ?: emptyList()
-                ingressRange != null -> rule.portRanges
-                  ?.map { PortRange(it.startPort!!, it.endPort!!) }
-                  ?.map { portRange ->
-                    CidrRule(
-                      protocol,
-                      portRange,
-                      ingressRange.ip + ingressRange.cidr
-                    )
-                  } ?: emptyList()
-                else -> emptyList()
-              }
-            }.toSet()
-          )
+  private suspend fun CloudDriverService.getSecurityGroup(
+    spec: SecurityGroupSpec,
+    serviceAccount: String
+  ): Map<String, SecurityGroup> =
+    coroutineScope {
+      spec.locations.regions.map { region ->
+        async {
+          try {
+            getSecurityGroup(
+              serviceAccount,
+              spec.locations.accountName,
+              CLOUD_PROVIDER,
+              spec.moniker.name,
+              region,
+              spec.vpcName?.let { cloudDriverCache.networkBy(it, spec.locations.accountName, region).id }
+            )
+              .toSecurityGroup()
+          } catch (e: HttpException) {
+            if (e.isNotFound) {
+              null
+            } else {
+              throw e
+            }
+          }
         }
-    } catch (e: HttpException) {
-      if (e.isNotFound) {
-        null
-      } else {
-        throw e
       }
+        .mapNotNull { it.await() }
+        .associateBy { it.location.region }
     }
+
+  private fun SecurityGroupModel.toSecurityGroup() =
+    SecurityGroup(
+      moniker = Moniker(app = moniker.app, stack = moniker.stack, detail = moniker.detail),
+      location = SecurityGroup.Location(
+        accountName,
+        region = region
+      ),
+      vpcName = if (vpcId != null) {
+        cloudDriverCache.networkBy(vpcId!!).name
+      } else {
+        null
+      },
+      description = description,
+      inboundRules = inboundRules.flatMap { rule ->
+        val ingressGroup = rule.securityGroup
+        val ingressRange = rule.range
+        val protocol = Protocol.valueOf(rule.protocol!!.toUpperCase())
+        when {
+          ingressGroup != null -> rule.portRanges
+            ?.map { PortRange(it.startPort!!, it.endPort!!) }
+            ?.map { portRange ->
+              when {
+                ingressGroup.accountName != accountName || ingressGroup.vpcId != vpcId -> CrossAccountReferenceRule(
+                  protocol,
+                  ingressGroup.name,
+                  ingressGroup.accountName!!,
+                  cloudDriverCache.networkBy(ingressGroup.vpcId!!).name!!,
+                  portRange
+                )
+                ingressGroup.name != name -> ReferenceRule(
+                  protocol,
+                  ingressGroup.name,
+                  portRange
+                )
+                else -> SelfReferenceRule(
+                  protocol,
+                  portRange
+                )
+              }
+            } ?: emptyList()
+          ingressRange != null -> rule.portRanges
+            ?.map { PortRange(it.startPort!!, it.endPort!!) }
+            ?.map { portRange ->
+              CidrRule(
+                protocol,
+                portRange,
+                ingressRange.ip + ingressRange.cidr
+              )
+            } ?: emptyList()
+          else -> emptyList()
+        }
+      }
+        .toSet()
+    )
 
   private fun SecurityGroup.toCreateJob(): Job =
     Job(
       "upsertSecurityGroup",
       mapOf(
         "application" to moniker.app,
-        "credentials" to accountName,
+        "credentials" to location.accountName,
         "cloudProvider" to CLOUD_PROVIDER,
         "name" to moniker.name,
-        "regions" to listOf(region),
-        "vpcId" to cloudDriverCache.networkBy(vpcName, accountName, region).id,
+        "regions" to listOf(location.region),
+        "vpcId" to cloudDriverCache.networkBy(vpcName, location.accountName, location.region).id,
         "description" to description,
         "securityGroupIngress" to inboundRules
           // we have to do a 2-phase create for self-referencing ingress rules as the referenced
@@ -225,7 +255,7 @@ class SecurityGroupHandler(
         "ipIngress" to inboundRules.mapNotNull {
           it.cidrRuleToJob()
         },
-        "accountName" to accountName
+        "accountName" to location.accountName
       )
     )
 
@@ -234,11 +264,11 @@ class SecurityGroupHandler(
       "upsertSecurityGroup",
       mapOf(
         "application" to moniker.app,
-        "credentials" to accountName,
+        "credentials" to location.accountName,
         "cloudProvider" to CLOUD_PROVIDER,
         "name" to moniker.name,
-        "regions" to listOf(region),
-        "vpcId" to cloudDriverCache.networkBy(vpcName, accountName, region).id,
+        "regions" to listOf(location.region),
+        "vpcId" to cloudDriverCache.networkBy(vpcName, location.accountName, location.region).id,
         "description" to description,
         "securityGroupIngress" to inboundRules.mapNotNull {
           it.referenceRuleToJob(this)
@@ -246,26 +276,11 @@ class SecurityGroupHandler(
         "ipIngress" to inboundRules.mapNotNull {
           it.cidrRuleToJob()
         },
-        "accountName" to accountName
+        "accountName" to location.accountName
       )
     )
 
-  private fun SecurityGroup.toDeleteJob(): Job {
-    return Job(
-      "deleteSecurityGroup",
-      mapOf(
-        "application" to moniker.app,
-        "credentials" to accountName,
-        "cloudProvider" to CLOUD_PROVIDER,
-        "securityGroupName" to moniker.name,
-        "regions" to listOf(region),
-        "vpcId" to vpcName,
-        "accountName" to accountName
-      )
-    )
-  }
-
-  private fun SecurityGroupRule.referenceRuleToJob(spec: SecurityGroup): Map<String, Any?>? =
+  private fun SecurityGroupRule.referenceRuleToJob(securityGroup: SecurityGroup): Map<String, Any?>? =
     when (this) {
       is ReferenceRule -> mapOf(
         "type" to protocol.name.toLowerCase(),
@@ -277,7 +292,7 @@ class SecurityGroupHandler(
         "type" to protocol.name.toLowerCase(),
         "startPort" to portRange.startPort,
         "endPort" to portRange.endPort,
-        "name" to spec.moniker.name
+        "name" to securityGroup.moniker.name
       )
       is CrossAccountReferenceRule -> mapOf(
         "type" to protocol.name.toLowerCase(),
@@ -289,7 +304,7 @@ class SecurityGroupHandler(
         "vpcId" to cloudDriverCache.networkBy(
           vpcName,
           account,
-          spec.region
+          securityGroup.location.region
         ).id
       )
       else -> null

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupTests.kt
@@ -21,8 +21,10 @@ internal object SecurityGroupTests : JUnit5Minutests {
           app = "fnord",
           stack = "ext"
         ),
-        accountName = "prod",
-        region = "us-north-2",
+        location = SecurityGroup.Location(
+          accountName = "prod",
+          region = "us-north-2"
+        ),
         vpcName = "vpc0",
         description = "I can see the fnords",
         inboundRules = setOf(
@@ -46,7 +48,10 @@ internal object SecurityGroupTests : JUnit5Minutests {
 
     derivedContext<ResourceDiff<SecurityGroup>>("security groups that differ in basic fields") {
       deriveFixture {
-        ResourceDiff(this, copy(region = "ap-south-1"))
+        ResourceDiff(this,
+          copy(location = SecurityGroup.Location(
+            accountName = location.accountName,
+            region = "ap-south-1")))
       }
 
       test("diff contains changes") {
@@ -55,7 +60,7 @@ internal object SecurityGroupTests : JUnit5Minutests {
 
       test("diff is detected on the changed property") {
         expectThat(this)
-          .get { diff.getChild("region").state }
+          .get { diff.getChild("location").state }
           .isEqualTo(CHANGED)
       }
     }
@@ -73,7 +78,10 @@ internal object SecurityGroupTests : JUnit5Minutests {
     derivedContext<ResourceDiff<SecurityGroup>>("security groups that differ in ignored and non-ignored fields") {
       deriveFixture {
         ResourceDiff(this, copy(
-          region = "ap-south-1",
+          location = SecurityGroup.Location(
+            accountName = location.accountName,
+            region = "ap-south-1"
+          ),
           description = "We can't actually make changes to this so it should be ignored by the diff"
         ))
       }
@@ -84,7 +92,7 @@ internal object SecurityGroupTests : JUnit5Minutests {
 
       test("diff is detected on the changed property") {
         expectThat(this)
-          .get { diff.getChild("region").state }
+          .get { diff.getChild("location").state }
           .isEqualTo(CHANGED)
       }
 
@@ -172,7 +180,7 @@ internal object SecurityGroupTests : JUnit5Minutests {
           this,
           copy(
             inboundRules = inboundRules
-              .plus(ReferenceRule(TCP, this, PortRange(80, 80)))
+              .plus(ReferenceRule(TCP, moniker.name, PortRange(80, 80)))
               .toSet()
           )
         )


### PR DESCRIPTION
- This is a breaking change for securityGroup resource definitions that standardizes on a `locations` object as used in `ClusterSpec` to contain account/region assignments. A single-region securityGroup called "keeldemo" that was previously defined in part as:
```
---
apiVersion: "ec2.spinnaker.netflix.com/v1"
kind: "security-group"
metadata:
  serviceAccount: "delivery@spinnaker"
spec:
  moniker:
    app: keeldemo
  accountName: test
  region: us-west-2
...
```
becomes:
```
---
apiVersion: "ec2.spinnaker.netflix.com/v1"
kind: "security-group"
metadata:
  serviceAccount: "delivery@spinnaker"
spec:
  moniker:
    app: keeldemo
  locations:
    accountName: test
    regions:
    - us-west-2
...
```
