### PR TITLE
feat(veto): slow down checking for diffs when unhappy

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -2,23 +2,16 @@ package com.netflix.spinnaker.keel.telemetry
 
 import com.netflix.spinnaker.keel.api.ApiVersion
 import com.netflix.spinnaker.keel.api.ArtifactType
-import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceId
-import com.netflix.spinnaker.keel.api.id
 
 sealed class TelemetryEvent
 
 data class ResourceCheckSkipped(
   val apiVersion: ApiVersion,
   val kind: String,
-  val id: ResourceId
-) : TelemetryEvent() {
-  constructor(resource: Resource<*>) : this(
-    resource.apiVersion,
-    resource.kind,
-    resource.id
-  )
-}
+  val id: ResourceId,
+  val skipper: String = "unknown"
+) : TelemetryEvent()
 
 data class ArtifactVersionUpdated(
   val name: String,

--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -45,7 +45,8 @@ class TelemetryListener(
       listOf(
         BasicTag("resourceId", event.id.value),
         BasicTag("apiVersion", event.apiVersion.toString()),
-        BasicTag("resourceKind", event.kind)
+        BasicTag("resourceKind", event.kind),
+        BasicTag("skipper", event.skipper)
       )
     ).safeIncrement()
   }

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -2,14 +2,13 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
-import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCheckResult
+import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
@@ -84,7 +83,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
       context("the resource check is not vetoed") {
         before {
-          every { veto.check(resource.id) } returns VetoResponse(true)
+          every { veto.check(resource) } returns VetoResponse(true, "all")
         }
 
         context("the plugin is already actuating this resource") {
@@ -319,7 +318,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
       context("the resource check is vetoed") {
         before {
-          every { veto.check(resource.id) } returns VetoResponse(false)
+          every { veto.check(resource) } returns VetoResponse(false, "ApplicationVeto")
 
           runBlocking {
             subject.checkResource(resource)
@@ -334,7 +333,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
       context("actuation was paused and veto is removed") {
         before {
-          every { veto.check(resource.id) } returns VetoResponse(true)
+          every { veto.check(resource) } returns VetoResponse(true, "all")
           coEvery { plugin1.actuationInProgress(resource) } returns false
           coEvery { plugin1.desired(resource) } returns DummyResource(resource.spec)
           coEvery { plugin1.current(resource) } returns DummyResource(resource.spec)

--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.api.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
@@ -109,7 +110,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
           }
 
           test("a telemetry event is published") {
-            verify { publisher.publishEvent(ResourceCheckSkipped(resource)) }
+            verify { publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, resource.id, "ActuationInProgress")) }
           }
         }
 
@@ -331,7 +332,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
         }
 
         test("resource checking is skipped and actuation is paused") {
-          verify { publisher.publishEvent(ResourceCheckSkipped(resource)) }
+          verify { publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, resource.id, "ApplicationVeto")) }
           verify { publisher.publishEvent(ofType<ResourceActuationPaused>()) }
         }
       }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -9,10 +9,12 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.persistence.ApplicationVetoRepository
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryApplicationVetoRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.supporting
@@ -63,6 +65,10 @@ class DefaultConfiguration {
   @Bean
   @ConditionalOnMissingBean
   fun applicationVetoRepository(): ApplicationVetoRepository = InMemoryApplicationVetoRepository()
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun diffFingerprintRepository(clock: Clock): DiffFingerprintRepository = InMemoryDiffFingerprintRepository(clock)
 
   @Bean
   @ConditionalOnMissingBean(ResourceHandler::class)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
@@ -1,0 +1,82 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.Clock
+
+abstract class DiffFingerprintRepositoryTests<T : DiffFingerprintRepository> : JUnit5Minutests {
+  abstract fun factory(clock: Clock): T
+
+  open fun T.flush() {}
+
+  val clock = MutableClock()
+  val r = resource()
+
+  data class Fixture<T : DiffFingerprintRepository>(
+    val subject: T
+  )
+
+  fun tests() = rootContext<Fixture<T>> {
+    fixture {
+      Fixture(subject = factory(clock))
+    }
+    after { subject.flush() }
+
+    context("storing hash") {
+      test("succeeds when new") {
+        val diff = ResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "bye"))
+        subject.store(r.id, diff)
+        expectThat(subject.diffCount(r.id)).isEqualTo(1)
+      }
+
+      test("updates count") {
+        val diff = ResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "bye"))
+        subject.store(r.id, diff)
+        subject.store(r.id, diff)
+        subject.store(r.id, diff)
+        subject.store(r.id, diff)
+        subject.store(r.id, diff)
+        expectThat(subject.diffCount(r.id)).isEqualTo(5)
+      }
+
+      test("resets count when different hash") {
+        val diff = ResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "bye"))
+        subject.store(r.id, diff)
+        subject.store(r.id, diff)
+        expectThat(subject.diffCount(r.id)).isEqualTo(2)
+        val diff2 = ResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "byeBYEbyeee"))
+        subject.store(r.id, diff2)
+        expectThat(subject.diffCount(r.id)).isEqualTo(1)
+      }
+    }
+
+    context("querying when nothing exists") {
+      test("returns 0") {
+        expectThat(subject.diffCount(r.id)).isEqualTo(0)
+      }
+    }
+  }
+}

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepositoryTests.kt
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.mockk
 import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
@@ -40,8 +39,7 @@ abstract class UnhappyVetoRepositoryTests<T : UnhappyVetoRepository> : JUnit5Min
   val application = "keeldemo"
 
   data class Fixture<T : UnhappyVetoRepository>(
-    val subject: T,
-    val callback: (ResourceHeader) -> Unit = mockk(relaxed = true)
+    val subject: T
   )
 
   fun tests() = rootContext<Fixture<T>> {
@@ -59,7 +57,7 @@ abstract class UnhappyVetoRepositoryTests<T : UnhappyVetoRepository> : JUnit5Min
 
     context("basic operations") {
       before {
-        subject.markUnhappy(resourceId, application)
+        subject.markUnhappyForWaitingTime(resourceId, application)
       }
 
       test("marking unhappy works") {
@@ -74,7 +72,7 @@ abstract class UnhappyVetoRepositoryTests<T : UnhappyVetoRepository> : JUnit5Min
 
     context("expiring the time") {
       before {
-        subject.markUnhappy(resourceId, application)
+        subject.markUnhappyForWaitingTime(resourceId, application)
       }
 
       test("should skip right after we mark unhappy") {
@@ -106,7 +104,7 @@ abstract class UnhappyVetoRepositoryTests<T : UnhappyVetoRepository> : JUnit5Min
 
     context("filtering") {
       before {
-        subject.markUnhappy(resourceId, application)
+        subject.markUnhappyForWaitingTime(resourceId, application)
       }
       test("filters out resources that are past the recheck time") {
         clock.incrementBy(Duration.ofMinutes(11))
@@ -120,10 +118,10 @@ abstract class UnhappyVetoRepositoryTests<T : UnhappyVetoRepository> : JUnit5Min
       val resource1 = ResourceId("ec2:securityGroup:test:us-west-2:keeldemo-managed")
       val resource2 = ResourceId("ec2:securityGroup:test:us-west-2:keel-managed")
       before {
-        subject.markUnhappy(bake1, "keeldemo")
-        subject.markUnhappy(bake2, "keel")
-        subject.markUnhappy(resource1, "keeldemo")
-        subject.markUnhappy(resource2, "keel")
+        subject.markUnhappyForWaitingTime(bake1, "keeldemo")
+        subject.markUnhappyForWaitingTime(bake2, "keel")
+        subject.markUnhappyForWaitingTime(resource1, "keeldemo")
+        subject.markUnhappyForWaitingTime(resource2, "keel")
       }
 
       test("get for keel returns only correct resources") {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepositoryTests.kt
@@ -1,0 +1,121 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.hasSize
+import strikt.assertions.isEqualTo
+import java.time.Clock
+import java.time.Duration
+
+abstract class UnhappyVetoRepositoryTests<T : UnhappyVetoRepository> : JUnit5Minutests {
+  abstract fun factory(clock: Clock): T
+
+  open fun T.flush() {}
+
+  val clock = MutableClock()
+  val resourceId = ResourceId("ec2:securityGroup:test:us-west-2:keeldemo-managed")
+  val application = "keeldemo"
+
+  data class Fixture<T : UnhappyVetoRepository>(
+    val subject: T,
+    val callback: (ResourceHeader) -> Unit = mockk(relaxed = true)
+  )
+
+  fun tests() = rootContext<Fixture<T>> {
+    fixture {
+      Fixture(subject = factory(clock))
+    }
+
+    after { subject.flush() }
+
+    context("nothing currently vetoed") {
+      test("no applications returned") {
+        expectThat(subject.getAll()).hasSize(0)
+      }
+    }
+
+    context("basic operations") {
+      test("marking unhappy works") {
+        subject.markUnhappy(resourceId, application)
+        expectThat(subject.getAll()).hasSize(1)
+      }
+
+      test("marking happy works") {
+        subject.markUnhappy(resourceId, application)
+        subject.markHappy(resourceId)
+        expectThat(subject.getAll()).hasSize(0)
+      }
+    }
+
+    context("expiring the time") {
+      before {
+        subject.markUnhappy(resourceId, application)
+      }
+
+      test("should skip right after we mark unhappy") {
+        expectThat(subject.shouldSkip(resourceId)).isEqualTo(true)
+      }
+
+      test("9 minutes later we should still skip") {
+        clock.incrementBy(Duration.ofMinutes(9))
+        expectThat(subject.shouldSkip(resourceId)).isEqualTo(true)
+      }
+
+      test("11 minutes later don't skip") {
+        clock.incrementBy(Duration.ofMinutes(11))
+        expectThat(subject.shouldSkip(resourceId)).isEqualTo(false)
+      }
+    }
+
+    context("filtering works") {
+      before {
+        subject.markUnhappy(resourceId, application)
+      }
+      test("even if we don't mark happy again") {
+        clock.incrementBy(Duration.ofMinutes(11))
+        expectThat(subject.getAll()).hasSize(0)
+      }
+    }
+
+    context("getting all by app name") {
+      val bake1 = ResourceId("bakery:image:keeldemo")
+      val bake2 = ResourceId("bakery:image:keel")
+      val resource1 = ResourceId("ec2:securityGroup:test:us-west-2:keeldemo-managed")
+      val resource2 = ResourceId("ec2:securityGroup:test:us-west-2:keel-managed")
+      before {
+        subject.markUnhappy(bake1, "keeldemo")
+        subject.markUnhappy(bake2, "keel")
+        subject.markUnhappy(resource1, "keeldemo")
+        subject.markUnhappy(resource2, "keel")
+      }
+
+      test("get for keel returns only correct resources") {
+        val resources = subject.getAllForApp("keel")
+        expectThat(resources)
+          .hasSize(2).containsExactlyInAnyOrder(bake2, resource2)
+      }
+    }
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
@@ -25,7 +25,12 @@ import com.netflix.spinnaker.keel.serialization.ResourceIdDeserializer
 data class ResourceId(val value: String) {
   override fun toString(): String = value
 
-  // Resource names (the last token in a ResourceId) follow the Moniker format (<app>-<stack>-<detail>)
-  val application: String
-    get() = value.split(":").last().split("-").first()
+  // Resource names (the last token in a ResourceId) follow the Moniker format (<app>-<stack>-<detail>),
+  // unless it's a resource which doesn't support this, then we return null (like an image)
+  val application: String?
+    get() = if (value.startsWith("bakery:")) {
+      null
+    } else {
+      value.split(":").last().split("-").first()
+    }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceId.kt
@@ -20,17 +20,12 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
 import com.netflix.spinnaker.keel.serialization.ResourceIdDeserializer
 
+/**
+ * Note: You cannot reliably parse the application name from the resource id.
+ * The application is a property on the resource spec.
+ */
 @JsonSerialize(using = ToStringSerializer::class)
 @JsonDeserialize(using = ResourceIdDeserializer::class)
 data class ResourceId(val value: String) {
   override fun toString(): String = value
-
-  // Resource names (the last token in a ResourceId) follow the Moniker format (<app>-<stack>-<detail>),
-  // unless it's a resource which doesn't support this, then we return null (like an image)
-  val application: String?
-    get() = if (value.startsWith("bakery:")) {
-      null
-    } else {
-      value.split(":").last().split("-").first()
-    }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -244,6 +244,32 @@ data class ResourceActuationPaused(
 }
 
 /**
+ * Actuation on the managed resource has been vetoed.
+ *
+ * @property reason The reason why actuation was vetoed.
+ */
+data class ResourceActuationVetoed(
+  override val apiVersion: ApiVersion,
+  override val kind: String,
+  override val id: String,
+  override val application: String,
+  val reason: String?,
+  override val timestamp: Instant
+) : ResourceEvent() {
+  @JsonIgnore
+  override val ignoreRepeatedInHistory = true
+
+  constructor(resource: Resource<*>, reason: String?, clock: Clock = Companion.clock) : this(
+    resource.apiVersion,
+    resource.kind,
+    resource.id.value,
+    resource.application,
+    reason,
+    clock.instant()
+  )
+}
+
+/**
  * Actuation on the managed resource has resumed.
  */
 data class ResourceActuationResumed(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepository.kt
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import java.security.MessageDigest
+import javax.xml.bind.DatatypeConverter
+
+/**
+ * Stores a hash of the diff
+ */
+interface DiffFingerprintRepository {
+  fun store(resourceId: ResourceId, diff: ResourceDiff<*>)
+
+  fun diffCount(resourceId: ResourceId): Int
+
+  fun ResourceDiff<*>.generateHash(): String {
+    val bytes = MessageDigest
+      .getInstance("SHA-1")
+      .digest(this.toDeltaJson().toString().toByteArray())
+    return DatatypeConverter.printHexBinary(bytes).toUpperCase()
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
@@ -35,16 +35,28 @@ abstract class UnhappyVetoRepository(
     log.info("Using ${javaClass.simpleName}")
   }
 
-  abstract fun markUnhappy(resourceId: ResourceId, application: String)
+  /**
+   * Marks [resourceId] as unhappy for [waitingTime]
+   */
+  abstract fun markUnhappyForWaitingTime(resourceId: ResourceId, application: String)
 
+  /**
+   * Clears unhappy marking for [resourceId]
+   */
   abstract fun markHappy(resourceId: ResourceId)
 
+  /**
+   * Calculates whether a resource should be skipped or rechecked at this instant
+   */
   abstract fun getVetoStatus(resourceId: ResourceId): UnhappyVetoStatus
 
+  /**
+   * Returns all currently vetoed resources
+   */
   abstract fun getAll(): Set<ResourceId>
 
   /**
-   * Get all resources for an application that this veto is currently vetoing
+   * Returns all currently vetoed resources for an [application]
    */
   abstract fun getAllForApp(application: String): Set<ResourceId>
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
@@ -39,7 +39,7 @@ abstract class UnhappyVetoRepository(
 
   abstract fun markHappy(resourceId: ResourceId)
 
-  abstract fun shouldSkip(resourceId: ResourceId): Boolean
+  abstract fun getVetoStatus(resourceId: ResourceId): UnhappyVetoStatus
 
   abstract fun getAll(): Set<ResourceId>
 
@@ -50,4 +50,9 @@ abstract class UnhappyVetoRepository(
 
   fun calculateExpirationTime(): Instant =
     clock.instant().plus(Duration.parse(waitingTime))
+
+  data class UnhappyVetoStatus(
+    val shouldSkip: Boolean = false,
+    val shouldRecheck: Boolean = false
+  )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
@@ -1,0 +1,53 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+abstract class UnhappyVetoRepository(
+  open val clock: Clock,
+  @Value("veto.unhappy.waiting-time") var waitingTime: String = "PT10M"
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  init {
+    log.info("Using ${javaClass.simpleName}")
+  }
+
+  abstract fun markUnhappy(resourceId: ResourceId, application: String)
+
+  abstract fun markHappy(resourceId: ResourceId)
+
+  abstract fun shouldSkip(resourceId: ResourceId): Boolean
+
+  abstract fun getAll(): Set<ResourceId>
+
+  /**
+   * Get all resources for an application that this veto is currently vetoing
+   */
+  abstract fun getAllForApp(application: String): Set<ResourceId>
+
+  fun calculateExpirationTime(): Instant =
+    clock.instant().plus(Duration.parse(waitingTime))
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepository.kt
@@ -1,0 +1,54 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence.memory
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
+import java.time.Clock
+import java.time.Instant
+
+class InMemoryDiffFingerprintRepository(
+  private val clock: Clock = Clock.systemDefaultZone()
+) : DiffFingerprintRepository {
+  private val hashes: MutableMap<ResourceId, Record> = mutableMapOf()
+
+  override fun store(resourceId: ResourceId, diff: ResourceDiff<*>) {
+    val existing = hashes[resourceId]
+    val hash = diff.generateHash()
+
+    if (existing != null && hash == existing.hash) {
+      hashes[resourceId] = existing.copy(count = existing.count + 1)
+    } else {
+      hashes[resourceId] = Record(hash, clock.instant())
+    }
+  }
+
+  override fun diffCount(resourceId: ResourceId): Int =
+    hashes[resourceId]?.count ?: 0
+
+  private data class Record(
+    val hash: String,
+    val timestamp: Instant, // timestamp when diff was first seen
+    val count: Int = 1
+  )
+
+  fun flush() {
+    hashes.clear()
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
@@ -1,0 +1,62 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence.memory
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
+import java.time.Clock
+import java.time.Instant
+
+class InMemoryUnhappyVetoRepository(
+  override val clock: Clock
+) : UnhappyVetoRepository(clock) {
+
+  private val resources: MutableMap<ResourceId, Record> = mutableMapOf()
+
+  override fun markUnhappy(resourceId: ResourceId, application: String) {
+    resources[resourceId] = Record(application, calculateExpirationTime())
+  }
+
+  override fun markHappy(resourceId: ResourceId) {
+    resources.remove(resourceId)
+  }
+
+  override fun shouldSkip(resourceId: ResourceId): Boolean {
+    val record = resources[resourceId] ?: return false
+    return record.recheckTime > clock.instant()
+  }
+
+  override fun getAll(): Set<ResourceId> {
+    val now = clock.instant()
+    return resources.filter { it.value.recheckTime > now }.keys.toSet()
+  }
+
+  override fun getAllForApp(application: String): Set<ResourceId> {
+    val now = clock.instant()
+    return resources.filter { (id, record) ->
+      record.recheckTime > now && (record.application == null || record.application == application)
+    }.keys.toSet()
+  }
+
+  fun flush() = resources.clear()
+
+  private data class Record(
+    val application: String,
+    val recheckTime: Instant
+  )
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
@@ -28,7 +28,7 @@ class InMemoryUnhappyVetoRepository(
 
   private val resources: MutableMap<ResourceId, Record> = mutableMapOf()
 
-  override fun markUnhappy(resourceId: ResourceId, application: String) {
+  override fun markUnhappyForWaitingTime(resourceId: ResourceId, application: String) {
     resources[resourceId] = Record(application, calculateExpirationTime())
   }
 
@@ -51,7 +51,7 @@ class InMemoryUnhappyVetoRepository(
 
   override fun getAllForApp(application: String): Set<ResourceId> {
     val now = clock.instant()
-    return resources.filter { (id, record) ->
+    return resources.filter { (_, record) ->
       record.recheckTime > now && record.application == application
     }.keys.toSet()
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
@@ -36,9 +36,12 @@ class InMemoryUnhappyVetoRepository(
     resources.remove(resourceId)
   }
 
-  override fun shouldSkip(resourceId: ResourceId): Boolean {
-    val record = resources[resourceId] ?: return false
-    return record.recheckTime > clock.instant()
+  override fun getVetoStatus(resourceId: ResourceId): UnhappyVetoStatus {
+    val record = resources[resourceId] ?: return UnhappyVetoStatus()
+    return UnhappyVetoStatus(
+      shouldSkip = record.recheckTime > clock.instant(),
+      shouldRecheck = record.recheckTime < clock.instant()
+    )
   }
 
   override fun getAll(): Set<ResourceId> {
@@ -49,7 +52,7 @@ class InMemoryUnhappyVetoRepository(
   override fun getAllForApp(application: String): Set<ResourceId> {
     val now = clock.instant()
     return resources.filter { (id, record) ->
-      record.recheckTime > now && (record.application == null || record.application == application)
+      record.recheckTime > now && record.application == application
     }.keys.toSet()
   }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepositoryTests.kt
@@ -1,0 +1,31 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence.memory
+
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepositoryTests
+import java.time.Clock
+
+class InMemoryDiffFingerprintRepositoryTests : DiffFingerprintRepositoryTests<InMemoryDiffFingerprintRepository>() {
+  override fun factory(clock: Clock): InMemoryDiffFingerprintRepository {
+    return InMemoryDiffFingerprintRepository(clock)
+  }
+
+  override fun InMemoryDiffFingerprintRepository.flush() {
+    flush()
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepositoryTests.kt
@@ -1,0 +1,29 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.persistence.memory
+
+import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepositoryTests
+import java.time.Clock
+
+class InMemoryUnhappyVetoRepositoryTests : UnhappyVetoRepositoryTests<InMemoryUnhappyVetoRepository>() {
+  override fun factory(clock: Clock) = InMemoryUnhappyVetoRepository(clock)
+
+  override fun InMemoryUnhappyVetoRepository.flush() {
+    flush()
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -1,11 +1,13 @@
 package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.events.ResourceEvent.Companion.clock
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.sql.SqlApplicationVetoRepository
 import com.netflix.spinnaker.keel.sql.SqlArtifactRepository
 import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
 import com.netflix.spinnaker.keel.sql.SqlResourceRepository
+import com.netflix.spinnaker.keel.sql.SqlUnhappyVetoRepository
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
 import org.jooq.DSLContext
 import org.jooq.impl.DefaultConfiguration
@@ -60,4 +62,10 @@ class SqlConfiguration {
     jooq: DSLContext
   ) =
     SqlApplicationVetoRepository(jooq)
+
+  @Bean
+  fun unhappyVetoRepository(
+    jooq: DSLContext
+  ) =
+    SqlUnhappyVetoRepository(clock, jooq)
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.sql.SqlApplicationVetoRepository
 import com.netflix.spinnaker.keel.sql.SqlArtifactRepository
 import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
+import com.netflix.spinnaker.keel.sql.SqlDiffFingerprintRepository
 import com.netflix.spinnaker.keel.sql.SqlResourceRepository
 import com.netflix.spinnaker.keel.sql.SqlUnhappyVetoRepository
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
@@ -56,6 +57,12 @@ class SqlConfiguration {
     resourceTypeIdentifier: ResourceTypeIdentifier
   ) =
     SqlDeliveryConfigRepository(jooq, clock, resourceTypeIdentifier)
+
+  @Bean
+  fun diffFingerprintRepository(
+    jooq: DSLContext,
+    clock: Clock
+  ) = SqlDiffFingerprintRepository(jooq, clock)
 
   @Bean
   fun applicationVetoRepository(

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepository.kt
@@ -1,0 +1,76 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DIFF_FINGERPRINT
+import org.jooq.DSLContext
+import java.time.Clock
+
+class SqlDiffFingerprintRepository(
+  private val jooq: DSLContext,
+  private val clock: Clock
+) : DiffFingerprintRepository {
+  override fun store(resourceId: ResourceId, diff: ResourceDiff<*>) {
+    val hash = diff.generateHash()
+    jooq
+      .select(DIFF_FINGERPRINT.COUNT, DIFF_FINGERPRINT.FIRST_DETECTION_TIME)
+      .from(DIFF_FINGERPRINT)
+      .where(DIFF_FINGERPRINT.RESOURCE_ID.eq(resourceId.toString()))
+      .and(DIFF_FINGERPRINT.HASH.eq(hash))
+      .forUpdate()
+      .fetchOne()
+      ?.let { (count, firstDetectionTime) ->
+        jooq.insertInto(DIFF_FINGERPRINT)
+          .set(DIFF_FINGERPRINT.RESOURCE_ID, resourceId.toString())
+          .set(DIFF_FINGERPRINT.COUNT, count + 1)
+          .set(DIFF_FINGERPRINT.HASH, hash)
+          .set(DIFF_FINGERPRINT.FIRST_DETECTION_TIME, firstDetectionTime)
+          .onDuplicateKeyUpdate()
+          .set(DIFF_FINGERPRINT.COUNT, count + 1)
+          .execute()
+        return
+      }
+
+    jooq.insertInto(DIFF_FINGERPRINT)
+      .set(DIFF_FINGERPRINT.RESOURCE_ID, resourceId.toString())
+      .set(DIFF_FINGERPRINT.HASH, hash)
+      .set(DIFF_FINGERPRINT.COUNT, 1)
+      .set(DIFF_FINGERPRINT.FIRST_DETECTION_TIME, clock.instant().toEpochMilli())
+      .onDuplicateKeyUpdate()
+      .set(DIFF_FINGERPRINT.HASH, hash)
+      .set(DIFF_FINGERPRINT.COUNT, 1)
+      .set(DIFF_FINGERPRINT.FIRST_DETECTION_TIME, clock.instant().toEpochMilli())
+      .execute()
+  }
+
+  override fun diffCount(resourceId: ResourceId): Int {
+    val count = jooq
+      .select(DIFF_FINGERPRINT.COUNT)
+      .from(DIFF_FINGERPRINT)
+      .where(DIFF_FINGERPRINT.RESOURCE_ID.eq(resourceId.toString()))
+      .fetchOne()
+      ?.let { (count) ->
+        count
+      }
+
+    return count ?: 0
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
@@ -1,0 +1,83 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.UNHAPPY_VETO
+import org.jooq.DSLContext
+import java.time.Clock
+
+class SqlUnhappyVetoRepository(
+  override val clock: Clock,
+  private val jooq: DSLContext
+) : UnhappyVetoRepository(clock) {
+
+  override fun markUnhappy(resourceId: ResourceId, application: String) {
+    jooq.insertInto(UNHAPPY_VETO)
+      .set(UNHAPPY_VETO.RESOURCE_ID, resourceId.toString())
+      .set(UNHAPPY_VETO.APPLICATION, application)
+      .set(UNHAPPY_VETO.RECHECK_TIME, calculateExpirationTime().toEpochMilli())
+      .onDuplicateKeyUpdate()
+      .set(UNHAPPY_VETO.RECHECK_TIME, calculateExpirationTime().toEpochMilli())
+      .execute()
+  }
+
+  override fun markHappy(resourceId: ResourceId) {
+    jooq.deleteFrom(UNHAPPY_VETO)
+      .where(UNHAPPY_VETO.RESOURCE_ID.eq(resourceId.toString()))
+      .execute()
+  }
+
+  override fun shouldSkip(resourceId: ResourceId): Boolean {
+    jooq
+      .select(UNHAPPY_VETO.RECHECK_TIME)
+      .from(UNHAPPY_VETO)
+      .where(UNHAPPY_VETO.RESOURCE_ID.eq(resourceId.toString()))
+      .fetchOne()
+      ?.let { (recheckTime) ->
+        return recheckTime > clock.instant().toEpochMilli()
+      }
+    return false
+  }
+
+  override fun getAll(): Set<ResourceId> {
+    val now = clock.instant().toEpochMilli()
+    return jooq.select(UNHAPPY_VETO.RESOURCE_ID)
+      .from(UNHAPPY_VETO)
+      .where(UNHAPPY_VETO.RECHECK_TIME.greaterOrEqual(now))
+      .fetch()
+      .map { (json: String) ->
+        ResourceId(json)
+      }
+      .toSet()
+  }
+
+  override fun getAllForApp(application: String): Set<ResourceId> {
+    val now = clock.instant().toEpochMilli()
+    return jooq.select(UNHAPPY_VETO.RESOURCE_ID)
+      .from(UNHAPPY_VETO)
+      .where(UNHAPPY_VETO.APPLICATION.eq(application))
+      .and(UNHAPPY_VETO.RECHECK_TIME.greaterOrEqual(now))
+      .fetch()
+      .map { (json: String) ->
+        ResourceId(json)
+      }
+      .toSet()
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
@@ -28,7 +28,7 @@ class SqlUnhappyVetoRepository(
   private val jooq: DSLContext
 ) : UnhappyVetoRepository(clock) {
 
-  override fun markUnhappy(resourceId: ResourceId, application: String) {
+  override fun markUnhappyForWaitingTime(resourceId: ResourceId, application: String) {
     jooq.insertInto(UNHAPPY_VETO)
       .set(UNHAPPY_VETO.RESOURCE_ID, resourceId.toString())
       .set(UNHAPPY_VETO.APPLICATION, application)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
@@ -44,16 +44,19 @@ class SqlUnhappyVetoRepository(
       .execute()
   }
 
-  override fun shouldSkip(resourceId: ResourceId): Boolean {
+  override fun getVetoStatus(resourceId: ResourceId): UnhappyVetoStatus {
     jooq
       .select(UNHAPPY_VETO.RECHECK_TIME)
       .from(UNHAPPY_VETO)
-      .where(UNHAPPY_VETO.RESOURCE_ID.eq(resourceId.toString()))
+      .where(UNHAPPY_VETO.RESOURCE_ID.eq(resourceId.value))
       .fetchOne()
       ?.let { (recheckTime) ->
-        return recheckTime > clock.instant().toEpochMilli()
+        return UnhappyVetoStatus(
+          shouldSkip = recheckTime > clock.instant().toEpochMilli(),
+          shouldRecheck = recheckTime < clock.instant().toEpochMilli()
+        )
       }
-    return false
+    return UnhappyVetoStatus()
   }
 
   override fun getAll(): Set<ResourceId> {

--- a/keel-sql/src/main/resources/db/changelog/20191125-create-unhappy-veto-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191125-create-unhappy-veto-table.yml
@@ -21,6 +21,13 @@ databaseChangeLog:
                   type: bigint
                   constraints:
                     - nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"
+      rollback:
+        - dropTable:
+            tableName: unhappy_veto
   - changeSet:
       id: create-unhappy-veto-constraint-indicies
       author: emjburns
@@ -39,3 +46,10 @@ databaseChangeLog:
                   name: resource_id
               - column:
                   name: recheck_time
+      rollback:
+        - dropPrimaryKey:
+            constraintName: unhappy_veto_pk
+            tableName: unhappy_veto
+        - dropIndex:
+            indexName: unhappy_veto_idx
+            tableName: unhappy_veto

--- a/keel-sql/src/main/resources/db/changelog/20191125-create-unhappy-veto-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191125-create-unhappy-veto-table.yml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-unhappy-veto-table
+      author: emjburns
+      changes:
+        - createTable:
+            tableName: unhappy_veto
+            columns:
+              - column:
+                  name: resource_id
+                  type: varchar(255)
+                  constraints:
+                    - nullable: false
+              - column:
+                  name: application
+                  type: varchar(255)
+                  constraints:
+                    - nullable: false
+              - column:
+                  name: recheck_time
+                  type: bigint
+                  constraints:
+                    - nullable: false
+  - changeSet:
+      id: create-unhappy-veto-constraint-indicies
+      author: emjburns
+      changes:
+        - addPrimaryKey:
+            tableName: unhappy_veto
+            constraintName: unhappy_veto_pk
+            columnNames: resource_id
+        - createIndex:
+            tableName: unhappy_veto
+            indexName: unhappy_veto_idx
+            columns:
+              - column:
+                  name: application
+              - column:
+                  name: resource_id
+              - column:
+                  name: recheck_time

--- a/keel-sql/src/main/resources/db/changelog/20191202-create-diff-fingerprint-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191202-create-diff-fingerprint-table.yml
@@ -24,7 +24,7 @@ databaseChangeLog:
                     nullable: false
               - column:
                   name: hash
-                  type: longtext
+                  type: char(40)
                   constraints:
                     nullable: false
         - modifySql:
@@ -45,4 +45,4 @@ databaseChangeLog:
       rollback:
         - dropPrimaryKey:
             constraintName: diff_fingerprint_pk
-            tableName: resource_id
+            tableName: diff_fingerprint

--- a/keel-sql/src/main/resources/db/changelog/20191202-create-diff-fingerprint-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191202-create-diff-fingerprint-table.yml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-diff-fingerprint-table
+      author: emjburns
+      changes:
+        - createTable:
+            tableName: diff_fingerprint
+            columns:
+              - column:
+                  name: resource_id
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: first_detection_time
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: count
+                  type: int
+                  defaultValue: 1
+                  constraints:
+                    nullable: false
+              - column:
+                  name: hash
+                  type: longtext
+                  constraints:
+                    nullable: false
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"
+      rollback:
+        - dropTable:
+            tableName: diff_fingerprint
+  - changeSet:
+      id: create-diff-fingerprint-constraint-indicies
+      author: emjburns
+      changes:
+        - addPrimaryKey:
+            tableName: diff_fingerprint
+            constraintName: diff_fingerprint_pk
+            columnNames: resource_id
+      rollback:
+        - dropPrimaryKey:
+            constraintName: diff_fingerprint_pk
+            tableName: resource_id

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -47,3 +47,6 @@ databaseChangeLog:
   - include:
       file: changelog/20191125-create-unhappy-veto-table.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20191202-create-diff-fingerprint-table.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -44,3 +44,6 @@ databaseChangeLog:
   - include:
       file: changelog/20191123-rename-resource-check-pending-event.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20191125-create-unhappy-veto-table.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepositoryTests.kt
@@ -1,0 +1,42 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepositoryTests
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import org.junit.jupiter.api.AfterAll
+import java.time.Clock
+
+internal object SqlDiffFingerprintRepositoryTests : DiffFingerprintRepositoryTests<SqlDiffFingerprintRepository>() {
+  private val testDatabase = initTestDatabase()
+  private val jooq = testDatabase.context
+
+  override fun factory(clock: Clock): SqlDiffFingerprintRepository {
+    return SqlDiffFingerprintRepository(jooq, clock)
+  }
+
+  override fun SqlDiffFingerprintRepository.flush() {
+    SqlTestUtil.cleanupDb(jooq)
+  }
+
+  @JvmStatic
+  @AfterAll
+  fun shutdown() {
+    testDatabase.dataSource.close()
+  }
+}

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepositoryTests.kt
@@ -1,0 +1,46 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepositoryTests
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import org.junit.jupiter.api.AfterAll
+import java.time.Clock
+
+internal object SqlUnhappyVetoRepositoryTests : UnhappyVetoRepositoryTests<SqlUnhappyVetoRepository>() {
+
+  private val testDatabase = initTestDatabase()
+  private val jooq = testDatabase.context
+
+  override fun factory(clock: Clock): SqlUnhappyVetoRepository {
+    return SqlUnhappyVetoRepository(
+      clock,
+      jooq
+    )
+  }
+
+  override fun SqlUnhappyVetoRepository.flush() {
+    SqlTestUtil.cleanupDb(jooq)
+  }
+
+  @JvmStatic
+  @AfterAll
+  fun shutdown() {
+    testDatabase.dataSource.close()
+  }
+}

--- a/keel-veto/keel-veto.gradle.kts
+++ b/keel-veto/keel-veto.gradle.kts
@@ -8,8 +8,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.boot:spring-boot-starter-web")
 
+  testImplementation(project(":keel-core-test"))
   testImplementation(project(":keel-plugin"))
-  testImplementation(project(":keel-bakery-plugin"))
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
 }

--- a/keel-veto/keel-veto.gradle.kts
+++ b/keel-veto/keel-veto.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-actuator")
   implementation("org.springframework.boot:spring-boot-starter-web")
 
+  testImplementation(project(":keel-test"))
   testImplementation(project(":keel-core-test"))
   testImplementation(project(":keel-plugin"))
   testImplementation("dev.minutest:minutest")

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/config/UnhappyVetoConfig.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/config/UnhappyVetoConfig.kt
@@ -1,0 +1,34 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.config
+
+import com.netflix.spinnaker.keel.events.ResourceEvent.Companion.clock
+import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryUnhappyVetoRepository
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class UnhappyVetoConfig {
+
+  @Bean
+  @ConditionalOnMissingBean
+  fun unhappyVetoRepository(): UnhappyVetoRepository =
+    InMemoryUnhappyVetoRepository(clock)
+}

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
@@ -34,14 +34,16 @@ interface Veto {
   fun name(): String = javaClass.simpleName
 
   /**
-   * Check whether the resource (identified by name) can be checked according to this veto
-   */
-  fun check(id: ResourceId): VetoResponse
-
-  /**
    * Check whether the resource can be checked according to this veto
    */
   fun check(resource: Resource<*>): VetoResponse
+
+  /**
+   * Check whether the resource can be checked according to this veto,
+   * by id and application. Application is not always calculable from the resourceId,
+   * so it needs to be passed in
+   */
+  fun check(resourceId: ResourceId, application: String): VetoResponse
 
   /**
    * The message format a veto accepts
@@ -57,9 +59,21 @@ interface Veto {
    * What's currently being vetoed
    */
   fun currentRejections(): List<String>
+
+  /**
+   * What's currently being vetoed for an app
+   */
+  fun currentRejectionsByApp(application: String): List<ResourceId>
+
+  fun allowedResponse(): VetoResponse =
+    VetoResponse(allowed = true, vetoName = name())
+
+  fun deniedResponse(message: String): VetoResponse =
+    VetoResponse(allowed = false, vetoName = name(), message = message)
 }
 
 data class VetoResponse(
   val allowed: Boolean,
+  val vetoName: String,
   val message: String? = null
 )

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/VetoController.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/VetoController.kt
@@ -66,6 +66,15 @@ class VetoController(
     return veto.currentRejections()
   }
 
+  @GetMapping(
+    path = ["/application/{application}/rejections"],
+    produces = [MediaType.APPLICATION_JSON_VALUE]
+  )
+  fun getVetoRejectionsByApp(@PathVariable application: String): List<String> =
+    vetos.map { veto ->
+      veto.currentRejectionsByApp(application)
+    }.flatten().map { it.value }.toList()
+
   @PostMapping(
     path = ["/{name}"],
     produces = [MediaType.APPLICATION_JSON_VALUE]

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcer.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcer.kt
@@ -18,7 +18,7 @@
 
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.Resource
 import org.springframework.stereotype.Component
 
 /**
@@ -32,13 +32,13 @@ class VetoEnforcer(
   val vetos: List<Veto>
 ) {
 
-  fun canCheck(id: ResourceId): VetoResponse {
+  fun canCheck(resource: Resource<*>): VetoResponse {
     vetos.forEach { veto ->
-      val response = veto.check(id)
+      val response = veto.check(resource)
       if (!response.allowed) {
         return response
       }
     }
-    return VetoResponse(allowed = true)
+    return VetoResponse(allowed = true, vetoName = "all")
   }
 }

--- a/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-veto/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -1,0 +1,79 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.veto.unhappy
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
+import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
+import com.netflix.spinnaker.keel.veto.Veto
+import com.netflix.spinnaker.keel.veto.VetoResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+/**
+ * A veto that stops keel from checking a resource for a configurable
+ * amount of time so that we don't flap on a resource forever.
+ */
+@Component
+class UnhappyVeto(
+  private val resourceRepository: ResourceRepository,
+  private val unhappyVetoRepository: UnhappyVetoRepository
+) : Veto {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  @Value("veto.unhappy.waiting-time")
+  var waitingTime: String = "PT10M"
+
+  override fun check(resource: Resource<*>) =
+    check(resource.id, resource.spec.application)
+
+  override fun check(resourceId: ResourceId, application: String): VetoResponse {
+    val shouldSkip = unhappyVetoRepository.shouldSkip(resourceId)
+    if (shouldSkip) {
+      return deniedResponse("Resource is unhappy and will be checked again for a diff after $waitingTime")
+    }
+
+    val status = resourceRepository.getStatus(resourceId)
+    return if (status == UNHAPPY) {
+      unhappyVetoRepository.markUnhappy(resourceId, application)
+      deniedResponse("Resource is unhappy and will be checked again for a diff after $waitingTime")
+    } else {
+      unhappyVetoRepository.markHappy(resourceId)
+      allowedResponse()
+    }
+  }
+
+  override fun messageFormat(): Map<String, Any> {
+    TODO("not implemented")
+  }
+
+  override fun passMessage(message: Map<String, Any>) {
+    TODO("not implemented")
+  }
+
+  override fun currentRejections(): List<String> =
+    unhappyVetoRepository.getAll().map { it.toString() }.toList()
+
+  override fun currentRejectionsByApp(application: String) =
+    unhappyVetoRepository.getAllForApp(application).toList()
+}

--- a/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/ApplicationVetoTests.kt
+++ b/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/ApplicationVetoTests.kt
@@ -17,17 +17,10 @@
  */
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ArtifactStatus
-import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceId
-import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.bakery.api.BaseLabel
-import com.netflix.spinnaker.keel.bakery.api.ImageSpec
-import com.netflix.spinnaker.keel.bakery.api.StoreType
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryApplicationVetoRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
-  import com.netflix.spinnaker.keel.plugin.SupportedKind
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.veto.application.ApplicationVeto
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -40,34 +33,9 @@ import strikt.assertions.isTrue
 class ApplicationVetoTests : JUnit5Minutests {
   private val appName = "keeldemo"
   private val friggaAppName = "test"
-  private val clusterResourceId = ResourceId("ec2:securityGroup:test:us-west-2:$appName-managed")
+  private val r = resource()
 
-  private val imageId = "bakery:image:$friggaAppName-$appName"
-  private val imageResourceId = ResourceId(imageId)
-  private val imageSpec = ImageSpec(
-    artifactName = "$friggaAppName-$appName",
-    baseLabel = BaseLabel.RELEASE,
-    baseOs = "bionic",
-    regions = setOf("us-west-1"),
-    storeType = StoreType.EBS,
-    artifactStatuses = listOf(ArtifactStatus.FINAL),
-    application = appName
-  )
-  private val imageKind = SupportedKind(SPINNAKER_API_V1.subApi("bakery"), "image", ImageSpec::class.java)
-  private val imageResource: Resource<ImageSpec> = Resource(
-    apiVersion = imageKind.apiVersion,
-    kind = imageKind.kind,
-    metadata = mapOf(
-      "application" to appName,
-      "id" to imageId,
-      "serviceAccount" to "fnord@keel"
-    ),
-    spec = imageSpec
-  )
-
-  internal
-
-  class Fixture {
+  internal class Fixture {
     val vetoRepository = InMemoryApplicationVetoRepository()
     val resourceRepository = InMemoryResourceRepository()
     val subject = ApplicationVeto(vetoRepository, resourceRepository, configuredObjectMapper())
@@ -82,17 +50,17 @@ class ApplicationVetoTests : JUnit5Minutests {
       }
 
       test("when no applications are opted out we allow any app") {
-        val response = subject.check(clusterResourceId)
+        val response = subject.check(r)
         expectThat(response.allowed).isTrue()
       }
 
-      test("when myapp is excluded, we don't allow it") {
+      test("when the resource's app is excluded, we don't allow it") {
         subject.passMessage(mapOf(
-          "application" to appName,
+          "application" to r.spec.application,
           "optedOut" to true
         ))
 
-        val response = subject.check(clusterResourceId)
+        val response = subject.check(r)
         expectThat(response.allowed).isFalse()
       }
 
@@ -113,54 +81,6 @@ class ApplicationVetoTests : JUnit5Minutests {
 
         expectThat(subject.currentRejections())
           .hasSize(0)
-      }
-    }
-
-    context("testing an image with a different appname according to frigga") {
-      after {
-        vetoRepository.flush()
-      }
-
-      before {
-        resourceRepository.store(imageResource)
-      }
-
-      test("resource application differs from frigga application, where resource app is vetoed") {
-        subject.passMessage(mapOf(
-          "application" to appName,
-          "optedOut" to true
-        ))
-
-        val responseById = subject.check(imageResourceId)
-        expectThat(responseById.allowed).isFalse()
-
-        val responseBySpec = subject.check(imageResource)
-        expectThat(responseBySpec.allowed).isFalse()
-      }
-
-      test("resource application differs from frigga application, where only frigga app is vetoed") {
-        subject.passMessage(mapOf(
-          "application" to friggaAppName,
-          "optedOut" to true
-        ))
-
-        val responseById = subject.check(imageResourceId)
-        expectThat(responseById.allowed).isTrue()
-
-        val responseBySpec = subject.check(imageResource)
-        expectThat(responseBySpec.allowed).isTrue()
-      }
-
-      test("fallback to frigga for unpersisted resources") {
-        resourceRepository.dropAll()
-
-        subject.passMessage(mapOf(
-          "application" to friggaAppName,
-          "optedOut" to true
-        ))
-
-        val responseBy = subject.check(imageResourceId)
-        expectThat(responseBy.allowed).isFalse()
       }
     }
   }

--- a/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/UnhappyVetoTests.kt
+++ b/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/UnhappyVetoTests.kt
@@ -1,0 +1,95 @@
+/*
+ *
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package com.netflix.spinnaker.keel.veto
+
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryUnhappyVetoRepository
+import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.keel.veto.unhappy.UnhappyVeto
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import java.time.Duration
+
+class UnhappyVetoTests : JUnit5Minutests {
+  val r = resource()
+
+  internal class Fixture {
+    val clock = MutableClock()
+    val unhappyRepository = InMemoryUnhappyVetoRepository(clock)
+    val resourceRepository: ResourceRepository = mockk()
+    val subject = UnhappyVeto(resourceRepository, unhappyRepository)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    after {
+      unhappyRepository.flush()
+    }
+
+    context("resource is happy") {
+      before {
+        every { resourceRepository.getStatus(r.id) } returns HAPPY
+      }
+
+      test("happy resources aren't vetoed") {
+        expectThat(subject.check(r).allowed).isEqualTo(true)
+      }
+    }
+
+    context("resource is unhappy") {
+      before {
+        every { resourceRepository.getStatus(r.id) } returns UNHAPPY
+      }
+
+      test("unhappy resources are vetoed") {
+        expectThat(subject.check(r).allowed).isEqualTo(false)
+      }
+
+      test("unhappy resources are checked again after the duration") {
+        before {
+          every { resourceRepository.getStatus(r.id) } returns UNHAPPY
+        }
+
+        val response1 = subject.check(r)
+        clock.incrementBy(Duration.ofMinutes(5))
+        val response2 = subject.check(r)
+        clock.incrementBy(Duration.ofMinutes(5))
+
+        // returnsMany seems to not work for enums, so this is a workaround.
+        every { resourceRepository.getStatus(r.id) } returns HAPPY
+
+        val response3 = subject.check(r)
+        expect {
+          that(response1.allowed).isEqualTo(false)
+          that(response2.allowed).isEqualTo(false)
+          that(response3.allowed).isEqualTo(true)
+        }
+      }
+    }
+  }
+}

--- a/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcerTests.kt
+++ b/keel-veto/src/test/kotlin/com/netflix/spinnaker/keel/veto/VetoEnforcerTests.kt
@@ -17,10 +17,10 @@
  */
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryApplicationVetoRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.veto.application.ApplicationVeto
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -30,7 +30,7 @@ import strikt.assertions.isTrue
 
 class VetoEnforcerTests : JUnit5Minutests {
 
-  val appName = "myapp"
+  val r = resource()
 
   internal class Fixture {
     val applicationVetoRepository = InMemoryApplicationVetoRepository()
@@ -48,19 +48,19 @@ class VetoEnforcerTests : JUnit5Minutests {
       }
 
       test("no vetos means it's allowed") {
-        val response = subject.canCheck(ResourceId(appName))
+        val response = subject.canCheck(r)
         expectThat(response.allowed).isTrue()
       }
 
       test("when we have one deny we deny overall") {
         applicationVeto.passMessage(
           mapOf(
-            "application" to appName,
+            "application" to r.spec.application,
             "optedOut" to true
           )
         )
 
-        val response = subject.canCheck(ResourceId(appName))
+        val response = subject.canCheck(r)
         expectThat(response.allowed).isFalse()
       }
     }


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/629 (which I definitely just opened but still!).

This pr introduces an "unhappy" veto that will let us not check an unhappy resource for a configurable amount of time. Some small changes to support that:
- support for sending different events based on which veto said no
- vetos accept either the whole resource, or id + application, because we can't reliably determine application from just id (like for images)
- changes around tests to support ^
- a new resource status: `vetoed` (not used yet)

The status of a resource that is vetoed by the "application veto" (pause management) will be `paused`, while the status of a resource that has been vetoed by the "unhappy veto" will remain `unhappy` to continue to convey that to the user.

_edit_

Updated this PR to 
- introduce basic diff fingerprinting
- move vetoing to after we calculate the diff of a resource

Diff fingerprinting means that we immediately check a resource again if the diff has changed so that we can react quickly to someone making updates to a resource.

Moving vetoing to after the diff has been calculated means that we now always make the calls to clouddriver to calculate a diff _even_ if the resource is paused or will be vetoed. Essentially, vetoing stops the *action* of resolving the diff, not checking the resource in general. This is necessary for the unhappy veto to recheck as soon as the diff changes (which is really a much nicer experience).

