### PR TITLE
fix(bake): rebake if region missing

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -131,7 +131,15 @@ class ImageHandler(
               "storeType" to resource.spec.storeType.name.toLowerCase(),
               "user" to "keel",
               "vmType" to "hvm"
-            )
+            ).let { job ->
+              if (resourceDiff.isRegionOnly()) {
+                job + mapOf(
+                  "rebake" to true
+                )
+              } else {
+                job
+              }
+            }
           )
         ),
         trigger = OrchestrationTrigger(
@@ -164,6 +172,9 @@ class ImageHandler(
         }
       } ?: throw BaseAmiNotFound(baseImage)
   }
+
+  private fun ResourceDiff<Image>.isRegionOnly(): Boolean =
+    current != null && (current as Image).regions.size != desired.regions.size
 }
 
 class BaseAmiNotFound(baseImage: String) : RuntimeException("Could not find a base AMI for base image $baseImage")


### PR DESCRIPTION
If we have an image diff where the image exists in one region but not any of the others a simple "bake" doesn't fix it. Instead, we bake every minute for the rest of time.

This change adds a force rebake to try and remedy this situation (context parameter checked in orca [here](https://github.com/spinnaker/orca/blob/master/orca-bakery/src/main/groovy/com/netflix/spinnaker/orca/bakery/tasks/CreateBakeTask.groovy#L140)).