### PR TITLE
feat(resource-status): Return PAUSED status for vetoed resources

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -44,12 +44,8 @@ class ResourceActuator(
     if (!response.allowed) {
       log.debug("Skipping actuation for resource {} because it was vetoed: {}", id, response.message)
       publisher.publishEvent(ResourceCheckSkipped(apiVersion, kind, id))
-
-      if (resourceRepository.lastEvent(id) !is ResourceActuationPaused) {
-        log.info("Actuation for resource {} paused due to veto: {}", id, response.message)
-        publisher.publishEvent(ResourceActuationPaused(apiVersion, kind, id.value, id.applicationName, response.message,
-          clock.instant()))
-      }
+      publisher.publishEvent(ResourceActuationPaused(apiVersion, kind, id.value, id.application, response.message,
+        clock.instant()))
       return
     }
 
@@ -65,7 +61,7 @@ class ResourceActuator(
 
     if (resourceRepository.lastEvent(id) is ResourceActuationPaused) {
       log.info("Actuation for resource {} resuming", id)
-      publisher.publishEvent(ResourceActuationResumed(apiVersion, kind, id.value, id.applicationName, clock.instant()))
+      publisher.publishEvent(ResourceActuationResumed(apiVersion, kind, id.value, id.application, clock.instant()))
     }
 
     val resource = resourceRepository.get(id)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -18,7 +18,6 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
-import com.netflix.spinnaker.keel.veto.VetoEnforcer
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
@@ -30,8 +29,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/application"])
 class ApplicationController(
-  private val resourceRepository: ResourceRepository,
-  private val vetoEnforcer: VetoEnforcer
+  private val resourceRepository: ResourceRepository
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -18,7 +18,6 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
-import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.keel.veto.VetoEnforcer
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -47,12 +46,6 @@ class ApplicationController(
     if (includeDetails) {
       val resources = resourceRepository.getSummaryByApplication(application)
         .filter { it.kind != "keel-tag" }
-        .map { resourceSummary ->
-          when {
-            vetoEnforcer.canCheck(resourceSummary.id).allowed -> resourceSummary
-            else -> resourceSummary.copy(status = ResourceStatus.PAUSED)
-          }
-        }
 
       return mapOf(
         "hasManagedResources" to resources.isNotEmpty(),

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -68,21 +68,4 @@ internal class ApplicationControllerTests {
         """{"hasManagedResources":true,"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}]}"""
       ))
   }
-
-  @Test
-  fun `overrides resource status to PAUSED when vetoed`() {
-    val res = resource(id = "test:whatever:fnord")
-    resourceRepository.store(res)
-    resourceRepository.appendHistory(ResourceCreated(res))
-    applicationVetoRepository.optOut(res.application)
-
-    val request = get("/application/${res.application}?includeDetails=true")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andExpect(content().string(
-        """{"hasManagedResources":true,"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"PAUSED"}]}"""
-      ))
-  }
 }

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -1,0 +1,88 @@
+package com.netflix.spinnaker.keel.rest
+
+import com.netflix.spinnaker.keel.KeelApplication
+import com.netflix.spinnaker.keel.api.application
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.events.ResourceCreated
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryApplicationVetoRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
+import com.netflix.spinnaker.keel.test.resource
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+  classes = [KeelApplication::class, MockEurekaConfiguration::class],
+  webEnvironment = MOCK
+)
+@AutoConfigureMockMvc
+internal class ApplicationControllerTests {
+  @Autowired
+  lateinit var mvc: MockMvc
+
+  @Autowired
+  lateinit var resourceRepository: InMemoryResourceRepository
+
+  @Autowired
+  lateinit var applicationVetoRepository: InMemoryApplicationVetoRepository
+
+  @AfterEach
+  fun clearRepository() {
+    resourceRepository.dropAll()
+    applicationVetoRepository.flush()
+  }
+
+  @Test
+  fun `can get resource summaries by application`() {
+    val res = resource()
+    resourceRepository.store(res)
+    resourceRepository.appendHistory(ResourceCreated(res))
+
+    var request = get("/application/${res.application}")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+    mvc
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().string(
+        """{"hasManagedResources":true}"""
+      ))
+
+    request = get("/application/${res.application}?includeDetails=true")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+    mvc
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().string(
+        """{"hasManagedResources":true,"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}]}"""
+      ))
+  }
+
+  @Test
+  fun `overrides resource status to PAUSED when vetoed`() {
+    val res = resource(id = "test:whatever:fnord")
+    resourceRepository.store(res)
+    resourceRepository.appendHistory(ResourceCreated(res))
+    applicationVetoRepository.optOut(res.application)
+
+    val request = get("/application/${res.application}?includeDetails=true")
+      .accept(MediaType.APPLICATION_JSON_VALUE)
+    mvc
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().string(
+        """{"hasManagedResources":true,"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"PAUSED"}]}"""
+      ))
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
@@ -26,6 +26,6 @@ data class ResourceId(val value: String) {
   override fun toString(): String = value
 
   // Resource names (the last token in a ResourceId) follow the Moniker format (<app>-<stack>-<detail>)
-  val applicationName: String
+  val application: String
     get() = value.split(":").last().split("-").first()
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
@@ -24,4 +24,8 @@ import com.netflix.spinnaker.keel.serialization.ResourceIdDeserializer
 @JsonDeserialize(using = ResourceIdDeserializer::class)
 data class ResourceId(val value: String) {
   override fun toString(): String = value
+
+  // Resource names (the last token in a ResourceId) follow the Moniker format (<app>-<stack>-<detail>)
+  val applicationName: String
+    get() = value.split(":").last().split("-").first()
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -249,6 +249,48 @@ data class ResourceActuationLaunched(
 }
 
 /**
+ * Actuation on the managed resource has been paused.
+ *
+ * @property reason The reason why actuation was paused.
+ */
+data class ResourceActuationPaused(
+  override val apiVersion: ApiVersion,
+  override val kind: String,
+  override val id: String,
+  override val application: String,
+  val reason: String?,
+  override val timestamp: Instant
+) : ResourceEvent() {
+  constructor(resource: Resource<*>, reason: String?, clock: Clock = Companion.clock) : this(
+    resource.apiVersion,
+    resource.kind,
+    resource.id.value,
+    resource.application,
+    reason,
+    clock.instant()
+  )
+}
+
+/**
+ * Actuation on the managed resource has resumed.
+ */
+data class ResourceActuationResumed(
+  override val apiVersion: ApiVersion,
+  override val kind: String,
+  override val id: String,
+  override val application: String,
+  override val timestamp: Instant
+) : ResourceEvent() {
+  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
+    resource.apiVersion,
+    resource.kind,
+    resource.id.value,
+    resource.application,
+    clock.instant()
+  )
+}
+
+/**
  * The desired and actual states of a managed resource now match where previously there was a delta
  * (or the resource did not exist).
  */

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -56,7 +56,9 @@ import java.time.Instant
   Type(value = ResourceDeltaDetected::class, name = "ResourceDeltaDetected"),
   Type(value = ResourceDeltaResolved::class, name = "ResourceDeltaResolved"),
   Type(value = ResourceValid::class, name = "ResourceValid"),
-  Type(value = ResourceCheckError::class, name = "ResourceCheckError")
+  Type(value = ResourceCheckError::class, name = "ResourceCheckError"),
+  Type(value = ResourceActuationPaused::class, name = "ResourceActuationPaused"),
+  Type(value = ResourceActuationResumed::class, name = "ResourceActuationResumed")
 )
 sealed class ResourceEvent {
   abstract val apiVersion: ApiVersion
@@ -261,6 +263,9 @@ data class ResourceActuationPaused(
   val reason: String?,
   override val timestamp: Instant
 ) : ResourceEvent() {
+  @JsonIgnore
+  override val ignoreRepeatedInHistory = true
+
   constructor(resource: Resource<*>, reason: String?, clock: Clock = Companion.clock) : this(
     resource.apiVersion,
     resource.kind,
@@ -281,6 +286,9 @@ data class ResourceActuationResumed(
   override val application: String,
   override val timestamp: Instant
 ) : ResourceEvent() {
+  @JsonIgnore
+  override val ignoreRepeatedInHistory = true
+
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
     resource.apiVersion,
     resource.kind,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -104,6 +104,14 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
   fun eventHistory(id: ResourceId, limit: Int = DEFAULT_MAX_EVENTS): List<ResourceEvent>
 
   /**
+   * Retrieves the last event from the history of state change events for the resource represented by [id] or null if
+   * none found.
+   *
+   * @param id the resource id.
+   */
+  fun lastEvent(id: ResourceId): ResourceEvent? = eventHistory(id, 1).firstOrNull()
+
+  /**
    * Records an event associated with a resource.
    */
   fun appendHistory(event: ResourceEvent)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
+import com.netflix.spinnaker.keel.events.ResourceActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
@@ -40,6 +41,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNKNOWN
 import com.netflix.spinnaker.keel.events.ResourceValid
 
@@ -135,6 +137,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
       history.isError() -> ERROR
       history.isCreated() -> CREATED
       history.isPaused() -> PAUSED
+      history.isResumed() -> RESUMED
       else -> UNKNOWN
     }
   }
@@ -161,6 +164,10 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
 
   private fun List<ResourceEvent>.isPaused(): Boolean {
     return first() is ResourceActuationPaused
+  }
+
+  private fun List<ResourceEvent>.isResumed(): Boolean {
+    return first() is ResourceActuationResumed
   }
 
   /**
@@ -211,5 +218,5 @@ sealed class NoSuchResourceException(override val message: String?) : RuntimeExc
 class NoSuchResourceId(id: ResourceId) : NoSuchResourceException("No resource with id $id exists in the repository")
 
 enum class ResourceStatus {
-  HAPPY, ACTUATING, UNHAPPY, CREATED, DIFF, ERROR, PAUSED, UNKNOWN
+  HAPPY, ACTUATING, UNHAPPY, CREATED, DIFF, ERROR, PAUSED, RESUMED, UNKNOWN
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -195,5 +195,5 @@ sealed class NoSuchResourceException(override val message: String?) : RuntimeExc
 class NoSuchResourceId(id: ResourceId) : NoSuchResourceException("No resource with id $id exists in the repository")
 
 enum class ResourceStatus {
-  HAPPY, ACTUATING, UNHAPPY, CREATED, DIFF, ERROR, UNKNOWN
+  HAPPY, ACTUATING, UNHAPPY, CREATED, DIFF, ERROR, PAUSED, UNKNOWN
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -26,20 +26,23 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
+import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceMissing
-import com.netflix.spinnaker.keel.events.ResourceValid
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNKNOWN
+import com.netflix.spinnaker.keel.events.ResourceValid
+
 import java.time.Duration
 
 data class ResourceHeader(
@@ -123,6 +126,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
       history.isActuating() -> ACTUATING
       history.isError() -> ERROR
       history.isCreated() -> CREATED
+      history.isPaused() -> PAUSED
       else -> UNKNOWN
     }
   }
@@ -145,6 +149,10 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
 
   private fun List<ResourceEvent>.isDiff(): Boolean {
     return first() is ResourceDeltaDetected || first() is ResourceMissing
+  }
+
+  private fun List<ResourceEvent>.isPaused(): Boolean {
+    return first() is ResourceActuationPaused
   }
 
   /**

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -19,12 +19,13 @@ package com.netflix.spinnaker.keel.events
 
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.exceptions.InvalidResourceFormatException
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -42,6 +43,9 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val actuationLaunchedEvent = ResourceActuationLaunched(resource, "resourceHandlerPlugin", listOf(Task("1", "task name")))
     val deltaResolvedEvent = ResourceDeltaResolved(resource)
     val errorEvent = ResourceCheckError(resource, InvalidResourceFormatException("bad resource", "who knows"))
+    val actuationPausedEvent = ResourceActuationPaused(resource, "whatever")
+    val actuationResumedEvent = ResourceActuationResumed(resource)
+    val resourceValidEvent = ResourceValid(resource)
   }
 
   fun tests() = rootContext<Fixture> {
@@ -67,7 +71,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(missingEvent)
       }
 
-      test("returns diff") {
+      test("returns diff status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(DIFF)
       }
     }
@@ -78,7 +82,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(deltaDetectedEvent)
       }
 
-      test("returns returns diff") {
+      test("returns diff status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(DIFF)
       }
     }
@@ -90,7 +94,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(actuationLaunchedEvent)
       }
 
-      test("returns returns actuating") {
+      test("returns actuating status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(ACTUATING)
       }
     }
@@ -110,7 +114,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(actuationLaunchedEvent)
       }
 
-      test("returns returns unhappy") {
+      test("returns unhappy status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(UNHAPPY)
       }
     }
@@ -131,7 +135,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(deltaResolvedEvent)
       }
 
-      test("returns returns happy") {
+      test("returns happy status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
@@ -144,7 +148,17 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(deltaResolvedEvent)
       }
 
-      test("returns returns happy") {
+      test("returns happy status") {
+        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
+      }
+    }
+
+    context("resource valid") {
+      before {
+        resourceRepository.appendHistory(resourceValidEvent)
+      }
+
+      test("returns happy status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
@@ -154,8 +168,30 @@ internal class ResourceStatusTests : JUnit5Minutests {
         resourceRepository.appendHistory(errorEvent)
       }
 
-      test("returns returns error") {
+      test("returns error status") {
         expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(ERROR)
+      }
+    }
+
+    context("resource actuation paused") {
+      before {
+        resourceRepository.appendHistory(actuationPausedEvent)
+      }
+
+      test("returns paused status") {
+        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(PAUSED)
+      }
+    }
+
+    context("resource actuation resumed") {
+      before {
+        resourceRepository.appendHistory(actuationPausedEvent)
+        resourceRepository.appendHistory(actuationResumedEvent)
+        resourceRepository.appendHistory(resourceValidEvent)
+      }
+
+      test("returns status according to first event after resuming") {
+        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -187,11 +188,10 @@ internal class ResourceStatusTests : JUnit5Minutests {
       before {
         resourceRepository.appendHistory(actuationPausedEvent)
         resourceRepository.appendHistory(actuationResumedEvent)
-        resourceRepository.appendHistory(resourceValidEvent)
       }
 
-      test("returns status according to first event after resuming") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
+      test("returns resumed status") {
+        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(RESUMED)
       }
     }
   }

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
@@ -34,6 +34,8 @@ class ApplicationVeto(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun check(id: ResourceId): VetoResponse {
+    // FIXME (lpollo): The following expects a ResourceId to have a specific format, but it's not defined/enforced
+    //  anywhere. We should add a validation and perhaps token extraction methods to ResourceId to be used consistently.
     val appName = id.toString().split(":").last().split("-").first()
     if (applicationVetoRepository.appVetoed(appName)) {
       return VetoResponse(allowed = false, message = "Application $appName has been opted out.")

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
@@ -34,11 +34,8 @@ class ApplicationVeto(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun check(id: ResourceId): VetoResponse {
-    // FIXME (lpollo): The following expects a ResourceId to have a specific format, but it's not defined/enforced
-    //  anywhere. We should add a validation and perhaps token extraction methods to ResourceId to be used consistently.
-    val appName = id.toString().split(":").last().split("-").first()
-    if (applicationVetoRepository.appVetoed(appName)) {
-      return VetoResponse(allowed = false, message = "Application $appName has been opted out.")
+    if (applicationVetoRepository.appVetoed(id.applicationName)) {
+      return VetoResponse(allowed = false, message = "Application ${id.applicationName} has been opted out.")
     }
     return VetoResponse(allowed = true)
   }

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/application/ApplicationVeto.kt
@@ -34,8 +34,8 @@ class ApplicationVeto(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun check(id: ResourceId): VetoResponse {
-    if (applicationVetoRepository.appVetoed(id.applicationName)) {
-      return VetoResponse(allowed = false, message = "Application ${id.applicationName} has been opted out.")
+    if (applicationVetoRepository.appVetoed(id.application)) {
+      return VetoResponse(allowed = false, message = "Application ${id.application} has been opted out.")
     }
     return VetoResponse(allowed = true)
   }


### PR DESCRIPTION
Addresses #561 

~After discussing with @emjburns, I implemented an override of the resource status in `ApplicationController`, which is what the UI calls to get resource summaries, so that it was possible to use the auto-wired `VetoEnforcer` bean without introducing new cross-module dependencies (the `ResourceRepository` interface, which is where status is currently calculated for resources, is in `keel-core`, and `VetoEnforcer` is in `keel-veto`). This works, but has the undesired side-effect that the `PAUSED` status as defined by a presence of any veto on a resource is only visible from the `/application` API. For example, if you call `/resources` you'll still get whatever the "real" status of the resource is.~

@asher @robfletcher If you have any ideas on how to do this in a different/better way, I'd be happy to change things around.

@erikmunson FYI.

Update: based on feedback below, I revisited the implementation to follow the existing pattern of emitting `ResourceEvent`s from `ResourceActuator`, and introduced new events for when actuation is paused/resumed. I kept the tests for `ApplicationController` (which are now unrelated) because we didn't have any before. I extracted the logic to parse the app name from a `ResourceId` into a getter so it can be used consistently. Hope this will make more sense now.

~P.S. I think I may have uncovered an issue with different assumptions we make about the `ResourceId` format in different places (see `FIXME` comment in `ApplicationVeto`).~