### PR TITLE
chore(dependencies): fiatVersion 1.7.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Wed Oct 23 19:57:00 UTC 2019
-fiatVersion=1.7.1
+fiatVersion=1.7.2
 enablePublishing=false
 korkVersion=6.14.3
 spinnakerGradleVersion=7.0.2


### PR DESCRIPTION
fiat-api 1.7.2 reverts a breaking change from 1.6.0