### PR TITLE
feat(artifact): pull version on demand if none found

### DIFF
--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -159,6 +159,12 @@ internal class ImageHandlerTests : JUnit5Minutests {
         before {
           val artifact = DeliveryArtifact("keel", DEB)
           artifactRepository.register(artifact)
+          every {
+            baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
+          } returns "xenialbase-x86_64-201904291721-ebs"
+          coEvery {
+            igorService.getVersions("keel", any())
+          } returns listOf()
         }
 
         test("an exception is thrown") {
@@ -171,6 +177,12 @@ internal class ImageHandlerTests : JUnit5Minutests {
           val artifact = DeliveryArtifact("keel", DEB)
           artifactRepository.register(artifact)
           artifactRepository.store(artifact, image.appVersion, FINAL)
+          every {
+            baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
+          } returns "xenialbase-x86_64-201904291721-ebs"
+          coEvery {
+            igorService.getVersions("keel", any())
+          } returns listOf()
         }
 
         test("an exception is thrown") {


### PR DESCRIPTION
Right now if you try and calculate the desired state for an image it'll fail if the artifact isn't registered. Sure, we register the artifact for you, but that only takes affect the next time.

This PR changes the behavior slightly so that if the artifact isn't registered or it is but we don't have any versions for it we fetch the versions from igor. If we still can't find a version we throw an exception. 

This makes it possible to create an ad-hoc diff for images and clusters.