### PR TITLE
feat(api): provide resource summary info by app

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -42,8 +42,9 @@ class ApplicationController(
     @RequestParam("includeDetails", required = false, defaultValue = "false") includeDetails: Boolean
   ): Map<String, Any> {
     if (includeDetails) {
-      val resources = resourceRepository.getByApplication(application)
-        .filter { !it.startsWith("tag:keel-tag") }
+      val resources = resourceRepository.getSummaryByApplication(application)
+        .filter { it.kind != "keel-tag" }
+
       return mapOf(
         "hasManagedResources" to resources.isNotEmpty(),
         "resources" to resources

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/ec2/normalizers/ClusterAvailabilityZonesResolverTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/ec2/normalizers/ClusterAvailabilityZonesResolverTests.kt
@@ -2,14 +2,13 @@ package com.netflix.spinnaker.keel.ec2.normalizers
 
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.HealthSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.Locations
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.Dependencies
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType.ELB
@@ -20,6 +19,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -56,12 +56,12 @@ internal class ClusterAvailabilityZonesResolverTests : JUnit5Minutests {
         locations = Locations(
           accountName = "test",
           regions = setOf(
-            ClusterRegion(
+            SubnetAwareRegionSpec(
               region = "us-east-1",
               subnet = "internal (vpc0)",
               availabilityZones = eastAvailabilityZones ?: emptySet()
             ),
-            ClusterRegion(
+            SubnetAwareRegionSpec(
               region = "us-west-2",
               subnet = "internal (vpc0)",
               availabilityZones = westAvailabilityZones ?: emptySet()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api
+
+/**
+ * An object which is located in an account and region
+ */
+interface Locatable {
+  val locations: Locations<out RegionSpec>
+}
+
+open class Locations<T : RegionSpec>(
+  val accountName: String,
+  val regions: Set<T>
+) {
+  override fun equals(other: Any?): Boolean {
+    return other is Locations<*> &&
+      accountName == other.accountName &&
+      regions == other.regions
+  }
+
+  override fun hashCode(): Int {
+    var result = accountName.hashCode()
+    result = 31 * result + regions.hashCode()
+    return result
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -24,19 +24,7 @@ interface Locatable {
   val locations: Locations<out RegionSpec>
 }
 
-open class Locations<T : RegionSpec>(
+data class Locations<T : RegionSpec>(
   val accountName: String,
   val regions: Set<T>
-) {
-  override fun equals(other: Any?): Boolean {
-    return other is Locations<*> &&
-      accountName == other.accountName &&
-      regions == other.regions
-  }
-
-  override fun hashCode(): Int {
-    var result = accountName.hashCode()
-    result = 31 * result + regions.hashCode()
-    return result
-  }
-}
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/RegionSpec.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/RegionSpec.kt
@@ -1,0 +1,22 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api
+
+interface RegionSpec {
+  val region: String
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSummary.kt
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api
+
+import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.persistence.ResourceStatus
+
+/**
+ * A summary version of a resource that contains identifying information, location information, and status.
+ * This powers the UI view of resource status.
+ */
+data class ResourceSummary(
+  val id: ResourceId,
+  val kind: String,
+  val status: ResourceStatus,
+  val moniker: Moniker?,
+  val locations: Locations<out RegionSpec>?
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/model/SimpleRegionSpec.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/model/SimpleRegionSpec.kt
@@ -1,0 +1,41 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.model
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import com.netflix.spinnaker.keel.api.RegionSpec
+
+@JsonSerialize(using = ToStringSerializer::class)
+@JsonDeserialize(using = SimpleRegionSpecDeserializer::class)
+data class SimpleRegionSpec(
+  override val region: String
+) : RegionSpec {
+  override fun toString(): String {
+    return region
+  }
+}
+
+class SimpleRegionSpecDeserializer : StdDeserializer<SimpleRegionSpec>(SimpleRegionSpec::class.java) {
+  override fun deserialize(parser: JsonParser, context: DeserializationContext): SimpleRegionSpec =
+    SimpleRegionSpec(parser.valueAsString)
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/model/SubnetAwareRegionSpec.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/model/SubnetAwareRegionSpec.kt
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.model
+
+import com.netflix.spinnaker.keel.api.RegionSpec
+
+data class SubnetAwareRegionSpec(
+  override val region: String,
+  val subnet: String,
+  /**
+   * If empty this implies the resource should use all availability zones.
+   */
+  val availabilityZones: Set<String> = emptySet()
+) : RegionSpec

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel.persistence.memory
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.ResourceSummary
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ResourceEvent
@@ -53,6 +54,13 @@ class InMemoryResourceRepository(
     resources
       .filterValues { it.application == application }
       .map { it.value.id.toString() }
+
+  override fun getSummaryByApplication(application: String): List<ResourceSummary> =
+    resources
+      .filterValues { it.application == application }
+      .map { (_, resource) ->
+        resource.toResourceSummary()
+      }
 
   override fun store(resource: Resource<*>) {
     resources[resource.id] = resource

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LoadBalancer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LoadBalancer.kt
@@ -1,8 +1,12 @@
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Monikered
+import com.netflix.spinnaker.keel.api.RegionSpec
+import com.netflix.spinnaker.keel.model.SimpleRegionSpec
 
-interface LoadBalancer : Monikered {
+interface LoadBalancer : Monikered, Locatable {
   val location: Location
   val loadBalancerType: LoadBalancerType
   val internal: Boolean
@@ -10,4 +14,10 @@ interface LoadBalancer : Monikered {
   val subnetType: String?
   val securityGroupNames: Set<String>
   val idleTimeout: Int
+
+  override val locations: Locations<out RegionSpec>
+    get() = Locations(
+      accountName = location.accountName,
+      regions = setOf(SimpleRegionSpec(location.region))
+    )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
@@ -15,29 +15,27 @@
  */
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.MultiRegion
 import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.model.SimpleRegionSpec
 import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
 import de.danielbechler.diff.introspection.ObjectDiffProperty
 
 data class SecurityGroupSpec(
   override val moniker: Moniker,
-  val locations: Locations,
+  override val locations: Locations<SimpleRegionSpec>,
   val vpcName: String?,
   val description: String?,
   val inboundRules: Set<SecurityGroupRule> = emptySet(),
   val overrides: Map<String, SecurityGroupOverride> = emptyMap()
-) : MultiRegion {
+) : MultiRegion, Locatable {
   override val id = "${locations.accountName}:${moniker.name}"
 
   override val regionalIds = locations.regions.map { region ->
     "${locations.accountName}:$region:${moniker.name}"
   }.sorted()
-
-  data class Locations(
-    val accountName: String,
-    val regions: Set<String>
-  )
 }
 
 data class SecurityGroupOverride(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/normalizers/ClusterAvailabilityZonesResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/normalizers/ClusterAvailabilityZonesResolver.kt
@@ -1,14 +1,13 @@
 package com.netflix.spinnaker.keel.ec2.normalizers
 
-import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.plugin.Resolver
 import org.springframework.stereotype.Component
 
-import com.netflix.spinnaker.keel.plugin.Resolver
 @Component
 class ClusterAvailabilityZonesResolver(
   private val cloudDriverCache: CloudDriverCache
@@ -27,10 +26,8 @@ class ClusterAvailabilityZonesResolver(
     }
     return resource.copy(
       spec = resource.spec.copy(
-        locations = Locations(
-          accountName = resource.spec.locations.accountName,
-          regions = regions.toSet()
-        )
+        locations = resource.spec.locations.copy(
+          regions = regions.toSet())
       )
     )
   }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/normalizers/ClusterAvailabilityZonesResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/normalizers/ClusterAvailabilityZonesResolver.kt
@@ -1,13 +1,14 @@
 package com.netflix.spinnaker.keel.ec2.normalizers
 
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
-import com.netflix.spinnaker.keel.plugin.Resolver
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import org.springframework.stereotype.Component
 
+import com.netflix.spinnaker.keel.plugin.Resolver
 @Component
 class ClusterAvailabilityZonesResolver(
   private val cloudDriverCache: CloudDriverCache
@@ -26,7 +27,8 @@ class ClusterAvailabilityZonesResolver(
     }
     return resource.copy(
       spec = resource.spec.copy(
-        locations = resource.spec.locations.copy(
+        locations = Locations(
+          accountName = resource.spec.locations.accountName,
           regions = regions.toSet()
         )
       )
@@ -34,7 +36,7 @@ class ClusterAvailabilityZonesResolver(
   }
 }
 
-private fun CloudDriverCache.resolveAvailabilityZones(accountName: String, region: ClusterRegion) =
+private fun CloudDriverCache.resolveAvailabilityZones(accountName: String, region: SubnetAwareRegionSpec) =
   availabilityZonesBy(
     accountName,
     subnetBy(accountName, region.region, region.subnet).vpcId,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolver.kt
@@ -8,7 +8,6 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.UnsupportedStrategy
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
 import com.netflix.spinnaker.keel.api.ec2.IdImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ImageProvider
 import com.netflix.spinnaker.keel.api.ec2.JenkinsImageProvider
@@ -18,6 +17,7 @@ import com.netflix.spinnaker.keel.clouddriver.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -89,7 +89,7 @@ class ImageResolver(
 
       ResolvedImages(
         artifactVersion,
-        image.toResolvedImage(resource.spec.locations.regions.map(ClusterRegion::region))
+        image.toResolvedImage(resource.spec.locations.regions.map(SubnetAwareRegionSpec::region))
       )
     } else {
       val image = imageService.getLatestNamedImage(
@@ -99,7 +99,7 @@ class ImageResolver(
 
       ResolvedImages(
         image.appVersion,
-        image.toResolvedImage(resource.spec.locations.regions.map(ClusterRegion::region))
+        image.toResolvedImage(resource.spec.locations.regions.map(SubnetAwareRegionSpec::region))
       )
     }
   }
@@ -119,7 +119,7 @@ class ImageResolver(
     log.info("Image found for {}: {}", imageProvider.packageName, image)
     return ResolvedImages(
       image.appVersion,
-      image.toResolvedImage(resource.spec.locations.regions.map(ClusterRegion::region))
+      image.toResolvedImage(resource.spec.locations.regions.map(SubnetAwareRegionSpec::region))
     )
   }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
@@ -3,16 +3,16 @@ package com.netflix.spinnaker.keel.api.ec2
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.HealthSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.Locations
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType.ELB
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.MemoryCloudDriverCache
 import com.netflix.spinnaker.keel.ec2.resource.ResolvedImages
 import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import dev.minutest.TestContextBuilder
@@ -42,12 +42,12 @@ internal class ClusterSpecTests : JUnit5Minutests {
           locations = Locations(
             accountName = "test",
             regions = setOf(
-              ClusterRegion(
+              SubnetAwareRegionSpec(
                 region = "us-east-1",
                 subnet = "internal (vpc0)",
                 availabilityZones = setOf("us-east-1c", "us-east-1d", "us-east-1e")
               ),
-              ClusterRegion(
+              SubnetAwareRegionSpec(
                 region = "us-west-2",
                 subnet = "internal (vpc0)",
                 availabilityZones = setOf("us-west-2a", "us-west-2b", "us-west-2c")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/image/CurrentlyDeployedImageApproverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/image/CurrentlyDeployedImageApproverTests.kt
@@ -21,17 +21,17 @@ import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.Locations
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.IdImageProvider
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
@@ -78,7 +78,7 @@ internal class CurrentlyDeployedImageApproverTests : JUnit5Minutests {
         locations = Locations(
           accountName = "test",
           regions = setOf(
-            ClusterRegion(
+            SubnetAwareRegionSpec(
               region = "ap-south-1",
               subnet = "internal (vpc0)",
               availabilityZones = setOf("ap-south1-a", "ap-south1-b", "ap-south1-c")
@@ -105,7 +105,7 @@ internal class CurrentlyDeployedImageApproverTests : JUnit5Minutests {
         locations = Locations(
           accountName = "test",
           regions = setOf(
-            ClusterRegion(
+            SubnetAwareRegionSpec(
               region = "ap-south-1",
               subnet = "internal (vpc0)",
               availabilityZones = setOf("ap-south1-a", "ap-south1-b", "ap-south1-c")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -2,12 +2,11 @@ package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.Locations
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.Dependencies
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType
@@ -37,6 +36,7 @@ import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.ec2.image.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
@@ -99,7 +99,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     locations = Locations(
       accountName = vpcWest.account,
       regions = listOf(vpcWest, vpcEast).map { subnet ->
-        ClusterRegion(
+        SubnetAwareRegionSpec(
           region = subnet.region,
           subnet = subnet.name!!,
           availabilityZones = listOf("a", "b", "c").map { "${subnet.region}$it" }.toSet()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ImageResolverTests.kt
@@ -7,15 +7,14 @@ import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.NoImageFound
 import com.netflix.spinnaker.keel.api.NoImageFoundForRegions
 import com.netflix.spinnaker.keel.api.NoImageSatisfiesConstraints
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ClusterRegion
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.Locations
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.IdImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ImageProvider
@@ -24,6 +23,7 @@ import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.model.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.test.resource
@@ -120,7 +120,7 @@ internal class ImageResolverTests : JUnit5Minutests {
         locations = Locations(
           accountName = account,
           regions = setOf(
-            ClusterRegion(
+            SubnetAwareRegionSpec(
               region = resourceRegion,
               subnet = "internal (vpc0)",
               availabilityZones = setOf()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -16,15 +16,16 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.ec2.CidrRule
 import com.netflix.spinnaker.keel.api.ec2.CrossAccountReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.PortRange
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroup
-import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupOverride
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol.TCP
+import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.SelfReferenceRule
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -39,6 +40,7 @@ import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
+import com.netflix.spinnaker.keel.model.SimpleRegionSpec
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
@@ -114,9 +116,9 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           app = "keel",
           stack = "fnord"
         ),
-        locations = SecurityGroupSpec.Locations(
+        locations = Locations(
           accountName = vpcRegion1.account,
-          regions = setOf(vpcRegion1.region, vpcRegion2.region)
+          regions = setOf(SimpleRegionSpec(vpcRegion1.region), SimpleRegionSpec(vpcRegion2.region))
         ),
         vpcName = vpcRegion1.name,
         description = "dummy security group"
@@ -191,9 +193,9 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           app = "keel",
           stack = "fnord"
         ),
-        locations = SecurityGroupSpec.Locations(
+        locations = Locations(
           accountName = vpcRegion1.account,
-          regions = setOf(vpcRegion1.region, vpcRegion2.region)
+          regions = setOf(SimpleRegionSpec(vpcRegion1.region), SimpleRegionSpec(vpcRegion2.region))
         ),
         vpcName = vpcRegion1.name,
         description = "dummy security group"
@@ -394,7 +396,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
           before {
             securityGroupSpec.locations.regions.forEach { region ->
-              Network(CLOUD_PROVIDER, randomUUID().toString(), "vpc1", "test", region)
+              Network(CLOUD_PROVIDER, randomUUID().toString(), "vpc1", "test", region.region)
                 .also {
                   every { cloudDriverCache.networkBy(it.id) } returns it
                   every { cloudDriverCache.networkBy(it.name, it.account, it.region) } returns it
@@ -644,9 +646,9 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           val onlyInEast = resource
             .copy(
               spec = resource.spec.copy(
-                locations = SecurityGroupSpec.Locations(
+                locations = Locations(
                   accountName = securityGroupSpec.locations.accountName,
-                  regions = setOf("us-east-17"))))
+                  regions = setOf(SimpleRegionSpec("us-east-17")))))
 
           handler.update(
             resource,

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/DummyResourceTypeIdentifier.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/DummyResourceTypeIdentifier.kt
@@ -3,8 +3,14 @@ package com.netflix.spinnaker.keel.sql
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
+import com.netflix.spinnaker.keel.test.DummyLocatableResourceSpec
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 
 internal object DummyResourceTypeIdentifier : ResourceTypeIdentifier {
-  override fun identify(apiVersion: ApiVersion, kind: String): Class<out ResourceSpec> = DummyResourceSpec::class.java
+  override fun identify(apiVersion: ApiVersion, kind: String): Class<out ResourceSpec> {
+    return when (kind) {
+      "locatable" -> DummyLocatableResourceSpec::class.java
+      else -> DummyResourceSpec::class.java
+    }
+  }
 }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -1,11 +1,14 @@
 package com.netflix.spinnaker.keel.test
 
 import com.netflix.spinnaker.keel.api.ApiVersion
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.model.SimpleRegionSpec
 import com.netflix.spinnaker.keel.plugin.SimpleResourceHandler
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import java.util.UUID
@@ -19,6 +22,24 @@ fun resource(
   application: String = "fnord"
 ): Resource<DummyResourceSpec> =
   DummyResourceSpec(id = id, application = application)
+    .let { spec ->
+      resource(
+        apiVersion = apiVersion,
+        kind = kind,
+        spec = spec,
+        id = spec.id,
+        application = application
+      )
+    }
+
+fun locatableResource(
+  apiVersion: ApiVersion = TEST_API,
+  kind: String = "locatable",
+  id: String = randomString(),
+  application: String = "fnord",
+  locations: Locations<SimpleRegionSpec> = Locations("test", setOf(SimpleRegionSpec("us-west-1")))
+): Resource<DummyLocatableResourceSpec> =
+  DummyLocatableResourceSpec(id = id, application = application, locations = locations)
     .let { spec ->
       resource(
         apiVersion = apiVersion,
@@ -64,6 +85,13 @@ data class DummyResourceSpec(
   val data: String = randomString(),
   override val application: String = "fnord"
 ) : ResourceSpec
+
+data class DummyLocatableResourceSpec(
+  override val id: String = randomString(),
+  val data: String = randomString(),
+  override val application: String = "fnord",
+  override val locations: Locations<SimpleRegionSpec> = Locations("test", setOf(SimpleRegionSpec("us-west-1")))
+) : ResourceSpec, Locatable
 
 data class DummyResource(
   val id: String = randomString(),


### PR DESCRIPTION
For the UI views for managed delivery we need an endpoint (by app) to poll for status and info. 

This implementation is expensive - we recalculate the status on every call. There's a todo in there to fix that. 

`GET https://localhost:8087/application/emburnstest?includeDetails=true` 
```json
{
  "hasManagedResources": true,
  "resources": [
    {
      "id": "ec2:cluster:test:emburnstest-md-wow",
      "kind": "cluster",
      "status": "ERROR",
      "moniker": {
        "app": "emburnstest",
        "stack": "md",
        "detail": "wow"
      },
      "locations": {
        "accountName": "test",
        "regions": [
          "us-west-1"
        ]
      }
    },
    {
      "id": "ec2:security-group:test:emburnstest-managed",
      "kind": "security-group",
      "status": "HAPPY",
      "moniker": {
        "app": "emburnstest",
        "stack": "managed"
      },
      "locations": {
        "accountName": "test",
        "regions": [
          "us-west-1"
        ]
      }
    }
  ]
}
```