### PR TITLE
fix(bake): ignore image where region or tags are missing

### DIFF
--- a/keel-clouddriver/src/test/resources/named-images.json
+++ b/keel-clouddriver/src/test/resources/named-images.json
@@ -1,0 +1,98 @@
+[
+  {
+    "imageName": "keel-0.312.0-h240.44eaaa3-x86_64-20191025212812-xenial-hvm-sriov-ebs",
+    "attributes": {
+      "virtualizationType": "hvm",
+      "creationDate": "2019-10-25T21:32:36.000Z"
+    },
+    "tagsByImageId": {
+      "ami-0dfd69c2297ccd8b0": {
+        "build_host": "https://jenkins/",
+        "base_ami_version": "nflx-base-1.0.0-h1.111111",
+        "creator": "keel@spinnaker.io",
+        "appversion": "keel-0.312.0-h240.44eaaa3/jenkins/240",
+        "creation_time": "2019-10-25 21:32:37 UTC"
+      },
+      "ami-0be384457d4e8471c": {
+        "creator": "keel@spinnaker.io",
+        "appversion": "keel-0.312.0-h240.44eaaa3/jenkins/240",
+        "creation_time": "2019-10-25 21:32:18 UTC",
+        "base_ami_version": "nflx-base-1.0.0-h1.111111",
+        "build_host": "https://jenkins/"
+      }
+    },
+    "accounts": [
+      "test",
+      "prod"
+    ],
+    "amis": {
+      "us-east-1": [
+        "ami-000000000e"
+      ],
+      "us-west-2": [
+        "ami-000000000w"
+      ]
+    },
+    "tags": {
+    }
+  },
+  {
+    "imageName": "keel-0.312.0-h240.44eaaa3-x86_64-20191025213413-xenial-hvm-sriov-ebs",
+    "attributes": {
+      "virtualizationType": "hvm",
+      "creationDate": "2019-10-25T21:37:24.000Z"
+    },
+    "tagsByImageId": {
+      "ami-09c6554a125f6dbe0": {
+        "creation_time": "2019-10-25 21:37:25 UTC",
+        "base_ami_version": "nflx-base-1.0.0-h1.111111",
+        "build_host": "https://jenkins/",
+        "appversion": "keel-0.312.0-h240.44eaaa3/jenkins/240",
+        "creator": "keel@spinnaker.io"
+      },
+      "ami-0359a955c4706c30b": {
+      }
+    },
+    "accounts": [
+      "test",
+      "prod"
+    ],
+    "amis": {
+      "us-east-1": [
+        "ami-0359a955c4706c30b"
+      ],
+      "us-west-2": [
+        "ami-09c6554a125f6dbe0"
+      ]
+    },
+    "tags": {
+    }
+  },
+  {
+    "imageName": "keel-0.312.0-h240.44eaaa3-x86_64-20191025213914-xenial-hvm-sriov-ebs",
+    "attributes": {
+      "virtualizationType": "hvm",
+      "creationDate": "2019-10-25T21:43:10.000Z"
+    },
+    "tagsByImageId": {
+      "ami-08ce2848d92d61bde": {
+        "appversion": "keel-0.312.0-h240.44eaaa3/jenkins/240",
+        "creation_time": "2019-10-25 21:43:32 UTC",
+        "creator": "keel@spinnaker.io",
+        "base_ami_version": "nflx-base-1.0.0-h1.111111",
+        "build_host": "https://jenkins/"
+      }
+    },
+    "accounts": [
+      "test",
+      "prod"
+    ],
+    "amis": {
+      "us-east-1": [
+        "ami-08ce2848d92d61bde"
+      ]
+    },
+    "tags": {
+    }
+  }
+]

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -70,14 +70,16 @@ class ImageResolver(
           imageProvider.artifactStatuses
         }
       ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
-      imageService.getLatestNamedImage(
+      imageService.getLatestImageWithAllRegions(
         appVersion = AppVersion.parseName(artifactVersion),
-        account = account
+        account = account,
+        regions = resource.spec.locations.regions.map { it.name }
       ) ?: throw NoImageFound(artifactVersion)
     } else {
-      imageService.getLatestNamedImage(
+      imageService.getLatestImageWithAllRegions(
         packageName = artifact.name,
-        account = account
+        account = account,
+        regions = resource.spec.locations.regions.map { it.name }
       ) ?: throw NoImageFound(artifact.name)
     }
   }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.api.NoImageFoundForRegions
 import com.netflix.spinnaker.keel.api.NoImageSatisfiesConstraints
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.model.Moniker
-import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.test.resource
@@ -156,7 +156,7 @@ internal class ImageResolverTests : JUnit5Minutests {
 
   fun tests() = rootContext<Fixture<*>> {
     context("no image provider") {
-        fixture { Fixture(null) }
+      fixture { Fixture(null) }
 
       test("returns the original spec unchanged") {
         expectThat(resolve())
@@ -174,7 +174,7 @@ internal class ImageResolverTests : JUnit5Minutests {
       context("the resource is not in an environment") {
         before {
           coEvery {
-            imageService.getLatestNamedImage(artifact.name, any(), null)
+            imageService.getLatestImageWithAllRegions(artifact.name, any(), listOf(resourceRegion))
           } answers {
             images.lastOrNull { it.appVersion.startsWith(firstArg<String>()) }
           }
@@ -206,7 +206,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             artifactRepository.store(artifact, "${artifact.name}-$version2", FINAL)
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
             coEvery {
-              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), null)
+              imageService.getLatestImageWithAllRegions(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
             }
@@ -258,7 +258,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             artifactRepository.store(artifact, "${artifact.name}-$version2", FINAL)
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
             coEvery {
-              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), null)
+              imageService.getLatestImageWithAllRegions(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } returns null
           }
 
@@ -292,7 +292,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             artifactRepository.store(artifact, "${artifact.name}-$version2", FINAL)
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
             coEvery {
-              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), null)
+              imageService.getLatestImageWithAllRegions(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
             }


### PR DESCRIPTION
When we search for an image we may get a list back where some images don't have a region, and some have a region but don't have tags in that region.

This is a problem because we assume an image has the same name in each region we're deploying to and we use the tags to figure out what package version the image is running.

This PR allows us to find the latest image which has all the regions we care about and also has tags for each region.

Thoughts on whether this will help with the amount of re-baking we're doing?