### PR TITLE
Titus actuation support

### DIFF
--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -102,5 +102,16 @@ class ConvertExampleFilesTest : JUnit5Minutests {
         }.succeeded()
       }
     }
+
+    context("simple titus cluster") {
+      mapper.registerSubtypes(NamedType(TitusClusterSpec::class.java, "titus-cluster"))
+      val file = this.javaClass.getResource("/examples/simple-titus-cluster-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<TitusClusterSpec>>(file)
+        }.succeeded()
+      }
+    }
   }
 }

--- a/keel-api/src/test/resources/examples/simple-titus-cluster-example.yml
+++ b/keel-api/src/test/resources/examples/simple-titus-cluster-example.yml
@@ -17,18 +17,6 @@ spec:
     regions:
       - name: us-west-2
       - name: us-east-1
-  runtimeOptions:
-    entrypoint: ""
-    resources:
-      cpu: 1
-      memory: 5000
-      disk: 10000
-      networkMbps: 128
-      gpu: 0
-    env:
-      myvar: myvalue
-    iamProfile: emburnstestInstanceProfile
-    capacityGroup: emburnstest
   capacity:
     min: 1
     max: 1

--- a/keel-api/src/test/resources/examples/titus-cluster-example.yml
+++ b/keel-api/src/test/resources/examples/titus-cluster-example.yml
@@ -17,18 +17,17 @@ spec:
     regions:
       - name: us-west-2
       - name: us-east-1
-  runtimeOptions:
-    entrypoint: ""
-    resources:
-      cpu: 1
-      memory: 5000
-      disk: 10000
-      networkMbps: 128
-      gpu: 0
-    env:
-      myvar: myvalue
-    iamProfile: emburnstestInstanceProfile
-    capacityGroup: emburnstest
+  entrypoint: ""
+  resources:
+    cpu: 1
+    memory: 5000
+    disk: 10000
+    networkMbps: 128
+    gpu: 0
+  env:
+    myvar: myvalue
+  iamProfile: emburnstestInstanceProfile
+  capacityGroup: emburnstest
   capacity:
     min: 1
     max: 1

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -148,4 +148,10 @@ interface CloudDriverService {
     @QueryMap allParameters: Map<String, String>,
     @Header("X-SPINNAKER-USER") serviceAccount: String = DEFAULT_SERVICE_ACCOUNT
   ): EntityTags
+
+  @GET("/credentials/{account}")
+  suspend fun getAccountInformation(
+    @Path("account") account: String,
+    @Header("X-SPINNAKER-USER") serviceAccount: String = DEFAULT_SERVICE_ACCOUNT
+  ): Map<String, Any?>
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
@@ -35,7 +35,6 @@ data class TitusActiveServerGroup(
   val cloudProvider: String,
   val moniker: Moniker,
   val env: Map<String, String>,
-  val labels: Map<String, String>,
   val containerAttributes: Map<String, String> = emptyMap(),
   val migrationPolicy: MigrationPolicy,
   val serviceJobProcesses: ServiceJobProcesses,

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -76,6 +76,7 @@ class ResourceTagger(
 
   private val taggableResources = listOf(
     "cluster",
+    "titus-cluster", // todo eb: fix to just be cluster
     "security-group",
     "classic-load-balancer",
     "application-load-balancer"

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -18,25 +18,40 @@
 package com.netflix.spinnaker.keel.api.titus.cluster
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.Capacity
 import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
+import com.netflix.spinnaker.keel.api.titus.exceptions.RegistryNotFoundException
+import com.netflix.spinnaker.keel.api.titus.exceptions.TitusAccountConfigurationException
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.events.Task
+import com.netflix.spinnaker.keel.model.EchoNotification
+import com.netflix.spinnaker.keel.model.Job
+import com.netflix.spinnaker.keel.model.OrchestrationRequest
+import com.netflix.spinnaker.keel.model.OrchestrationTrigger
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationEventPublisher
 import retrofit2.HttpException
 import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 class TitusClusterHandler(
   private val cloudDriverService: CloudDriverService,
@@ -60,7 +75,7 @@ class TitusClusterHandler(
       resolve().byRegion()
     }
 
-  override suspend fun current(resource: Resource<TitusClusterSpec>): Map<String, TitusServerGroup>? =
+  override suspend fun current(resource: Resource<TitusClusterSpec>): Map<String, TitusServerGroup> =
     cloudDriverService
       .getServerGroups(resource)
       .byRegion()
@@ -69,6 +84,152 @@ class TitusClusterHandler(
     orcaService
       .getCorrelatedExecutions(id.value)
       .isNotEmpty()
+
+  override suspend fun upsert(
+    resource: Resource<TitusClusterSpec>,
+    resourceDiff: ResourceDiff<Map<String, TitusServerGroup>>
+  ): List<Task> =
+    coroutineScope {
+      resourceDiff
+        .toIndividualDiffs()
+        .filter { diff -> diff.hasChanges() }
+        .map { diff ->
+          val desired = diff.desired
+          val job = when {
+            diff.isCapacityOnly() -> diff.resizeServerGroupJob()
+            else -> diff.upsertServerGroupJob()
+          }
+
+          log.info("Upserting server group using task: {}", job)
+          val description = "Upsert server group ${desired.moniker.name} in ${desired.location.account}/${desired.location.region}"
+
+          // todo eb: support notifications
+          val notifications: List<EchoNotification> = emptyList()
+
+          async {
+            orcaService
+              .orchestrate(
+                resource.serviceAccount,
+                OrchestrationRequest(
+                  name = description,
+                  application = desired.moniker.app,
+                  description = description,
+                  job = listOf(Job(job["type"].toString(), job)),
+                  trigger = OrchestrationTrigger(correlationId = "${resource.id}{${desired.location.region}}", notifications = notifications)
+                ))
+              .let {
+                log.info("Started task {} to upsert server group", it.ref)
+                Task(id = it.taskId, name = description)
+              }
+          }
+        }.map { it.await() }
+    }
+
+  private fun ResourceDiff<TitusServerGroup>.resizeServerGroupJob(): Map<String, Any?> {
+    val current = requireNotNull(current) {
+      "Current server group must not be null when generating a resize job"
+    }
+    return mapOf(
+      "type" to "resizeServerGroup",
+      "capacity" to mapOf(
+        "min" to desired.capacity.min,
+        "max" to desired.capacity.max,
+        "desired" to desired.capacity.desired
+      ),
+      "cloudProvider" to CLOUD_PROVIDER,
+      "credentials" to desired.location.account,
+      "moniker" to mapOf(
+        "app" to current.moniker.app,
+        "stack" to current.moniker.stack,
+        "detail" to current.moniker.detail,
+        "cluster" to current.moniker.name,
+        "sequence" to current.moniker.sequence
+      ),
+      "region" to current.location.region,
+      "serverGroupName" to current.name
+    )
+  }
+
+  private fun ResourceDiff<TitusServerGroup>.upsertServerGroupJob(): Map<String, Any?> =
+    with(desired) {
+      mapOf(
+        "application" to moniker.app,
+        "credentials" to location.account,
+        "region" to location.region,
+        "network" to "default",
+        // <things to do with the strategy>
+        // TODO: parameterize strategy
+        "strategy" to if (current == null) "" else "redblack",
+        "delayBeforeDisableSec" to 0,
+        "delayBeforeScaleDownSec" to 0,
+        "maxRemainingAsgs" to 2,
+        // todo: does 30 minutes then rollback make sense?
+        "stageTimeoutMs" to Duration.ofMinutes(30).toMillis(),
+        "rollback" to mapOf(
+          "onFailure" to true
+        ),
+        "scaleDown" to false,
+        "inService" to true,
+        // </things to do with the strategy>
+        "capacity" to mapOf(
+          "min" to capacity.min,
+          "max" to capacity.max,
+          "desired" to capacity.desired
+        ),
+        "targetHealthyDeployPercentage" to 100, // TODO: any reason to do otherwise?
+        "iamProfile" to runtimeOptions.iamProfile,
+        // <titus things>
+        "capacityGroup" to runtimeOptions.capacityGroup,
+        "entryPoint" to runtimeOptions.entryPoint,
+        "env" to runtimeOptions.env,
+        "constraints" to runtimeOptions.constraints,
+        "digest" to container.digest,
+        "registry" to runBlocking { getRegistryForTitusAccount(location.account) },
+        "migrationPolicy" to runtimeOptions.migrationPolicy,
+        "resources" to runtimeOptions.resources,
+        "imageId" to "${container.organization}/${container.image}:${container.digest}",
+        // </titus things>
+        "stack" to moniker.stack,
+        "freeFormDetails" to moniker.detail,
+        "tags" to tags,
+        "moniker" to mapOf(
+          "app" to moniker.app,
+          "stack" to moniker.stack,
+          "detail" to moniker.detail,
+          "cluster" to moniker.name
+        ),
+        "reason" to "Diff detected at ${clock.instant().iso()}",
+        "type" to if (current == null) "createServerGroup" else "upsertServerGroup",
+        "cloudProvider" to CLOUD_PROVIDER,
+        "securityGroups" to securityGroupIds(),
+        "loadBalancers" to dependencies.loadBalancerNames,
+        "targetGroups" to dependencies.targetGroups,
+        "account" to location.account
+      )
+    }
+      .let { job ->
+        current?.run {
+          job + mapOf(
+            "source" to mapOf(
+              "account" to location.account,
+              "region" to location.region,
+              "asgName" to moniker.serverGroup
+            )
+          )
+        } ?: job
+      }
+
+  /**
+   * @return `true` if the only changes in the diff are to capacity.
+   */
+  private fun ResourceDiff<TitusServerGroup>.isCapacityOnly(): Boolean =
+    current != null && affectedRootPropertyTypes.all { it == Capacity::class.java }
+
+  private fun ResourceDiff<Map<String, TitusServerGroup>>.toIndividualDiffs() =
+    desired
+      .map { (region, desired) ->
+        ResourceDiff(desired, current?.get(region))
+      }
 
   private suspend fun CloudDriverService.getServerGroups(resource: Resource<TitusClusterSpec>): Iterable<TitusServerGroup> =
     coroutineScope {
@@ -106,16 +267,16 @@ class TitusClusterHandler(
       ),
       capacity = capacity,
       container = Container(
-        image = image.dockerImageName,
-        digest = image.dockerImageDigest,
-        tag = ""
+        organization = image.dockerImageName.split("/").first(),
+        image = image.dockerImageName.split("/").last(),
+        digest = image.dockerImageDigest
       ),
-      containerOptions = ContainerOptions(
+      runtimeOptions = RuntimeOptions(
         entryPoint = entryPoint,
         resources = resources,
         env = env,
         constraints = constraints,
-        iamProfile = iamProfile,
+        iamProfile = iamProfile.substringAfterLast("/"),
         capacityGroup = capacityGroup,
         migrationPolicy = migrationPolicy
       ),
@@ -126,19 +287,31 @@ class TitusClusterHandler(
       )
     )
 
-  private val TitusServerGroup.securityGroupIds: Collection<String>
-    get() = dependencies
-      .securityGroupNames
-      // no need to specify these as Orca will auto-assign them, also the application security group
-      // gets auto-created so may not exist yet
-      .filter { it !in setOf("nf-infrastructure", "nf-datacenter", moniker.app) }
-      .map {
-        cloudDriverCache.securityGroupByName(location.account, location.region, it).id
-      }
+  private suspend fun getAwsAccountNameForTitusAccount(titusAccount: String): String =
+    cloudDriverService.getAccountInformation(titusAccount)["awsAccount"]?.toString()
+      ?: throw TitusAccountConfigurationException(titusAccount, "awsAccount")
+
+  private suspend fun getRegistryForTitusAccount(titusAccount: String): String =
+    cloudDriverService.getAccountInformation(titusAccount)["registry"]?.toString()
+      ?: throw RegistryNotFoundException(titusAccount)
+
+  fun TitusServerGroup.securityGroupIds(): Collection<String> =
+    runBlocking {
+      val awsAccount = getAwsAccountNameForTitusAccount(location.account)
+      dependencies
+        .securityGroupNames
+        // no need to specify these as Orca will auto-assign them, also the application security group
+        // gets auto-created so may not exist yet
+        .filter { it !in setOf("nf-infrastructure", "nf-datacenter", moniker.app) }
+        .map { cloudDriverCache.securityGroupByName(awsAccount, location.region, it).id }
+    }
 
   private val TitusActiveServerGroup.securityGroupNames: Set<String>
     get() = securityGroups.map {
       cloudDriverCache.securityGroupById(awsAccount, region, it).name
     }
       .toSet()
+
+  private fun Instant.iso() =
+    atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_DATE_TIME)
 }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -177,16 +177,16 @@ class TitusClusterHandler(
           "desired" to capacity.desired
         ),
         "targetHealthyDeployPercentage" to 100, // TODO: any reason to do otherwise?
-        "iamProfile" to runtimeOptions.iamProfile,
+        "iamProfile" to iamProfile,
         // <titus things>
-        "capacityGroup" to runtimeOptions.capacityGroup,
-        "entryPoint" to runtimeOptions.entryPoint,
-        "env" to runtimeOptions.env,
-        "constraints" to runtimeOptions.constraints,
+        "capacityGroup" to capacityGroup,
+        "entryPoint" to entryPoint,
+        "env" to env,
+        "constraints" to constraints,
         "digest" to container.digest,
         "registry" to runBlocking { getRegistryForTitusAccount(location.account) },
-        "migrationPolicy" to runtimeOptions.migrationPolicy,
-        "resources" to runtimeOptions.resources,
+        "migrationPolicy" to migrationPolicy,
+        "resources" to resources,
         "imageId" to "${container.organization}/${container.image}:${container.digest}",
         // </titus things>
         "stack" to moniker.stack,
@@ -271,15 +271,13 @@ class TitusClusterHandler(
         image = image.dockerImageName.split("/").last(),
         digest = image.dockerImageDigest
       ),
-      runtimeOptions = RuntimeOptions(
-        entryPoint = entryPoint,
-        resources = resources,
-        env = env,
-        constraints = constraints,
-        iamProfile = iamProfile.substringAfterLast("/"),
-        capacityGroup = capacityGroup,
-        migrationPolicy = migrationPolicy
-      ),
+      entryPoint = entryPoint,
+      resources = resources,
+      env = env,
+      constraints = constraints,
+      iamProfile = iamProfile.substringAfterLast("/"),
+      capacityGroup = capacityGroup,
+      migrationPolicy = migrationPolicy,
       dependencies = ClusterDependencies(
         loadBalancers,
         securityGroupNames = securityGroupNames,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -37,7 +37,7 @@ data class TitusServerGroup(
   val name: String,
   val container: Container,
   val location: Location,
-  val containerOptions: ContainerOptions,
+  val runtimeOptions: RuntimeOptions,
   val capacity: Capacity,
   val tags: Map<String, String> = emptyMap(),
   val dependencies: ClusterDependencies = ClusterDependencies(),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -19,6 +19,9 @@ package com.netflix.spinnaker.keel.api.titus.cluster
 
 import com.netflix.spinnaker.keel.api.Capacity
 import com.netflix.spinnaker.keel.api.ClusterDependencies
+import com.netflix.spinnaker.keel.clouddriver.model.Constraints
+import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
+import com.netflix.spinnaker.keel.clouddriver.model.Resources
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.parseMoniker
 import de.danielbechler.diff.inclusion.Inclusion
@@ -37,7 +40,13 @@ data class TitusServerGroup(
   val name: String,
   val container: Container,
   val location: Location,
-  val runtimeOptions: RuntimeOptions,
+  val env: Map<String, String> = emptyMap(),
+  val resources: Resources = Resources(),
+  val iamProfile: String,
+  val entryPoint: String = "",
+  val capacityGroup: String,
+  val constraints: Constraints = Constraints(),
+  val migrationPolicy: MigrationPolicy = MigrationPolicy(),
   val capacity: Capacity,
   val tags: Map<String, String> = emptyMap(),
   val dependencies: ClusterDependencies = ClusterDependencies(),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/RegistryNotFoundException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/RegistryNotFoundException.kt
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.exceptions
+
+/**
+ * A titus registry was not provided by clouddriver for the specified titus account
+ */
+class RegistryNotFoundException(
+  val titusAccount: String
+) : RuntimeException("Unable to find a registry configured for Titus account $titusAccount")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/TitusAccountConfigurationException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/TitusAccountConfigurationException.kt
@@ -1,0 +1,23 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.exceptions
+
+class TitusAccountConfigurationException(
+  val titusAccount: String,
+  val missingProperty: String
+) : RuntimeException("Titus account $titusAccount misconfigured: missing value for $missingProperty")

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -1,0 +1,411 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.titus.resource
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.ClusterDependencies
+import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.titus.cluster.Container
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterSpec
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusServerGroup
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusServerGroupSpec
+import com.netflix.spinnaker.keel.api.titus.cluster.byRegion
+import com.netflix.spinnaker.keel.api.titus.cluster.moniker
+import com.netflix.spinnaker.keel.api.titus.cluster.resolve
+import com.netflix.spinnaker.keel.api.titus.cluster.resolveCapacity
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.Placement
+import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
+import com.netflix.spinnaker.keel.clouddriver.model.ServiceJobProcesses
+import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroupImage
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.model.Moniker
+import com.netflix.spinnaker.keel.model.OrchestrationRequest
+import com.netflix.spinnaker.keel.model.parseMoniker
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.plugin.Resolver
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType
+import okhttp3.ResponseBody
+import org.apache.commons.lang3.RandomStringUtils
+import org.springframework.context.ApplicationEventPublisher
+import retrofit2.HttpException
+import retrofit2.Response
+import strikt.api.Assertion
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.containsKey
+import strikt.assertions.get
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
+import strikt.assertions.map
+import java.time.Clock
+import java.util.UUID
+
+// todo eb: we could probably have generic cluster tests
+// where you provide the correct info for the spec and active server groups
+class TitusClusterHandlerTests : JUnit5Minutests {
+  val cloudDriverService = mockk<CloudDriverService>()
+  val cloudDriverCache = mockk<CloudDriverCache>()
+  val orcaService = mockk<OrcaService>()
+  val objectMapper = ObjectMapper().registerKotlinModule()
+  val resolvers = emptyList<Resolver<TitusClusterSpec>>()
+  val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
+  val clock = Clock.systemDefaultZone()
+
+  val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
+  val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
+  val sg1East = SecurityGroupSummary("keel", "sg-279585936", "vpc-1")
+  val sg2East = SecurityGroupSummary("keel-elb", "sg-610264122", "vpc-1")
+
+  val titusAccount = "titustest"
+  val awsAccount = "test"
+
+  val spec = TitusClusterSpec(
+    moniker = Moniker(app = "keel", stack = "test"),
+    locations = SimpleLocations(
+      account = titusAccount,
+      regions = setOf(SimpleRegionSpec("us-east-1"), SimpleRegionSpec("us-west-2"))
+    ),
+    container = Container(
+      organization = "spinnaker",
+      image = "keel",
+      digest = "sha:1111"
+    ),
+    _defaults = TitusServerGroupSpec(
+      capacity = Capacity(1, 6, 4),
+      dependencies = ClusterDependencies(
+        loadBalancerNames = setOf("keel-test-frontend"),
+        securityGroupNames = setOf(sg1West.name)
+      ),
+      container = Container(
+        organization = "spinnaker",
+        image = "keel",
+        digest = "sha:1111"
+      )
+    )
+  )
+
+  val serverGroups = spec.resolve()
+  val serverGroupEast = serverGroups.first { it.location.region == "us-east-1" }
+  val serverGroupWest = serverGroups.first { it.location.region == "us-west-2" }
+
+  val activeServerGroupResponseEast = serverGroupEast.toClouddriverResponse(listOf(sg1East, sg2East))
+  val activeServerGroupResponseWest = serverGroupWest.toClouddriverResponse(listOf(sg1West, sg2West))
+
+  val resource = resource(
+    apiVersion = SPINNAKER_API_V1,
+    kind = "titus-cluster",
+    spec = spec
+  )
+
+  private fun TitusServerGroup.toClouddriverResponse(
+    securityGroups: List<SecurityGroupSummary>
+  ): TitusActiveServerGroup =
+    RandomStringUtils.randomNumeric(3).padStart(3, '0').let { sequence ->
+      TitusActiveServerGroup(
+        name = "$name-v$sequence",
+        awsAccount = awsAccount,
+        placement = Placement(location.account, location.region, emptyList()),
+        region = location.region,
+        image = TitusActiveServerGroupImage("${container.organization}/${container.image}", "", container.digest),
+        iamProfile = moniker.app + "InstanceProfile",
+        entryPoint = runtimeOptions.entryPoint,
+        targetGroups = dependencies.targetGroups,
+        loadBalancers = dependencies.loadBalancerNames,
+        securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
+        capacity = capacity,
+        cloudProvider = CLOUD_PROVIDER,
+        moniker = parseMoniker("$name-v$sequence"),
+        env = runtimeOptions.env,
+        constraints = runtimeOptions.constraints,
+        migrationPolicy = runtimeOptions.migrationPolicy,
+        serviceJobProcesses = ServiceJobProcesses(),
+        tags = emptyMap(),
+        resources = runtimeOptions.resources,
+        capacityGroup = moniker.app
+      )
+    }
+
+  fun tests() = rootContext<TitusClusterHandler> {
+    fixture {
+      TitusClusterHandler(
+        cloudDriverService,
+        cloudDriverCache,
+        orcaService,
+        clock,
+        publisher,
+        objectMapper,
+        resolvers
+      )
+    }
+
+    before {
+      with(cloudDriverCache) {
+        every { securityGroupById(awsAccount, "us-west-2", sg1West.id) } returns sg1West
+        every { securityGroupById(awsAccount, "us-west-2", sg2West.id) } returns sg2West
+        every { securityGroupByName(awsAccount, "us-west-2", sg1West.name) } returns sg1West
+        every { securityGroupByName(awsAccount, "us-west-2", sg2West.name) } returns sg2West
+
+        every { securityGroupById(awsAccount, "us-east-1", sg1East.id) } returns sg1East
+        every { securityGroupById(awsAccount, "us-east-1", sg2East.id) } returns sg2East
+        every { securityGroupByName(awsAccount, "us-east-1", sg1East.name) } returns sg1East
+        every { securityGroupByName(awsAccount, "us-east-1", sg2East.name) } returns sg2East
+
+        coEvery { cloudDriverService.getAccountInformation(titusAccount) } returns mapOf(
+          "awsAccount" to awsAccount,
+          "registry" to awsAccount + "registry"
+        )
+      }
+      coEvery { orcaService.orchestrate("keel@spinnaker", any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
+    }
+
+    after {
+      confirmVerified(orcaService)
+      clearAllMocks()
+    }
+
+    context("the cluster does not exist or has no active server groups") {
+      before {
+        coEvery { cloudDriverService.titusActiveServerGroup("us-east-1") } returns activeServerGroupResponseEast
+        coEvery { cloudDriverService.titusActiveServerGroup("us-west-2") } throws RETROFIT_NOT_FOUND
+      }
+
+      test("the current model is null") {
+        val current = runBlocking {
+          current(resource)
+        }
+        expectThat(current)
+          .hasSize(1)
+          .not()
+          .containsKey("us-west-2")
+      }
+
+      test("annealing a diff creates a new server group") {
+        runBlocking {
+          upsert(resource, ResourceDiff(serverGroups.byRegion(), emptyMap()))
+        }
+
+        val slot = slot<OrchestrationRequest>()
+        coVerify { orcaService.orchestrate("keel@spinnaker", capture(slot)) }
+
+        expectThat(slot.captured.job.first()) {
+          get("type").isEqualTo("createServerGroup")
+        }
+      }
+    }
+
+    context("the cluster has active server groups") {
+      before {
+        coEvery { cloudDriverService.titusActiveServerGroup("us-east-1") } returns activeServerGroupResponseEast
+        coEvery { cloudDriverService.titusActiveServerGroup("us-west-2") } returns activeServerGroupResponseWest
+      }
+
+      // TODO: test for multiple server group response
+      derivedContext<Map<String, TitusServerGroup>>("fetching the current server group state") {
+        deriveFixture {
+          runBlocking {
+            current(resource)
+          }
+        }
+
+        test("the current model is converted to a set of server group") {
+          expectThat(this).isNotEmpty()
+        }
+
+        test("the server group name is derived correctly") {
+          expectThat(values)
+            .map { it.name }
+            .containsExactlyInAnyOrder(
+              activeServerGroupResponseEast.name,
+              activeServerGroupResponseWest.name
+            )
+        }
+      }
+    }
+
+    context("a diff has been detected") {
+      context("the diff is only in capacity") {
+
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+        )
+        val diff = ResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+
+        test("annealing resizes the current server group") {
+          runBlocking {
+            upsert(resource, diff)
+          }
+
+          val slot = slot<OrchestrationRequest>()
+          coVerify { orcaService.orchestrate("keel@spinnaker", capture(slot)) }
+
+          expectThat(slot.captured.job.first()) {
+            get("type").isEqualTo("resizeServerGroup")
+            get("capacity").isEqualTo(
+              spec.resolveCapacity("us-west-2").let {
+                mapOf(
+                  "min" to it.min,
+                  "max" to it.max,
+                  "desired" to it.desired
+                )
+              }
+            )
+            get("serverGroupName").isEqualTo(activeServerGroupResponseWest.name)
+          }
+        }
+      }
+
+      context("the diff is something other than just capacity") {
+
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity().withDifferentRuntimeOptions()
+        )
+        val diff = ResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+
+        test("annealing clones the current server group") {
+          runBlocking {
+            upsert(resource, diff)
+          }
+
+          val slot = slot<OrchestrationRequest>()
+          coVerify { orcaService.orchestrate("keel@spinnaker", capture(slot)) }
+
+          expectThat(slot.captured.job.first()) {
+            get("type").isEqualTo("upsertServerGroup")
+            get("source").isEqualTo(
+              mapOf(
+                "account" to activeServerGroupResponseWest.placement.account,
+                "region" to activeServerGroupResponseWest.region,
+                "asgName" to activeServerGroupResponseWest.name
+              )
+            )
+          }
+        }
+      }
+
+      context("multiple server groups have a diff") {
+
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentRuntimeOptions(),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+        )
+        val diff = ResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+
+        before {
+          runBlocking {
+            upsert(resource, diff)
+          }
+        }
+
+        test("annealing launches one task per server group") {
+          val tasks = mutableListOf<OrchestrationRequest>()
+          coVerify { orcaService.orchestrate(any(), capture(tasks)) }
+
+          expectThat(tasks)
+            .hasSize(2)
+            .map { it.job.first()["type"] }
+            .containsExactlyInAnyOrder("upsertServerGroup", "resizeServerGroup")
+        }
+
+        test("each task has a distinct correlation id") {
+          val tasks = mutableListOf<OrchestrationRequest>()
+          coVerify { orcaService.orchestrate(any(), capture(tasks)) }
+
+          expectThat(tasks)
+            .hasSize(2)
+            .map { it.trigger.correlationId }
+            .containsDistinctElements()
+        }
+      }
+    }
+  }
+
+  private suspend fun CloudDriverService.titusActiveServerGroup(region: String) = titusActiveServerGroup(
+    serviceAccount = "keel@spinnaker",
+    app = spec.moniker.app,
+    account = spec.locations.account,
+    cluster = spec.moniker.name,
+    region = region,
+    cloudProvider = CLOUD_PROVIDER
+  )
+}
+
+private fun TitusServerGroup.withDoubleCapacity(): TitusServerGroup =
+  copy(
+    capacity = Capacity(
+      min = capacity.min * 2,
+      max = capacity.max * 2,
+      desired = capacity.desired * 2
+    )
+  )
+
+private fun TitusServerGroup.withDifferentRuntimeOptions(): TitusServerGroup =
+  copy(
+    runtimeOptions = runtimeOptions.copy(
+      capacityGroup = "aDifferentGroup"
+    )
+  )
+
+private fun <E, T : Iterable<E>> Assertion.Builder<T>.containsDistinctElements() =
+  assert("contains distinct elements") { subject ->
+    val duplicates = subject
+      .associateWith { elem -> subject.count { it == elem } }
+      .filterValues { it > 1 }
+      .keys
+    when (duplicates.size) {
+      0 -> pass()
+      1 -> fail(duplicates.first(), "The element %s occurs more than once")
+      else -> fail(duplicates, "The elements %s occur more than once")
+    }
+  }
+
+val RETROFIT_NOT_FOUND = HttpException(
+  Response.error<Any>(404, ResponseBody.create(MediaType.parse("application/json"), ""))
+)

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -145,19 +145,19 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         region = location.region,
         image = TitusActiveServerGroupImage("${container.organization}/${container.image}", "", container.digest),
         iamProfile = moniker.app + "InstanceProfile",
-        entryPoint = runtimeOptions.entryPoint,
+        entryPoint = entryPoint,
         targetGroups = dependencies.targetGroups,
         loadBalancers = dependencies.loadBalancerNames,
         securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
         capacity = capacity,
         cloudProvider = CLOUD_PROVIDER,
         moniker = parseMoniker("$name-v$sequence"),
-        env = runtimeOptions.env,
-        constraints = runtimeOptions.constraints,
-        migrationPolicy = runtimeOptions.migrationPolicy,
+        env = env,
+        constraints = constraints,
+        migrationPolicy = migrationPolicy,
         serviceJobProcesses = ServiceJobProcesses(),
         tags = emptyMap(),
-        resources = runtimeOptions.resources,
+        resources = resources,
         capacityGroup = moniker.app
       )
     }
@@ -387,11 +387,7 @@ private fun TitusServerGroup.withDoubleCapacity(): TitusServerGroup =
   )
 
 private fun TitusServerGroup.withDifferentRuntimeOptions(): TitusServerGroup =
-  copy(
-    runtimeOptions = runtimeOptions.copy(
-      capacityGroup = "aDifferentGroup"
-    )
-  )
+  copy(capacityGroup = "aDifferentGroup")
 
 private fun <E, T : Iterable<E>> Assertion.Builder<T>.containsDistinctElements() =
   assert("contains distinct elements") { subject ->


### PR DESCRIPTION
Changes in titus spec to flatten structure. Actuation support needed for managing titus resources. Tests!

Still todo:
- notification support for environments
- an "image provider" instead of specifying a digest
- have kind be `cluster` instead of `titus-cluster`