### PR TITLE
feat(titus): initial support of ad-hoc titus diffing

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
@@ -52,12 +52,10 @@ class AdHocDiffer(
         val (desired, current) = plugin.resolve(resource)
         val diff = ResourceDiff(desired, current)
 
-        if (current == null) {
-          DiffResult(status = MISSING, resourceId = resourceId, resource = resource)
-        } else if (diff.hasChanges()) {
-          DiffResult(status = DIFF, diff = diff.toDeltaJson(), resourceId = resourceId, resource = resource)
-        } else {
-          DiffResult(status = NO_DIFF, resourceId = resourceId, resource = resource)
+        when {
+          current == null -> DiffResult(status = MISSING, resourceId = resourceId, resource = resource)
+          diff.hasChanges() -> DiffResult(status = DIFF, diff = diff.toDeltaJson(), resourceId = resourceId, resource = resource)
+          else -> DiffResult(status = NO_DIFF, resourceId = resourceId, resource = resource)
         }
       } catch (e: Exception) {
         DiffResult(status = ERROR, errorMsg = e.message, resourceId = resourceId, resource = resource)

--- a/keel-api/keel-api.gradle.kts
+++ b/keel-api/keel-api.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation(project(":keel-bakery-plugin"))
   implementation(project(":keel-ec2-plugin"))
   implementation(project(":keel-tagging-plugin"))
+  implementation(project(":keel-titus-plugin"))
 
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("com.netflix.spinnaker.kork:kork-core")

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/Main.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/Main.kt
@@ -81,6 +81,7 @@ class KeelApplication {
   @Autowired
   lateinit var objectMappers: List<ObjectMapper>
 
+  // todo eb: https://github.com/spinnaker/keel/issues/527
   @PostConstruct
   fun registerResourceSpecSubtypes() {
     plugins

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterSpec
 import com.netflix.spinnaker.keel.bakery.api.ImageSpec
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import dev.minutest.junit.JUnit5Minutests
@@ -87,6 +88,17 @@ class ConvertExampleFilesTest : JUnit5Minutests {
       test("yml can be parsed") {
         expectCatching {
           mapper.readValue<SubmittedResource<ApplicationLoadBalancerSpec>>(file)
+        }.succeeded()
+      }
+    }
+
+    context("titus cluster") {
+      mapper.registerSubtypes(NamedType(TitusClusterSpec::class.java, "titus-cluster"))
+      val file = this.javaClass.getResource("/examples/titus-cluster-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<TitusClusterSpec>>(file)
         }.succeeded()
       }
     }

--- a/keel-api/src/test/resources/examples/titus-cluster-example.yml
+++ b/keel-api/src/test/resources/examples/titus-cluster-example.yml
@@ -1,0 +1,51 @@
+---
+apiVersion: titus.spinnaker.netflix.com/v1
+kind: titus-cluster
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  moniker:
+    app: keeldemo
+    stack: examples
+    detail: ec2v1
+  container:
+    registry: testregistry
+    organization: emburns
+    image: emburns/spin-titus-demo
+    digest: ""
+    tag: latest
+  locations:
+    account: titustestvpc
+    regions:
+      - name: us-west-2
+      - name: us-east-1
+  containerOptions:
+    entrypoint: ''
+    resources:
+      cpu: 1
+      memory: 5000
+      disk: 10000
+      networkMbps: 128
+      gpu: 0
+    env:
+      what: hi
+    constraints:
+      hard: {}
+      soft:
+        ZoneBalance: true
+    iamProfile: emburnstestInstanceProfile
+    capacityGroup: emburnstest
+    migrationPolicy:
+      type: systemDefault
+  capacity:
+    min: 1
+    max: 1
+    desired: 1
+  overrides: {}
+  dependencies:
+    loadBalancerNames: []
+    securityGroupNames:
+      - keeldemo
+      - nf-datacenter
+      - nf-infrastructure
+    targetGroups: []

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -15,15 +15,16 @@
  */
 package com.netflix.spinnaker.keel.clouddriver
 
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ApplicationLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.ClassicLoadBalancerModel
-import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
+import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.tags.EntityTags
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -108,6 +109,18 @@ interface CloudDriverService {
     @Path("region") region: String,
     @Path("cloudProvider") cloudProvider: String
   ): ActiveServerGroup
+
+  // todo eb: titus has different fields than [ActiveServerGroup], so right now this is a separate call
+  // make above call general and roll titus into it.
+  @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{region}/serverGroups/target/current_asg_dynamic?onlyEnabled=true")
+  suspend fun titusActiveServerGroup(
+    @Header("X-SPINNAKER-USER") serviceAccount: String,
+    @Path("app") app: String,
+    @Path("account") account: String,
+    @Path("cluster") cluster: String,
+    @Path("region") region: String,
+    @Path("cloudProvider") cloudProvider: String = "titus"
+  ): TitusActiveServerGroup
 
   @GET("/aws/images/find")
   suspend fun namedImages(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -1,8 +1,10 @@
 package com.netflix.spinnaker.keel.clouddriver.model
 
 import com.fasterxml.jackson.annotation.JsonCreator
+import com.netflix.spinnaker.keel.api.Capacity
 import com.netflix.spinnaker.keel.model.Moniker
 
+// todo eb: this should be more general so that it works for all server groups, not just ec2
 data class ActiveServerGroup(
   val name: String,
   val region: String,
@@ -13,7 +15,7 @@ data class ActiveServerGroup(
   val vpcId: String,
   val targetGroups: Set<String>,
   val loadBalancers: Set<String>,
-  val capacity: ServerGroupCapacity,
+  val capacity: Capacity,
   val cloudProvider: String,
   val securityGroups: Set<String>,
   val accountName: String,
@@ -72,12 +74,6 @@ data class SuspendedProcess(
 data class Tag(
   val key: String,
   val value: String
-)
-
-data class ServerGroupCapacity(
-  val min: Int,
-  val max: Int,
-  val desired: Int
 )
 
 data class InstanceMonitoring(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
@@ -1,0 +1,80 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.clouddriver.model
+
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.model.Moniker
+
+data class TitusActiveServerGroup(
+  val name: String,
+  val awsAccount: String,
+  val placement: Placement,
+  val region: String,
+  val image: TitusActiveServerGroupImage,
+  val iamProfile: String,
+  val entryPoint: String,
+  val targetGroups: Set<String>,
+  val loadBalancers: Set<String>,
+  val securityGroups: Set<String>,
+  val capacity: Capacity,
+  val cloudProvider: String,
+  val moniker: Moniker,
+  val env: Map<String, String>,
+  val labels: Map<String, String>,
+  val containerAttributes: Map<String, String> = emptyMap(),
+  val migrationPolicy: MigrationPolicy,
+  val serviceJobProcesses: ServiceJobProcesses,
+  val constraints: Constraints,
+  val tags: Map<String, String>,
+  val resources: Resources,
+  val capacityGroup: String
+)
+
+data class Placement(
+  val account: String,
+  val region: String,
+  val zones: List<String> = emptyList()
+)
+
+data class MigrationPolicy(
+  val type: String = "systemDefault"
+)
+
+data class TitusActiveServerGroupImage(
+  val dockerImageName: String,
+  val dockerImageVersion: String,
+  val dockerImageDigest: String
+)
+
+data class Resources(
+  val cpu: Int = 1,
+  val disk: Int = 10000,
+  val gpu: Int = 0,
+  val memory: Int = 512,
+  val networkMbps: Int = 128
+)
+
+data class Constraints(
+  val hard: Map<String, Any> = emptyMap(),
+  val soft: Map<String, Any> = mapOf("ZoneBalance" to "true")
+)
+
+data class ServiceJobProcesses(
+  val disableIncreaseDesired: Boolean = false,
+  val disableDecreaseDesired: Boolean = false
+)

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.clouddriver.model
 
+import com.netflix.spinnaker.keel.api.Capacity
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.retrofit.model.ModelParsingTestSupport
@@ -385,7 +386,7 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
     ),
     vpcId = vpc,
     loadBalancers = emptySet(),
-    capacity = ServerGroupCapacity(1, 1, 1),
+    capacity = Capacity(1, 1, 1),
     securityGroups = securityGroups.values.toSet(),
     moniker = Moniker(
       app = app,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Capacity.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Capacity.kt
@@ -1,0 +1,24 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api
+
+data class Capacity(
+  val min: Int,
+  val max: Int,
+  val desired: Int
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDependencies.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDependencies.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-package com.netflix.spinnaker.keel.api.ec2
+package com.netflix.spinnaker.keel.api
 
 data class ClusterDependencies(
   val loadBalancerNames: Set<String> = emptySet(),

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Capacity.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Capacity.kt
@@ -1,7 +1,0 @@
-package com.netflix.spinnaker.keel.api.ec2
-
-data class Capacity(
-  val min: Int,
-  val max: Int,
-  val desired: Int
-)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -3,12 +3,14 @@ package com.netflix.spinnaker.keel.api.ec2
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.MultiRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
-import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.model.Moniker
 import java.time.Duration
 
 /**

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -1,12 +1,12 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.Health
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfiguration
@@ -34,8 +34,8 @@ import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.OrchestrationTrigger
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.Resolver
+import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
@@ -2,15 +2,17 @@ package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.HealthSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.VirtualMachineImage
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType.ELB
 import com.netflix.spinnaker.keel.model.Moniker
-import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import dev.minutest.junit.JUnit5Minutests

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.keel.ec2.resolvers
 
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.RegionSpec
@@ -9,10 +11,8 @@ import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
-import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerHealthCheck
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
-import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.HealthSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -2,14 +2,15 @@ package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
-import com.netflix.spinnaker.keel.api.ec2.Capacity
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.VirtualMachineImage
-import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType
 import com.netflix.spinnaker.keel.api.ec2.Metric
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup
@@ -26,7 +27,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
 import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
-import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCapacity
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.clouddriver.model.SuspendedProcess
 import com.netflix.spinnaker.keel.clouddriver.model.Tag
@@ -36,7 +36,6 @@ import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.ec2.image.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
-import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
@@ -175,7 +174,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         vpc.id,
         dependencies.targetGroups,
         dependencies.loadBalancerNames,
-        capacity.let { ServerGroupCapacity(it.min, it.max, it.desired) },
+        capacity.let { Capacity(it.min, it.max, it.desired) },
         CLOUD_PROVIDER,
         securityGroups.map(SecurityGroupSummary::id).toSet(),
         location.account,

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+  `java-library`
+  id("kotlin-spring")
+}
+
+dependencies {
+  api(project(":keel-plugin"))
+  implementation(project(":keel-clouddriver"))
+  implementation(project(":keel-orca"))
+  implementation(project(":keel-retrofit"))
+  implementation("com.netflix.spinnaker.kork:kork-core")
+  implementation("com.netflix.spinnaker.kork:kork-web")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+  implementation("org.springframework:spring-context")
+  implementation("org.springframework.boot:spring-boot-autoconfigure")
+  implementation("com.netflix.frigga:frigga")
+
+  testImplementation(project(":keel-test"))
+  testImplementation("io.strikt:strikt-jackson")
+  testImplementation("dev.minutest:minutest")
+  testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
+  testImplementation("org.funktionale:funktionale-partials")
+  testImplementation("org.apache.commons:commons-lang3")
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.plugin.Resolver
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+@ConditionalOnProperty("keel.plugins.titus.enabled")
+class TitusConfig {
+  @Bean
+  fun titusClusterHandler(
+    cloudDriverService: CloudDriverService,
+    cloudDriverCache: CloudDriverCache,
+    orcaService: OrcaService,
+    clock: Clock,
+    publisher: ApplicationEventPublisher,
+    objectMapper: ObjectMapper,
+    resolvers: List<Resolver<*>>
+  ): TitusClusterHandler = TitusClusterHandler(
+    cloudDriverService,
+    cloudDriverCache,
+    orcaService,
+    clock,
+    publisher,
+    objectMapper,
+    resolvers
+  )
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -1,0 +1,144 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.cluster
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.ClusterDependencies
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.serviceAccount
+import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.plugin.Resolver
+import com.netflix.spinnaker.keel.plugin.ResourceHandler
+import com.netflix.spinnaker.keel.retrofit.isNotFound
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import org.springframework.context.ApplicationEventPublisher
+import retrofit2.HttpException
+import java.time.Clock
+
+class TitusClusterHandler(
+  private val cloudDriverService: CloudDriverService,
+  private val cloudDriverCache: CloudDriverCache,
+  private val orcaService: OrcaService,
+  private val clock: Clock,
+  private val publisher: ApplicationEventPublisher,
+  objectMapper: ObjectMapper,
+  resolvers: List<Resolver<*>>
+) : ResourceHandler<TitusClusterSpec, Map<String, TitusServerGroup>>(objectMapper, resolvers) {
+
+  override val apiVersion = SPINNAKER_TITUS_API_V1
+  override val supportedKind = ResourceKind(
+    group = apiVersion.group,
+    singular = "titus-cluster",
+    plural = "titus-clusters"
+  ) to TitusClusterSpec::class.java
+
+  override suspend fun toResolvedType(resource: Resource<TitusClusterSpec>): Map<String, TitusServerGroup> =
+    with(resource.spec) {
+      resolve().byRegion()
+    }
+
+  override suspend fun current(resource: Resource<TitusClusterSpec>): Map<String, TitusServerGroup>? =
+    cloudDriverService
+      .getServerGroups(resource)
+      .byRegion()
+
+  override suspend fun actuationInProgress(id: ResourceId) =
+    orcaService
+      .getCorrelatedExecutions(id.value)
+      .isNotEmpty()
+
+  private suspend fun CloudDriverService.getServerGroups(resource: Resource<TitusClusterSpec>): Iterable<TitusServerGroup> =
+    coroutineScope {
+      resource.spec.locations.regions.map {
+        async {
+          try {
+            titusActiveServerGroup(
+              resource.serviceAccount,
+              resource.spec.moniker.app,
+              resource.spec.locations.account,
+              resource.spec.moniker.name,
+              it.name,
+              CLOUD_PROVIDER
+            )
+              .toTitusServerGroup()
+          } catch (e: HttpException) {
+            if (!e.isNotFound) {
+              throw e
+            }
+            null
+          }
+        }
+      }
+        .mapNotNull { it.await() }
+      // todo eb: how can we tell what version is deployed here?
+      // todo: emit an event for the version that's deployed
+    }
+
+  private fun TitusActiveServerGroup.toTitusServerGroup() =
+    TitusServerGroup(
+      name = name,
+      location = Location(
+        account = placement.account,
+        region = region
+      ),
+      capacity = capacity,
+      container = Container(
+        image = image.dockerImageName,
+        digest = image.dockerImageDigest,
+        tag = ""
+      ),
+      containerOptions = ContainerOptions(
+        entryPoint = entryPoint,
+        resources = resources,
+        env = env,
+        constraints = constraints,
+        iamProfile = iamProfile,
+        capacityGroup = capacityGroup,
+        migrationPolicy = migrationPolicy
+      ),
+      dependencies = ClusterDependencies(
+        loadBalancers,
+        securityGroupNames = securityGroupNames,
+        targetGroups = targetGroups
+      )
+    )
+
+  private val TitusServerGroup.securityGroupIds: Collection<String>
+    get() = dependencies
+      .securityGroupNames
+      // no need to specify these as Orca will auto-assign them, also the application security group
+      // gets auto-created so may not exist yet
+      .filter { it !in setOf("nf-infrastructure", "nf-datacenter", moniker.app) }
+      .map {
+        cloudDriverCache.securityGroupByName(location.account, location.region, it).id
+      }
+
+  private val TitusActiveServerGroup.securityGroupNames: Set<String>
+    get() = securityGroups.map {
+      cloudDriverCache.securityGroupById(awsAccount, region, it).name
+    }
+      .toSet()
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -1,0 +1,181 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.cluster
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.MultiRegion
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.clouddriver.model.Constraints
+import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
+import com.netflix.spinnaker.keel.clouddriver.model.Resources
+import com.netflix.spinnaker.keel.model.Moniker
+
+/**
+ * "Simplified" representation of
+ * https://github.com/Netflix/titus-api-definitions/blob/master/src/main/proto/netflix/titus/titus_job_api.proto
+ */
+data class TitusClusterSpec(
+  override val moniker: Moniker,
+  override val locations: SimpleLocations,
+  val container: ContainerSpec,
+  private val _defaults: TitusServerGroupSpec,
+  val overrides: Map<String, TitusServerGroupSpec> = emptyMap()
+) : MultiRegion, Locatable<SimpleLocations> {
+
+  @JsonIgnore
+  override val id = "${locations.account}:${moniker.name}"
+
+  override val regionalIds = locations.regions.map { clusterRegion ->
+    "${locations.account}:${clusterRegion.name}:${moniker.name}"
+  }.sorted()
+
+  val defaults: TitusServerGroupSpec
+    @JsonUnwrapped get() = _defaults
+
+  @JsonCreator
+  constructor(
+    moniker: Moniker,
+    locations: SimpleLocations,
+    container: ContainerSpec,
+    capacity: Capacity?,
+    constraints: Constraints?,
+    containerOptions: ContainerOptions?,
+    dependencies: ClusterDependencies?,
+    tags: Map<String, String>?,
+    overrides: Map<String, TitusServerGroupSpec> = emptyMap()
+  ) : this(
+    moniker,
+    locations,
+    container,
+    TitusServerGroupSpec(
+      capacity,
+      constraints,
+      containerOptions,
+      dependencies,
+      container,
+      tags
+    ),
+    overrides
+  )
+}
+
+data class Container(
+  val image: String,
+  val digest: String,
+  val tag: String
+)
+
+data class ContainerSpec(
+  val organization: String,
+  val registry: String,
+  val image: String,
+  val digest: String,
+  val tag: String
+)
+
+data class ContainerOptions(
+  val iamProfile: String,
+  val entryPoint: String = "",
+  val resources: Resources = Resources(),
+  val env: Map<String, String> = emptyMap(),
+  val constraints: Constraints = Constraints(),
+  val capacityGroup: String,
+  val migrationPolicy: MigrationPolicy = MigrationPolicy()
+)
+
+data class TitusServerGroupSpec(
+  val capacity: Capacity? = null,
+  val constraints: Constraints? = null,
+  val containerOptions: ContainerOptions? = null,
+  val dependencies: ClusterDependencies? = null,
+  val container: ContainerSpec? = null,
+  val tags: Map<String, String>? = null,
+  val deferredInitialization: Boolean? = null,
+  val delayBeforeDisableSec: Int? = null,
+  val delayBeforeScaleDownSec: Int? = null
+)
+
+private fun TitusClusterSpec.resolveCapacity(region: String) =
+  overrides[region]?.capacity ?: defaults.capacity ?: Capacity(1, 1, 1)
+
+private fun TitusClusterSpec.resolveContainer(region: String): Container =
+  checkNotNull(overrides[region]?.container?.toContainer() ?: defaults.container?.toContainer()) {
+    "No docker container supplied for $region"
+  }
+
+private fun TitusClusterSpec.resolveContainerOptions(region: String, application: String): ContainerOptions =
+  overrides[region]?.containerOptions ?: defaults.containerOptions ?: ContainerOptions(
+    iamProfile = "${application}InstanceProfile",
+    capacityGroup = application
+  )
+
+private fun TitusClusterSpec.resolveDependencies(region: String): ClusterDependencies =
+  ClusterDependencies(
+    loadBalancerNames = defaults.dependencies?.loadBalancerNames + overrides[region]?.dependencies?.loadBalancerNames,
+    securityGroupNames = defaults.dependencies?.securityGroupNames + overrides[region]?.dependencies?.securityGroupNames,
+    targetGroups = defaults.dependencies?.targetGroups + overrides[region]?.dependencies?.targetGroups
+  )
+
+private fun ContainerSpec.toContainer() =
+  Container(
+    image = image,
+    digest = digest,
+    tag = tag
+  )
+
+fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
+  locations.regions.map {
+    TitusServerGroup(
+      name = moniker.name,
+      location = Location(
+        account = locations.account,
+        region = it.name
+      ),
+      capacity = resolveCapacity(it.name),
+      container = resolveContainer(it.name),
+      containerOptions = resolveContainerOptions(it.name, moniker.app),
+      dependencies = resolveDependencies(it.name),
+      tags = defaults.tags + overrides[it.name]?.tags
+    )
+  }
+    .toSet()
+
+private operator fun <E> Set<E>?.plus(elements: Set<E>?): Set<E> =
+  when {
+    this == null || isEmpty() -> elements ?: emptySet()
+    elements == null || elements.isEmpty() -> this
+    else -> mutableSetOf<E>().also {
+      it.addAll(this)
+      it.addAll(elements)
+    }
+  }
+
+private operator fun <K, V> Map<K, V>?.plus(map: Map<K, V>?): Map<K, V> =
+  when {
+    this == null || isEmpty() -> map ?: emptyMap()
+    map == null || map.isEmpty() -> this
+    else -> mutableMapOf<K, V>().also {
+      it.putAll(this)
+      it.putAll(map)
+    }
+  }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/titus.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/titus.kt
@@ -1,0 +1,23 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus
+
+import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+
+val SPINNAKER_TITUS_API_V1 = SPINNAKER_API_V1.subApi("titus")
+const val CLOUD_PROVIDER = "titus"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -36,6 +36,7 @@ include(
   "keel-sql",
   "keel-tagging-plugin",
   "keel-test",
+  "keel-titus-plugin",
   "keel-veto"
 )
 


### PR DESCRIPTION
An initial stab at titus support. Ad-hoc diffing support allows us to prove out the model. I'm opening this PR for feedback on the yaml representation, as well as to pull some classes up to the `keel-api` module for sharing.

This is subject to changes as I figure out what attributes I need to submit a task to orca, as well as make the common functions in `keel-clouddriver` support multiple resource types.