### PR TITLE
don't treat missing AMI as a fatal resolution error

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.id
@@ -9,6 +10,7 @@ import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
+import com.netflix.spinnaker.keel.events.ResourceCheckDependencyMissing
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
@@ -101,6 +103,9 @@ class ResourceActuator(
           }
         }
       }
+    } catch (e: ResourceDependencyNotFound) {
+      log.warn("Resource check for {} failed (hopefully temporarily) due to {}", id, e.message)
+      publisher.publishEvent(ResourceCheckDependencyMissing(resource, e, clock))
     } catch (e: Exception) {
       log.error("Resource check for $id failed", e)
       publisher.publishEvent(ResourceCheckError(resource, e, clock))
@@ -112,6 +117,8 @@ class ResourceActuator(
       val desired = async {
         try {
           desired(resource)
+        } catch (e: ResourceDependencyNotFound) {
+          throw e
         } catch (e: Throwable) {
           throw CannotResolveDesiredState(resource.id, e)
         }

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.id
@@ -10,7 +10,7 @@ import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
-import com.netflix.spinnaker.keel.events.ResourceCheckDependencyMissing
+import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
@@ -103,9 +103,9 @@ class ResourceActuator(
           }
         }
       }
-    } catch (e: ResourceDependencyNotFound) {
+    } catch (e: ResourceCurrentlyUnresolvable) {
       log.warn("Resource check for {} failed (hopefully temporarily) due to {}", id, e.message)
-      publisher.publishEvent(ResourceCheckDependencyMissing(resource, e, clock))
+      publisher.publishEvent(ResourceCheckUnresolvable(resource, e, clock))
     } catch (e: Exception) {
       log.error("Resource check for $id failed", e)
       publisher.publishEvent(ResourceCheckError(resource, e, clock))
@@ -117,7 +117,7 @@ class ResourceActuator(
       val desired = async {
         try {
           desired(resource)
-        } catch (e: ResourceDependencyNotFound) {
+        } catch (e: ResourceCurrentlyUnresolvable) {
           throw e
         } catch (e: Throwable) {
           throw CannotResolveDesiredState(resource.id, e)

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -1,13 +1,13 @@
 package com.netflix.spinnaker.keel.actuation
 
-import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
-import com.netflix.spinnaker.keel.events.ResourceCheckDependencyMissing
+import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCheckResult
 import com.netflix.spinnaker.keel.events.ResourceCreated
@@ -286,7 +286,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
           context("plugin throws a transient dependency exception in desired state resolution") {
             before {
-              coEvery { plugin1.desired(resource) } throws object : ResourceDependencyNotFound("o noes") {}
+              coEvery { plugin1.desired(resource) } throws object : ResourceCurrentlyUnresolvable("o noes") {}
               coEvery { plugin1.current(resource) } returns null
 
               with(resource) {
@@ -301,10 +301,10 @@ internal class ResourceActuatorTests : JUnit5Minutests {
             }
 
             test("a telemetry event is published with detail of the problem") {
-              val event = slot<ResourceCheckDependencyMissing>()
+              val event = slot<ResourceCheckUnresolvable>()
               verify { publisher.publishEvent(capture(event)) }
               expectThat(event.captured)
-                .isA<ResourceCheckDependencyMissing>()
+                .isA<ResourceCheckUnresolvable>()
                 .get { message }
                 .isEqualTo("o noes")
             }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceCurrentlyUnresolvable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceCurrentlyUnresolvable.kt
@@ -7,5 +7,5 @@ package com.netflix.spinnaker.keel.api
  *
  * Exceptions of this type are not treated as fatal as they are expected to be transient.
  */
-abstract class ResourceDependencyNotFound(message: String, cause: Throwable? = null) :
+abstract class ResourceCurrentlyUnresolvable(message: String, cause: Throwable? = null) :
   RuntimeException(message, cause)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceDependencyNotFound.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceDependencyNotFound.kt
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.keel.api
+
+/**
+ * Sub-classes of this exception type may be thrown during resource desired state resolution
+ * implementations to indicate that some object the resource relies on is not (yet) available. For
+ * example, an AMI has not yet been baked.
+ *
+ * Exceptions of this type are not treated as fatal as they are expected to be transient.
+ */
+abstract class ResourceDependencyNotFound(message: String, cause: Throwable? = null) :
+  RuntimeException(message, cause)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
@@ -57,7 +57,7 @@ import java.time.Instant
   Type(value = ResourceDeltaResolved::class, name = "ResourceDeltaResolved"),
   Type(value = ResourceValid::class, name = "ResourceValid"),
   Type(value = ResourceCheckError::class, name = "ResourceCheckError"),
-  Type(value = ResourceDependencyNotFound::class, name = "ResourceDependencyNotFound"),
+  Type(value = ResourceCheckUnresolvable::class, name = "ResourceCheckPending"),
   Type(value = ResourceActuationPaused::class, name = "ResourceActuationPaused"),
   Type(value = ResourceActuationResumed::class, name = "ResourceActuationResumed")
 )
@@ -317,7 +317,7 @@ data class ResourceValid(
     )
 }
 
-data class ResourceCheckDependencyMissing(
+data class ResourceCheckUnresolvable(
   override val apiVersion: ApiVersion,
   override val kind: String,
   override val id: String,
@@ -331,7 +331,7 @@ data class ResourceCheckDependencyMissing(
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, exception: ResourceDependencyNotFound, clock: Clock = Companion.clock) :
+  constructor(resource: Resource<*>, exception: ResourceCurrentlyUnresolvable, clock: Clock = Companion.clock) :
     this(
       resource.apiVersion,
       resource.kind,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
 import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
@@ -56,6 +57,7 @@ import java.time.Instant
   Type(value = ResourceDeltaResolved::class, name = "ResourceDeltaResolved"),
   Type(value = ResourceValid::class, name = "ResourceValid"),
   Type(value = ResourceCheckError::class, name = "ResourceCheckError"),
+  Type(value = ResourceDependencyNotFound::class, name = "ResourceDependencyNotFound"),
   Type(value = ResourceActuationPaused::class, name = "ResourceActuationPaused"),
   Type(value = ResourceActuationResumed::class, name = "ResourceActuationResumed")
 )
@@ -312,6 +314,31 @@ data class ResourceValid(
       resource.id.value,
       resource.application,
       clock.instant()
+    )
+}
+
+data class ResourceCheckDependencyMissing(
+  override val apiVersion: ApiVersion,
+  override val kind: String,
+  override val id: String,
+  override val application: String,
+  override val timestamp: Instant,
+  val message: String?
+) : ResourceCheckResult() {
+  @JsonIgnore
+  override val state = Diff
+
+  @JsonIgnore
+  override val ignoreRepeatedInHistory = true
+
+  constructor(resource: Resource<*>, exception: ResourceDependencyNotFound, clock: Clock = Companion.clock) :
+    this(
+      resource.apiVersion,
+      resource.kind,
+      resource.id.value,
+      resource.application,
+      clock.instant(),
+      exception.message
     )
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
+import com.netflix.spinnaker.keel.events.ResourceCheckDependencyMissing
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
@@ -159,7 +160,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
   }
 
   private fun List<ResourceEvent>.isDiff(): Boolean {
-    return first() is ResourceDeltaDetected || first() is ResourceMissing
+    return first() is ResourceDeltaDetected || first() is ResourceMissing || first() is ResourceCheckDependencyMissing
   }
 
   private fun List<ResourceEvent>.isPaused(): Boolean {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -28,7 +28,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
-import com.netflix.spinnaker.keel.events.ResourceCheckDependencyMissing
+import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
@@ -160,7 +160,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<ResourceHeader> {
   }
 
   private fun List<ResourceEvent>.isDiff(): Boolean {
-    return first() is ResourceDeltaDetected || first() is ResourceMissing || first() is ResourceCheckDependencyMissing
+    return first() is ResourceDeltaDetected || first() is ResourceMissing || first() is ResourceCheckUnresolvable
   }
 
   private fun List<ResourceEvent>.isPaused(): Boolean {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -17,7 +17,7 @@
  */
 package com.netflix.spinnaker.keel.events
 
-import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.exceptions.InvalidResourceFormatException
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
@@ -44,7 +44,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val deltaDetectedEvent = ResourceDeltaDetected(resource, mapOf("hi" to "wow"))
     val actuationLaunchedEvent = ResourceActuationLaunched(resource, "resourceHandlerPlugin", listOf(Task("1", "task name")))
     val deltaResolvedEvent = ResourceDeltaResolved(resource)
-    val dependencyMissingEvent = ResourceCheckDependencyMissing(resource, object : ResourceDependencyNotFound("I guess I can't find the AMI or something") {})
+    val dependencyMissingEvent = ResourceCheckUnresolvable(resource, object : ResourceCurrentlyUnresolvable("I guess I can't find the AMI or something") {})
     val errorEvent = ResourceCheckError(resource, InvalidResourceFormatException("bad resource", "who knows"))
     val actuationPausedEvent = ResourceActuationPaused(resource, "whatever")
     val actuationResumedEvent = ResourceActuationResumed(resource)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
@@ -15,16 +15,15 @@
  * limitations under the License.
  *
  */
-package com.netflix.spinnaker.keel.api
+package com.netflix.spinnaker.keel.ec2
+
+import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
 
 class NoImageFound(artifactName: String) :
-  RuntimeException("No image found for artifact $artifactName")
-
-class NoImageFoundForRegion(artifactName: String, region: String) :
-  RuntimeException("No image found for artifact $artifactName in region $region")
+  ResourceDependencyNotFound("No image found for artifact $artifactName")
 
 class NoImageFoundForRegions(artifactName: String, regions: Collection<String>) :
-  RuntimeException("No image found for artifact $artifactName in regions ${regions.joinToString()}")
+  ResourceDependencyNotFound("No image found for artifact $artifactName in regions ${regions.joinToString()}")
 
 class NoImageSatisfiesConstraints(artifactName: String, environment: String) :
-  RuntimeException("No image found for artifact $artifactName in $environment")
+  ResourceDependencyNotFound("No image found for artifact $artifactName in $environment")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
@@ -17,13 +17,13 @@
  */
 package com.netflix.spinnaker.keel.ec2
 
-import com.netflix.spinnaker.keel.api.ResourceDependencyNotFound
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 
 class NoImageFound(artifactName: String) :
-  ResourceDependencyNotFound("No image found for artifact $artifactName")
+  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName")
 
 class NoImageFoundForRegions(artifactName: String, regions: Collection<String>) :
-  ResourceDependencyNotFound("No image found for artifact $artifactName in regions ${regions.joinToString()}")
+  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in regions ${regions.joinToString()}")
 
 class NoImageSatisfiesConstraints(artifactName: String, environment: String) :
-  ResourceDependencyNotFound("No image found for artifact $artifactName in $environment")
+  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in $environment")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -7,9 +7,8 @@ import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
-import com.netflix.spinnaker.keel.api.NoImageFound
-import com.netflix.spinnaker.keel.api.NoImageFoundForRegions
-import com.netflix.spinnaker.keel.api.NoImageSatisfiesConstraints
+import com.netflix.spinnaker.keel.ec2.NoImageFoundForRegions
+import com.netflix.spinnaker.keel.ec2.NoImageSatisfiesConstraints
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
@@ -269,7 +268,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           test("throws an exception") {
             expectCatching { resolve() }
               .failed()
-              .isA<NoImageFound>()
+              .isA<NoImageFoundForRegions>()
           }
         }
 


### PR DESCRIPTION
This creates a new base exception type we can use for any "transient" failures in resolving desired state. In this case I'm using it to treat the inability to resolve an AMI for the desired app version as a fatal error as the presumption is it's currently baking (or about to bake).