### PR TITLE
feat(logging): Add X-SPINNAKER-RESOURCE-ID to logs for traceability

### DIFF
--- a/keel-actuator/keel-actuator.gradle.kts
+++ b/keel-actuator/keel-actuator.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   implementation("com.netflix.spectator:spectator-api")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.springframework:spring-tx")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
 
   testImplementation(project(":keel-test"))
   testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")

--- a/keel-api/keel-api.gradle.kts
+++ b/keel-api/keel-api.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation("com.netflix.spinnaker.fiat:fiat-core:${property("fiatVersion")}")
 
   implementation("net.logstash.logback:logstash-logback-encoder")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
 
   testImplementation("io.strikt:strikt-jackson")
   testImplementation(project(":keel-test"))

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -10,7 +10,9 @@ import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.supporting
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.slf4j.MDCContext
 import org.slf4j.LoggerFactory
+import org.slf4j.MDC
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.ExceptionHandler
@@ -87,7 +89,8 @@ class ExportController(
       kind = kind
     )
 
-    return runBlocking {
+    MDC.put("X-SPINNAKER-RESOURCE-ID", "$cloudProvider:$kind:$account:$name")
+    return runBlocking(MDCContext()) {
       handler.export(exportable)
     }
   }

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
 
   testImplementation(project(":keel-test"))
   testImplementation("io.strikt:strikt-jackson")

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
 
   testImplementation(project(":keel-test"))
   testImplementation("io.strikt:strikt-jackson")


### PR DESCRIPTION
This is a proof-of-concept to instrument keel with a discrete field in the logs that can be used to aid in tracing the processing of resources and in troubleshooting. I recommend viewing the diff with the "ignore white space" option enabled.

As part of this exercise, I investigated/learned the following:
- Logging setup of Spinnaker services at Netflix
   -  Linux `init.d` scripts redirect console output emitted by the logger to a file
   - A SumoLogic collector process monitors the log file and ships logs to SumoLogic
   - We use logback as the SLF4J logging backend, configured to output log messages to the console in a JSON format that is easily understood/parsed by SumoLogic. This means our logs outside of development environments are already in a structured format. Here's the relevant SLF4J config:
     ```xml
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
       <encoder class="net.logstash.logback.encoder.LogstashEncoder">
         <provider class="net.logstash.logback.composite.loggingevent.ArgumentsJsonProvider"/>
       </encoder>
     </appender>
      ```
    - The fact that we're using a logstash encoder and provider class above is misleading, since we're no longer shipping logs to logstash. But, as I said, the same JSON format generated by those classes is understood by SumoLogic

- Behavior of SLF4J [MDC](http://www.slf4j.org/manual.html#mdc) (Mapped Diagnostic Context) support with the above configuration
  - It turns out any key/value pairs added to the MDC map are automatically added as discrete fields in the generated JSON log output. This means that the only thing we need to do to add more metadata to our logs is to add that data to the MDC context.
  - MDC implementations in the logging frameworks rely on thread-local objects and hence do not work out-of-the-box with Kotlin coroutines.
  - Official SLF4J MDC support for Kotlin coroutines is offered in this module: https://github.com/Kotlin/kotlinx.coroutines/tree/master/integration/kotlinx-coroutines-slf4j
  - The challenge is finding the right places to instrument with the provided coroutine context

With the above in place, and the changes in this PR, you get the following logging output when the resource check loop kicks in (note the presence of the `X-SPINNAKER-RESOURCE-ID` field in the JSON, and that the thread names are different but the MDC context is preserved):
```json
{"@timestamp":"2019-12-04T21:21:56.305-08:00","@version":1,"message":"Testing MDC (current)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"DefaultDispatcher-worker-1","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo"}
{"@timestamp":"2019-12-04T21:21:56.306-08:00","@version":1,"message":"Testing MDC (getServerGroups)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"DefaultDispatcher-worker-1","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo"}
{"@timestamp":"2019-12-04T21:21:56.306-08:00","@version":1,"message":"Testing MDC (getServerGroups)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"DefaultDispatcher-worker-8","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo"}
{"@timestamp":"2019-12-04T21:21:56.307-08:00","@version":1,"message":"Testing MDC (getServerGroups)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"DefaultDispatcher-worker-7","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo"}
{"@timestamp":"2019-12-04T21:22:02.939-08:00","@version":1,"message":"Checking resource titus:cluster:titustestvpc:serverlablpollo","logger_name":"com.netflix.spinnaker.keel.actuation.ResourceActuator","thread_name":"DefaultDispatcher-worker-11","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo"}
{"@timestamp":"2019-12-04T21:22:02.966-08:00","@version":1,"message":"Resource titus:cluster:titustestvpc:serverlablpollo is valid","logger_name":"com.netflix.spinnaker.keel.actuation.ResourceActuator","thread_name":"DefaultDispatcher-worker-11","level":"INFO","level_value":20000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo"}
```
...and when exporting that same resource (where you get the added benefit of propagating the `X-SPINNAKER-USER` MDC field added at the start of REST request processing to the downstream coroutines):
```json
{"@timestamp":"2019-12-04T21:22:13.465-08:00","@version":1,"message":"Testing MDC (export)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"https-jsse-nio-8087-exec-4","level":"INFO","level_value":20000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo","X-SPINNAKER-USER":"lpollo@netflix.com"}
{"@timestamp":"2019-12-04T21:22:13.466-08:00","@version":1,"message":"Testing MDC (getServerGroups)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"https-jsse-nio-8087-exec-4","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo","X-SPINNAKER-USER":"lpollo@netflix.com"}
{"@timestamp":"2019-12-04T21:22:13.466-08:00","@version":1,"message":"Testing MDC (getServerGroups)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"https-jsse-nio-8087-exec-4","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo","X-SPINNAKER-USER":"lpollo@netflix.com"}
{"@timestamp":"2019-12-04T21:22:13.466-08:00","@version":1,"message":"Testing MDC (getServerGroups)","logger_name":"com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler","thread_name":"https-jsse-nio-8087-exec-4","level":"DEBUG","level_value":10000,"X-SPINNAKER-RESOURCE-ID":"titus:cluster:titustestvpc:serverlablpollo","X-SPINNAKER-USER":"lpollo@netflix.com"}
```

As you can see in the PR changes, unfortunately we need to explicitly instrument the code with `MDCContext()` in various places so that the MDC context will be preserved/propagated. My intention with the PR in the current state is to explain how this can be done and get feedback on whether folks think it's a helpful thing to add. If there's interest, I'll try to instrument other areas of the code.

Open questions:
* It's not clear to me whether the MDC context is automatically inherited by "child" coroutines (meaning you'd only need to instrument the outermost coroutine call). It seems to be the case, but there's not a whole log of logging in place to test the theory, and reasoning about multiple levels of coroutines is particularly hard.