### PR TITLE
fix(export): better mapping between clouddriver types and keel kinds

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -1,20 +1,24 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.google.common.base.CaseFormat
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.supporting
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -23,6 +27,7 @@ class ExportController(
   private val handlers: List<ResourceHandler<*, *>>,
   private val cloudDriverCache: CloudDriverCache
 ) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   /**
    * Assist for mapping between Deck and Clouddriver cloudProvider names
@@ -30,6 +35,17 @@ class ExportController(
    */
   private val cloudProviderOverrides = mapOf(
     "aws" to "ec2"
+  )
+
+  private val typeToKind = mapOf(
+    "classicloadbalancer" to "classic-load-balancer",
+    "classicloadbalancers" to "classic-load-balancer",
+    "applicationloadbalancer" to "application-load-balancer",
+    "applicationloadbalancers" to "application-load-balancer",
+    "securitygroup" to "security-group",
+    "securitygroups" to "security-group",
+    "cluster" to "cluster",
+    "clustersx" to "cluster"
   )
 
   /**
@@ -55,7 +71,7 @@ class ExportController(
     @RequestParam("serviceAccount") serviceAccount: String
   ): SubmittedResource<*> {
     val apiVersion = SPINNAKER_API_V1.subApi(cloudProviderOverrides[cloudProvider] ?: cloudProvider)
-    val kind = CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_HYPHEN, type)
+    val kind = typeToKind.getOrDefault(type, type)
     val handler = handlers.supporting(apiVersion, kind)
     val exportable = Exportable(
       account = account,
@@ -74,5 +90,11 @@ class ExportController(
     return runBlocking {
       handler.export(exportable)
     }
+  }
+
+  @ExceptionHandler(ResourceNotFound::class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  fun onNotFound(e: ResourceNotFound) {
+    log.info(e.message)
   }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
@@ -122,6 +123,11 @@ class ApplicationLoadBalancerHandler(
       regions = exportable.regions,
       serviceAccount = exportable.serviceAccount
     )
+
+    if (albs.isEmpty()) {
+      throw ResourceNotFound("Could not find application load balancer: ${exportable.moniker.name} " +
+        "in account: ${exportable.account}")
+    }
 
     val zonesByRegion = albs.map { (region, alb) ->
       region to cloudDriverCache.availabilityZonesBy(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -18,6 +18,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
@@ -123,6 +124,10 @@ class ClassicLoadBalancerHandler(
       regions = exportable.regions,
       serviceAccount = exportable.serviceAccount)
 
+    if (clbs.isEmpty()) {
+      throw ResourceNotFound("Could not find classic load balancer: ${exportable.moniker.name} " +
+        "in account: ${exportable.account} for ")
+    }
     val zonesByRegion = clbs.map { (region, clb) ->
       region to cloudDriverCache.availabilityZonesBy(
         account = exportable.account,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.Tag
 import com.netflix.spinnaker.keel.diff.ResourceDiff
@@ -127,6 +128,11 @@ class ClusterHandler(
       serviceAccount = exportable.serviceAccount
     )
       .byRegion()
+
+    if (serverGroups.isEmpty()) {
+      throw ResourceNotFound("Could not find cluster: ${exportable.moniker.name} " +
+        "in account: ${exportable.account} for export")
+    }
 
     val zonesByRegion = serverGroups.map { (region, serverGroup) ->
       region to cloudDriverCache.availabilityZonesBy(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -178,6 +178,11 @@ class SecurityGroupHandler(
           .associateBy { it.location.region }
       }
 
+    if (securityGroups.isEmpty()) {
+      throw ResourceNotFound("Could not find security group: ${exportable.moniker.name} " +
+        "in account: ${exportable.account}")
+    }
+
     val base = securityGroups.values.first()
     val spec = SecurityGroupSpec(
       moniker = base.moniker,


### PR DESCRIPTION
- also return a 404 instead of 500 when attempting to export resources
that cannot be found.