### PR TITLE
fix(image): look at latest complete image, cut down on bakes

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -63,7 +63,7 @@ class ImageHandler(
 
   override suspend fun current(resource: Resource<ImageSpec>): Image? =
     with(resource) {
-      imageService.getLatestImage(spec.artifactName, "test")?.let {
+      imageService.getLatestImageWithAllRegions(spec.artifactName, "test", resource.spec.regions.toList())?.let {
         it.copy(regions = it.regions.intersect(resource.spec.regions))
       }
     }

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -229,7 +229,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
       context("the image already exists in more regions than desired") {
         before {
           coEvery {
-            imageService.getLatestImage("keel", "test")
+            imageService.getLatestImageWithAllRegions("keel", "test", image.regions.toList())
           } returns image.copy(regions = image.regions + "eu-west-1")
         }
         test("current should filter the undesireable regions out of the image") {

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -326,7 +326,7 @@ internal class ImageServiceTests {
     } returns realImages
 
     runBlocking {
-      val image = subject.getLatestImageWithAllRegions(packageName, "test", regions)
+      val image = subject.getLatestNamedImageWithAllRegions(packageName, "test", regions)
       expectThat(image)
         .isNotNull()
         .get { imageName }
@@ -347,7 +347,7 @@ internal class ImageServiceTests {
     } returns realImages
 
     runBlocking {
-      val image = subject.getLatestImageWithAllRegions(appVersion, "test", regions)
+      val image = subject.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName(appVersion), "test", regions)
       expectThat(image)
         .isNotNull()
         .get { imageName }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -70,13 +70,13 @@ class ImageResolver(
           imageProvider.artifactStatuses
         }
       ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
-      imageService.getLatestImageWithAllRegions(
+      imageService.getLatestNamedImageWithAllRegionsForAppVersion(
         appVersion = AppVersion.parseName(artifactVersion),
         account = account,
         regions = resource.spec.locations.regions.map { it.name }
       ) ?: throw NoImageFound(artifactVersion)
     } else {
-      imageService.getLatestImageWithAllRegions(
+      imageService.getLatestNamedImageWithAllRegions(
         packageName = artifact.name,
         account = account,
         regions = resource.spec.locations.regions.map { it.name }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -174,7 +174,7 @@ internal class ImageResolverTests : JUnit5Minutests {
       context("the resource is not in an environment") {
         before {
           coEvery {
-            imageService.getLatestImageWithAllRegions(artifact.name, any(), listOf(resourceRegion))
+            imageService.getLatestNamedImageWithAllRegions(artifact.name, any(), listOf(resourceRegion))
           } answers {
             images.lastOrNull { it.appVersion.startsWith(firstArg<String>()) }
           }
@@ -206,7 +206,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             artifactRepository.store(artifact, "${artifact.name}-$version2", FINAL)
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
             coEvery {
-              imageService.getLatestImageWithAllRegions(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
+              imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
             }
@@ -258,7 +258,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             artifactRepository.store(artifact, "${artifact.name}-$version2", FINAL)
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
             coEvery {
-              imageService.getLatestImageWithAllRegions(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
+              imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } returns null
           }
 
@@ -292,7 +292,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             artifactRepository.store(artifact, "${artifact.name}-$version2", FINAL)
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
             coEvery {
-              imageService.getLatestImageWithAllRegions(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
+              imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
             }


### PR DESCRIPTION
Instead of finding the latest image and shouting "DIFF!" when it's not perfect, look for an image that is in all the regions we want and has tags in all regions. If one can't be found, fall back to the latest image.

This should help us not find diffs as much in images and rebake.

I also changed function names because I was a little confused when working with them.