### PR TITLE
feat(constraints): crud support for state

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -1,20 +1,30 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
+import com.netflix.spinnaker.keel.api.ConstraintState
+import com.netflix.spinnaker.keel.api.ConstraintStatus
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.diff.AdHocDiffer
 import com.netflix.spinnaker.keel.diff.EnvironmentDiff
+import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
 
 @RestController
 @RequestMapping(path = ["/delivery-configs"])
@@ -44,6 +54,51 @@ class DeliveryConfigController(
   )
   fun diff(@RequestBody deliveryConfig: SubmittedDeliveryConfig): List<EnvironmentDiff> =
     adHocDiffer.calculate(deliveryConfig)
+
+  @GetMapping(
+    path = ["/{name}/environment/{environment}/constraints"],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  fun getConstraintState(
+    @PathVariable("name") name: String,
+    @PathVariable("environment") environment: String,
+    @RequestParam("limit") limit: Int?
+  ): List<ConstraintState> =
+    deliveryConfigRepository.constraintStateFor(name, environment, limit ?: DEFAULT_MAX_EVENTS)
+
+  @PostMapping(
+    path = ["/{name}/environment/{environment}/constraint/{type}"],
+    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  // TODO: This should be validated against write access to a service account. Service accounts should
+  //  become a top-level property of either delivery configs or environments.
+  fun updateConstraintStatus(
+    @RequestHeader("X-SPINNAKER-USER") user: String,
+    @PathVariable("name") name: String,
+    @PathVariable("environment") environment: String,
+    @PathVariable("type") type: String,
+    @RequestParam("artifactVersion") artifactVersion: String,
+    @RequestParam("status") status: String,
+    @RequestParam("comment") comment: String?
+  ) {
+    val currentState = deliveryConfigRepository.getConstraintState(name, environment, artifactVersion, type)
+      ?: throw InvalidConstraintException("$name/$environment/$type/$artifactVersion", "constraint not found")
+
+    deliveryConfigRepository.storeConstraintState(
+      currentState.copy(
+        status = ConstraintStatus.valueOf(status),
+        comment = comment ?: currentState.comment,
+        judgedAt = Instant.now(),
+        judgedBy = user
+      ))
+  }
+
+  @ExceptionHandler(InvalidConstraintException::class)
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  fun onNotFound(e: InvalidConstraintException) {
+    log.info(e.message)
+  }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -55,8 +55,13 @@ internal class ApplicationControllerTests {
     mvc
       .perform(request)
       .andExpect(status().isOk)
-      .andExpect(content().string(
-        """{"hasManagedResources":true}"""
+      .andExpect(content().json(
+        """
+          {
+            "hasManagedResources":true,
+            "hasDeliveryConfig":false
+          }
+        """.trimIndent()
       ))
 
     request = get("/application/${res.application}?includeDetails=true")
@@ -64,8 +69,15 @@ internal class ApplicationControllerTests {
     mvc
       .perform(request)
       .andExpect(status().isOk)
-      .andExpect(content().string(
-        """{"hasManagedResources":true,"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}]}"""
+      .andExpect(content().json(
+        """
+          |{
+          |"hasManagedResources":true,
+          |"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}],
+          |"hasDeliveryConfig":false,
+          |"currentEnvironmentConstraints":[]
+          |}
+        """.trimMargin()
       ))
   }
 }

--- a/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-api/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -1,8 +1,12 @@
 package com.netflix.spinnaker.keel.rest
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
 import com.netflix.spinnaker.keel.api.ArtifactType.DEB
+import com.netflix.spinnaker.keel.api.ConstraintState
+import com.netflix.spinnaker.keel.api.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.api.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
@@ -12,16 +16,21 @@ import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
+import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
@@ -32,6 +41,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.assertions.hasSize
+import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.succeeded
@@ -201,6 +212,9 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
         |              "tz": "America/Los_Angeles"
         |            }
         |          ]
+        |        },
+        |        {
+        |          "type": "manual-judgement"
         |        }
         |      ],
         |      "resources": [
@@ -257,8 +271,88 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
                 ?.constraints
             ).isNotNull()
           }
+
+          context("no environments with stateful constraints have been evaluated") {
+            test("no constraint state") {
+              getProdConstraintResponse(contentType)
+                // Response assertions that aren't dependent on contentType or deserialization
+                .andExpect(status().isOk)
+                .andExpect(content().string(not(containsString("status"))))
+
+              val states = getProdConstraintStates(contentType)
+              expectThat(states).isEmpty()
+            }
+          }
+
+          derivedContext<ResultActions>("interacting with manual judgement") {
+            fixture {
+              val judgement = ConstraintState("keel-manifest", "prod", "keel-1.0.2", "manual-judgement", PENDING)
+              deliveryConfigRepository.storeConstraintState(judgement)
+
+              getProdConstraintResponse(contentType)
+            }
+
+            test("pending manual judgement") {
+              andExpect(status().isOk)
+              andExpect(content().string(containsString("manual-judgement")))
+              andExpect(content().string(containsString("PENDING")))
+            }
+
+            derivedContext<ResultActions>("approving manual judgement") {
+              fixture {
+                val request = post(
+                  "/delivery-configs/keel-manifest/environment/prod/constraint/manual-judgement" +
+                    "?artifactVersion=keel-1.0.2&status=PASS")
+                  .accept(contentType)
+                  .contentType(contentType)
+                  .header("X-SPINNAKER-USER", "keel")
+
+                mvc.perform(request)
+              }
+
+              test("judgement is persisted") {
+                andExpect(status().isOk)
+
+                val judgement = deliveryConfigRepository
+                  .getConstraintState("keel-manifest", "prod", "keel-1.0.2", "manual-judgement")
+
+                expectThat(judgement).isNotNull()
+                expectThat(judgement!!.status).isEqualTo(PASS)
+                expectThat(judgement.judgedBy).isEqualTo("keel")
+              }
+
+              test("persisted judgement is in rest response") {
+                val states = getProdConstraintStates(contentType)
+                expectThat(states).hasSize(1)
+                with(states.first()) {
+                  expectThat(status).isEqualTo(PASS)
+                  expectThat(judgedBy).isEqualTo("keel")
+                }
+              }
+            }
+          }
         }
       }
     }
   }
+
+  private fun getProdConstraintResponse(contentType: MediaType) =
+    mvc.perform(
+      get("/delivery-configs/keel-manifest/environment/prod/constraints")
+        .accept(contentType)
+        .contentType(contentType)
+    )
+
+  private fun getProdConstraintStates(contentType: MediaType): List<ConstraintState> =
+    getProdConstraintResponse(contentType)
+      .andReturn()
+      .response
+      .contentAsString
+      .let {
+        if (contentType == APPLICATION_YAML) {
+          configuredYamlMapper().readValue(it)
+        } else {
+          configuredObjectMapper().readValue(it)
+        }
+      }
 }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -89,7 +89,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
               deliveryConfigName = deliveryConfig.name,
               environmentName = env.name,
               artifactVersion = "${art.name}-1.0.0",
-              constraintType = "manual-judgement",
+              type = "manual-judgement",
               status = ConstraintStatus.PENDING
             )
           )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Constraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Constraint.kt
@@ -57,7 +57,6 @@ data class TimeWindowConstraint(
 }
 
 data class ManualJudgementConstraint(
-  // TODO: process timeouts
   val timeout: Duration = Duration.ofDays(7)
 ) : StatefulConstraint("manual-judgement")
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ConstraintState.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ConstraintState.kt
@@ -7,7 +7,7 @@ data class ConstraintState(
   val deliveryConfigName: String,
   val environmentName: String,
   val artifactVersion: String,
-  val constraintType: String,
+  val type: String,
   val status: ConstraintStatus,
   val createdAt: Instant = Instant.now(),
   val judgedBy: String? = null,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ManualJudgementConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ManualJudgementConstraintEvaluator.kt
@@ -37,7 +37,7 @@ class ManualJudgementConstraintEvaluator(
         deliveryConfigName = deliveryConfig.name,
         environmentName = targetEnvironment.name,
         artifactVersion = version,
-        constraintType = constraint.type,
+        type = constraint.type,
         status = ConstraintStatus.PENDING
       )
         .also {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -7,18 +7,63 @@ import com.netflix.spinnaker.keel.api.ResourceId
 
 interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfig> {
 
+  /**
+   * Persists a [DeliveryConfig].
+   */
   fun store(deliveryConfig: DeliveryConfig)
 
+  /**
+   * Retrieves a [DeliveryConfig] by its unique [name].
+   *
+   * @return The [DeliveryConfig]
+   * @throws NoSuchDeliveryConfigException if [name] does not map to a persisted config
+   */
   fun get(name: String): DeliveryConfig
 
+  /**
+   * Check if the given application has a [DeliveryConfig].
+   * @return Boolean
+   */
+  fun hasDeliveryConfig(application: String): Boolean
+
+  /**
+   * Retrieve the [Environment] a resource belongs to, by the resource [id].
+   *
+   * @return An [Environment] or `null` if the resource is not managed via an [Environment]
+   */
   fun environmentFor(resourceId: ResourceId): Environment?
 
+  /**
+   * Retrieve the [DeliveryConfig] a resource belongs to (the parent of its environment).
+   *
+   * @return A [DeliveryConfig] or `null` if the resource is not managed via a [DeliveryConfig].]
+   */
   fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig?
 
+  /**
+   * Delete the [DeliveryConfig] persisted for an application. This does not delete the underlying
+   * resources.
+   *
+   * @return The number of deleted [DeliveryConfig]s.
+   */
   fun deleteByApplication(application: String): Int
 
+  /**
+   * Updates state for a stateful [Environment] constraint.
+   */
   fun storeConstraintState(state: ConstraintState)
 
+  /**
+   * Get the latest state of an [Environment] constraint for a specific artifact.
+   *
+   * @param deliveryConfigName the [DeliveryConfig] name
+   * @param environmentName the [Environment] name
+   * @param artifactVersion the version of the artifact we're checking constraint state for
+   * @param type the type of constraint
+   *
+   * @return [ConstraintState] or `null` if the given constraint type has no state for
+   * the given Artifact/Environment combination.
+   */
   fun getConstraintState(
     deliveryConfigName: String,
     environmentName: String,
@@ -26,6 +71,27 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
     type: String
   ): ConstraintState?
 
+  /**
+   * Rolls up the most recent constraint states (maximum of one per (Environment, ConstraintType))
+   * related to a application retrieved by its name.
+   *
+   * @param application the application name
+   *
+   * @return A list of the most recent [ConstraintState]'s by environment per type or an
+   * empty list if none exist.
+   */
+  fun constraintStateFor(application: String): List<ConstraintState>
+
+  /**
+   * Retrieves recent [ConstraintState]'s for an [Environment].
+   *
+   * @param deliveryConfigName the [DeliveryConfig] name
+   * @param environmentName the [Environment] name
+   * @param limit the maximum number of [ConstraintState]'s to return, sorted by recency
+   *
+   * @return A list of up-to the most recent `limit` [ConstraintState]'s or an empty list if
+   * none exist.
+   */
   fun constraintStateFor(
     deliveryConfigName: String,
     environmentName: String,

--- a/keel-sql/src/main/resources/db/changelog/20191108-environment-artifact-constraint.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191108-environment-artifact-constraint.yml
@@ -93,3 +93,73 @@ databaseChangeLog:
             oldColumnName: json
             newColumnName: attributes
             columnDataType: longtext
+
+  # work around for https://liquibase.jira.com/browse/CORE-2111 to get the new uid column
+  # in the first position, since it's going to be the primary key
+  - changeSet:
+      id: mysql-envconstraint-add-uid
+      author: asher
+      changes:
+        - sql:
+            dbms: mysql
+            sql: alter table `environment_artifact_constraint` add column `uid` char(26) not null first
+
+  - changeSet:
+      id: envconstraint-add-uid
+      author: asher
+      changes:
+        - dropPrimaryKey:
+            tableName: environment_artifact_constraint
+            constraintName: constraint_pk
+            dropIndex: true
+        - renameColumn:
+            tableName: environment_artifact_constraint
+            columnDataType: varchar(255)
+            oldColumnName: constraint_type
+            newColumnName: type
+        - addPrimaryKey:
+            tableName: environment_artifact_constraint
+            constraintName: constraint_pk
+            columnNames: uid
+        - addUniqueConstraint:
+            tableName: environment_artifact_constraint
+            constraintName: constraint_pk
+            columnNames: environment_uid, type, artifact_version
+
+  - changeSet:
+      id: create-current-constraint-table
+      author: asher
+      changes:
+        - createTable:
+            tableName: current_constraint
+            columns:
+              - column:
+                  name: application
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: environment_uid
+                  type: char(26)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: constraint_uid
+                  type: char(26)
+                  constraints:
+                    nullable: false
+        - addPrimaryKey:
+            tableName: current_constraint
+            constraintName: current_constraint_pk
+            columnNames: application, environment_uid, type
+        - createIndex:
+            tableName: current_constraint
+            indexName: current_constraint_uid_idx
+            columns:
+              - column:
+                  name: constraint_uid


### PR DESCRIPTION
- Includes all current constraint states in the `ApplicationController` method polled by deck, when the application has a delivery-config and details are expanded.
- REST methods to read constraint history and update status.
- Persistence refactor, including adding a `current_constraint` table to serve the `ApplicationController` access pattern. 