### PR TITLE
feat(titus): docker artifact support

### DIFF
--- a/keel-api/keel-api.gradle.kts
+++ b/keel-api/keel-api.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(project(":keel-artifact"))
   api(project(":keel-veto"))
   api(project(":keel-sql"))
+  api(project(":keel-docker"))
 
   implementation(project(":keel-bakery-plugin"))
   implementation(project(":keel-ec2-plugin"))

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterSpec
 import com.netflix.spinnaker.keel.bakery.api.ImageSpec
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
-import dev.minutest.experimental.minus
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectCatching
@@ -126,6 +125,20 @@ class ConvertExampleFilesTest : JUnit5Minutests {
     context("simple titus cluster") {
       mapper.registerSubtypes(NamedType(TitusClusterSpec::class.java, "cluster"))
       val file = this.javaClass.getResource("/examples/simple-titus-cluster-example.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<*>>(file)
+        }
+          .succeeded()
+          .get { spec }
+          .isA<TitusClusterSpec>()
+      }
+    }
+
+    context("titus cluster with artifact") {
+      mapper.registerSubtypes(NamedType(TitusClusterSpec::class.java, "cluster"))
+      val file = this.javaClass.getResource("/examples/titus-cluster-with-artifact-example.yml").readText()
 
       test("yml can be parsed") {
         expectCatching {

--- a/keel-api/src/test/resources/examples/titus-cluster-with-artifact-example.yml
+++ b/keel-api/src/test/resources/examples/titus-cluster-with-artifact-example.yml
@@ -1,0 +1,31 @@
+---
+apiVersion: titus.spinnaker.netflix.com/v1
+kind: cluster
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  moniker:
+    app: keeldemo
+    stack: examples
+    detail: ec2v1
+  container:
+    organization: emburns
+    image: spin-titus-demo
+    tagVersionStrategy: semver_tag
+  locations:
+    account: titustestvpc
+    regions:
+      - name: us-west-2
+      - name: us-east-1
+  capacity:
+    min: 1
+    max: 1
+    desired: 1
+  overrides: {}
+  dependencies:
+    loadBalancerNames: []
+    securityGroupNames:
+      - keeldemo
+      - nf-datacenter
+      - nf-infrastructure
+    targetGroups: []

--- a/keel-api/src/test/resources/examples/titus-cluster-with-artifact-example.yml
+++ b/keel-api/src/test/resources/examples/titus-cluster-with-artifact-example.yml
@@ -11,7 +11,7 @@ spec:
   container:
     organization: emburns
     image: spin-titus-demo
-    tagVersionStrategy: semver_tag
+    tagVersionStrategy: semver-tag
   locations:
     account: titustestvpc
     regions:

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListenerTests.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.igor.ArtifactService
 import com.netflix.spinnaker.keel.api.ArtifactStatus.FINAL
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
@@ -34,9 +35,10 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     val artifact: DeliveryArtifact,
     val repository: ArtifactRepository = mockk(relaxUnitFun = true),
     val artifactService: ArtifactService = mockk(relaxUnitFun = true),
+    val clouddriverService: CloudDriverService = mockk(relaxUnitFun = true),
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   ) {
-    val listener: ArtifactListener = ArtifactListener(repository, artifactService, publisher)
+    val listener: ArtifactListener = ArtifactListener(repository, artifactService, clouddriverService, publisher)
   }
 
   fun artifactEventTests() = rootContext<ArtifactFixture> {
@@ -46,6 +48,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
           artifacts = listOf(korkArtifact),
           details = emptyMap()
         ),
+
         artifact = DeliveryArtifact(
           name = "fnord",
           type = DEB
@@ -113,9 +116,10 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     val artifact: DeliveryArtifact,
     val repository: ArtifactRepository = mockk(relaxUnitFun = true),
     val artifactService: ArtifactService = mockk(relaxUnitFun = true),
+    val clouddriverService: CloudDriverService = mockk(relaxUnitFun = true),
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   ) {
-    val listener: ArtifactListener = ArtifactListener(repository, artifactService, publisher)
+    val listener: ArtifactListener = ArtifactListener(repository, artifactService, clouddriverService, publisher)
   }
 
   fun artifactRegisteredEventTests() = rootContext<RegisteredFixture> {
@@ -205,9 +209,10 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     val artifact: DeliveryArtifact,
     val repository: ArtifactRepository = mockk(relaxUnitFun = true),
     val artifactService: ArtifactService = mockk(relaxUnitFun = true),
+    val clouddriverService: CloudDriverService = mockk(relaxUnitFun = true),
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   ) {
-    val listener: ArtifactListener = ArtifactListener(repository, artifactService, publisher)
+    val listener: ArtifactListener = ArtifactListener(repository, artifactService, clouddriverService, publisher)
   }
 
   fun syncArtifactsFixture() = rootContext<SyncArtifactsFixture> {

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -139,7 +139,7 @@ interface CloudDriverService {
   ): List<NamedImage>
 
   @GET("/dockerRegistry/images/find")
-  suspend fun findDockerImage(
+  suspend fun findDockerImages(
     @Query("account") account: String? = null,
     @Query("repository") repository: String? = null,
     @Query("tag") tag: String? = null,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ApplicationLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.ClassicLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
+import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel
@@ -136,6 +137,22 @@ interface CloudDriverService {
     @Query("q") name: String,
     @Header("X-SPINNAKER-USER") serviceAccount: String = DEFAULT_SERVICE_ACCOUNT
   ): List<NamedImage>
+
+  @GET("/dockerRegistry/images/find")
+  suspend fun findDockerImage(
+    @Query("account") account: String? = null,
+    @Query("repository") repository: String? = null,
+    @Query("tag") tag: String? = null,
+    @Query("q") q: String? = null,
+    @Header("X-SPINNAKER-USER") serviceAccount: String = DEFAULT_SERVICE_ACCOUNT
+  ): List<DockerImage>
+
+  @GET("/dockerRegistry/images/tags")
+  suspend fun findDockerTagsForImage(
+    @Query("account") account: String,
+    @Query("repository") repository: String,
+    @Header("X-SPINNAKER-USER") serviceAccount: String = DEFAULT_SERVICE_ACCOUNT
+  ): List<String>
 
   @GET("/tags/{entityId}")
   suspend fun getTagsForEntity(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/DockerImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/DockerImage.kt
@@ -1,0 +1,25 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.clouddriver.model
+
+data class DockerImage(
+  val account: String,
+  val repository: String,
+  val tag: String,
+  val digest: String?
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -35,6 +35,7 @@ interface ArtifactRepository {
    * @return the latest version of [artifact] approved for use in [targetEnvironment],
    * optionally filtering by status if provided.
    */
+  // todo eb: move artifact sorting to artifact https://github.com/spinnaker/keel/issues/619
   fun latestVersionApprovedIn(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,

--- a/keel-docker/keel-docker.gradle.kts
+++ b/keel-docker/keel-docker.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 
 dependencies {
   implementation(project(":keel-core"))
-  implementation(project(":keel-actuator"))
   implementation(project(":keel-igor"))
-  implementation(project(":keel-clouddriver"))
+  implementation(project(":keel-plugin"))
   implementation("org.springframework:spring-context")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+  implementation("net.swiftzer.semver:semver:1.1.0")
 
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/Container.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/Container.kt
@@ -24,7 +24,9 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 sealed class Container(
   open val organization: String,
   open val image: String
-)
+) {
+  fun repository() = "$organization/$image"
+}
 
 @JsonDeserialize(using = JsonDeserializer.None::class)
 data class ContainerWithDigest(

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/Container.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/Container.kt
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+@JsonDeserialize(using = ContainerDeserializer::class)
+sealed class Container(
+  open val organization: String,
+  open val image: String
+)
+
+@JsonDeserialize(using = JsonDeserializer.None::class)
+data class ContainerWithDigest(
+  override val organization: String,
+  override val image: String,
+  val digest: String
+) : Container(organization, image)
+
+@JsonDeserialize(using = JsonDeserializer.None::class)
+data class ContainerWithVersionedTag(
+  override val organization: String,
+  override val image: String,
+  val tagVersionStrategy: TagVersionStrategy,
+  val captureGroupRegex: String? = null
+) : Container(organization, image)

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/ContainerDeserializer.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/ContainerDeserializer.kt
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.netflix.spinnaker.keel.serialization.PropertyNamePolymorphicDeserializer
+
+class ContainerDeserializer :
+  PropertyNamePolymorphicDeserializer<Container>(Container::class.java) {
+  override fun identifySubType(fieldNames: Collection<String>): Class<out Container> =
+    when {
+      "digest" in fieldNames -> ContainerWithDigest::class.java
+      else -> ContainerWithVersionedTag::class.java
+    }
+}

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerComparator.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerComparator.kt
@@ -1,0 +1,87 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.INCREASING
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER
+import net.swiftzer.semver.SemVer
+
+class DockerComparator {
+  companion object {
+    fun sort(tags: List<String>, strategy: TagVersionStrategy, captureGroup: String?): List<String> =
+      when (captureGroup) {
+        null -> sortRegular(tags, strategy)
+        else -> sortRegex(tags, strategy, captureGroup)
+      }
+
+    private fun sortRegular(tags: List<String>, strategy: TagVersionStrategy): List<String> =
+      when (strategy) {
+        INCREASING -> tags.sorted().reversed()
+        SEMVER -> tags.filter { isSemver(it) }.sortedWith(SEMVER_COMPARATOR).reversed()
+      }
+
+    /**
+     * To process the tags we create a map where:
+     *  the key is result of applying the regex and extraction the capture group
+     *  and the value is the original tag.
+     *
+     *  We process this way so that we can sort the keys while still remembering the tag value to return.
+     */
+    private fun sortRegex(tags: List<String>, strategy: TagVersionStrategy, captureGroup: String): List<String> {
+      val tagMap: MutableMap<String, String> = mutableMapOf()
+      tags.forEach { tag ->
+        parseTag(tag, captureGroup)?.let { result ->
+          tagMap.put(result, tag)
+        }
+      }
+      return when (strategy) {
+        INCREASING -> tagMap.toSortedMap().values.reversed()
+        SEMVER -> tagMap.filter { isSemver(it.key) }.toSortedMap(SEMVER_COMPARATOR).values.toList().reversed()
+      }
+    }
+
+    fun parseTag(tag: String, captureGroup: String): String? {
+      val regex = Regex(captureGroup)
+      val result = regex.find(tag)
+      return if (result == null) {
+        null
+      } else {
+        if (result.groupValues.size != 2) {
+          throw InvalidRegexException(captureGroup, tag)
+        }
+        result.groupValues[1]
+      }
+    }
+  }
+}
+
+fun isSemver(input: String) =
+  try {
+    SemVer.parse(input.removePrefix("v"))
+    true
+  } catch (e: IllegalArgumentException) {
+    false
+  }
+
+/**
+ * SemVer comparator that also trims a leading "v" off of the version, if present.
+ */
+val SEMVER_COMPARATOR: Comparator<String> = Comparator<String> { a, b ->
+  SemVer.parse(a.removePrefix("v"))
+    .compareTo(SemVer.parse(b.removePrefix("v")))
+}

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
@@ -112,5 +112,5 @@ abstract class DockerImageResolver<T : ResourceSpec>(
   }
 
   private fun Container.toArtifact() =
-    DeliveryArtifact("$organization/$image", DOCKER)
+    DeliveryArtifact(repository(), DOCKER)
 }

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
@@ -1,0 +1,116 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.netflix.spinnaker.keel.api.ArtifactStatus
+import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.plugin.Resolver
+
+/**
+ * Provides the basic functionality for deciding what digest is desired.
+ *
+ * Implement the methods in this interface for each cloud provider.
+ */
+abstract class DockerImageResolver<T : ResourceSpec>(
+  val deliveryConfigRepository: DeliveryConfigRepository,
+  val artifactRepository: ArtifactRepository
+) : Resolver<T> {
+
+  /**
+   * Pull the container out of the resource spec
+   */
+  abstract fun getContainerFromSpec(resource: Resource<T>): Container
+
+  /**
+   * Pull the correct docker account out of the spec
+   */
+  abstract fun getAccountFromSpec(resource: Resource<T>): String
+
+  /**
+   * Replace exiting container with resolved container
+   */
+  abstract fun updateContainerInSpec(resource: Resource<T>, container: Container): Resource<T>
+
+  /**
+   * Get all available the tags for an image
+   */
+  abstract fun getTags(account: String, organization: String, image: String): List<String>
+
+  /**
+   * Get the digest for a specific image
+   */
+  abstract fun getDigest(account: String, organization: String, image: String, tag: String): String
+
+  override fun invoke(resource: Resource<T>): Resource<T> {
+    val container = getContainerFromSpec(resource)
+    if (container is ContainerWithDigest) {
+      return resource
+    }
+    val account = getAccountFromSpec(resource)
+    val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
+    val environment = deliveryConfigRepository.environmentFor(resource.id)
+    val tag: String = if (deliveryConfig != null && environment != null) {
+      findTagGivenDeliveryConfig(deliveryConfig, environment, container.toArtifact())
+    } else {
+      findTagGivenStrategy(account, container as ContainerWithVersionedTag)
+    }
+
+    val newContainer = getContainer(account, container, tag)
+    return updateContainerInSpec(resource, newContainer)
+  }
+
+  fun findTagGivenDeliveryConfig(deliveryConfig: DeliveryConfig, environment: Environment, artifact: DeliveryArtifact) =
+    artifactRepository.latestVersionApprovedIn(
+      deliveryConfig,
+      artifact,
+      environment.name,
+      enumValues<ArtifactStatus>().toList()
+    ) ?: throw NoDockerImageSatisfiesConstraints(artifact.name, environment.name)
+
+  fun findTagGivenStrategy(
+    account: String,
+    container: ContainerWithVersionedTag
+  ): String {
+    val tags = getTags(account, container.organization, container.image)
+    return DockerComparator.sort(tags, container.tagVersionStrategy, container.captureGroupRegex).first()
+  }
+
+  fun getContainer(
+    account: String,
+    container: Container,
+    tag: String
+  ): ContainerWithDigest {
+    val digest = getDigest(account, container.organization, container.image, tag)
+    return ContainerWithDigest(
+      organization = container.organization,
+      image = container.image,
+      digest = digest
+    )
+  }
+
+  private fun Container.toArtifact() =
+    DeliveryArtifact("$organization/$image", DOCKER)
+}

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/InvalidRegexException.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/InvalidRegexException.kt
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
+
+/**
+ * The regex provided produced too many capture groups.
+ */
+class InvalidRegexException(
+  val regex: String,
+  val tag: String
+) : ResourceCurrentlyUnresolvable("The provided regex ($regex) produced did not produce one capture group on tag $tag")
+
+class NoDockerImageSatisfiesConstraints(
+  val artifactName: String,
+  val environment: String
+) : ResourceCurrentlyUnresolvable("No docker image found for artifact $artifactName in $environment")

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/TagVersionStrategy.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/TagVersionStrategy.kt
@@ -1,0 +1,24 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+enum class TagVersionStrategy {
+  SEMVER, INCREASING;
+}
+
+// todo eb: define other strategies that come with a regex.

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/TagVersionStrategy.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/TagVersionStrategy.kt
@@ -17,14 +17,20 @@
  */
 package com.netflix.spinnaker.keel.docker
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.keel.docker.SortType.INCREASING
 import com.netflix.spinnaker.keel.docker.SortType.SEMVER
 
 enum class TagVersionStrategy(val regex: String, val sortType: SortType) {
+  @JsonProperty("increasing-tag")
   INCREASING_TAG("""^.*$""", INCREASING),
+  @JsonProperty("semver-tag")
   SEMVER_TAG("""^.*$""", SEMVER),
+  @JsonProperty("branch-job-commit-by-job")
   BRANCH_JOB_COMMIT_BY_JOB("""^master-h(\d+).*$""", INCREASING), // popular netflix strategy
+  @JsonProperty("semver-job-commit-by-job")
   SEMVER_JOB_COMMIT_BY_JOB("""^v.*-h(\d+).*$""", INCREASING), // popular netflix strategy
+  @JsonProperty("semver-job-commit-by-semver")
   SEMVER_JOB_COMMIT_BY_SEMVER("""^v(.*)-h\d+.*$""", SEMVER); // popular netflix strategy
 }
 

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/TagVersionStrategy.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/TagVersionStrategy.kt
@@ -17,8 +17,18 @@
  */
 package com.netflix.spinnaker.keel.docker
 
-enum class TagVersionStrategy {
-  SEMVER, INCREASING;
+import com.netflix.spinnaker.keel.docker.SortType.INCREASING
+import com.netflix.spinnaker.keel.docker.SortType.SEMVER
+
+enum class TagVersionStrategy(val regex: String, val sortType: SortType) {
+  INCREASING_TAG("""^.*$""", INCREASING),
+  SEMVER_TAG("""^.*$""", SEMVER),
+  BRANCH_JOB_COMMIT_BY_JOB("""^master-h(\d+).*$""", INCREASING), // popular netflix strategy
+  SEMVER_JOB_COMMIT_BY_JOB("""^v.*-h(\d+).*$""", INCREASING), // popular netflix strategy
+  SEMVER_JOB_COMMIT_BY_SEMVER("""^v(.*)-h\d+.*$""", SEMVER); // popular netflix strategy
 }
 
-// todo eb: define other strategies that come with a regex.
+enum class SortType {
+  INCREASING,
+  SEMVER;
+}

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/DockerComparatorTests.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/DockerComparatorTests.kt
@@ -1,0 +1,104 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.INCREASING
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.failed
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNull
+
+class DockerComparatorTests : JUnit5Minutests {
+
+  private val incrTags = listOf("1", "2", "3", "0")
+  private val semVerTags = listOf("0.0.3", "0.1.3", "0.10.3", "0.4.1")
+  private val semVerTagsWithV = listOf("v0.0.3", "v0.1.3", "v0.10.3", "v0.4.1")
+  private val otherTags = listOf("master-h1.blah", "master-h2.blah", "master-h3.blah", "master-h0.blah")
+  private val trickyOtherTags = listOf("3master-h1.blah", "1master-h2.blah", "2master-h3.blah", "5master-h0.blah")
+
+  fun tests() = rootContext<Unit> {
+    context("increasing tags") {
+      test("comparing gets highest") {
+        val sorted = DockerComparator.sort(incrTags, INCREASING, null)
+        expectThat(sorted.first()).isEqualTo("3")
+      }
+    }
+
+    context("semver tags") {
+      test("leading v stripped") {
+        val sorted = DockerComparator.sort(semVerTagsWithV, SEMVER, null)
+        expectThat(sorted.first()).isEqualTo("v0.10.3")
+      }
+
+      test("plain numbers are ok") {
+        val sorted = DockerComparator.sort(semVerTags, SEMVER, null)
+        expectThat(sorted.first()).isEqualTo("0.10.3")
+      }
+    }
+
+    context("tags with regex parsing needed") {
+      test("finds highest by hversion") {
+        val regex = """^master-h(\d+).*${'$'}"""
+        val sorted = DockerComparator.sort(otherTags, INCREASING, regex)
+        expectThat(sorted.first()).isEqualTo("master-h3.blah")
+      }
+
+      test("finds highest with confusing number in front") {
+        val regex = """^\dmaster-h(\d+).*${'$'}"""
+        val sorted = DockerComparator.sort(trickyOtherTags, INCREASING, regex)
+        expectThat(sorted.first()).isEqualTo("2master-h3.blah")
+      }
+
+      test("ignores a bad tag") {
+        val regex = """^\dmaster-h(\d+).*${'$'}"""
+        val mixedTags = listOf("3master-h1.blah", "1master-h2.blah", "2master-h3.blah", "5master-h0.blah", "latest")
+        val sorted = DockerComparator.sort(mixedTags, INCREASING, regex)
+        expectThat(sorted.first()).isEqualTo("2master-h3.blah")
+      }
+    }
+
+    context("regex parsing") {
+      test("able to parse with capture group") {
+        val tag = "master-h1.blah"
+        val regex = """^master-h(\d+).*${'$'}"""
+        val result = DockerComparator.parseTag(tag, regex)
+        expectThat(result).isEqualTo("1")
+      }
+
+      test("too many captures throws exception") {
+        val tag = "master-h1.blah"
+        val regex = """^master-h(\d+)(.*)${'$'}"""
+        expectCatching { DockerComparator.parseTag(tag, regex) }
+          .failed()
+          .isA<InvalidRegexException>()
+      }
+
+      test("no match returns null") {
+        val tag = "v001"
+        val regex = """^master-h(\d+).*${'$'}"""
+        val result = DockerComparator.parseTag(tag, regex)
+        expectThat(result).isNull()
+      }
+    }
+  }
+}

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/DockerComparatorTests.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/DockerComparatorTests.kt
@@ -17,8 +17,11 @@
  */
 package com.netflix.spinnaker.keel.docker
 
-import com.netflix.spinnaker.keel.docker.TagVersionStrategy.INCREASING
-import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.INCREASING_TAG
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_JOB
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_SEMVER
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER_TAG
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectCatching
@@ -33,47 +36,57 @@ class DockerComparatorTests : JUnit5Minutests {
   private val incrTags = listOf("1", "2", "3", "0")
   private val semVerTags = listOf("0.0.3", "0.1.3", "0.10.3", "0.4.1")
   private val semVerTagsWithV = listOf("v0.0.3", "v0.1.3", "v0.10.3", "v0.4.1")
-  private val otherTags = listOf("master-h1.blah", "master-h2.blah", "master-h3.blah", "master-h0.blah")
+  private val branchJobCommitTags = listOf("master-h1.blah", "master-h2.blah", "master-h3.blah", "master-h0.blah")
+  private val semverJobCommitTags = listOf("v1.12.3-rc.1-h1192.f876e5a", "v1.12.2-h1188.35b8b29", "v1.12.2-h1182.8a5b962")
   private val trickyOtherTags = listOf("3master-h1.blah", "1master-h2.blah", "2master-h3.blah", "5master-h0.blah")
 
   fun tests() = rootContext<Unit> {
     context("increasing tags") {
       test("comparing gets highest") {
-        val sorted = DockerComparator.sort(incrTags, INCREASING, null)
+        val sorted = DockerComparator.sort(incrTags, INCREASING_TAG, null)
         expectThat(sorted.first()).isEqualTo("3")
       }
     }
 
     context("semver tags") {
       test("leading v stripped") {
-        val sorted = DockerComparator.sort(semVerTagsWithV, SEMVER, null)
+        val sorted = DockerComparator.sort(semVerTagsWithV, SEMVER_TAG, null)
         expectThat(sorted.first()).isEqualTo("v0.10.3")
       }
 
       test("plain numbers are ok") {
-        val sorted = DockerComparator.sort(semVerTags, SEMVER, null)
+        val sorted = DockerComparator.sort(semVerTags, SEMVER_TAG, null)
         expectThat(sorted.first()).isEqualTo("0.10.3")
       }
     }
 
     context("tags with regex parsing needed") {
-      test("finds highest by hversion") {
-        val regex = """^master-h(\d+).*${'$'}"""
-        val sorted = DockerComparator.sort(otherTags, INCREASING, regex)
+      test("finds highest by branchJobCommit by job") {
+        val sorted = DockerComparator.sort(branchJobCommitTags, BRANCH_JOB_COMMIT_BY_JOB, null)
         expectThat(sorted.first()).isEqualTo("master-h3.blah")
       }
 
       test("finds highest with confusing number in front") {
         val regex = """^\dmaster-h(\d+).*${'$'}"""
-        val sorted = DockerComparator.sort(trickyOtherTags, INCREASING, regex)
+        val sorted = DockerComparator.sort(trickyOtherTags, INCREASING_TAG, regex)
         expectThat(sorted.first()).isEqualTo("2master-h3.blah")
       }
 
       test("ignores a bad tag") {
         val regex = """^\dmaster-h(\d+).*${'$'}"""
         val mixedTags = listOf("3master-h1.blah", "1master-h2.blah", "2master-h3.blah", "5master-h0.blah", "latest")
-        val sorted = DockerComparator.sort(mixedTags, INCREASING, regex)
+        val sorted = DockerComparator.sort(mixedTags, INCREASING_TAG, regex)
         expectThat(sorted.first()).isEqualTo("2master-h3.blah")
+      }
+
+      test("finds highest with semverJobCommit by job") {
+        val sorted = DockerComparator.sort(semverJobCommitTags, SEMVER_JOB_COMMIT_BY_JOB, null)
+        expectThat(sorted.first()).isEqualTo("v1.12.3-rc.1-h1192.f876e5a")
+      }
+
+      test("finds highest with semverJobCommit by semver") {
+        val sorted = DockerComparator.sort(semverJobCommitTags, SEMVER_JOB_COMMIT_BY_SEMVER, null)
+        expectThat(sorted.first()).isEqualTo("v1.12.3-rc.1-h1192.f876e5a")
       }
     }
 

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
@@ -1,0 +1,74 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.ApiVersion
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+
+class SampleDockerImageResolver(
+  deliveryConfigRepository: DeliveryConfigRepository,
+  artifactRepository: ArtifactRepository
+) : DockerImageResolver<SampleSpecWithContainer>(
+  deliveryConfigRepository,
+  artifactRepository
+) {
+
+  override val apiVersion: ApiVersion = SAMPLE_API_VERSION
+  override val supportedKind: String = "sample"
+
+  override fun getContainerFromSpec(resource: Resource<SampleSpecWithContainer>) =
+    resource.spec.container
+
+  override fun getAccountFromSpec(resource: Resource<SampleSpecWithContainer>) =
+    resource.spec.account
+
+  override fun updateContainerInSpec(resource: Resource<SampleSpecWithContainer>, container: Container) =
+    resource.copy(spec = resource.spec.copy(container = container))
+
+  // this would normally call out to clouddriver
+  override fun getTags(account: String, organization: String, image: String) =
+    listOf("latest", "v0.0.1", "v0.0.2", "v0.0.4", "v0.1.1", "v0.1.0")
+
+  // this would normally call out to clouddriver
+  override fun getDigest(account: String, organization: String, image: String, tag: String) =
+    when (tag) {
+      "v0.0.1" -> "sha256:2763a2b9d53e529c62b326b7331d1b44aae344be0b79ff64c74559c5c96b76b7"
+      "v0.0.2" -> "sha256:b4857d7596462aeb1977e6e5d1e31b20a5b5eecf890cd64ac62f145b3839ee97"
+      "v0.0.4" -> "sha256:85741705089153592531668168c265bacd79d71368d14a956140ccc446d6f9aa"
+      "v0.1.0" -> "sha256:5854562820b00313022005bdad50efa09c267777daf178aad108faaf10d7ce08"
+      "v0.1.1" -> "sha256:0d49cebbbb00d5cefd384fcbb2f46c97b7412b59b62862a3459f09232d6acf28"
+      else -> "sha256:c5d3b32d4af6bae7fb337d1df32f32d2e6fd2fba622d98743280c2d0bf47dbe1"
+    }
+}
+
+data class SampleSpecWithContainer(
+  val container: Container,
+  val account: String
+) : ResourceSpec {
+  @JsonIgnore
+  override val id: String = "sample-resource"
+
+  @JsonIgnore
+  override val application: String = "myapp"
+}
+
+val SAMPLE_API_VERSION = ApiVersion("sample.resource", "v1")

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import dev.minutest.junit.JUnit5Minutests
@@ -46,7 +46,7 @@ class SampleDockerImageResolverTests : JUnit5Minutests {
     container = ContainerWithVersionedTag(
       organization = "spkr",
       image = "keeldemo",
-      tagVersionStrategy = SEMVER
+      tagVersionStrategy = SEMVER_TAG
     ),
     account = "test"
   )

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
@@ -1,0 +1,127 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.docker
+
+import com.netflix.spinnaker.keel.api.ArtifactStatus.FINAL
+import com.netflix.spinnaker.keel.api.ArtifactType.DOCKER
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.docker.TagVersionStrategy.SEMVER
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expect
+import strikt.api.expectThrows
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+/**
+ * Tests of the Docker Image Resolver with a sample implementation of the resolver.
+ * The goal of this test is to test the overall logic of resolving the sha from a list of tags, but not the
+ * underlying logic of pulling the right tag or right digest.
+ */
+class SampleDockerImageResolverTests : JUnit5Minutests {
+
+  val configRepo: InMemoryDeliveryConfigRepository = InMemoryDeliveryConfigRepository()
+  val artifactRepo: InMemoryArtifactRepository = InMemoryArtifactRepository()
+  private val spec = SampleSpecWithContainer(
+    container = ContainerWithVersionedTag(
+      organization = "spkr",
+      image = "keeldemo",
+      tagVersionStrategy = SEMVER
+    ),
+    account = "test"
+  )
+
+  private val resource = Resource(
+    apiVersion = SAMPLE_API_VERSION,
+    kind = "sample",
+    spec = spec,
+    metadata = mapOf(
+      "id" to "${SAMPLE_API_VERSION.prefix}:sample:sample-resource",
+      "application" to "myapp",
+      "serviceAccount" to "keel@spinnaker"
+    ))
+
+  private val artifact = DeliveryArtifact(
+    name = "spkr/keeldemo",
+    type = DOCKER
+  )
+
+  private val env = Environment(
+    name = "test",
+    resources = setOf(resource)
+  )
+  private val deliveryConfig = DeliveryConfig(
+    name = "mydeliveryconfig",
+    application = "keel",
+    artifacts = setOf(artifact),
+    environments = setOf(env)
+  )
+
+  fun tests() = rootContext<SampleDockerImageResolver> {
+    fixture {
+      SampleDockerImageResolver(configRepo, artifactRepo)
+    }
+
+    context("a semantic versioned resource") {
+      test("resolves latest to correct digest") {
+        val resolvedResource = this.invoke(resource)
+        expect {
+          that(resolvedResource.spec.container).isA<ContainerWithDigest>()
+          that(resolvedResource.spec.container as ContainerWithDigest).get { digest }.isEqualTo("sha256:0d49cebbbb00d5cefd384fcbb2f46c97b7412b59b62862a3459f09232d6acf28")
+        }
+      }
+    }
+
+    context("a resource part of a delivery config") {
+      before {
+        configRepo.store(deliveryConfig)
+        artifactRepo.register(artifact)
+      }
+
+      after {
+        configRepo.dropAll()
+        artifactRepo.dropAll()
+      }
+
+      test("no versions throws exception") {
+        expectThrows<NoDockerImageSatisfiesConstraints> { this.invoke(resource) }
+      }
+
+      test("no versions approved yet") {
+        artifactRepo.store(artifact, "v0.0.1", FINAL)
+        expectThrows<NoDockerImageSatisfiesConstraints> { this.invoke(resource) }
+      }
+
+      test("there is a version approved") {
+        artifactRepo.store(artifact, "v0.0.1", FINAL)
+        artifactRepo.approveVersionFor(deliveryConfig, artifact, "v0.0.1", env.name)
+
+        val resolvedResource = this.invoke(resource)
+        expect {
+          that(resolvedResource.spec.container).isA<ContainerWithDigest>()
+          that(resolvedResource.spec.container as ContainerWithDigest).get { digest }.isEqualTo("sha256:2763a2b9d53e529c62b326b7331d1b44aae344be0b79ff64c74559c5c96b76b7")
+        }
+      }
+    }
+  }
+}

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   implementation(project(":keel-clouddriver"))
   implementation(project(":keel-orca"))
   implementation(project(":keel-retrofit"))
+  implementation(project(":keel-docker"))
   implementation("com.netflix.spinnaker.kork:kork-core")
   implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/NoDockerImageFound.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/NoDockerImageFound.kt
@@ -1,0 +1,26 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.cluster
+
+import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
+
+class NoDigestFound(repository: String, tag: String) :
+  ResourceCurrentlyUnresolvable("No digest found for docker image $repository:$tag in any registry")
+
+class RegistryNotFound(titusAccount: String) :
+  ResourceCurrentlyUnresolvable("Unable to find docker registry for titus account $titusAccount")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -38,13 +38,14 @@ import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.docker.ContainerWithDigest
 import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
+import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -225,7 +226,7 @@ class TitusClusterHandler(
           "cluster" to moniker.name
         ),
         "reason" to "Diff detected at ${clock.instant().iso()}",
-        "type" to if (current == null) "createServerGroup" else "upsertServerGroup",
+        "type" to "createServerGroup",
         "cloudProvider" to CLOUD_PROVIDER,
         "securityGroups" to securityGroupIds(),
         "loadBalancers" to dependencies.loadBalancerNames,
@@ -347,7 +348,7 @@ class TitusClusterHandler(
         region = region
       ),
       capacity = capacity,
-      container = Container(
+      container = ContainerWithDigest(
         organization = image.dockerImageName.split("/").first(),
         image = image.dockerImageName.split("/").last(),
         digest = image.dockerImageDigest

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -20,13 +20,13 @@ package com.netflix.spinnaker.keel.api.titus.cluster
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Capacity
 import com.netflix.spinnaker.keel.api.ClusterDependencies
+import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.SimpleLocations
-import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.SubmittedResource
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
@@ -260,7 +260,7 @@ class TitusClusterHandler(
 
   private fun TitusClusterSpec.generateOverrides(serverGroups: Map<String, TitusServerGroup>) =
     serverGroups.forEach { (region, serverGroup) ->
-      var newSpec = TitusServerGroupSpec()
+      var newSpec = TitusServerGroupSpec(defaults.container)
       val workingSpec = serverGroup.exportSpec()
       val diff = ResourceDiff(workingSpec, defaults)
       if (diff.hasChanges()) {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -27,9 +27,12 @@ import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.titus.exceptions.ErrorResolvingContainerException
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
+import com.netflix.spinnaker.keel.docker.Container
+import com.netflix.spinnaker.keel.docker.ContainerWithDigest
 import com.netflix.spinnaker.keel.model.Moniker
 
 /**
@@ -88,12 +91,6 @@ data class TitusClusterSpec(
   )
 }
 
-data class Container(
-  val organization: String,
-  val image: String,
-  val digest: String
-)
-
 data class TitusServerGroupSpec(
   val capacity: Capacity? = null,
   val capacityGroup: String? = null,
@@ -145,6 +142,16 @@ internal fun TitusClusterSpec.resolveCapacityGroup(region: String) =
 internal fun TitusClusterSpec.resolveConstraints(region: String) =
   overrides[region]?.constraints ?: defaults.constraints ?: Constraints()
 
+internal fun resolveContainer(container: Container): ContainerWithDigest {
+  if (container is ContainerWithDigest) {
+    return container
+  } else {
+    // The spec container should be replaced with a resolved container by now.
+    // If not, something is wrong.
+    throw ErrorResolvingContainerException(container)
+  }
+}
+
 internal fun TitusClusterSpec.resolveMigrationPolicy(region: String) =
   overrides[region]?.migrationPolicy ?: defaults.migrationPolicy ?: MigrationPolicy()
 
@@ -166,7 +173,7 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       capacity = resolveCapacity(it.name),
       capacityGroup = resolveCapacityGroup(it.name),
       constraints = resolveConstraints(it.name),
-      container = defaults.container ?: error("Container not specified or resolved"),
+      container = resolveContainer(defaults.container),
       dependencies = resolveDependencies(it.name),
       entryPoint = resolveEntryPoint(it.name),
       env = resolveEnv(it.name),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -92,10 +92,10 @@ data class TitusClusterSpec(
 }
 
 data class TitusServerGroupSpec(
+  val container: Container,
   val capacity: Capacity? = null,
   val capacityGroup: String? = null,
   val constraints: Constraints? = null,
-  val container: Container? = null,
   val dependencies: ClusterDependencies? = null,
   val entryPoint: String? = null,
   val env: Map<String, String>? = null,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -49,13 +49,13 @@ class TitusImageResolver(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun getContainerFromSpec(resource: Resource<TitusClusterSpec>) =
-    resource.spec.container
+    resource.spec.defaults.container
 
   override fun getAccountFromSpec(resource: Resource<TitusClusterSpec>) =
     resource.spec.deriveRegistry()
 
   override fun updateContainerInSpec(resource: Resource<TitusClusterSpec>, container: Container) =
-    resource.copy(spec = resource.spec.copy(container = container))
+    resource.copy(spec = resource.spec.copy(_defaults = resource.spec.defaults.copy(container = container)))
 
   override fun getTags(account: String, organization: String, image: String) =
     runBlocking {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -1,0 +1,77 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.cluster
+
+import com.netflix.spinnaker.keel.api.ApiVersion
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.docker.Container
+import com.netflix.spinnaker.keel.docker.DockerImageResolver
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Assumption: docker container digest is the same in all regions
+ */
+@Component
+class TitusImageResolver(
+  deliveryConfigRepository: DeliveryConfigRepository,
+  artifactRepository: ArtifactRepository,
+  private val cloudDriverCache: CloudDriverCache,
+  private val cloudDriverService: CloudDriverService
+) : DockerImageResolver<TitusClusterSpec>(
+  deliveryConfigRepository,
+  artifactRepository
+) {
+  override val apiVersion: ApiVersion = SPINNAKER_TITUS_API_V1
+  override val supportedKind: String = "cluster"
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  override fun getContainerFromSpec(resource: Resource<TitusClusterSpec>) =
+    resource.spec.container
+
+  override fun getAccountFromSpec(resource: Resource<TitusClusterSpec>) =
+    resource.spec.deriveRegistry()
+
+  override fun updateContainerInSpec(resource: Resource<TitusClusterSpec>, container: Container) =
+    resource.copy(spec = resource.spec.copy(container = container))
+
+  override fun getTags(account: String, organization: String, image: String) =
+    runBlocking {
+      val repository = "$organization/$image"
+      cloudDriverService.findDockerTagsForImage(account, repository)
+    }
+
+  override fun getDigest(account: String, organization: String, image: String, tag: String) =
+    runBlocking {
+      val repository = "$organization/$image"
+      val images = cloudDriverService.findDockerImage(account, repository, tag)
+      images.first().digest
+        ?: throw NoDigestFound(repository, tag) // sha should be the same in all accounts for titus
+    }
+
+  protected fun TitusClusterSpec.deriveRegistry(): String =
+    cloudDriverCache.credentialBy(locations.account).attributes["registry"]?.toString()
+      ?: throw RegistryNotFound(locations.account)
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -66,7 +66,7 @@ class TitusImageResolver(
   override fun getDigest(account: String, organization: String, image: String, tag: String) =
     runBlocking {
       val repository = "$organization/$image"
-      val images = cloudDriverService.findDockerImage(account, repository, tag)
+      val images = cloudDriverService.findDockerImages(account, repository, tag)
       images.first().digest
         ?: throw NoDigestFound(repository, tag) // sha should be the same in all accounts for titus
     }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
+import com.netflix.spinnaker.keel.docker.ContainerWithDigest
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.parseMoniker
 import de.danielbechler.diff.inclusion.Inclusion
@@ -38,7 +39,7 @@ data class TitusServerGroup(
    */
   @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
   val name: String,
-  val container: Container,
+  val container: ContainerWithDigest,
   val location: Location,
   val env: Map<String, String> = emptyMap(),
   val resources: Resources = Resources(),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ErrorResolvingContainerException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ErrorResolvingContainerException.kt
@@ -1,0 +1,24 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.api.titus.exceptions
+
+import com.netflix.spinnaker.keel.docker.Container
+
+class ErrorResolvingContainerException(
+  val container: Container
+) : RuntimeException("There was an error resolving the correct docker container (current container: $container)")

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -112,21 +112,16 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       account = titusAccount,
       regions = setOf(SimpleRegionSpec("us-east-1"), SimpleRegionSpec("us-west-2"))
     ),
-    container = ContainerWithDigest(
-      organization = "spinnaker",
-      image = "keel",
-      digest = "sha:1111"
-    ),
     _defaults = TitusServerGroupSpec(
-      capacity = Capacity(1, 6, 4),
-      dependencies = ClusterDependencies(
-        loadBalancerNames = setOf("keel-test-frontend"),
-        securityGroupNames = setOf(sg1West.name)
-      ),
       container = ContainerWithDigest(
         organization = "spinnaker",
         image = "keel",
         digest = "sha:1111"
+      ),
+      capacity = Capacity(1, 6, 4),
+      dependencies = ClusterDependencies(
+        loadBalancerNames = setOf("keel-test-frontend"),
+        securityGroupNames = setOf(sg1West.name)
       )
     )
   )
@@ -488,7 +483,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
           }
 
           test("has overrides matching differences in the server groups") {
-            val defaults = TitusServerGroupSpec()
+            val defaults = TitusServerGroupSpec(spec.defaults.container)
             val overrideDiff = ResourceDiff(spec.overrides["us-west-2"]!!, defaults)
             expectThat(resource.kind)
               .isEqualTo("cluster")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ include(
   "keel-clouddriver",
   "keel-core",
   "keel-core-test",
+  "keel-docker",
   "keel-ec2-plugin",
   "keel-eureka",
   "keel-front50",


### PR DESCRIPTION
This PR provides the start for artifact support for docker images. Most of the logic is in a `keel-docker` module so it can be reused for kubernetes. You can now define a container like:

```
"container": {
      "organization": "emburns",
      "image": "spin-titus-demo",
      "tagVersionStrategy": "increasing",
      "captureGroupRegex": "^master-h(\\d+).*$"
    }
```
The capture group that you provide will be used to parse the tag and get something that can be compared either with semver or numerically.

Still to do for full support: 
- https://github.com/spinnaker/keel/issues/619 (to facilitate correct sorting in lots of places)
- actually sort correctly using ^ for "latest artifact approved in"
- refresh the version info of docker images (just like we do for debs) so it's easy to run locally
- more real testing
