### PR TITLE
feat(resources/export): export for ec2 load balancers

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/RegionSpec.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/RegionSpec.kt
@@ -17,6 +17,9 @@
  */
 package com.netflix.spinnaker.keel.api
 
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
+
 interface RegionSpec {
   val name: String
 }
@@ -26,6 +29,7 @@ data class SubnetAwareRegionSpec(
   /**
    * If empty this implies the resource should use _all_ availability zones.
    */
+  @JsonInclude(NON_EMPTY)
   val availabilityZones: Set<String> = emptySet()
 ) : RegionSpec
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LoadBalancerSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LoadBalancerSpec.kt
@@ -2,10 +2,11 @@ package com.netflix.spinnaker.keel.api.ec2
 
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
+import com.netflix.spinnaker.keel.api.MultiRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import java.time.Duration
 
-interface LoadBalancerSpec : Monikered, Locatable<SubnetAwareLocations> {
+interface LoadBalancerSpec : MultiRegion, Monikered, Locatable<SubnetAwareLocations> {
   val loadBalancerType: LoadBalancerType
   override val locations: SubnetAwareLocations
   val internal: Boolean

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
@@ -16,6 +16,8 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.MultiRegion
 import com.netflix.spinnaker.keel.api.SimpleLocations
@@ -28,6 +30,7 @@ data class SecurityGroupSpec(
   override val locations: SimpleLocations,
   val description: String?,
   val inboundRules: Set<SecurityGroupRule> = emptySet(),
+  @JsonInclude(NON_EMPTY)
   val overrides: Map<String, SecurityGroupOverride> = emptyMap()
 ) : MultiRegion, Locatable<SimpleLocations> {
   @JsonIgnore


### PR DESCRIPTION
- The `type` sent to `ExportController` should be "${loadBalancerType}$type", i.e. "classicLoadBalancers" or "applicationLoadBalancers" -> `/export/aws/{account}/applicationLoadBalancers/{name}?serviceAccount=foo@spinnaker.io`