### PR TITLE
fix(bake): include account in find packages

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -98,10 +98,10 @@ class ImageService(
    * Each ami must have tags.
    */
   suspend fun getLatestNamedImageWithAllRegionsForAppVersion(appVersion: AppVersion, account: String, regions: List<String>): NamedImage? =
-    cloudDriverService.images(
+    cloudDriverService.namedImages(
       serviceAccount = DEFAULT_SERVICE_ACCOUNT,
-      provider = "aws",
-      name = appVersion.toImageName().replace("~", "_")
+      imageName = appVersion.toImageName().replace("~", "_"),
+      account = account
     )
       .sortedWith(NamedImageComparator)
       .findLast {
@@ -115,10 +115,10 @@ class ImageService(
    * Each ami must have tags.
    */
   suspend fun getLatestNamedImageWithAllRegions(packageName: String, account: String, regions: List<String>): NamedImage? =
-    cloudDriverService.images(
+    cloudDriverService.namedImages(
       serviceAccount = DEFAULT_SERVICE_ACCOUNT,
-      provider = "aws",
-      name = packageName
+      imageName = packageName,
+      account = account
     )
       .sortedWith(NamedImageComparator)
       .findLast {

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -318,10 +318,10 @@ internal class ImageServiceTests {
     val packageName = "keel"
     val regions = listOf("us-west-2", "us-east-1")
     coEvery {
-      cloudDriver.images(
+      cloudDriver.namedImages(
         serviceAccount = DEFAULT_SERVICE_ACCOUNT,
-        provider = "aws",
-        name = packageName
+        imageName = packageName,
+        account = "test"
       )
     } returns realImages
 
@@ -339,10 +339,10 @@ internal class ImageServiceTests {
     val appVersion = "keel-0.312.0-h240.44eaaa3"
     val regions = listOf("us-west-2", "us-east-1")
     coEvery {
-      cloudDriver.images(
+      cloudDriver.namedImages(
         serviceAccount = DEFAULT_SERVICE_ACCOUNT,
-        provider = "aws",
-        name = appVersion
+        imageName = appVersion,
+        account = "test"
       )
     } returns realImages
 

--- a/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
+++ b/keel-tagging-plugin/src/main/kotlin/com/netflix/spinnaker/keel/tagging/ResourceTagger.kt
@@ -77,7 +77,6 @@ class ResourceTagger(
 
   private val taggableResources = listOf(
     "cluster",
-    "titus-cluster", // todo eb: fix to just be cluster
     "security-group",
     "classic-load-balancer",
     "application-load-balancer"


### PR DESCRIPTION
Accidentally didn't use account in the query to find an image by package name. That didn't work. Trying again with the right api calls here.

Also removing `titus-cluster` from tag-able things because I forgot to earlier