### PR TITLE
require vpc on locations but default to vpc0

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -30,22 +30,27 @@ interface Locations<T : RegionSpec> {
    * If not specified here, this should be derived from the [SubnetAwareLocations.subnet] (if
    * present) or use a default VPC name.
    */
-  val vpc: String?
+  val vpc: String
   val regions: Set<T>
 }
 
 data class SubnetAwareLocations(
   override val account: String,
-  override val vpc: String?,
   /**
    * If not specified here, this should be derived from a default subnet purpose using [vpc].
    */
   val subnet: String?,
+  // TODO: this is not ideal as we'd like this default to be configurable
+  override val vpc: String = defaultVPC(subnet),
   override val regions: Set<SubnetAwareRegionSpec>
 ) : Locations<SubnetAwareRegionSpec>
 
 data class SimpleLocations(
   override val account: String,
-  override val vpc: String?,
+  // TODO: this is not ideal as we'd like this default to be configurable
+  override val vpc: String = "vpc0",
   override val regions: Set<SimpleRegionSpec>
 ) : Locations<SimpleRegionSpec>
+
+fun defaultVPC(subnet: String?) =
+  subnet?.let { Regex("""^.+\((.+)\)$""").find(it)?.groupValues?.get(1) } ?: "vpc0"

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -21,7 +21,7 @@ fun ClusterSpec.resolve(): Set<ServerGroup> =
       location = Location(
         account = locations.account,
         region = it.name,
-        vpc = locations.vpc ?: error("No VPC name supplied or resolved"),
+        vpc = locations.vpc,
         subnet = locations.subnet ?: error("No subnet purpose supplied or resolved"),
         availabilityZones = it.availabilityZones
       ),

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
@@ -3,30 +3,24 @@ package com.netflix.spinnaker.keel.ec2.resolvers
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.plugin.Resolver
 import org.springframework.stereotype.Component
 
-abstract class NetworkResolver<T : Locatable<*>>(
+abstract class NetworkResolver<T : Locatable<SubnetAwareLocations>>(
   private val cloudDriverCache: CloudDriverCache
 ) : Resolver<T> {
 
   protected fun SubnetAwareLocations.withResolvedNetwork(): SubnetAwareLocations {
-    val resolvedVpcName: String =
-      vpc
-        ?: subnet?.let { Regex("""^.+\((.+)\)$""").find(it)?.groupValues?.get(1) }
-        ?: DEFAULT_VPC_NAME
-    val resolvedSubnet = subnet ?: DEFAULT_SUBNET_PURPOSE.format(resolvedVpcName)
+    val resolvedSubnet = subnet ?: DEFAULT_SUBNET_PURPOSE.format(vpc)
     return copy(
-      vpc = resolvedVpcName,
+      vpc = vpc,
       subnet = resolvedSubnet,
       regions = regions.map { region ->
         if (region.availabilityZones.isEmpty()) {
@@ -44,30 +38,10 @@ abstract class NetworkResolver<T : Locatable<*>>(
     )
   }
 
-  protected fun SimpleLocations.withResolvedNetwork(): SimpleLocations =
-    copy(vpc = vpc ?: DEFAULT_VPC_NAME)
-
   companion object {
     const val DEFAULT_VPC_NAME = "vpc0"
     const val DEFAULT_SUBNET_PURPOSE = "internal (%s)"
   }
-}
-
-@Component
-class SecurityGroupNetworkResolver(cloudDriverCache: CloudDriverCache) : NetworkResolver<SecurityGroupSpec>(cloudDriverCache) {
-  override val apiVersion: ApiVersion = SPINNAKER_EC2_API_V1
-  override val supportedKind: String = "security-group"
-
-  override fun invoke(resource: Resource<SecurityGroupSpec>): Resource<SecurityGroupSpec> =
-    resource.run {
-      copy(
-        spec = spec.run {
-          copy(
-            locations = locations.withResolvedNetwork()
-          )
-        }
-      )
-    }
 }
 
 @Component

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -51,11 +51,11 @@ class ApplicationLoadBalancerHandler(
         ApplicationLoadBalancer(
           moniker,
           Location(
-            locations.account,
-            it.name,
-            locations.vpc ?: error("No VPC name supplied or resolved"),
-            locations.subnet ?: error("No subnet purpose supplied or resolved"),
-            it.availabilityZones
+            account = locations.account,
+            region = it.name,
+            vpc = locations.vpc,
+            subnet = locations.subnet ?: error("No subnet purpose supplied or resolved"),
+            availabilityZones = it.availabilityZones
           ),
           internal,
           dependencies,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -53,11 +53,11 @@ class ClassicLoadBalancerHandler(
         ClassicLoadBalancer(
           moniker,
           Location(
-            locations.account,
-            it.name,
-            locations.vpc ?: error("No VPC name supplied or resolved"),
-            locations.subnet ?: error("No subnet purpose supplied or resolved"),
-            it.availabilityZones
+            account = locations.account,
+            region = it.name,
+            vpc = locations.vpc,
+            subnet = locations.subnet ?: error("No subnet purpose supplied or resolved"),
+            availabilityZones = it.availabilityZones
           ),
           internal,
           dependencies,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -78,7 +78,7 @@ class SecurityGroupHandler(
           moniker = Moniker(app = moniker.app, stack = moniker.stack, detail = moniker.detail),
           location = SecurityGroup.Location(
             account = locations.account,
-            vpc = locations.vpc ?: error("No VPC name supplied or resolved"),
+            vpc = locations.vpc,
             region = region.name
           ),
           description = overrides[region.name]?.description ?: description,


### PR DESCRIPTION
This fixes the situation where we can't resolve current state of a security group because its `vpc` property is `null`. We need to map `vpc` to a VPC id so we can send that to CloudDriver to fetch the current state. We don't currently apply resolvers to the spec passed to `ResourceHandler.desired` so the property can be `null` if the spec relies on the default applied by `NetworkResolver`. This is an interim fix until we figure out the proper approach.