### PR TITLE
feat(examples): yaml that will break if you change the spec

### DIFF
--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -1,0 +1,94 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.rest
+
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.SubmittedResource
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancer
+import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancer
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
+import com.netflix.spinnaker.keel.bakery.api.ImageSpec
+import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectCatching
+import strikt.assertions.succeeded
+
+class ConvertExampleFilesTest : JUnit5Minutests {
+  private val mapper = configuredYamlMapper()
+
+  fun tests() = rootContext<Unit> {
+
+    context("cluster") {
+      mapper.registerSubtypes(NamedType(ClusterSpec::class.java, "cluster"))
+      val file = this.javaClass.getResource("/examples/cluster-example.yml").readText()
+
+      test("yaml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<ClusterSpec>>(file)
+        }.succeeded()
+      }
+    }
+
+    context("security group") {
+      mapper.registerSubtypes(NamedType(SecurityGroupSpec::class.java, "security-group"))
+      val file = this.javaClass.getResource("/examples/security-group-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<SecurityGroupSpec>>(file)
+        }.succeeded()
+      }
+    }
+
+    context("image") {
+      mapper.registerSubtypes(NamedType(ImageSpec::class.java, "image"))
+      val file = this.javaClass.getResource("/examples/image-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<ImageSpec>>(file)
+        }.succeeded()
+      }
+    }
+
+    context("clb") {
+      mapper.registerSubtypes(NamedType(ClassicLoadBalancer::class.java, "classic-load-balancer"))
+      val file = this.javaClass.getResource("/examples/clb-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<ClassicLoadBalancer>>(file)
+        }.succeeded()
+      }
+    }
+
+    context("alb") {
+      mapper.registerSubtypes(NamedType(ApplicationLoadBalancer::class.java, "application-load-balancer"))
+      val file = this.javaClass.getResource("/examples/alb-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<ApplicationLoadBalancer>>(file)
+        }.succeeded()
+      }
+    }
+  }
+}

--- a/keel-api/src/test/resources/examples/alb-example.yml
+++ b/keel-api/src/test/resources/examples/alb-example.yml
@@ -1,0 +1,27 @@
+---
+apiVersion: ec2.spinnaker.netflix.com/v1
+kind: application-load-balancer
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  vpcName: vpc0
+  subnetType: internal (vpc0)
+  moniker:
+    app: keeldemo
+    stack: example
+    detail: albec2v1
+  location:
+    accountName: test
+    region: us-east-1
+    availabilityZones:
+      - us-east-1c
+      - us-east-1d
+      - us-east-1e
+  listeners:
+    - port: 80
+      protocol: HTTP
+  targetGroups:
+    - name: keeldemo-example-tgec2v1
+      port: 7001
+      attributes:
+        stickinessEnabled: false

--- a/keel-api/src/test/resources/examples/clb-example.yml
+++ b/keel-api/src/test/resources/examples/clb-example.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: ec2.spinnaker.netflix.com/v1
+kind: classic-load-balancer
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  moniker:
+    app: keeldemo
+    stack: example
+    detail: clbec2v1
+  location:
+    accountName: test
+    region: us-east-1
+    availabilityZones:
+      - us-east-1c
+      - us-east-1d
+      - us-east-1e
+  loadBalancerType: CLASSIC
+  internal: true
+  vpcName: vpc0
+  subnetType: internal (vpc0)
+  securityGroupNames: []
+  idleTimeout: 60
+  listeners:
+    - internalProtocol: HTTP
+      internalPort: 7001
+      externalProtocol: HTTP
+      externalPort: 80
+      sslCertificateId:
+  healthCheck: HTTP:7001/health
+  healthInterval: 10
+  healthyThreshold: 5
+  unhealthyThreshold: 2
+  healthTimeout: 5

--- a/keel-api/src/test/resources/examples/cluster-example.yml
+++ b/keel-api/src/test/resources/examples/cluster-example.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: ec2.spinnaker.netflix.com/v1
+kind: cluster
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  moniker:
+    app: keeldemo
+    stack: examples
+    detail: ec2v1
+  imageProvider:
+    deliveryArtifact:
+      name: keeldemo
+      type: DEB
+  locations:
+    accountName: test
+    regions:
+      - region: us-west-2
+        subnet: internal (vpc0)
+      - region: us-east-1
+        subnet: internal (vpc0)
+  overrides: {}
+  launchConfiguration:
+    instanceType: m5.large
+    ebsOptimized: true
+    iamRole: keeldemoInstanceProfile
+    keyPair: nf-test-keypair-a
+  capacity:
+    min: 1
+    max: 1
+    desired: 1
+  dependencies:
+    loadBalancerNames: []
+    securityGroupNames:
+      - keeldemo
+      - nf-datacenter
+      - nf-infrastructure
+    targetGroups: []

--- a/keel-api/src/test/resources/examples/image-example.yml
+++ b/keel-api/src/test/resources/examples/image-example.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: bakery.spinnaker.netflix.com/v1
+kind: image
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  artifactName: keeldemo
+  baseLabel: RELEASE
+  baseOs: xenial
+  regions:
+    - us-east-1
+    - us-west-2
+  storeType: EBS
+  application: keeldemo

--- a/keel-api/src/test/resources/examples/security-group-example.yml
+++ b/keel-api/src/test/resources/examples/security-group-example.yml
@@ -1,0 +1,22 @@
+---
+apiVersion: ec2.spinnaker.netflix.com/v1
+kind: security-group
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  moniker:
+    app: keeldemo
+    stack: example
+    detail: ec2v1
+  locations:
+    accountName: test
+    regions:
+      - us-west-2
+      - us-east-1
+  vpcName: vpc0
+  description: Managed Security Group for keeldemo example
+  inboundRules:
+    - protocol: TCP
+      portRange:
+        startPort: 7001
+        endPort: 7001


### PR DESCRIPTION
I've created examples of valid yaml files that will be objectmappered to their corresponding java classes every time tests are run. This should help us keep a current folder of yaml examples that is less likely to break.