### PR TITLE
fix(actuation) Fix stack overflow in ResourceActuator

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.keel.telemetry.ResourceCheckSkipped
 import com.netflix.spinnaker.keel.veto.VetoEnforcer
 import com.netflix.spinnaker.keel.veto.VetoResponse
 import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.supervisorScope
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -124,7 +124,7 @@ class ResourceActuator(
   }
 
   private suspend fun ResourceHandler<*, *>.resolve(resource: Resource<out ResourceSpec>): Pair<Any, Any?> =
-    coroutineScope {
+    supervisorScope {
       val desired = async {
         try {
           desired(resource)

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
@@ -10,7 +10,7 @@ class DefaultBaseImageCache(
     baseImages[os]?.get(label.name.toLowerCase()) ?: throw UnknownBaseImage(os, label)
 }
 
-@ConfigurationProperties("keel.plugins.bakery.base-images")
+@ConfigurationProperties(prefix = "keel.plugins.bakery")
 class BaseImageCacheProperties {
   var baseImages: Map<String, Map<String, String>> = emptyMap()
 }


### PR DESCRIPTION
Fixes #610.

The root cause for this error was twofold:
1. An `UnknownBaseImage` exception was being thrown here since there were no base images in the config file and the `@ConfigurationProperties` responsible from loading that data into the config properties class had one path too many in the prefix:
  https://github.com/spinnaker/keel/blob/78b9e61498f3a27078cf97f53badab517c92568c/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt#L10

2. The `resolve` extension function defined in `ResourceActuator` was using a [`coroutineScope`](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/coroutine-scope.html) to run the current and desired state evaluations in parallel, which, according to the documentation, has the behavior that "when any child coroutine in this scope fails, this scope fails and all the rest of the children are cancelled". This is why the HTTP requests to clouddriver were being stopped mid-way (socket closed exception) -- when the `UnknownBaseImage` exception was thrown in one child coroutine, the other was forcefully cancelled.
   https://github.com/spinnaker/keel/blob/18d60daf007182401da91dceb08298163b53b999/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt#L126-L145

I've replaced `coroutineScope` with [`supervisorScope`](https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines/supervisor-scope.html), where "a failure of a child does not cause this scope to fail and does not affect its other children".

After fixing the coroutine scope issue, I now get this in the logs:
```
{"@timestamp":"2019-12-06T15:59:11.461-08:00","@version":1,"message":"Resource check for bakery:image:server-lab-lpollo failed","logger_name":"com.netflix.spinnaker.keel.actuation.ResourceActuator","thread_name":"DefaultDispatcher-worker-7","level":"ERROR","level_value":40000,"stack_trace":"com.netflix.spinnaker.keel.plugin.CannotResolveDesiredState: Unable to resolve desired state of bakery:image:server-lab-lpollo due to: Could not identify base image for os xenial and label RELEASE\n\tat com.netflix.spinnaker.keel.actuation.ResourceActuator$resolve$2$desired$1.invokeSuspend(ResourceActuator.kt:135)\n\tat kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)\n\tat kotlinx.coroutines.DispatchedTask.run(Dispatched.kt:241)\n\tat kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:594)\n\tat kotlinx.coroutines.scheduling.CoroutineScheduler.access$runSafely(CoroutineScheduler.kt:60)\n\tat kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:740)\nCaused by: com.netflix.spinnaker.keel.bakery.UnknownBaseImage: Could not identify base image for os xenial and label RELEASE\n\tat com.netflix.spinnaker.keel.bakery.DefaultBaseImageCache.getBaseImage(DefaultBaseImageCache.kt:10)\n\tat com.netflix.spinnaker.keel.bakery.resource.ImageHandler.toResolvedType(ImageHandler.kt:56)\n\tat com.netflix.spinnaker.keel.plugin.ResourceHandler.desired(ResourceHandler.kt:79)\n\tat com.netflix.spinnaker.keel.actuation.ResourceActuator.desired(ResourceActuator.kt:181)\n\tat com.netflix.spinnaker.keel.actuation.ResourceActuator$resolve$2$desired$1.invokeSuspend(ResourceActuator.kt:131)\n\t... 5 common frames omitted\n"}
```

Adding the base images to the config file fixes that (now harmless) exception.