### PR TITLE
feat(serialization): Use friendly names for artifact types

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -1,12 +1,23 @@
 package com.netflix.spinnaker.keel.api
 
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
 data class DeliveryArtifact(
   val name: String,
   val type: ArtifactType = ArtifactType.DEB
 )
 
-enum class ArtifactType {
-  DEB, DOCKER
+enum class ArtifactType(@JsonValue val friendlyName: String) {
+  DEB("deb"),
+  DOCKER("docker");
+
+  companion object {
+    @JsonCreator @JvmStatic
+    fun fromFriendlyName(friendlyName: String): ArtifactType? {
+      return valueOf(friendlyName.toUpperCase())
+    }
+  }
 }
 
 // todo eb: add RELEASE

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/ArtifactTypeSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/ArtifactTypeSerializationTests.kt
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.keel.serialization
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.ArtifactType
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.get
+import strikt.assertions.isEqualTo
+
+internal class ArtifactTypeSerializationTests : JUnit5Minutests {
+
+  val mapper = configuredYamlMapper()
+
+  fun tests() = rootContext<Unit> {
+    context("custom (de)serialization") {
+      test("serializes enum value to friendly name") {
+        for (enumValue in ArtifactType.values()) {
+          expectThat(mapper.writeValueAsString(enumValue)).isEqualTo("--- \"${enumValue.friendlyName}\"\n")
+        }
+      }
+
+      test("deserializes friendly name to enum value") {
+        for (enumValue in ArtifactType.values()) {
+          expectThat(mapper.readValue<ArtifactType>(enumValue.friendlyName)).isEqualTo(enumValue)
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/ArtifactTypeSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/ArtifactTypeSerializationTests.kt
@@ -15,14 +15,20 @@ internal class ArtifactTypeSerializationTests : JUnit5Minutests {
   fun tests() = rootContext<Unit> {
     context("custom (de)serialization") {
       test("serializes enum value to friendly name") {
-        for (enumValue in ArtifactType.values()) {
-          expectThat(mapper.writeValueAsString(enumValue)).isEqualTo("--- \"${enumValue.friendlyName}\"\n")
+        for (artifactType in ArtifactType.values()) {
+          expectThat(mapper.writeValueAsString(artifactType)).isEqualTo("--- \"${artifactType.friendlyName}\"\n")
         }
       }
 
       test("deserializes friendly name to enum value") {
-        for (enumValue in ArtifactType.values()) {
-          expectThat(mapper.readValue<ArtifactType>(enumValue.friendlyName)).isEqualTo(enumValue)
+        for (artifactType in ArtifactType.values()) {
+          expectThat(mapper.readValue<ArtifactType>(artifactType.friendlyName)).isEqualTo(artifactType)
+        }
+      }
+
+      test("deserialization is backwards-compatible with original enum names") {
+        for (artifactType in ArtifactType.values()) {
+          expectThat(mapper.readValue<ArtifactType>(artifactType.name)).isEqualTo(artifactType)
         }
       }
     }


### PR DESCRIPTION
Addresses #557 by introducing "friendly names" for artifact types (i.e. lower-case names as opposed to the default enum value names). Given that all current friendly names match the upper-case enum names, this could probably be even simpler, but when I started we had a conversion between `"docker"` and `DOCKER_TYPE` and so I figured it's OK to have a place to add that kind of logic if we ever have other types that don't match the friendly name. The `@JsonCreator` factory method also allows for backwards-compatibility with existing specs still using the upper-as names.