### PR TITLE
feat(notifications): add env notifications for infra tasks

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
@@ -51,7 +51,8 @@ class ResourcePersister(
           resources = env.resources.mapTo(mutableSetOf()) { resource ->
             upsert(resource)
           },
-          constraints = env.constraints
+          constraints = env.constraints,
+          notifications = env.notifications
         )
       }
     )

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -118,6 +118,7 @@ class ImageHandler(
         ),
         trigger = OrchestrationTrigger(
           correlationId = resource.id.toString(),
+          notifications = emptyList(),
           artifacts = listOf(artifact)
         )
       )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -17,7 +17,8 @@ data class SubmittedDeliveryConfig(
 data class SubmittedEnvironment(
   val name: String,
   val resources: Set<SubmittedResource<*>>,
-  val constraints: Set<Constraint> = emptySet()
+  val constraints: Set<Constraint> = emptySet(),
+  val notifications: Set<NotificationConfig> = emptySet()
 )
 
 val DeliveryConfig.resources: Set<Resource<*>>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
@@ -3,5 +3,6 @@ package com.netflix.spinnaker.keel.api
 data class Environment(
   val name: String,
   val resources: Set<Resource<*>> = emptySet(),
-  val constraints: Set<Constraint> = emptySet()
+  val constraints: Set<Constraint> = emptySet(),
+  val notifications: Set<NotificationConfig> = emptySet() // applies to each resource
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/NotificationConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/NotificationConfig.kt
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api
+
+// todo eb: this does not allow you to customize the notification message, but we can add that later.
+data class NotificationConfig(
+  val type: NotificationType,
+  val address: String, // either slack channel or email address
+  val frequency: NotificationFrequency
+)
+
+enum class NotificationFrequency {
+  VERBOSE, // notification on task starting, completing, failing
+  NORMAL, // notification on task completing or failing
+  QUIET // notification only for failure
+}
+
+enum class NotificationType {
+  SLACK, EMAIL;
+
+  override fun toString(): String {
+    return name.toLowerCase()
+  }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.ec2.resource.ApplicationLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
+import com.netflix.spinnaker.keel.ec2.resource.EnvironmentResolver
 import com.netflix.spinnaker.keel.ec2.resource.ImageResolver
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
 import com.netflix.spinnaker.keel.orca.OrcaService
@@ -57,11 +58,20 @@ class EC2Config {
     )
 
   @Bean
+  fun environmentResolver(
+    deliveryConfigRepository: DeliveryConfigRepository
+  ): EnvironmentResolver =
+    EnvironmentResolver(
+      deliveryConfigRepository
+    )
+
+  @Bean
   fun clusterHandler(
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
     imageResolver: ImageResolver,
+    environmentResolver: EnvironmentResolver,
     clock: Clock,
     objectMapper: ObjectMapper,
     normalizers: List<ResourceNormalizer<*>>,
@@ -72,6 +82,7 @@ class EC2Config {
       cloudDriverCache,
       orcaService,
       imageResolver,
+      environmentResolver,
       clock,
       publisher,
       objectMapper,
@@ -83,6 +94,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
+    environmentResolver: EnvironmentResolver,
     objectMapper: ObjectMapper,
     normalizers: List<ResourceNormalizer<*>>
   ): SecurityGroupHandler =
@@ -90,6 +102,7 @@ class EC2Config {
       cloudDriverService,
       cloudDriverCache,
       orcaService,
+      environmentResolver,
       objectMapper,
       normalizers
     )
@@ -99,6 +112,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
+    environmentResolver: EnvironmentResolver,
     objectMapper: ObjectMapper,
     normalizers: List<ResourceNormalizer<*>>
   ): ClassicLoadBalancerHandler =
@@ -106,6 +120,7 @@ class EC2Config {
       cloudDriverService,
       cloudDriverCache,
       orcaService,
+      environmentResolver,
       objectMapper,
       normalizers
     )
@@ -115,6 +130,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
+    environmentResolver: EnvironmentResolver,
     objectMapper: ObjectMapper,
     normalizers: List<ResourceNormalizer<*>>
   ): ApplicationLoadBalancerHandler =
@@ -122,6 +138,7 @@ class EC2Config {
       cloudDriverService,
       cloudDriverCache,
       orcaService,
+      environmentResolver,
       objectMapper,
       normalizers
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
@@ -31,6 +31,7 @@ class ApplicationLoadBalancerHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
+  private val environmentResolver: EnvironmentResolver,
   override val objectMapper: ObjectMapper,
   override val normalizers: List<ResourceNormalizer<*>>
 ) : ResourceHandler<ApplicationLoadBalancer> {
@@ -58,6 +59,8 @@ class ApplicationLoadBalancerHandler(
     val description = "$action ${resource.kind} load balancer ${resource.spec.moniker.name} in " +
       "${resource.spec.location.accountName}/${resource.spec.location.region}"
 
+    val notifications = environmentResolver.getNotificationsFor(resource.id)
+
     val taskRef =
       resource.spec.let { spec ->
 
@@ -69,7 +72,7 @@ class ApplicationLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toUpsertJob()),
-              OrchestrationTrigger(resource.id.toString())
+              OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
             )
           )
       }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -85,6 +85,8 @@ class ApplicationLoadBalancerHandler(
     val description = "Delete load balancer ${resource.spec.moniker.name} in " +
       "${resource.spec.location.accountName}/${resource.spec.location.region}"
 
+    val notifications = environmentResolver.getNotificationsFor(resource.id)
+
     val taskRef =
       resource.spec.let { spec ->
         orcaService
@@ -95,7 +97,7 @@ class ApplicationLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toDeleteJob()),
-              OrchestrationTrigger(resource.id.toString())
+              OrchestrationTrigger(correlationId = resource.id.toString(), notifications = emptyList())
             )
           )
       }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerListener
@@ -33,6 +33,7 @@ class ClassicLoadBalancerHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
+  private val environmentResolver: EnvironmentResolver,
   override val objectMapper: ObjectMapper,
   override val normalizers: List<ResourceNormalizer<*>>
 ) : ResourceHandler<ClassicLoadBalancer> {
@@ -60,6 +61,8 @@ class ClassicLoadBalancerHandler(
     val description = "$action ${resource.kind} load balancer ${resource.spec.moniker.name} in " +
       "${resource.spec.location.accountName}/${resource.spec.location.region}"
 
+    val notifications = environmentResolver.getNotificationsFor(resource.id)
+
     val taskRef =
       resource.spec.let { spec ->
         orcaService
@@ -70,7 +73,7 @@ class ClassicLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toUpsertJob()),
-              OrchestrationTrigger(resource.id.toString())
+              OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
             )
           )
       }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -86,6 +86,8 @@ class ClassicLoadBalancerHandler(
     val description = "Delete load balancer ${resource.spec.moniker.name} in " +
       "${resource.spec.location.accountName}/${resource.spec.location.region}"
 
+    val notifications = environmentResolver.getNotificationsFor(resource.id)
+
     val taskRef =
       resource.spec.let { spec ->
         orcaService
@@ -96,7 +98,7 @@ class ClassicLoadBalancerHandler(
               spec.moniker.app,
               description,
               listOf(spec.toDeleteJob()),
-              OrchestrationTrigger(resource.id.toString())
+              OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
             )
           )
       }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/EnvironmentResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/EnvironmentResolver.kt
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.ec2.resource
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.model.EchoNotification
+import com.netflix.spinnaker.keel.model.toEchoNotification
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+
+/**
+ * Helper class for resource handlers to get specific information out of the environment for a resource.
+ */
+class EnvironmentResolver(
+  private val deliveryConfigRepository: DeliveryConfigRepository
+) {
+  fun getNotificationsFor(resourceId: ResourceId): List<EchoNotification> =
+    deliveryConfigRepository.environmentFor(resourceId)?.notifications?.map { it.toEchoNotification() } ?: emptyList()
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -71,6 +71,9 @@ class SecurityGroupHandler(
     resource: Resource<SecurityGroup>,
     resourceDiff: ResourceDiff<SecurityGroup>
   ): List<Task> {
+
+    val notifications = environmentResolver.getNotificationsFor(resource.id)
+
     val description: String
     val taskRef = resource.spec.let { spec ->
       description = "Create security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}"
@@ -82,7 +85,7 @@ class SecurityGroupHandler(
             spec.moniker.app,
             description,
             listOf(spec.toCreateJob()),
-            OrchestrationTrigger(resource.id.toString())
+            OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
           ))
     }
     log.info("Started task {} to create security group", taskRef.ref)
@@ -113,6 +116,7 @@ class SecurityGroupHandler(
   }
 
   override suspend fun delete(resource: Resource<SecurityGroup>) {
+    val notifications = environmentResolver.getNotificationsFor(resource.id)
     val taskRef = resource.spec.let { spec ->
       orcaService
         .orchestrate(
@@ -122,7 +126,7 @@ class SecurityGroupHandler(
             spec.moniker.app,
             "Delete security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}",
             listOf(spec.toDeleteJob()),
-            OrchestrationTrigger(resource.id.toString())
+            OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
           ))
     }
     log.info("Started task {} to upsert security group", taskRef.ref)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -17,8 +17,8 @@ package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.CidrRule
 import com.netflix.spinnaker.keel.api.ec2.CrossAccountReferenceRule
@@ -51,6 +51,7 @@ class SecurityGroupHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
+  private val environmentResolver: EnvironmentResolver,
   override val objectMapper: ObjectMapper,
   override val normalizers: List<ResourceNormalizer<*>>
 ) : ResourceHandler<SecurityGroup> {
@@ -95,6 +96,7 @@ class SecurityGroupHandler(
     val description: String
     val taskRef = resource.spec.let { spec ->
       description = "Update security group ${spec.moniker.name} in ${spec.accountName}/${spec.region}"
+      val notifications = environmentResolver.getNotificationsFor(resource.id)
       orcaService
         .orchestrate(
           resource.serviceAccount,
@@ -103,7 +105,7 @@ class SecurityGroupHandler(
             spec.moniker.app,
             description,
             listOf(spec.toUpdateJob()),
-            OrchestrationTrigger(resource.id.toString())
+            OrchestrationTrigger(correlationId = resource.id.toString(), notifications = notifications)
           ))
     }
     log.info("Started task {} to update security group", taskRef.ref)

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTest.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTest.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.ec2.normalizers.ApplicationLoadBalancerNormali
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.test.resource
@@ -32,6 +33,7 @@ import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.get
 import strikt.assertions.isEqualTo
+import java.time.Clock
 import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")
@@ -39,6 +41,8 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverService = mockk<CloudDriverService>()
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
+  private val clock = Clock.systemDefaultZone()
+  private val environmentResolver: EnvironmentResolver = EnvironmentResolver(InMemoryDeliveryConfigRepository(clock))
   private val mapper = ObjectMapper().registerKotlinModule()
   private val yamlMapper = configuredYamlMapper()
 
@@ -137,6 +141,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
         cloudDriverService,
         cloudDriverCache,
         orcaService,
+        environmentResolver,
         mapper,
         normalizers
       )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.keel.ec2.normalizers.ClassicLoadBalancerNormalizer
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.test.resource
@@ -36,6 +37,7 @@ import strikt.api.expectThat
 import strikt.assertions.get
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNull
+import java.time.Clock
 import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")
@@ -44,6 +46,8 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverService = mockk<CloudDriverService>()
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
+  private val clock = Clock.systemDefaultZone()
+  private val environmentResolver: EnvironmentResolver = EnvironmentResolver(InMemoryDeliveryConfigRepository(clock))
   private val mapper = ObjectMapper().registerKotlinModule()
   private val yamlMapper = configuredYamlMapper()
 
@@ -122,6 +126,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
         cloudDriverService,
         cloudDriverCache,
         orcaService,
+        environmentResolver,
         mapper,
         normalizers
       )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.ResourceNormalizer
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -76,6 +77,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val objectMapper = ObjectMapper().registerKotlinModule()
   val normalizers = emptyList<ResourceNormalizer<ClusterSpec>>()
   val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
+  val clock = Clock.systemDefaultZone()
+  val environmentResolver: EnvironmentResolver = EnvironmentResolver(InMemoryDeliveryConfigRepository(clock))
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
   val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
@@ -193,7 +196,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         cloudDriverCache,
         orcaService,
         imageResolver,
-        Clock.systemDefaultZone(),
+        environmentResolver,
+        clock,
         publisher,
         objectMapper,
         normalizers

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/EnvironmentResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/EnvironmentResolverTests.kt
@@ -1,0 +1,85 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.ec2.resource
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.NotificationConfig
+import com.netflix.spinnaker.keel.api.NotificationFrequency.QUIET
+import com.netflix.spinnaker.keel.api.NotificationType.SLACK
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_FAILED
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
+import java.time.Clock
+
+class EnvironmentResolverTests : JUnit5Minutests {
+  data class Fixture(
+    val clock: Clock = Clock.systemDefaultZone(),
+    val deliveryConfigRepository: InMemoryDeliveryConfigRepository = InMemoryDeliveryConfigRepository(clock),
+    val environmentResolver: EnvironmentResolver = EnvironmentResolver(deliveryConfigRepository),
+    val resource: Resource<DummyResourceSpec> = resource()
+  )
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    context("no environments") {
+      test("empty list gets returned") {
+        expectThat(environmentResolver.getNotificationsFor(ResourceId("blah"))).isEmpty()
+      }
+    }
+
+    context("an environment exists") {
+      before {
+        val notification = NotificationConfig(SLACK, "#my-channel", QUIET)
+        val env = Environment(
+          name = "test",
+          resources = setOf(resource),
+          notifications = setOf(notification)
+        )
+        val deliveryConfig = DeliveryConfig(name = "keel", application = "keel", environments = setOf(env))
+        deliveryConfigRepository.store(deliveryConfig)
+      }
+
+      test("notifications get retrieved") {
+        val n = environmentResolver.getNotificationsFor(resource.id)
+        expect {
+          that(n).isNotEmpty()
+          that(n.size).isEqualTo(1)
+          that(n.first().`when`).isEqualTo(listOf(ORCHESTRATION_FAILED.text()))
+          that(n.first().message).isEqualTo(
+            mapOf(ORCHESTRATION_FAILED.text() to ORCHESTRATION_FAILED.notificationMessage())
+          )
+        }
+      }
+    }
+  }
+}

--- a/keel-orca/keel-orca.gradle.kts
+++ b/keel-orca/keel-orca.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
   api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
   implementation(project(":keel-clouddriver"))
+  implementation(project(":keel-core"))
   implementation("com.fasterxml.jackson.core:jackson-databind")
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/EchoNotification.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/EchoNotification.kt
@@ -1,0 +1,77 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.model
+
+import com.netflix.spinnaker.keel.api.NotificationConfig
+import com.netflix.spinnaker.keel.api.NotificationFrequency
+import com.netflix.spinnaker.keel.api.NotificationFrequency.NORMAL
+import com.netflix.spinnaker.keel.api.NotificationFrequency.QUIET
+import com.netflix.spinnaker.keel.api.NotificationFrequency.VERBOSE
+import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_COMPLETE
+import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_FAILED
+import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_STARTING
+
+data class EchoNotification(
+  val type: String,
+  val address: String,
+  val `when`: List<String>,
+  val level: String = "pipeline",
+  val message: Map<String, NotificationMessage>
+)
+
+enum class NotificationEvent {
+  ORCHESTRATION_STARTING {
+    override fun text(): String = "orchestration.starting"
+    override fun notificationMessage(): NotificationMessage = NotificationMessage("$RAINBOW Managed update starting")
+  },
+  ORCHESTRATION_COMPLETE {
+    override fun text(): String = "orchestration.complete"
+    override fun notificationMessage(): NotificationMessage = NotificationMessage("$RAINBOW Managed update succeeded")
+  },
+  ORCHESTRATION_FAILED {
+    override fun text(): String = "orchestration.failed"
+    override fun notificationMessage(): NotificationMessage = NotificationMessage("$RAINBOW Managed update failed")
+  };
+
+  abstract fun text(): String
+  abstract fun notificationMessage(): NotificationMessage
+}
+
+data class NotificationMessage(
+  val text: String
+)
+
+const val RAINBOW = "\uD83C\uDF08"
+
+fun NotificationConfig.toEchoNotification() =
+  EchoNotification(
+    type = this.type.toString().toLowerCase(),
+    address = this.address,
+    `when` = translateFrequencyToEvents(frequency).map { it.text() },
+    message = generateCustomMessages(frequency)
+  )
+
+fun translateFrequencyToEvents(frequency: NotificationFrequency): List<NotificationEvent> =
+  when (frequency) {
+    VERBOSE -> listOf(ORCHESTRATION_FAILED, ORCHESTRATION_STARTING, ORCHESTRATION_COMPLETE)
+    NORMAL -> listOf(ORCHESTRATION_FAILED, ORCHESTRATION_COMPLETE)
+    QUIET -> listOf(ORCHESTRATION_FAILED)
+  }
+
+fun generateCustomMessages(frequency: NotificationFrequency): Map<String, NotificationMessage> =
+  translateFrequencyToEvents(frequency).map { it.text() to it.notificationMessage() }.toMap()

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/EchoNotification.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/EchoNotification.kt
@@ -45,7 +45,7 @@ enum class NotificationEvent {
   },
   ORCHESTRATION_FAILED {
     override fun text(): String = "orchestration.failed"
-    override fun notificationMessage(): NotificationMessage = NotificationMessage("$RAINBOW Managed update failed")
+    override fun notificationMessage(): NotificationMessage = NotificationMessage("$THUNDERCLOUD Managed update failed")
   };
 
   abstract fun text(): String
@@ -57,6 +57,7 @@ data class NotificationMessage(
 )
 
 const val RAINBOW = "\uD83C\uDF08"
+const val THUNDERCLOUD = "\u26c8\ufe0f"
 
 fun NotificationConfig.toEchoNotification() =
   EchoNotification(

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrchestrationRequest.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrchestrationRequest.kt
@@ -31,5 +31,6 @@ data class OrchestrationTrigger(
   val correlationId: String,
   val type: String = "keel",
   val user: String = "keel",
-  val artifacts: List<Artifact> = emptyList()
+  val artifacts: List<Artifact> = emptyList(),
+  val notifications: List<EchoNotification> = emptyList()
 )

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrchestrationRequest.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrchestrationRequest.kt
@@ -29,8 +29,8 @@ class Job(type: String, m: Map<String, Any?>) : HashMap<String, Any?>(m + mapOf(
 
 data class OrchestrationTrigger(
   val correlationId: String,
+  val notifications: List<EchoNotification>,
   val type: String = "keel",
   val user: String = "keel",
-  val artifacts: List<Artifact> = emptyList(),
-  val notifications: List<EchoNotification> = emptyList()
+  val artifacts: List<Artifact> = emptyList()
 )

--- a/keel-sql/src/main/resources/db/changelog/20191002-add-env-notifications.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191002-add-env-notifications.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-env-notifications
+      author: emjburns
+      changes:
+        - addColumn:
+            tableName: environment
+            columns:
+              - column:
+                  name: notifications
+                  type: text
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: environment
+            columnName: notifications

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -35,3 +35,6 @@ databaseChangeLog:
   - include:
       file: changelog/20190913-add-status-to-artifact-version.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20191002-add-env-notifications.yml
+      relativeToChangelogFile: true

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandler.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/KeelTagHandler.kt
@@ -59,6 +59,7 @@ class KeelTagHandler(
     "keel-tag",
     "keel-tags"
   ) to KeelTagSpec::class.java
+
   override suspend fun desired(resource: Resource<KeelTagSpec>): TaggedResource {
     when (resource.spec.tagState) {
       is TagDesired -> {
@@ -119,7 +120,7 @@ class KeelTagHandler(
         desired.entityRef.application,
         description,
         listOf(Job(job["type"].toString(), job)),
-        OrchestrationTrigger(resource.id.toString())
+        OrchestrationTrigger(correlationId = resource.id.toString(), notifications = emptyList())
       ))
     log.info("Started task {} to upsert entity tags", taskResponse.ref)
     return listOf(Task(id = taskResponse.taskId, name = description))


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/442 (Details about format in the issue)

Environments can now have notifications, they are applied at the environment level (examples in the ticket). For now we support either slack or email, and you can't define your own custom message (`:rainbow: Managed update succeeded`). 

The environment level notification applies to every resource who cares (load balancers, security groups, clusters). You can't override it or shut it off for a specific resource (for now).
