### PR TITLE
refactor(artifacts): Use builder to create artifacts

### DIFF
--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListenerTests.kt
@@ -19,18 +19,15 @@ import io.mockk.verify
 import org.springframework.context.ApplicationEventPublisher
 
 internal class ArtifactListenerTests : JUnit5Minutests {
-  val korkArtifact = Artifact(
-    "DEB",
-    false,
-    "fnord",
-    "0.156.0-h58.f67fe09",
-    null,
-    "debian-local:pool/f/fnord/fnord_0.156.0-h58.f67fe09_all.deb",
-    mapOf("releaseStatus" to FINAL),
-    null,
-    "https://my.jenkins.master/jobs/fnord-release/58",
-    null
-  )
+  val korkArtifact = Artifact.builder()
+    .type("DEB")
+    .customKind(false)
+    .name("fnord")
+    .version("0.156.0-h58.f67fe09")
+    .reference("debian-local:pool/f/fnord/fnord_0.156.0-h58.f67fe09_all.deb")
+    .metadata(mapOf("releaseStatus" to FINAL))
+    .provenance("https://my.jenkins.master/jobs/fnord-release/58")
+    .build()
 
   data class ArtifactFixture(
     val event: ArtifactEvent,
@@ -194,18 +191,15 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     }
   }
 
-  val newerKorkArtifact = Artifact(
-    "DEB",
-    false,
-    "fnord",
-    "0.161.0-h61.116f116",
-    null,
-    "debian-local:pool/f/fnord/fnord_0.161.0-h61.116f116_all.deb",
-    mapOf("releaseStatus" to FINAL),
-    null,
-    "https://my.jenkins.master/jobs/fnord-release/60",
-    null
-  )
+  val newerKorkArtifact = Artifact.builder()
+    .type("DEB")
+    .customKind(false)
+    .name("fnord")
+    .version("0.161.0-h61.116f116")
+    .reference("debian-local:pool/f/fnord/fnord_0.161.0-h61.116f116_all.deb")
+    .metadata(mapOf("releaseStatus" to FINAL))
+    .provenance("https://my.jenkins.master/jobs/fnord-release/60")
+    .build()
 
   data class SyncArtifactsFixture(
     val artifact: DeliveryArtifact,

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -243,22 +243,21 @@ internal class ImageHandlerTests : JUnit5Minutests {
     context("baking a new AMI") {
       before {
         coEvery { igorService.getArtifact("keel", "0.161.0-h63.24d0843") } returns
-          Artifact(
-            "DEB",
-            false,
-            "keel",
-            "0.161.0-h63.24d0843",
-            "rocket",
-            "debian-local:pool/k/keel/keel_0.160.0-h62.02c0fbf_all.deb",
-            mapOf(
-              "repoKey" to "stash/spkr/keel-nflx",
-              "rocketMessageId" to "84c1ecca-7f76-482e-9952-226fb2c4c410",
-              "releaseStatus" to "FINAL"
-            ),
-            null,
-            "https://spinnaker.builds.test.netflix.net/job/SPINNAKER-rocket-package-keel/62",
-            null
-          )
+          Artifact.builder()
+            .type("DEB")
+            .customKind(false)
+            .name("keel")
+            .version("0.161.0-h63.24d0843")
+            .location("rocket")
+            .reference("debian-local:pool/k/keel/keel_0.160.0-h62.02c0fbf_all.deb")
+            .metadata(
+                mapOf(
+                "repoKey" to "stash/spkr/keel-nflx",
+                "rocketMessageId" to "84c1ecca-7f76-482e-9952-226fb2c4c410",
+                "releaseStatus" to "FINAL"
+              ))
+            .provenance("https://spinnaker.builds.test.netflix.net/job/SPINNAKER-rocket-package-keel/62")
+            .build()
       }
 
       test("artifact is attached to the trigger") {


### PR DESCRIPTION
The all-arg and no-arg constructors for Artifact and ExpectedArtifact were deprecated in spinnaker/kork#429. Replace their usages with a builder.