### PR TITLE
feat(docker): react to and store docker images

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
-import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER_IMAGE
+import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
@@ -43,7 +43,7 @@ class ArtifactController(
     echoArtifactEvent.payload.artifacts.forEach { artifact ->
       if (artifact.type.equals(DEB.toString(), true) && artifact.isFromArtifactEvent()) {
         publisher.publishEvent(ArtifactEvent(listOf(artifact), emptyMap()))
-      } else if (artifact.type.equals(DOCKER_IMAGE.toString(), true)) {
+      } else if (artifact.type.equals(DOCKER.toString(), true)) {
         publisher.publishEvent(ArtifactEvent(listOf(artifact), emptyMap()))
       } else {
         log.debug("Ignoring artifact event with type {}: {}", artifact.type, artifact)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -1,8 +1,11 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.ArtifactType
+import com.netflix.spinnaker.keel.api.ArtifactType.DEB
+import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER_IMAGE
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.events.ArtifactEvent
+import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
@@ -38,12 +41,23 @@ class ArtifactController(
   @ResponseStatus(ACCEPTED)
   fun submitArtifact(@RequestBody echoArtifactEvent: EchoArtifactEvent) {
     echoArtifactEvent.payload.artifacts.forEach { artifact ->
-      if (artifact.type.equals(ArtifactType.DEB.toString(), true) && artifact.isFromArtifactEvent()) {
+      if (artifact.type.equals(DEB.toString(), true) && artifact.isFromArtifactEvent()) {
+        publisher.publishEvent(ArtifactEvent(listOf(artifact), emptyMap()))
+      } else if (artifact.type.equals(DOCKER_IMAGE.toString(), true)) {
         publisher.publishEvent(ArtifactEvent(listOf(artifact), emptyMap()))
       } else {
         log.debug("Ignoring artifact event with type {}: {}", artifact.type, artifact)
       }
     }
+  }
+
+  @PostMapping(
+    path = ["/register"],
+    consumes = [APPLICATION_JSON_VALUE]
+  )
+  @ResponseStatus(ACCEPTED)
+  fun register(@RequestBody artifact: DeliveryArtifact) {
+    publisher.publishEvent(ArtifactRegisteredEvent(artifact))
   }
 
   @GetMapping(
@@ -68,7 +82,7 @@ class ArtifactController(
     log.error(e.message)
   }
 
-  // Artifacts should contain a releaseStatus in the metadata
+  // Debian Artifacts should contain a releaseStatus in the metadata
   private fun Artifact.isFromArtifactEvent() =
     this.metadata.containsKey("releaseStatus") && this.metadata["releaseStatus"] != null
 }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -3,6 +3,8 @@ package com.netflix.spinnaker.keel.artifact
 import com.netflix.spinnaker.igor.ArtifactService
 import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.ArtifactType
+import com.netflix.spinnaker.keel.api.ArtifactType.DEB
+import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER_IMAGE
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
@@ -30,8 +32,19 @@ class ArtifactListener(
       .forEach { korkArtifact ->
         val artifact = korkArtifact.toDeliveryArtifact()
         if (artifactRepository.isRegistered(artifact.name, artifact.type)) {
-          val version = "${korkArtifact.name}-${korkArtifact.version}"
-          val status = artifactStatus(korkArtifact)
+          val version: String
+          val status: ArtifactStatus
+          when {
+            korkArtifact.isDeb() -> {
+              version = "${korkArtifact.name}-${korkArtifact.version}"
+              status = debStatus(korkArtifact)
+            }
+            korkArtifact.isDockerImage() -> {
+              version = korkArtifact.name + ":" + korkArtifact.version
+              status = ArtifactStatus.FINAL // todo eb: should we default? should we re-think status? should status be null?
+            }
+            else -> throw UnsupportedArtifactTypeException(korkArtifact.type)
+          }
           log.info("Registering version {} ({}) of {} {}", version, status, artifact.name, artifact.type)
           artifactRepository.store(artifact, version, status)
             .also { wasAdded ->
@@ -53,22 +66,22 @@ class ArtifactListener(
       artifactRepository.register(artifact)
     }
 
-    if (artifactRepository.versions(artifact).isEmpty()) {
-      storeLatestVersion(artifact, event.statuses)
+    if (artifact.type == DEB && artifactRepository.versions(artifact).isEmpty()) {
+      storeLatestDebVersion(artifact, event.statuses)
     }
   }
 
   /**
    * Grab the latest version which matches the statuses we care about, so the artifact is relevant.
    */
-  protected fun storeLatestVersion(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>) =
+  protected fun storeLatestDebVersion(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>) =
     runBlocking {
       artifactService
         .getVersions(artifact.name, statuses.map { it.toString() })
         .firstOrNull()
         ?.let { firstVersion ->
           val version = "${artifact.name}-$firstVersion"
-          val status = artifactStatus(artifactService.getArtifact(artifact.name, firstVersion))
+          val status = debStatus(artifactService.getArtifact(artifact.name, firstVersion))
           log.debug("Storing latest version {} ({}) for registered artifact {}", version, status, artifact)
           artifactRepository.store(artifact, version, status)
         }
@@ -78,13 +91,19 @@ class ArtifactListener(
    * Parses the status from a kork artifact, and throws an error if [releaseStatus] isn't
    * present in [metadata]
    */
-  private fun artifactStatus(artifact: Artifact): ArtifactStatus {
+  private fun debStatus(artifact: Artifact): ArtifactStatus {
     val status = artifact.metadata["releaseStatus"]?.toString()
       ?: throw IllegalStateException("Artifact event received without 'releaseStatus' field")
     return ArtifactStatus.valueOf(status)
   }
 
   private val artifactTypeNames by lazy { ArtifactType.values().map(ArtifactType::name) }
+
+  private fun Artifact.isDeb(): Boolean =
+    type.equals(DEB.toString(), true)
+
+  private fun Artifact.isDockerImage(): Boolean =
+    type.equals(DOCKER_IMAGE.toString(), true)
 
   private fun Artifact.toDeliveryArtifact(): DeliveryArtifact =
     DeliveryArtifact(name, ArtifactType.valueOf(type.toUpperCase()))

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -4,7 +4,7 @@ import com.netflix.spinnaker.igor.ArtifactService
 import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
-import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER_IMAGE
+import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
@@ -34,13 +34,13 @@ class ArtifactListener(
         if (artifactRepository.isRegistered(artifact.name, artifact.type)) {
           val version: String
           val status: ArtifactStatus
-          when {
-            korkArtifact.isDeb() -> {
+          when (artifact.type) {
+            DEB -> {
               version = "${korkArtifact.name}-${korkArtifact.version}"
               status = debStatus(korkArtifact)
             }
-            korkArtifact.isDockerImage() -> {
-              version = korkArtifact.name + ":" + korkArtifact.version
+            DOCKER -> {
+              version = "${korkArtifact.name}:${korkArtifact.version}"
               status = ArtifactStatus.FINAL // todo eb: should we default? should we re-think status? should status be null?
             }
             else -> throw UnsupportedArtifactTypeException(korkArtifact.type)
@@ -98,12 +98,6 @@ class ArtifactListener(
   }
 
   private val artifactTypeNames by lazy { ArtifactType.values().map(ArtifactType::name) }
-
-  private fun Artifact.isDeb(): Boolean =
-    type.equals(DEB.toString(), true)
-
-  private fun Artifact.isDockerImage(): Boolean =
-    type.equals(DOCKER_IMAGE.toString(), true)
 
   private fun Artifact.toDeliveryArtifact(): DeliveryArtifact =
     DeliveryArtifact(name, ArtifactType.valueOf(type.toUpperCase()))

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/UnsupportedArtifactTypeException.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/UnsupportedArtifactTypeException.kt
@@ -17,8 +17,8 @@
  */
 package com.netflix.spinnaker.keel.artifact
 
-import com.netflix.spinnaker.keel.api.ArtifactStatus
+import com.netflix.spinnaker.keel.api.ArtifactType
 
 class UnsupportedArtifactTypeException(
   val type: String
-) : RuntimeException("Artifact type $type not in supported types: ${ArtifactStatus.values()}")
+) : RuntimeException("Artifact type $type not in supported types: ${ArtifactType.values()}")

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/UnsupportedArtifactTypeException.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/UnsupportedArtifactTypeException.kt
@@ -1,0 +1,24 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.artifact
+
+import com.netflix.spinnaker.keel.api.ArtifactStatus
+
+class UnsupportedArtifactTypeException(
+  val type: String
+) : RuntimeException("Artifact type $type not in supported types: ${ArtifactStatus.values()}")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -6,7 +6,7 @@ data class DeliveryArtifact(
 )
 
 enum class ArtifactType {
-  DEB, DOCKER_IMAGE
+  DEB, DOCKER
 }
 
 // todo eb: add RELEASE

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -6,7 +6,7 @@ data class DeliveryArtifact(
 )
 
 enum class ArtifactType {
-  DEB
+  DEB, DOCKER_IMAGE
 }
 
 // todo eb: add RELEASE


### PR DESCRIPTION
Add a new artifact type (`DOCKER_IMAGE`), and save those too.

Also, adding the `/artifact/register` endpoint back for easy testing.