### PR TITLE
fix(tags): serialize simple region correctly, tag sec groups

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/RegionSpec.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/RegionSpec.kt
@@ -35,4 +35,6 @@ data class SubnetAwareRegionSpec(
 
 data class SimpleRegionSpec(
   override val name: String
-) : RegionSpec
+) : RegionSpec {
+  override fun toString() = name
+}

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -71,7 +71,8 @@ class ResourceTagger(
 
   private val entityTypeTransforms = mapOf(
     "classic-load-balancer" to "loadbalancer",
-    "application-load-balancer" to "loadbalancer"
+    "application-load-balancer" to "loadbalancer",
+    "security-group" to "securitygroup"
   )
 
   private val taggableResources = listOf(


### PR DESCRIPTION
This PR fixes `SimpleRegionSpec` getting serialized (in ResourceId) as `SimpleRegionSpec(name=blah)`, but does not affect serialization into json. This has no impact on exporting resources to the correct yaml or submitting resources.

I also didn't see security group tags coming up in the ui locally, so I fixed the `resourceTagger` to have the correct "entity id" (`securitygroup` instead of `security-group`).