### PR TITLE
feat(status): include resource valid events in history

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceUpdated
-import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.locatableResource
 import com.netflix.spinnaker.keel.test.resource
@@ -52,7 +51,6 @@ import strikt.assertions.isGreaterThanOrEqualTo
 import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
 import strikt.assertions.map
-import strikt.assertions.none
 import java.time.Clock
 import java.time.Duration
 import java.time.Period
@@ -182,18 +180,6 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
       }
 
       context("updating the state of the resource") {
-        context("an event that should be ignored in history") {
-          before {
-            tick()
-            subject.appendHistory(ResourceValid(resource, clock))
-          }
-
-          test("the event is not included in the history") {
-            expectThat(subject.eventHistory(resource.id))
-              .none { isA<ResourceValid>() }
-          }
-        }
-
         context("an event that should be persisted in history") {
           before {
             tick()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -82,12 +82,6 @@ sealed class ResourceEvent {
     get() = ids?.map { ResourceId(it) }?.toSet() ?: emptySet()
 
   /**
-   * Should the event be recorded in a resource's history?
-   */
-  @JsonIgnore
-  open val ignoreInHistory: Boolean = false
-
-  /**
    * Should repeated events of the same type
    */
   @JsonIgnore
@@ -288,7 +282,7 @@ data class ResourceValid(
   override val state = Ok
 
   @JsonIgnore
-  override val ignoreInHistory = true
+  override val ignoreRepeatedInHistory = true
 
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) :
     this(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
@@ -86,8 +86,6 @@ class InMemoryResourceRepository(
   }
 
   override fun appendHistory(event: ResourceEvent) {
-    if (event.ignoreInHistory) return
-
     events.computeIfAbsent(event.resourceId) {
       mutableListOf()
     }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -146,8 +146,6 @@ open class SqlResourceRepository(
   }
 
   override fun appendHistory(event: ResourceEvent) {
-    if (event.ignoreInHistory) return
-
     if (event.ignoreRepeatedInHistory) {
       val previousEvent = jooq
         .select(RESOURCE_EVENT.JSON)


### PR DESCRIPTION
Right now if we have a "resource check error" we persist an error state. If we resolve this state but the outcome is that the resource is valid we stay in an "error" state (the last history event is an error). This PR changes the history a bit so that we persist one `ResourceValid` status if the resource is valid.

The event gets sent [here](https://github.com/spinnaker/keel/blob/684f9e546a5879cdce7c0cbfe615686df58200ba/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt#L88-L92)