### PR TITLE
vpcName -> vpc, accountName -> account

### DIFF
--- a/keel-api/src/test/resources/examples/alb-example.yml
+++ b/keel-api/src/test/resources/examples/alb-example.yml
@@ -9,8 +9,8 @@ spec:
     stack: example
     detail: albec2v1
   locations:
-    accountName: test
-    vpcName: vpc0
+    account: test
+    vpc: vpc0
     subnet: internal (vpc0)
     regions:
     - name: us-east-1

--- a/keel-api/src/test/resources/examples/clb-example.yml
+++ b/keel-api/src/test/resources/examples/clb-example.yml
@@ -9,8 +9,8 @@ spec:
     stack: example
     detail: clbec2v1
   locations:
-    accountName: test
-    vpcName: vpc0
+    account: test
+    vpc: vpc0
     subnet: internal (vpc0)
     regions:
     - name: us-east-1

--- a/keel-api/src/test/resources/examples/cluster-example.yml
+++ b/keel-api/src/test/resources/examples/cluster-example.yml
@@ -13,8 +13,8 @@ spec:
       name: keeldemo
       type: DEB
   locations:
-    accountName: test
-    vpcName: vpc0
+    account: test
+    vpc: vpc0
     subnet: internal (vpc0)
     regions:
       - name: us-west-2

--- a/keel-api/src/test/resources/examples/security-group-example.yml
+++ b/keel-api/src/test/resources/examples/security-group-example.yml
@@ -9,8 +9,8 @@ spec:
     stack: example
     detail: ec2v1
   locations:
-    accountName: test
-    vpcName: vpc0
+    account: test
+    vpc: vpc0
     regions:
     - name: us-west-2
     - name: us-east-1

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -25,27 +25,27 @@ interface Locatable<T : Locations<*>> : ResourceSpec {
 }
 
 interface Locations<T : RegionSpec> {
-  val accountName: String
+  val account: String
   /**
    * If not specified here, this should be derived from the [SubnetAwareLocations.subnet] (if
    * present) or use a default VPC name.
    */
-  val vpcName: String?
+  val vpc: String?
   val regions: Set<T>
 }
 
 data class SubnetAwareLocations(
-  override val accountName: String,
-  override val vpcName: String?,
+  override val account: String,
+  override val vpc: String?,
   /**
-   * If not specified here, this should be derived from a default subnet purpose using [vpcName].
+   * If not specified here, this should be derived from a default subnet purpose using [vpc].
    */
   val subnet: String?,
   override val regions: Set<SubnetAwareRegionSpec>
 ) : Locations<SubnetAwareRegionSpec>
 
 data class SimpleLocations(
-  override val accountName: String,
-  override val vpcName: String?,
+  override val account: String,
+  override val vpc: String?,
   override val regions: Set<SimpleRegionSpec>
 ) : Locations<SimpleRegionSpec>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -172,8 +172,8 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
       },
       locations = if (spec is Locatable<*>) {
         SimpleLocations(
-          accountName = spec.locations.accountName,
-          vpcName = spec.locations.vpcName,
+          account = spec.locations.account,
+          vpc = spec.locations.vpc,
           regions = spec.locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
         )
       } else {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
@@ -29,7 +29,7 @@ data class ApplicationLoadBalancerSpec(
   override val loadBalancerType: LoadBalancerType = APPLICATION
 
   @JsonIgnore
-  override val id: String = "${locations.accountName}:${moniker.name}"
+  override val id: String = "${locations.account}:${moniker.name}"
 
   data class Listener(
     val port: Int,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpec.kt
@@ -25,5 +25,5 @@ data class ClassicLoadBalancerSpec(
   override val loadBalancerType: LoadBalancerType = CLASSIC
 
   @JsonIgnore
-  override val id: String = "${locations.accountName}:${moniker.name}"
+  override val id: String = "${locations.account}:${moniker.name}"
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -19,9 +19,9 @@ fun ClusterSpec.resolve(): Set<ServerGroup> =
     ServerGroup(
       name = moniker.name,
       location = Location(
-        accountName = locations.accountName,
+        account = locations.account,
         region = it.name,
-        vpcName = locations.vpcName ?: error("No VPC name supplied or resolved"),
+        vpc = locations.vpc ?: error("No VPC name supplied or resolved"),
         subnet = locations.subnet ?: error("No subnet purpose supplied or resolved"),
         availabilityZones = it.availabilityZones
       ),
@@ -93,10 +93,10 @@ data class ClusterSpec(
   val overrides: Map<String, ServerGroupSpec> = emptyMap()
 ) : MultiRegion, Locatable<SubnetAwareLocations> {
   @JsonIgnore
-  override val id = "${locations.accountName}:${moniker.name}"
+  override val id = "${locations.account}:${moniker.name}"
 
   override val regionalIds = locations.regions.map { clusterRegion ->
-    "${locations.accountName}:${clusterRegion.name}:${moniker.name}"
+    "${locations.account}:${clusterRegion.name}:${moniker.name}"
   }.sorted()
 
   /**

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Location.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Location.kt
@@ -18,9 +18,9 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 data class Location(
-  val accountName: String,
+  val account: String,
   val region: String,
-  val vpcName: String,
+  val vpc: String,
   val subnet: String,
   val availabilityZones: Set<String>
 )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroup.kt
@@ -12,8 +12,8 @@ data class SecurityGroup(
   val inboundRules: Set<SecurityGroupRule> = emptySet()
 ) {
   data class Location(
-    val accountName: String,
-    val vpcName: String,
+    val account: String,
+    val vpc: String,
     val region: String
   )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
@@ -47,7 +47,7 @@ data class CrossAccountReferenceRule(
   override val protocol: Protocol,
   val name: String,
   val account: String,
-  val vpcName: String,
+  val vpc: String,
   override val portRange: PortRange
 ) : SecurityGroupRule()
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
@@ -29,10 +29,10 @@ data class SecurityGroupSpec(
   val inboundRules: Set<SecurityGroupRule> = emptySet(),
   val overrides: Map<String, SecurityGroupOverride> = emptyMap()
 ) : MultiRegion, Locatable<SimpleLocations> {
-  override val id = "${locations.accountName}:${moniker.name}"
+  override val id = "${locations.account}:${moniker.name}"
 
   override val regionalIds = locations.regions.map { region ->
-    "${locations.accountName}:$region:${moniker.name}"
+    "${locations.account}:$region:${moniker.name}"
   }.sorted()
 }
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/AvailabilityZonesResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/AvailabilityZonesResolver.kt
@@ -15,8 +15,8 @@ abstract class AvailabilityZonesResolver<T : Locatable<SubnetAwareLocations>>(
     val regions = resource.spec.locations.regions.map { region ->
       if (region.availabilityZones.isEmpty()) {
         region.copy(availabilityZones = cloudDriverCache.resolveAvailabilityZones(
-          accountName = resource.spec.locations.accountName,
-          subnetPurpose = resource.spec.locations.subnet ?: error("No subnet purpose specified or resolved"),
+          account = resource.spec.locations.account,
+          subnet = resource.spec.locations.subnet ?: error("No subnet purpose specified or resolved"),
           region = region
         ))
       } else {
@@ -31,13 +31,13 @@ abstract class AvailabilityZonesResolver<T : Locatable<SubnetAwareLocations>>(
   protected abstract fun T.withLocations(locations: SubnetAwareLocations): T
 }
 
-private fun CloudDriverCache.resolveAvailabilityZones(accountName: String, subnetPurpose: String, region: SubnetAwareRegionSpec) =
+private fun CloudDriverCache.resolveAvailabilityZones(account: String, subnet: String, region: SubnetAwareRegionSpec) =
   availabilityZonesBy(
-    accountName,
+    account,
     subnetBy(
-      accountName,
+      account,
       region.name,
-      subnetPurpose
+      subnet
     ).vpcId,
     region.name
   ).toSet()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
@@ -17,17 +17,17 @@ abstract class NetworkResolver<T : Locatable<*>> : Resolver<T> {
 
   protected fun SubnetAwareLocations.withResolvedNetwork(): SubnetAwareLocations {
     val resolvedVpcName: String =
-      vpcName
+      vpc
         ?: subnet?.let { Regex("""^.+\((.+)\)$""").find(it)?.groupValues?.get(1) }
         ?: DEFAULT_VPC_NAME
     return copy(
-      vpcName = resolvedVpcName,
+      vpc = resolvedVpcName,
       subnet = subnet ?: DEFAULT_SUBNET_PURPOSE.format(resolvedVpcName)
     )
   }
 
   protected fun SimpleLocations.withResolvedNetwork(): SimpleLocations {
-    return copy(vpcName = vpcName ?: DEFAULT_VPC_NAME)
+    return copy(vpc = vpc ?: DEFAULT_VPC_NAME)
   }
 
   companion object {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -51,9 +51,9 @@ class ApplicationLoadBalancerHandler(
         ApplicationLoadBalancer(
           moniker,
           Location(
-            locations.accountName,
+            locations.account,
             it.name,
-            locations.vpcName ?: error("No VPC name supplied or resolved"),
+            locations.vpc ?: error("No VPC name supplied or resolved"),
             locations.subnet ?: error("No subnet purpose supplied or resolved"),
             it.availabilityZones
           ),
@@ -87,7 +87,7 @@ class ApplicationLoadBalancerHandler(
           }
 
           val description = "$action ${resource.kind} load balancer ${desired.moniker.name} in " +
-            "${desired.location.accountName}/${desired.location.region}"
+            "${desired.location.account}/${desired.location.region}"
 
           val notifications = environmentResolver.getNotificationsFor(resource.id)
 
@@ -125,14 +125,14 @@ class ApplicationLoadBalancerHandler(
             getApplicationLoadBalancer(
               serviceAccount,
               CLOUD_PROVIDER,
-              spec.locations.accountName,
+              spec.locations.account,
               region.name,
               spec.moniker.name
             )
               .firstOrNull()
               ?.let { lb ->
                 val securityGroupNames = lb.securityGroups.map {
-                  cloudDriverCache.securityGroupById(spec.locations.accountName, region.name, it).name
+                  cloudDriverCache.securityGroupById(spec.locations.account, region.name, it).name
                 }.toMutableSet()
 
                 ApplicationLoadBalancer(
@@ -143,9 +143,9 @@ class ApplicationLoadBalancerHandler(
                     Moniker(app = parsedNamed[0], stack = parsedNamed.getOrNull(1), detail = parsedNamed.getOrNull(2))
                   },
                   location = Location(
-                    accountName = spec.locations.accountName,
+                    account = spec.locations.account,
                     region = region.name,
-                    vpcName = lb.vpcId.let { cloudDriverCache.networkBy(it).name }
+                    vpc = lb.vpcId.let { cloudDriverCache.networkBy(it).name }
                       ?: error("Keel does not support load balancers that are not in a VPC subnet"),
                     subnet = cloudDriverCache.subnetBy(lb.subnets.first()).purpose
                       ?: error("Keel does not support load balancers that are not in a VPC subnet"),
@@ -210,13 +210,13 @@ class ApplicationLoadBalancerHandler(
         "upsertLoadBalancer",
         mapOf(
           "application" to moniker.app,
-          "credentials" to location.accountName,
+          "credentials" to location.account,
           "cloudProvider" to CLOUD_PROVIDER,
           "name" to moniker.name,
           "region" to location.region,
           "availabilityZones" to mapOf(location.region to location.availabilityZones),
           "loadBalancerType" to loadBalancerType.toString().toLowerCase(),
-          "vpcId" to cloudDriverCache.networkBy(location.vpcName, location.accountName, location.region).id,
+          "vpcId" to cloudDriverCache.networkBy(location.vpc, location.account, location.region).id,
           "subnetType" to location.subnet,
           "isInternal" to internal,
           "idleTimeout" to idleTimeout.seconds,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -91,7 +91,7 @@ class ClusterHandler(
           }
 
           log.info("Upserting server group using task: {}", job)
-          val description = "Upsert server group ${desired.moniker.name} in ${desired.location.accountName}/${desired.location.region}"
+          val description = "Upsert server group ${desired.moniker.name} in ${desired.location.account}/${desired.location.region}"
 
           val notifications = environmentResolver.getNotificationsFor(resource.id)
 
@@ -136,7 +136,7 @@ class ClusterHandler(
     with(desired) {
       mapOf(
         "application" to moniker.app,
-        "credentials" to location.accountName,
+        "credentials" to location.account,
         // <things to do with the strategy>
         // TODO: this will be parameterizable ultimately
         "strategy" to "redblack",
@@ -197,14 +197,14 @@ class ClusterHandler(
         "cloudProvider" to CLOUD_PROVIDER,
         "loadBalancers" to dependencies.loadBalancerNames,
         "targetGroups" to dependencies.targetGroups,
-        "account" to location.accountName
+        "account" to location.account
       )
     }
       .let { job ->
         current?.run {
           job + mapOf(
             "source" to mapOf(
-              "account" to location.accountName,
+              "account" to location.account,
               "region" to location.region,
               "asgName" to moniker.serverGroup
             ),
@@ -225,7 +225,7 @@ class ClusterHandler(
         "desired" to desired.capacity.desired
       ),
       "cloudProvider" to CLOUD_PROVIDER,
-      "credentials" to desired.location.accountName,
+      "credentials" to desired.location.account,
       "moniker" to mapOf(
         "app" to current.moniker.app,
         "stack" to current.moniker.stack,
@@ -246,7 +246,7 @@ class ClusterHandler(
             activeServerGroup(
               resource.serviceAccount,
               resource.spec.moniker.app,
-              resource.spec.locations.accountName,
+              resource.spec.locations.account,
               resource.spec.moniker.name,
               it.name,
               CLOUD_PROVIDER
@@ -278,9 +278,9 @@ class ClusterHandler(
     ServerGroup(
       name = name,
       location = Location(
-        accountName = accountName,
+        account = accountName,
         region = region,
-        vpcName = cloudDriverCache.networkBy(vpcId).name ?: error("VPC with id $vpcId has no name!"),
+        vpc = cloudDriverCache.networkBy(vpcId).name ?: error("VPC with id $vpcId has no name!"),
         subnet = subnet,
         availabilityZones = zones
       ),
@@ -322,7 +322,7 @@ class ClusterHandler(
       // gets auto-created so may not exist yet
       .filter { it !in setOf("nf-infrastructure", "nf-datacenter", moniker.app) }
       .map {
-        cloudDriverCache.securityGroupByName(location.accountName, location.region, it).id
+        cloudDriverCache.securityGroupByName(location.account, location.region, it).id
       }
 
   private val ActiveServerGroup.subnet: String

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpecTests.kt
@@ -26,8 +26,8 @@ internal object ApplicationLoadBalancerSpecTests : JUnit5Minutests {
             |  stack: managedogge
             |  detail: wow
             |locations:
-            |  accountName: test
-            |  vpcName: vpc0
+            |  account: test
+            |  vpc: vpc0
             |  subnet: internal (vpc0)
             |  regions:
             |  - name: us-east-1

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpecTests.kt
@@ -26,8 +26,8 @@ internal object ClassicLoadBalancerSpecTests : JUnit5Minutests {
             |  stack: managedogge
             |  detail: wow
             |locations:
-            |  accountName: test
-            |  vpcName: vpc0
+            |  account: test
+            |  vpc: vpc0
             |  subnet: internal (vpc0)
             |  regions:
             |  - name: us-east-1

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
@@ -119,8 +119,8 @@ object Fixture {
     ),
     imageProvider = ArtifactImageProvider(DeliveryArtifact("fnord", DEB)),
     locations = SubnetAwareLocations(
-      accountName = "test",
-      vpcName = "vpc0",
+      account = "test",
+      vpc = "vpc0",
       subnet = "internal (vpc0)",
       regions = setOf(
         SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRuleTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRuleTests.kt
@@ -72,7 +72,7 @@ internal object SecurityGroupRuleTests : JUnit5Minutests {
             |protocol: "TCP"
             |name: "fnord"
             |account: "prod"
-            |vpcName: "vpc0"
+            |vpc: "vpc0"
             |portRange:
             |  startPort: 8080
             |  endPort: 8080
@@ -80,7 +80,7 @@ internal object SecurityGroupRuleTests : JUnit5Minutests {
           model = CrossAccountReferenceRule(
             protocol = TCP,
             account = "prod",
-            vpcName = "vpc0",
+            vpc = "vpc0",
             name = "fnord",
             portRange = PortRange(8080, 8080)
           )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupTests.kt
@@ -22,8 +22,8 @@ internal object SecurityGroupTests : JUnit5Minutests {
           stack = "ext"
         ),
         location = SecurityGroup.Location(
-          accountName = "prod",
-          vpcName = "vpc0",
+          account = "prod",
+          vpc = "vpc0",
           region = "us-north-2"
         ),
         description = "I can see the fnords",
@@ -51,8 +51,8 @@ internal object SecurityGroupTests : JUnit5Minutests {
         ResourceDiff(this,
           copy(
             location = SecurityGroup.Location(
-              accountName = location.accountName,
-              vpcName = "vpc0",
+              account = location.account,
+              vpc = "vpc0",
               region = "ap-south-1"
             )
           )
@@ -84,8 +84,8 @@ internal object SecurityGroupTests : JUnit5Minutests {
       deriveFixture {
         ResourceDiff(this, copy(
           location = SecurityGroup.Location(
-            accountName = location.accountName,
-            vpcName = "vpc0",
+            account = location.account,
+            vpc = "vpc0",
             region = "ap-south-1"
           ),
           description = "We can't actually make changes to this so it should be ignored by the diff"

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroupDiffTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroupDiffTests.kt
@@ -60,8 +60,8 @@ internal class ServerGroupDiffTests : JUnit5Minutests {
             ServerGroup(
               name = "fnord-main",
               location = Location(
-                accountName = "prod",
-                vpcName = "vpc0",
+                account = "prod",
+                vpc = "vpc0",
                 region = region,
                 subnet = "internal",
                 availabilityZones = setOf("a", "b", "c").map { "$region$it" }.toSet()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/image/CurrentlyDeployedImageApproverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/image/CurrentlyDeployedImageApproverTests.kt
@@ -75,8 +75,8 @@ internal class CurrentlyDeployedImageApproverTests : JUnit5Minutests {
       spec = ClusterSpec(
         moniker = Moniker("fnord", "api"),
         locations = SubnetAwareLocations(
-          accountName = "test",
-          vpcName = "vpc0",
+          account = "test",
+          vpc = "vpc0",
           subnet = "internal (vpc0)",
           regions = setOf(
             SubnetAwareRegionSpec(
@@ -107,8 +107,8 @@ internal class CurrentlyDeployedImageApproverTests : JUnit5Minutests {
         moniker = Moniker("fnord", "api"),
         imageProvider = ArtifactImageProvider(deliveryArtifact = artifact),
         locations = SubnetAwareLocations(
-          accountName = "test",
-          vpcName = "vpc0",
+          account = "test",
+          vpc = "vpc0",
           subnet = "internal (vpc0)",
           regions = setOf(
             SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ApplicationLoadBalancerAvailabilityZonesResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ApplicationLoadBalancerAvailabilityZonesResolverTests.kt
@@ -20,8 +20,8 @@ internal class ApplicationLoadBalancerAvailabilityZonesResolverTests : Availabil
             stack = "test"
           ),
           locations = SubnetAwareLocations(
-            accountName = "test",
-            vpcName = "vpc0",
+            account = "test",
+            vpc = "vpc0",
             subnet = "internal (vpc0)",
             regions = setOf(
               SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/AvailabilityZonesResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/AvailabilityZonesResolverTests.kt
@@ -31,13 +31,13 @@ internal abstract class AvailabilityZonesResolverTests<T : Locatable<SubnetAware
 
     abstract val subject: AvailabilityZonesResolver<T>
 
-    private val vpcEast = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.accountName, "us-east-1")
-    private val vpcWest = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.accountName, "us-west-2")
+    private val vpcEast = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.account, "us-east-1")
+    private val vpcWest = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.account, "us-west-2")
     private val usEastSubnets = setOf("c", "d", "e").map {
       Subnet(
         id = "subnet-${randomHex()}",
         vpcId = vpcEast.id,
-        account = resource.spec.locations.accountName,
+        account = resource.spec.locations.account,
         region = "us-east-1",
         availabilityZone = "us-east-1$it",
         purpose = "internal (vpc0)"
@@ -47,7 +47,7 @@ internal abstract class AvailabilityZonesResolverTests<T : Locatable<SubnetAware
       Subnet(
         id = "subnet-${randomHex()}",
         vpcId = vpcWest.id,
-        account = resource.spec.locations.accountName,
+        account = resource.spec.locations.account,
         region = "us-west-2",
         availabilityZone = "us-west-2$it",
         purpose = "internal (vpc0)"

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ClassicLoadBalancerAvailabilityZonesResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ClassicLoadBalancerAvailabilityZonesResolverTests.kt
@@ -21,8 +21,8 @@ internal class ClassicLoadBalancerAvailabilityZonesResolverTests : AvailabilityZ
             stack = "test"
           ),
           locations = SubnetAwareLocations(
-            accountName = "test",
-            vpcName = "vpc0",
+            account = "test",
+            vpc = "vpc0",
             subnet = "internal (vpc0)",
             regions = setOf(
               SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ClusterAvailabilityZonesResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ClusterAvailabilityZonesResolverTests.kt
@@ -32,8 +32,8 @@ internal class ClusterAvailabilityZonesResolverTests : AvailabilityZonesResolver
           ),
           imageProvider = ArtifactImageProvider(DeliveryArtifact("fnord", DEB)),
           locations = SubnetAwareLocations(
-            accountName = "test",
-            vpcName = "vpc0",
+            account = "test",
+            vpc = "vpc0",
             subnet = "internal (vpc0)",
             regions = setOf(
               SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -119,8 +119,8 @@ internal class ImageResolverTests : JUnit5Minutests {
         moniker = Moniker("fnord"),
         imageProvider = imageProvider,
         locations = SubnetAwareLocations(
-          accountName = account,
-          vpcName = "vpc0",
+          account = account,
+          vpc = "vpc0",
           subnet = "internal (vpc0)",
           regions = setOf(
             SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
@@ -36,7 +36,7 @@ import java.time.Duration
 
 internal abstract class NetworkResolverTests<T : Locatable<*>> : JUnit5Minutests {
   protected abstract fun createSubject(): NetworkResolver<T>
-  protected abstract fun createResource(vpcName: String?, subnetPurpose: String?): Resource<T>
+  protected abstract fun createResource(vpc: String?, subnetPurpose: String?): Resource<T>
 
   data class Fixture<T : Locatable<*>>(
     val subject: NetworkResolver<T>,
@@ -60,7 +60,7 @@ internal abstract class NetworkResolverTests<T : Locatable<*>> : JUnit5Minutests
 
     context("VPC name is not specified") {
       test("VPC name is defaulted") {
-        expectThat(resolved.spec.locations.vpcName)
+        expectThat(resolved.spec.locations.vpc)
           .isEqualTo(DEFAULT_VPC_NAME)
       }
     }
@@ -73,7 +73,7 @@ internal abstract class NetworkResolverTests<T : Locatable<*>> : JUnit5Minutests
       }
 
       test("specified VPC name is used") {
-        expectThat(resolved.spec.locations.vpcName)
+        expectThat(resolved.spec.locations.vpc)
           .isEqualTo("vpc5")
       }
     }
@@ -97,7 +97,7 @@ internal abstract class SubnetAwareNetworkResolverTests<T : Locatable<SubnetAwar
       }
 
       test("VPC name is defaulted") {
-        expectThat(resolved.spec.locations.vpcName)
+        expectThat(resolved.spec.locations.vpc)
           .isEqualTo(DEFAULT_VPC_NAME)
       }
 
@@ -130,7 +130,7 @@ internal abstract class SubnetAwareNetworkResolverTests<T : Locatable<SubnetAwar
       }
 
       test("VPC name is derived from subnets") {
-        expectThat(resolved.spec.locations.vpcName)
+        expectThat(resolved.spec.locations.vpc)
           .isEqualTo("vpc5")
       }
     }
@@ -140,7 +140,7 @@ internal abstract class SubnetAwareNetworkResolverTests<T : Locatable<SubnetAwar
 internal class SecurityGroupNetworkResolverTests : NetworkResolverTests<SecurityGroupSpec>() {
   override fun createSubject() = SecurityGroupNetworkResolver()
 
-  override fun createResource(vpcName: String?, subnetPurpose: String?): Resource<SecurityGroupSpec> =
+  override fun createResource(vpc: String?, subnetPurpose: String?): Resource<SecurityGroupSpec> =
     resource(
       apiVersion = SPINNAKER_EC2_API_V1,
       kind = "security-group",
@@ -150,8 +150,8 @@ internal class SecurityGroupNetworkResolverTests : NetworkResolverTests<Security
           stack = "test"
         ),
         locations = SimpleLocations(
-          accountName = "test",
-          vpcName = vpcName,
+          account = "test",
+          vpc = vpc,
           regions = setOf(
             SimpleRegionSpec(
               name = "us-west-2"
@@ -166,7 +166,7 @@ internal class SecurityGroupNetworkResolverTests : NetworkResolverTests<Security
 internal class ClusterNetworkResolverTests : SubnetAwareNetworkResolverTests<ClusterSpec>() {
   override fun createSubject(): NetworkResolver<ClusterSpec> = ClusterNetworkResolver()
 
-  override fun createResource(vpcName: String?, subnetPurpose: String?): Resource<ClusterSpec> =
+  override fun createResource(vpc: String?, subnetPurpose: String?): Resource<ClusterSpec> =
     resource(
       apiVersion = SPINNAKER_EC2_API_V1,
       kind = "cluster",
@@ -177,8 +177,8 @@ internal class ClusterNetworkResolverTests : SubnetAwareNetworkResolverTests<Clu
         ),
         imageProvider = ArtifactImageProvider(DeliveryArtifact("fnord", DEB)),
         locations = SubnetAwareLocations(
-          accountName = "test",
-          vpcName = vpcName,
+          account = "test",
+          vpc = vpc,
           subnet = subnetPurpose,
           regions = setOf(
             SubnetAwareRegionSpec(
@@ -230,7 +230,7 @@ internal class ClusterNetworkResolverTests : SubnetAwareNetworkResolverTests<Clu
 internal class ClassicLoadBalancerNetworkResolverTests : SubnetAwareNetworkResolverTests<ClassicLoadBalancerSpec>() {
   override fun createSubject(): NetworkResolver<ClassicLoadBalancerSpec> = ClassicLoadBalancerNetworkResolver()
 
-  override fun createResource(vpcName: String?, subnetPurpose: String?): Resource<ClassicLoadBalancerSpec> = resource(
+  override fun createResource(vpc: String?, subnetPurpose: String?): Resource<ClassicLoadBalancerSpec> = resource(
     apiVersion = SPINNAKER_EC2_API_V1,
     kind = "classic-load-balancer",
     spec = ClassicLoadBalancerSpec(
@@ -239,8 +239,8 @@ internal class ClassicLoadBalancerNetworkResolverTests : SubnetAwareNetworkResol
         stack = "test"
       ),
       locations = SubnetAwareLocations(
-        accountName = "test",
-        vpcName = vpcName,
+        account = "test",
+        vpc = vpc,
         subnet = subnetPurpose,
         regions = setOf(
           SubnetAwareRegionSpec(
@@ -258,7 +258,7 @@ internal class ClassicLoadBalancerNetworkResolverTests : SubnetAwareNetworkResol
 internal class ApplicationLoadBalancerNetworkResolverTests : SubnetAwareNetworkResolverTests<ApplicationLoadBalancerSpec>() {
   override fun createSubject(): NetworkResolver<ApplicationLoadBalancerSpec> = ApplicationLoadBalancerNetworkResolver()
 
-  override fun createResource(vpcName: String?, subnetPurpose: String?): Resource<ApplicationLoadBalancerSpec> = resource(
+  override fun createResource(vpc: String?, subnetPurpose: String?): Resource<ApplicationLoadBalancerSpec> = resource(
     apiVersion = SPINNAKER_EC2_API_V1,
     kind = "application-load-balancer",
     spec = ApplicationLoadBalancerSpec(
@@ -267,8 +267,8 @@ internal class ApplicationLoadBalancerNetworkResolverTests : SubnetAwareNetworkR
         stack = "test"
       ),
       locations = SubnetAwareLocations(
-        accountName = "test",
-        vpcName = vpcName,
+        account = "test",
+        vpc = vpc,
         subnet = subnetPurpose,
         regions = setOf(
           SubnetAwareRegionSpec(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerSpecHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerSpecHandlerTests.kt
@@ -61,8 +61,8 @@ internal class ApplicationLoadBalancerSpecHandlerTests : JUnit5Minutests {
     |  stack: managedogge
     |  detail: wow
     |locations:
-    |  accountName: test
-    |  vpcName: vpc0
+    |  account: test
+    |  vpc: vpc0
     |  subnet: internal (vpc0)
     |  regions:
     |  - name: us-east-1

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -71,8 +71,8 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
     |  stack: managedogge
     |  detail: wow
     |locations:
-    |  accountName: test
-    |  vpcName: vpc0
+    |  account: test
+    |  vpc: vpc0
     |  subnet: internal (vpc0)
     |  regions:
     |  - name: us-east-1

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -95,8 +95,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val spec = ClusterSpec(
     moniker = Moniker(app = "keel", stack = "test"),
     locations = SubnetAwareLocations(
-      accountName = vpcWest.account,
-      vpcName = "vpc0",
+      account = vpcWest.account,
+      vpc = "vpc0",
       subnet = subnet1West.purpose!!,
       regions = listOf(vpcWest, vpcEast).map { subnet ->
         SubnetAwareRegionSpec(
@@ -178,7 +178,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         capacity.let { ServerGroupCapacity(it.min, it.max, it.desired) },
         CLOUD_PROVIDER,
         securityGroups.map(SecurityGroupSummary::id).toSet(),
-        location.accountName,
+        location.account,
         parseMoniker("$name-v$sequence")
       )
     }
@@ -415,7 +415,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   private suspend fun CloudDriverService.activeServerGroup(region: String) = activeServerGroup(
     serviceAccount = "keel@spinnaker",
     app = spec.moniker.app,
-    account = spec.locations.accountName,
+    account = spec.locations.account,
     cluster = spec.moniker.name,
     region = region,
     cloudProvider = CLOUD_PROVIDER

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -117,8 +117,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           stack = "fnord"
         ),
         locations = SimpleLocations(
-          accountName = vpcRegion1.account,
-          vpcName = vpcRegion1.name!!,
+          account = vpcRegion1.account,
+          vpc = vpcRegion1.name!!,
           regions = setOf(SimpleRegionSpec(vpcRegion1.region), SimpleRegionSpec(vpcRegion2.region))
         ),
         description = "dummy security group"
@@ -130,8 +130,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           stack = "fnord"
         ),
         location = SecurityGroup.Location(
-          accountName = vpcRegion1.account,
-          vpcName = vpcRegion1.name!!,
+          account = vpcRegion1.account,
+          vpc = vpcRegion1.name!!,
           region = "placeholder"
         ),
         description = "dummy security group"
@@ -140,15 +140,15 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
       mapOf(
         "us-west-3" to securityGroupBase.copy(
           location = SecurityGroup.Location(
-            accountName = securityGroupBase.location.accountName,
-            vpcName = securityGroupBase.location.vpcName,
+            account = securityGroupBase.location.account,
+            vpc = securityGroupBase.location.vpc,
             region = "us-west-3"
           )
         ),
         "us-east-17" to securityGroupBase.copy(
           location = SecurityGroup.Location(
-            accountName = securityGroupBase.location.accountName,
-            vpcName = securityGroupBase.location.vpcName,
+            account = securityGroupBase.location.account,
+            vpc = securityGroupBase.location.vpc,
             region = "us-east-17"
           )
         )
@@ -200,8 +200,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           stack = "fnord"
         ),
         locations = SimpleLocations(
-          accountName = vpcRegion1.account,
-          vpcName = vpcRegion1.name!!,
+          account = vpcRegion1.account,
+          vpc = vpcRegion1.name!!,
           regions = setOf(SimpleRegionSpec(vpcRegion1.region), SimpleRegionSpec(vpcRegion2.region))
         ),
         description = "dummy security group"
@@ -213,8 +213,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           stack = "fnord"
         ),
         location = SecurityGroup.Location(
-          accountName = vpcRegion1.account,
-          vpcName = vpcRegion1.name!!,
+          account = vpcRegion1.account,
+          vpc = vpcRegion1.name!!,
           region = "placeholder"
         ),
         description = "dummy security group"
@@ -223,15 +223,15 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
       mapOf(
         "us-west-3" to securityGroupBase.copy(
           location = SecurityGroup.Location(
-            accountName = securityGroupBase.location.accountName,
-            vpcName = securityGroupBase.location.vpcName,
+            account = securityGroupBase.location.account,
+            vpc = securityGroupBase.location.vpc,
             region = "us-west-3"
           )
         ),
         "us-east-17" to securityGroupBase.copy(
           location = SecurityGroup.Location(
-            accountName = securityGroupBase.location.accountName,
-            vpcName = securityGroupBase.location.vpcName,
+            account = securityGroupBase.location.account,
+            vpc = securityGroupBase.location.vpc,
             region = "us-east-17"
           )
         )
@@ -398,7 +398,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
                     protocol = TCP,
                     account = "test",
                     name = "otherapp",
-                    vpcName = "vpc1",
+                    vpc = "vpc1",
                     portRange = PortRange(startPort = 443, endPort = 443)
                   )
                 )
@@ -640,7 +640,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
                 protocol = TCP,
                 account = "test",
                 name = "otherapp",
-                vpcName = "vpc1",
+                vpc = "vpc1",
                 portRange = PortRange(startPort = 443, endPort = 443)
               )
             )
@@ -659,8 +659,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
             .copy(
               spec = resource.spec.copy(
                 locations = SimpleLocations(
-                  accountName = securityGroupSpec.locations.accountName,
-                  vpcName = securityGroupSpec.locations.vpcName,
+                  account = securityGroupSpec.locations.account,
+                  vpc = securityGroupSpec.locations.vpc,
                   regions = setOf(SimpleRegionSpec("us-east-17"))
                 )
               )

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -53,8 +53,8 @@ fun locatableResource(
   id: String = randomString(),
   application: String = "fnord",
   locations: SimpleLocations = SimpleLocations(
-    accountName = "test",
-    vpcName = "vpc0",
+    account = "test",
+    vpc = "vpc0",
     regions = setOf(SimpleRegionSpec("us-west-1"))
   )
 ): Resource<DummyLocatableResourceSpec> =
@@ -124,8 +124,8 @@ data class DummyLocatableResourceSpec(
   val data: String = randomString(),
   override val application: String = "fnord",
   override val locations: SimpleLocations = SimpleLocations(
-    accountName = "test",
-    vpcName = "vpc0",
+    account = "test",
+    vpc = "vpc0",
     regions = setOf(SimpleRegionSpec("us-west-1"))
   )
 ) : ResourceSpec, Locatable<SimpleLocations>


### PR DESCRIPTION
Following on from #511 this simplifies configuration a little and makes naming more consistent.