### PR TITLE
fix(resolution): Gracefully handle missing appversion tag

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -26,7 +26,7 @@ data class ActiveServerGroup(
 
 data class ActiveServerGroupImage(
   val imageId: String,
-  val appVersion: String
+  val appVersion: String?
 ) {
   @JsonCreator
   constructor(
@@ -39,7 +39,6 @@ data class ActiveServerGroupImage(
       ?.get("value")
       ?.toString()
       ?.substringBefore("/")
-      ?: throw RequiredTagMissing("appversion", imageId)
   )
 }
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LaunchConfiguration.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LaunchConfiguration.kt
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.keel.api.ec2
 
 data class LaunchConfiguration(
   val imageId: String,
-  val appVersion: String,
+  val appVersion: String? = null,
   val instanceType: String,
   val ebsOptimized: Boolean = false,
   val iamRole: String,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LaunchConfiguration.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LaunchConfiguration.kt
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.keel.api.ec2
 
 data class LaunchConfiguration(
   val imageId: String,
-  val appVersion: String? = null,
+  val appVersion: String?,
   val instanceType: String,
   val ebsOptimized: Boolean = false,
   val iamRole: String,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -379,7 +379,7 @@ class ClusterHandler(
         if (them.distinctBy { it.launchConfiguration.appVersion }.size == 1) {
           publisher.publishEvent(ArtifactVersionDeployed(
             resourceId = resource.id,
-            artifactVersion = them.first().launchConfiguration.appVersion
+            artifactVersion = them.first().launchConfiguration.appVersion!!
           ))
         }
       }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -377,10 +377,13 @@ class ClusterHandler(
     )
       .also { them ->
         if (them.distinctBy { it.launchConfiguration.appVersion }.size == 1) {
-          publisher.publishEvent(ArtifactVersionDeployed(
-            resourceId = resource.id,
-            artifactVersion = them.first().launchConfiguration.appVersion!!
-          ))
+          val appVersion = them.first().launchConfiguration.appVersion
+          if (appVersion != null) {
+            publisher.publishEvent(ArtifactVersionDeployed(
+              resourceId = resource.id,
+              artifactVersion = appVersion
+            ))
+          }
         }
       }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -448,8 +448,6 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         expectThat(slot.captured.job.first()) {
           get("type").isEqualTo("createServerGroup")
           get { get("availabilityZones") as Map<String, String> }.containsKey("us-west-2")
-          // TODO (lpollo): since we rely on the tag when looking up server groups, should we add the tag when creating them?
-          // get("tags").isEqualTo(mapOf("appversion" to serverGroupWest.launchConfiguration.appVersion))
         }
       }
     }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -429,7 +429,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         verify(exactly = 0) { publisher.publishEvent(ofType<ArtifactVersionDeployed>()) }
       }
 
-      test("applying the diff creates a server group") {
+      test("applying the diff creates a server group in the region with missing tag") {
         val modified = setOf(
           serverGroupEast.copy(name = activeServerGroupResponseEast.name),
           serverGroupWest.copy(name = activeServerGroupResponseWest.name).withMissingAppVersion()
@@ -447,6 +447,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         expectThat(slot.captured.job.first()) {
           get("type").isEqualTo("createServerGroup")
+          get { get("availabilityZones") as Map<String, String> }.containsKey("us-west-2")
           // TODO (lpollo): since we rely on the tag when looking up server groups, should we add the tag when creating them?
           // get("tags").isEqualTo(mapOf("appversion" to serverGroupWest.launchConfiguration.appVersion))
         }


### PR DESCRIPTION
Fixes #555 by allowing the app version field in the launch configuration to be null instead of throwing an exception.