### PR TITLE
feat(export): Titus cluster export

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiff.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiff.kt
@@ -39,8 +39,8 @@ data class ResourceDiff<T : Any>(
         }
       }
 
-  val affectedRootPropertyNames: List<String>
-    get() = mutableListOf<String>()
+  val affectedRootPropertyNames: Set<String>
+    get() = mutableSetOf<String>()
       .also { names ->
         diff.visitChildren { node, visit ->
           visit.dontGoDeeper()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiff.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiff.kt
@@ -39,6 +39,15 @@ data class ResourceDiff<T : Any>(
         }
       }
 
+  val affectedRootPropertyNames: List<String>
+    get() = mutableListOf<String>()
+      .also { names ->
+        diff.visitChildren { node, visit ->
+          visit.dontGoDeeper()
+          names += node.propertyName
+        }
+      }
+
   fun toDeltaJson(): Map<String, Any?> =
     JsonVisitor(desired, current, "desired", "current")
       .also { diff.visit(it) }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -121,6 +121,7 @@ class TitusClusterHandler(
     }
 
   override suspend fun export(exportable: Exportable): SubmittedResource<TitusClusterSpec> {
+    // TODO[GY] : remove unchanged/default fields from response (across all export responses)
     val serverGroups = cloudDriverService.getServerGroups(
       exportable.account,
       exportable.moniker,
@@ -261,8 +262,6 @@ class TitusClusterHandler(
       val workingSpec = serverGroup.exportSpec()
       val diff = ResourceDiff(workingSpec, defaults)
       if (diff.hasChanges()) {
-        log.debug(diff.toDebug())
-        // man, I wish kotlin had **kwargs... :-P
         (overrides as MutableMap)[region] = TitusServerGroupSpec(
           capacity = if ("capacity" in diff.affectedRootPropertyNames) {
             workingSpec.capacity

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -154,6 +154,8 @@ class TitusClusterHandler(
         .filter { it.value.location.region != base.location.region }
     )
 
+    // TODO: omit defaults from exported spec
+
     return SubmittedResource(
       apiVersion = supportedKind.apiVersion,
       kind = supportedKind.kind,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -149,8 +149,6 @@ class TitusClusterHandler(
     )
 
     spec.generateOverrides(
-      exportable.account,
-      exportable.moniker.app,
       serverGroups
         .filter { it.value.location.region != base.location.region }
     )
@@ -258,11 +256,70 @@ class TitusClusterHandler(
         ResourceDiff(desired, current?.get(region))
       }
 
-  private fun TitusClusterSpec.generateOverrides(account: String, application: String, serverGroups: Map<String, TitusServerGroup>) =
+  private fun TitusClusterSpec.generateOverrides(serverGroups: Map<String, TitusServerGroup>) =
     serverGroups.forEach { (region, serverGroup) ->
-      if (ResourceDiff(serverGroup, defaults).hasChanges()) {
-        // FIXME (lpollo): return diff as TitusServerGroupSpec including only different values, other fields null
-        (overrides as MutableMap)[region] = serverGroup.exportSpec()
+      val workingSpec = serverGroup.exportSpec()
+      val diff = ResourceDiff(workingSpec, defaults)
+      if (diff.hasChanges()) {
+        log.debug(diff.toDebug())
+        // man, I wish kotlin had **kwargs... :-P
+        (overrides as MutableMap)[region] = TitusServerGroupSpec(
+          capacity = if ("capacity" in diff.affectedRootPropertyNames) {
+            workingSpec.capacity
+          } else {
+            null
+          },
+          capacityGroup = if ("capacityGroup" in diff.affectedRootPropertyNames) {
+            workingSpec.capacityGroup
+          } else {
+            null
+          },
+          constraints = if ("constraints" in diff.affectedRootPropertyNames) {
+            workingSpec.constraints
+          } else {
+            null
+          },
+          container = if ("container" in diff.affectedRootPropertyNames) {
+            workingSpec.container
+          } else {
+            null
+          },
+          dependencies = if ("dependencies" in diff.affectedRootPropertyNames) {
+            workingSpec.dependencies
+          } else {
+            null
+          },
+          entryPoint = if ("entryPoint" in diff.affectedRootPropertyNames) {
+            workingSpec.entryPoint
+          } else {
+            null
+          },
+          env = if ("env" in diff.affectedRootPropertyNames) {
+            workingSpec.env
+          } else {
+            null
+          },
+          iamProfile = if ("iamProfile" in diff.affectedRootPropertyNames) {
+            workingSpec.iamProfile
+          } else {
+            null
+          },
+          migrationPolicy = if ("migrationPolicy" in diff.affectedRootPropertyNames) {
+            workingSpec.migrationPolicy
+          } else {
+            null
+          },
+          resources = if ("resources" in diff.affectedRootPropertyNames) {
+            workingSpec.resources
+          } else {
+            null
+          },
+          tags = if ("tags" in diff.affectedRootPropertyNames) {
+            workingSpec.tags
+          } else {
+            null
+          }
+        )
       }
     }
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -138,7 +138,7 @@ class TitusClusterHandler(
 
     val locations = SimpleLocations(
       account = exportable.account,
-      regions = (exportable.regions.map {
+      regions = (serverGroups.keys.map {
         SimpleRegionSpec(it)
       }).toSet())
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -144,7 +144,6 @@ class TitusClusterHandler(
     val spec = TitusClusterSpec(
       moniker = exportable.moniker,
       locations = locations,
-      container = base.container,
       _defaults = base.exportSpec(),
       overrides = mutableMapOf()
     )

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -154,8 +154,6 @@ class TitusClusterHandler(
         .filter { it.value.location.region != base.location.region }
     )
 
-    // TODO: omit defaults from exported spec
-
     return SubmittedResource(
       apiVersion = supportedKind.apiVersion,
       kind = supportedKind.kind,
@@ -261,66 +259,44 @@ class TitusClusterHandler(
 
   private fun TitusClusterSpec.generateOverrides(serverGroups: Map<String, TitusServerGroup>) =
     serverGroups.forEach { (region, serverGroup) ->
+      var newSpec = TitusServerGroupSpec()
       val workingSpec = serverGroup.exportSpec()
       val diff = ResourceDiff(workingSpec, defaults)
       if (diff.hasChanges()) {
-        (overrides as MutableMap)[region] = TitusServerGroupSpec(
-          capacity = if ("capacity" in diff.affectedRootPropertyNames) {
-            workingSpec.capacity
-          } else {
-            null
-          },
-          capacityGroup = if ("capacityGroup" in diff.affectedRootPropertyNames) {
-            workingSpec.capacityGroup
-          } else {
-            null
-          },
-          constraints = if ("constraints" in diff.affectedRootPropertyNames) {
-            workingSpec.constraints
-          } else {
-            null
-          },
-          container = if ("container" in diff.affectedRootPropertyNames) {
-            workingSpec.container
-          } else {
-            null
-          },
-          dependencies = if ("dependencies" in diff.affectedRootPropertyNames) {
-            workingSpec.dependencies
-          } else {
-            null
-          },
-          entryPoint = if ("entryPoint" in diff.affectedRootPropertyNames) {
-            workingSpec.entryPoint
-          } else {
-            null
-          },
-          env = if ("env" in diff.affectedRootPropertyNames) {
-            workingSpec.env
-          } else {
-            null
-          },
-          iamProfile = if ("iamProfile" in diff.affectedRootPropertyNames) {
-            workingSpec.iamProfile
-          } else {
-            null
-          },
-          migrationPolicy = if ("migrationPolicy" in diff.affectedRootPropertyNames) {
-            workingSpec.migrationPolicy
-          } else {
-            null
-          },
-          resources = if ("resources" in diff.affectedRootPropertyNames) {
-            workingSpec.resources
-          } else {
-            null
-          },
-          tags = if ("tags" in diff.affectedRootPropertyNames) {
-            workingSpec.tags
-          } else {
-            null
-          }
-        )
+        if ("capacity" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(capacity = workingSpec.capacity)
+        }
+        if ("capacityGroup" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(capacityGroup = workingSpec.capacityGroup)
+        }
+        if ("constraints" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(constraints = workingSpec.constraints)
+        }
+        if ("container" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(container = workingSpec.container)
+        }
+        if ("dependencies" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(dependencies = workingSpec.dependencies)
+        }
+        if ("entryPoint" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(entryPoint = workingSpec.entryPoint)
+        }
+        if ("env" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(env = workingSpec.env)
+        }
+        if ("iamProfile" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(iamProfile = workingSpec.iamProfile)
+        }
+        if ("migrationPolicy" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(migrationPolicy = workingSpec.migrationPolicy)
+        }
+        if ("resources" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(resources = workingSpec.resources)
+        }
+        if ("tags" in diff.affectedRootPropertyNames) {
+          newSpec = newSpec.copy(tags = workingSpec.tags)
+        }
+        (overrides as MutableMap)[region] = newSpec
       }
     }
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -40,7 +40,6 @@ data class TitusClusterSpec(
   override val moniker: Moniker,
   val deployWith: ClusterDeployStrategy = RedBlack(),
   override val locations: SimpleLocations,
-  val container: Container,
   private val _defaults: TitusServerGroupSpec,
   val overrides: Map<String, TitusServerGroupSpec> = emptyMap()
 ) : Monikered, Locatable<SimpleLocations> {
@@ -72,7 +71,6 @@ data class TitusClusterSpec(
     moniker,
     deployWith,
     locations,
-    container,
     TitusServerGroupSpec(
       capacity = capacity,
       capacityGroup = capacityGroup,
@@ -168,7 +166,7 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       capacity = resolveCapacity(it.name),
       capacityGroup = resolveCapacityGroup(it.name),
       constraints = resolveConstraints(it.name),
-      container = container,
+      container = defaults.container ?: error("Container not specified or resolved"),
       dependencies = resolveDependencies(it.name),
       entryPoint = resolveEntryPoint(it.name),
       env = resolveEnv(it.name),

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.keel.api.Highlander
 import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
-import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
 import com.netflix.spinnaker.keel.api.titus.cluster.Container
@@ -446,17 +445,22 @@ class TitusClusterHandlerTests : JUnit5Minutests {
           coEvery { cloudDriverService.titusActiveServerGroup("us-west-2") } returns activeServerGroupResponseWest
         }
 
-        derivedContext<SubmittedResource<TitusClusterSpec>>("exported titus cluster spec") {
-          deriveFixture {
-            runBlocking {
-              export(exportable)
-            }
+        test("export omits properties with default values from complex fields") {
+          runBlocking {
+            export(exportable)
           }
 
+//        derivedContext<SubmittedResource<TitusClusterSpec>>("exported titus cluster spec") {
+//          deriveFixture {
+//            runBlocking {
+//              export(exportable)
+//            }
+//          }
+
           test("has the expected basic properties") {
-            expectThat(kind)
+            expectThat(resource.kind)
               .isEqualTo("cluster")
-            expectThat(apiVersion)
+            expectThat(resource.apiVersion)
               .isEqualTo(SPINNAKER_TITUS_API_V1)
             expectThat(spec.locations.regions)
               .hasSize(2)

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -313,7 +313,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
         val modified = setOf(
           serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity().withDifferentEnv()
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity().withDifferentRuntimeOptions()
         )
         val diff = ResourceDiff(
           serverGroups.byRegion(),
@@ -405,7 +405,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       context("multiple server groups have a diff") {
 
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentEnv(),
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentRuntimeOptions(),
           serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
         )
         val diff = ResourceDiff(
@@ -527,7 +527,7 @@ private fun TitusServerGroup.withDoubleCapacity(): TitusServerGroup =
     )
   )
 
-private fun TitusServerGroup.withDifferentEnv(): TitusServerGroup =
+private fun TitusServerGroup.withDifferentRuntimeOptions(): TitusServerGroup =
   copy(capacityGroup = "aDifferentGroup")
 
 private fun TitusActiveServerGroup.withDoubleCapacity(): TitusActiveServerGroup =

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -109,11 +109,6 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       account = titusAccount,
       regions = setOf(SimpleRegionSpec("us-east-1"), SimpleRegionSpec("us-west-2"))
     ),
-    container = Container(
-      organization = "spinnaker",
-      image = "keel",
-      digest = "sha:1111"
-    ),
     _defaults = TitusServerGroupSpec(
       capacity = Capacity(1, 6, 4),
       dependencies = ClusterDependencies(


### PR DESCRIPTION
Closes #570.

Other changes of note in this PR:
- Removes the top-level `container` field in `TitusClusterSpec` which was redundant with the `@JsonUnwrapped` `defaults.container` one and caused that field to show up twice in JSON/YAML