### PR TITLE
feat(deb): scheduled fetch latest artifact

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
+import com.netflix.spinnaker.keel.events.ArtifactSyncEvent
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
@@ -58,6 +59,14 @@ class ArtifactController(
   @ResponseStatus(ACCEPTED)
   fun register(@RequestBody artifact: DeliveryArtifact) {
     publisher.publishEvent(ArtifactRegisteredEvent(artifact))
+  }
+
+  @PostMapping(
+    path = ["/sync"]
+  )
+  @ResponseStatus(ACCEPTED)
+  fun sync() {
+    publisher.publishEvent(ArtifactSyncEvent(true))
   }
 
   @GetMapping(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ArtifactEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ArtifactEvent.kt
@@ -16,3 +16,7 @@ data class ArtifactRegisteredEvent(
   val artifact: DeliveryArtifact,
   val statuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList()
 )
+
+data class ArtifactSyncEvent(
+  val controllerTriggered: Boolean = false
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -15,6 +15,8 @@ interface ArtifactRepository {
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
+  fun getAll(type: ArtifactType? = null): List<DeliveryArtifact>
+
   /**
    * @return `true` if a new version is persisted, `false` if the specified version was already
    * known (in which case this method is a no-op).
@@ -88,7 +90,7 @@ interface ArtifactRepository {
   )
 }
 
-private val VERSION_COMPARATOR: Comparator<String> = object : Comparator<String> {
+val VERSION_COMPARATOR: Comparator<String> = object : Comparator<String> {
   override fun compare(s1: String, s2: String) =
     debComparator.compare(s1.toVersion(), s2.toVersion())
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -42,6 +42,9 @@ class InMemoryArtifactRepository : ArtifactRepository {
       it.name == name && it.type == type
     }
 
+  override fun getAll(type: ArtifactType?): List<DeliveryArtifact> =
+    artifacts.keys.toList().filter { type == null || it.type == type }
+
   override fun versions(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>): List<String> {
     val versions = artifacts[artifact] ?: throw NoSuchArtifactException(artifact)
     return versions.filter { it.status in statuses }.map { it.version }.sortAppVersion()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -62,6 +62,15 @@ class SqlArtifactRepository(
       .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
       .fetchOne() != null
 
+  override fun getAll(type: ArtifactType?): List<DeliveryArtifact> =
+    jooq
+      .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.TYPE)
+      .from(DELIVERY_ARTIFACT)
+      .apply { if (type != null) where(DELIVERY_ARTIFACT.TYPE.eq(type.toString())) }
+      .fetch { (name, type) ->
+        DeliveryArtifact(name, ArtifactType.valueOf(type))
+      }
+
   override fun versions(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>): List<String> {
     val status = statuses.map { it.toString() }
     return if (isRegistered(artifact.name, artifact.type)) {


### PR DESCRIPTION
Scheduled method to fetch the latest artifact version in case we
- we miss events
- can't handle the event we received so we throw it out
- are running locally and want to test out artifact version things

I have some open questions, namely:
- should this be a distributed mechanism so that we're not doing the fetching on each instance every 3 minutes?
- should I launch a bunch of async tasks with coroutines for the fetch for each artifact, instead of going one by one in a loop?