### PR TITLE
feat(constraints): pipeline execution constraint

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.keel.clouddriver
 
+import com.netflix.spinnaker.keel.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ApplicationLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.ClassicLoadBalancerModel
@@ -32,8 +33,6 @@ import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 import retrofit2.http.QueryMap
-
-const val DEFAULT_SERVICE_ACCOUNT = "keel@spinnaker.io"
 
 interface CloudDriverService {
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.keel.clouddriver
 
 import com.netflix.frigga.ami.AppVersion
+import com.netflix.spinnaker.keel.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.clouddriver.model.Image
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImageComparator

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.keel.clouddriver
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.frigga.ami.AppVersion
+import com.netflix.spinnaker.keel.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImageComparator
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Constraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Constraint.kt
@@ -17,7 +17,8 @@ import java.time.zone.ZoneRulesException
 @JsonSubTypes(
   Type(value = DependsOnConstraint::class, name = "depends-on"),
   Type(value = TimeWindowConstraint::class, name = "allowed-times"),
-  Type(value = ManualJudgementConstraint::class, name = "manual-judgement")
+  Type(value = ManualJudgementConstraint::class, name = "manual-judgement"),
+  Type(value = PipelineConstraint::class, name = "pipeline")
 )
 abstract class Constraint(val type: String)
 
@@ -59,6 +60,14 @@ data class TimeWindowConstraint(
 data class ManualJudgementConstraint(
   val timeout: Duration = Duration.ofDays(7)
 ) : StatefulConstraint("manual-judgement")
+
+data class PipelineConstraint(
+  val serviceAccount: String = "anonymous",
+  val timeout: Duration = Duration.ofHours(2),
+  val pipelineId: String,
+  val retries: Int = 0,
+  val parameters: Map<String, Any?> = emptyMap()
+) : StatefulConstraint("pipeline")
 
 data class TimeWindow(
   val days: String? = null,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ConstraintState.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ConstraintState.kt
@@ -1,5 +1,8 @@
 package com.netflix.spinnaker.keel.api
 
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Duration
 import java.time.Instant
 
@@ -13,10 +16,9 @@ data class ConstraintState(
   val judgedBy: String? = null,
   val judgedAt: Instant? = null,
   val comment: String? = null,
-  // TODO: reconsider type when implementing a constraint that uses attributes
-  val attributes: Map<String, Any?> = emptyMap()
+  val attributes: ConstraintStateAttributes? = null
 ) {
-  fun canPromote() = status.passes()
+  fun passed() = status.passes()
 
   fun failed() = status.failed()
 
@@ -34,3 +36,19 @@ enum class ConstraintStatus(private val passed: Boolean, private val failed: Boo
   fun passes() = passed
   fun failed() = failed
 }
+
+@JsonTypeInfo(
+  include = JsonTypeInfo.As.EXISTING_PROPERTY,
+  use = JsonTypeInfo.Id.NAME,
+  property = "type")
+@JsonSubTypes(
+  Type(value = PipelineConstraintStateAttributes::class, name = "pipeline")
+)
+abstract class ConstraintStateAttributes(val type: String)
+
+data class PipelineConstraintStateAttributes(
+  val executionId: String? = null,
+  val attempt: Int,
+  val latestAttempt: Instant,
+  val lastExecutionStatus: String? = null
+) : ConstraintStateAttributes("pipeline")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.keel.api
 
+const val DEFAULT_SERVICE_ACCOUNT = "keel@spinnaker.io"
+
 data class DeliveryConfig(
   val name: String,
   val application: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ConstraintEvaluator.kt
@@ -1,9 +1,13 @@
 package com.netflix.spinnaker.keel.constraints
 
 import com.netflix.spinnaker.keel.api.Constraint
+import com.netflix.spinnaker.keel.api.ConstraintState
+import com.netflix.spinnaker.keel.api.ConstraintStatus
 import com.netflix.spinnaker.keel.api.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.constraints.ConstraintEvaluator.Companion.getConstraintForEnvironment
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 
 interface ConstraintEvaluator<T : Constraint> {
 
@@ -33,5 +37,50 @@ interface ConstraintEvaluator<T : Constraint> {
     version: String,
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment
+  ): Boolean
+}
+
+abstract class StatefulConstraintEvaluator<T : Constraint> : ConstraintEvaluator<T> {
+  abstract val deliveryConfigRepository: DeliveryConfigRepository
+
+  override fun canPromote(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment
+  ): Boolean {
+    val constraint = getConstraintForEnvironment(deliveryConfig, targetEnvironment.name, constraintType)
+    val state = deliveryConfigRepository
+      .getConstraintState(
+        deliveryConfig.name,
+        targetEnvironment.name,
+        version,
+        constraint.type)
+      ?: ConstraintState(
+        deliveryConfigName = deliveryConfig.name,
+        environmentName = targetEnvironment.name,
+        artifactVersion = version,
+        type = constraint.type,
+        status = ConstraintStatus.PENDING
+      )
+        .also {
+          deliveryConfigRepository.storeConstraintState(it)
+          // TODO: Emit an event here?
+        }
+
+    return when {
+      state.failed() -> false
+      state.passed() -> true
+      else -> canPromote(artifact, version, deliveryConfig, targetEnvironment, constraint, state)
+    }
+  }
+
+  abstract fun canPromote(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    constraint: T,
+    state: ConstraintState
   ): Boolean
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -36,13 +35,6 @@ import java.time.Clock
 @Configuration
 @ConditionalOnProperty("keel.plugins.ec2.enabled")
 class EC2Config {
-
-  @Bean
-  fun taskLauncher(
-    orcaService: OrcaService,
-    deliveryConfigRepository: DeliveryConfigRepository
-  ): TaskLauncher =
-    TaskLauncher(orcaService, deliveryConfigRepository)
 
   @Bean
   fun clusterHandler(

--- a/keel-orca/keel-orca.gradle.kts
+++ b/keel-orca/keel-orca.gradle.kts
@@ -33,4 +33,13 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
+
+  testImplementation(project(":keel-test"))
+  testImplementation(project (":keel-core-test"))
+  testImplementation("io.strikt:strikt-jackson")
+  testImplementation("dev.minutest:minutest")
+
+  testImplementation("org.assertj:assertj-core")
+  testImplementation("org.junit.jupiter:junit-jupiter-api")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluator.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluator.kt
@@ -1,0 +1,221 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.ConstraintState
+import com.netflix.spinnaker.keel.api.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.ConstraintStatus.PASS
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.PipelineConstraint
+import com.netflix.spinnaker.keel.api.PipelineConstraintStateAttributes
+import com.netflix.spinnaker.keel.model.toEchoNotification
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import kotlinx.coroutines.runBlocking
+import org.springframework.stereotype.Component
+import java.lang.Exception
+import java.time.Clock
+import org.slf4j.LoggerFactory.getLogger
+
+/**
+ * An environment promotion constraint to gate promotions on the successful execution
+ * of a Spinnaker pipeline. The target pipeline is launched via orca the first time
+ * a pipeline constraint is evaluated for a given artifact version and [Environment].
+ *
+ * The state of that pipeline execution is then assessed on each subsequent evaluation
+ * and can optionally be retried on failure.
+ *
+ * Example env constraint:
+ *
+ * constraints:
+ *  - type: pipeline
+ *    serviceAccount: keel@spinnaker (OPTIONAL, defaults to keel's `DEFAULT_SERVICE_ACCOUNT`)
+ *    pipelineId: (the id visible when editing a pipeline, not its name)
+ *    retries: (OPTIONAL, the number of times to retry a failure, defaults to 0)
+ *    parameters: (OPTIONAL, Map of trigger parameters to pass along, `user` and `type` are reserved)
+ *
+ */
+@Component
+class PipelineConstraintEvaluator(
+  private val orcaService: OrcaService,
+  override val deliveryConfigRepository: DeliveryConfigRepository,
+  private val clock: Clock
+) : StatefulConstraintEvaluator<PipelineConstraint>() {
+  override val constraintType = PipelineConstraint::class.java
+  private val log by lazy { getLogger(javaClass) }
+
+  override fun canPromote(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    constraint: PipelineConstraint,
+    state: ConstraintState
+  ): Boolean {
+    var attributes = state.attributes as PipelineConstraintStateAttributes?
+    val status = pipelineStatus(attributes)
+
+    if (attributes != null && status != null && attributes.lastExecutionStatus != status.toString()) {
+      attributes = attributes.copy(lastExecutionStatus = status.toString())
+    }
+
+    val judge = "pipeline:${constraint.pipelineId}"
+
+    // TODO: if the constraint has timed out but the pipeline is still running, should we cancel it?
+    if (timedOut(constraint, state, attributes)) {
+      deliveryConfigRepository
+        .storeConstraintState(
+          state.copy(
+            status = FAIL,
+            attributes = attributes,
+            judgedBy = judge,
+            judgedAt = clock.instant(),
+            comment = "Timed out after ${constraint.timeout} and ${attributes?.attempt ?: "0"} attempt" +
+              if (attributes?.attempt != 1) {
+                "s"
+              } else {
+                ""
+              }))
+      // TODO: Emit event
+      return false
+    }
+
+    if (shouldTrigger(constraint, attributes)) {
+      try {
+        val executionId = runBlocking {
+          startPipeline(targetEnvironment, constraint)
+        }
+
+        attributes = PipelineConstraintStateAttributes(
+          executionId = executionId,
+          attempt = (attributes?.attempt ?: 0) + 1,
+          latestAttempt = clock.instant()
+        )
+      } catch (e: Exception) {
+        log.warn("Failed triggering pipeline ${constraint.pipelineId} for " +
+          "${deliveryConfig.application}:$deliveryConfig/$targetEnvironment", e)
+
+        attributes = PipelineConstraintStateAttributes(
+          executionId = null,
+          attempt = attributes?.attempt ?: 0 + 1,
+          latestAttempt = clock.instant()
+        )
+      }
+
+      deliveryConfigRepository.storeConstraintState(state.copy(attributes = attributes))
+      return false
+    } else if (attributes?.executionId == null) {
+      // If we don't have an executionId or available retries, fail
+      deliveryConfigRepository
+        .storeConstraintState(
+          state.copy(
+            status = FAIL,
+            comment = "Failed to trigger pipeline ${constraint.pipelineId}, please review pipeline constraint " +
+              "configuration in delivery-config ${deliveryConfig.name} for $targetEnvironment",
+            judgedAt = clock.instant(),
+            judgedBy = "keel"))
+
+      return false
+    }
+
+    if (status == null || status.isIncomplete()) {
+      // Persist the pipeline status if changed
+      if (attributes.lastExecutionStatus !=
+        (state.attributes as PipelineConstraintStateAttributes?)?.lastExecutionStatus) {
+        deliveryConfigRepository
+          .storeConstraintState(
+            state.copy(attributes = attributes))
+      }
+
+      return false
+    }
+
+    val newState = if (status.isFailure()) {
+      state.copy(
+        status = FAIL,
+        comment = "Failed to validate environment promotion via $judge",
+        judgedBy = judge,
+        judgedAt = clock.instant(),
+        attributes = attributes)
+    } else {
+      state.copy(
+        status = PASS,
+        comment = "Validated environment promotion via $judge",
+        judgedBy = judge,
+        judgedAt = clock.instant(),
+        attributes = attributes)
+    }
+
+    deliveryConfigRepository.storeConstraintState(newState)
+    return status.isSuccess()
+  }
+
+  private suspend fun startPipeline(
+    environment: Environment,
+    constraint: PipelineConstraint
+  ): String {
+
+    val trigger: MutableMap<String, Any?> = constraint.parameters.toMutableMap()
+    trigger["type"] = "managed"
+    trigger["user"] = "keel"
+
+    if (environment.notifications.isNotEmpty() && !trigger.containsKey("notifications")) {
+      trigger["notifications"] = environment.notifications
+        .map {
+          it.toEchoNotification()
+        }
+    }
+
+    return orcaService
+      .triggerPipeline(constraint.serviceAccount, constraint.pipelineId, trigger)
+      .taskId
+  }
+
+  private fun pipelineStatus(attributes: PipelineConstraintStateAttributes?): OrcaExecutionStatus? {
+    if (attributes?.executionId == null) {
+      return null
+    }
+
+    return runBlocking {
+      orcaService
+        .getPipelineExecution(attributes.executionId!!)
+        .status
+    }
+  }
+
+  private fun shouldTrigger(
+    constraint: PipelineConstraint,
+    attributes: PipelineConstraintStateAttributes?
+  ): Boolean {
+    val status = when (attributes?.lastExecutionStatus) {
+      null -> null
+      else -> OrcaExecutionStatus.valueOf(attributes.lastExecutionStatus!!)
+    }
+
+    return when {
+      attributes == null -> true
+      attributes.executionId == null && hasRetries(constraint, attributes) -> true
+      status.isFailure() && hasRetries(constraint, attributes) -> true
+      else -> false
+    }
+  }
+
+  private fun hasRetries(
+    constraint: PipelineConstraint,
+    attributes: PipelineConstraintStateAttributes
+  ): Boolean =
+    constraint.retries > 0 && constraint.retries < attributes.attempt - 1
+
+  private fun timedOut(
+    constraint: PipelineConstraint,
+    state: ConstraintState,
+    attributes: PipelineConstraintStateAttributes?
+  ): Boolean {
+    val now = clock.instant()
+    return attributes?.latestAttempt?.plus(constraint.timeout)?.isBefore(now)
+      ?: state.createdAt.plus(constraint.timeout).isBefore(now)
+  }
+
+  private fun OrcaExecutionStatus?.isFailure() = this != null && this.isFailure()
+}

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -30,10 +30,22 @@ interface OrcaService {
 
   @POST("/ops")
   @Headers("Content-Type: application/context+json")
-  suspend fun orchestrate(@Header("X-SPINNAKER-USER") serviceAccount: String, @Body request: OrchestrationRequest): TaskRefResponse
+  suspend fun orchestrate(@Header("X-SPINNAKER-USER") serviceAccount: String, @Body request: OrchestrationRequest):
+    TaskRefResponse
+
+  @POST("/orchestrate/{pipelineConfigId}")
+  @Headers("Content-Type: application/context+json")
+  suspend fun triggerPipeline(
+    @Header("X-SPINNAKER-USER") serviceAccount: String,
+    @Path("pipelineConfigId") pipelineConfigId: String,
+    @Body trigger: Map<String, Any?>
+  ): TaskRefResponse
 
   @GET("/tasks/{id}")
-  suspend fun getTask(@Path("id") id: String): TaskDetailResponse
+  suspend fun getTask(@Path("id") id: String): ExecutionDetailResponse
+
+  @GET("/pipelines/{id}")
+  suspend fun getPipelineExecution(@Path("id") id: String): ExecutionDetailResponse
 
   @GET("/executions/correlated/{correlationId}")
   suspend fun getCorrelatedExecutions(@Path("correlationId") correlationId: String): List<String>
@@ -45,7 +57,7 @@ data class TaskRefResponse(
   val taskId by lazy { ref.substringAfterLast("/") }
 }
 
-data class TaskDetailResponse(
+data class ExecutionDetailResponse(
   val id: String,
   val name: String,
   val application: String,

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
@@ -1,0 +1,190 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.ArtifactType
+import com.netflix.spinnaker.keel.api.ConstraintStatus
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.PipelineConstraint
+import com.netflix.spinnaker.keel.api.PipelineConstraintStateAttributes
+import com.netflix.spinnaker.keel.api.randomUID
+import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.orca.TaskRefResponse
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isLessThanOrEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+import strikt.assertions.isTrue
+import java.time.Clock
+
+internal class PipelineConstraintEvaluatorTests : JUnit5Minutests {
+
+  companion object {
+    val clock: Clock = Clock.systemUTC()
+    val deliveryConfigRepository = InMemoryDeliveryConfigRepository(clock)
+  }
+
+  data class Fixture(
+    val constraint: PipelineConstraint
+  ) {
+    val type = "pipeline"
+    val orcaService: OrcaService = mockk()
+    val artifact = DeliveryArtifact("fnord", ArtifactType.DEB)
+    val version = "1.1"
+    val environment = Environment(
+      name = "prod",
+      constraints = setOf(constraint)
+    )
+    val manifest = DeliveryConfig(
+      name = "my-manifest",
+      application = "fnord",
+      artifacts = setOf(artifact),
+      environments = setOf(environment)
+    )
+    val executionId = randomUID().toString()
+    val capturedId = slot<String>()
+    val trigger = slot<Map<String, Any?>>()
+    val subject = PipelineConstraintEvaluator(orcaService, deliveryConfigRepository, clock)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture(
+        constraint = PipelineConstraint(
+          pipelineId = randomUID().toString(),
+          parameters = mapOf("youSayManaged" to "weSayDelivery")
+        ))
+    }
+
+    context("promotion is gated on launching a pipeline and its final status") {
+      before {
+        deliveryConfigRepository.store(manifest)
+
+        coEvery {
+          orcaService.triggerPipeline(any(), capture(capturedId), capture(trigger))
+        } returns TaskRefResponse("/pipelines/$executionId")
+      }
+
+      test("first pass persists state and triggers the pipeline") {
+        expectThat(subject.canPromote(artifact, version, manifest, environment))
+          .isFalse()
+
+        expectThat(capturedId.captured)
+          .isEqualTo(constraint.pipelineId)
+
+        expectThat(trigger.captured)
+          .isEqualTo(
+            mapOf(
+              "youSayManaged" to "weSayDelivery",
+              "type" to "managed",
+              "user" to "keel"))
+
+        val state = deliveryConfigRepository.getConstraintState(manifest.name, environment.name, version, type)
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { attributes }
+              .isA<PipelineConstraintStateAttributes>()
+              .and {
+                get { executionId }.isEqualTo(fixture.executionId)
+                get { attempt }.isEqualTo(1)
+                get { latestAttempt }.isLessThanOrEqualTo(clock.instant())
+                get { lastExecutionStatus }.isNull()
+              }
+          }
+      }
+
+      test("the next pass updates the execution status") {
+        coEvery {
+          orcaService.getPipelineExecution(any())
+        } returns getExecutionDetailResponse(executionId, OrcaExecutionStatus.RUNNING)
+
+        expectThat(subject.canPromote(artifact, version, manifest, environment))
+          .isFalse()
+
+        val state = deliveryConfigRepository.getConstraintState(manifest.name, environment.name, version, type)
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.PENDING)
+            get { attributes }
+              .isA<PipelineConstraintStateAttributes>()
+              .and {
+                get { lastExecutionStatus }.isEqualTo("RUNNING")
+              }
+          }
+      }
+
+      test("promotion is allowed when the pipeline succeeds") {
+        coEvery {
+          orcaService.getPipelineExecution(any())
+        } returns getExecutionDetailResponse(executionId, OrcaExecutionStatus.SUCCEEDED)
+
+        expectThat(subject.canPromote(artifact, version, manifest, environment))
+          .isTrue()
+
+        val state = deliveryConfigRepository.getConstraintState(manifest.name, environment.name, version, type)
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.PASS)
+            get { attributes }
+              .isA<PipelineConstraintStateAttributes>()
+              .and {
+                get { lastExecutionStatus }.isEqualTo("SUCCEEDED")
+              }
+          }
+      }
+
+      test("the pipeline has failed") {
+        val state = deliveryConfigRepository
+          .getConstraintState(manifest.name, environment.name, version, type)!!
+          .copy(status = ConstraintStatus.PENDING)
+        val runningAttributes = (state.attributes as PipelineConstraintStateAttributes)
+          .copy(lastExecutionStatus = "RUNNING")
+        deliveryConfigRepository.storeConstraintState(state.copy(attributes = runningAttributes))
+
+        coEvery {
+          orcaService.getPipelineExecution(any())
+        } returns getExecutionDetailResponse(executionId, OrcaExecutionStatus.TERMINAL)
+
+        expectThat(subject.canPromote(artifact, version, manifest, environment))
+          .isFalse()
+
+        val endState = deliveryConfigRepository.getConstraintState(manifest.name, environment.name, version, type)
+        expectThat(endState)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.FAIL)
+            get { attributes }
+              .isA<PipelineConstraintStateAttributes>()
+              .and {
+                get { lastExecutionStatus }.isEqualTo("TERMINAL")
+              }
+          }
+      }
+    }
+  }
+
+  private fun getExecutionDetailResponse(id: String, status: OrcaExecutionStatus) =
+    ExecutionDetailResponse(
+      id = id,
+      name = "fnord",
+      application = "fnord",
+      buildTime = clock.instant(),
+      startTime = clock.instant(),
+      endTime = null,
+      status = status
+    )
+}

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
@@ -30,10 +30,12 @@ import com.netflix.spinnaker.keel.model.toEchoNotification
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
 
 /**
  * Wraps [OrcaService] to make it easier to launch tasks in a standard way.
  */
+@Component
 class TaskLauncher(
   private val orcaService: OrcaService,
   private val deliveryConfigRepository: DeliveryConfigRepository


### PR DESCRIPTION
 An environment promotion constraint to gate promotions on the successful execution
 of a Spinnaker pipeline. The target pipeline is launched via orca the first time
 a pipeline constraint is evaluated for a given artifact version and [Environment].

 The state of that pipeline execution is then assessed on each subsequent evaluation
 and can optionally be retried on failure.

 Example env constraint:
```
 constraints:
   - type: pipeline
     serviceAccount: keel@spinnaker (OPTIONAL, defaults to DEFAULT_SERVICE_ACCOUNT)
     pipelineId: (the id visible when editing a pipeline, not its name)
     retries: (OPTIONAL, the number of times to retry a failure, defaults to 0)
     parameters: (OPTIONAL, Map of trigger parameters to pass along, `user` and `type` are reserved)
```