### PR TITLE
feat(logging): Add X-SPINNAKER-RESOURCE-ID to logs for traceability

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -15,6 +15,7 @@ import com.netflix.spinnaker.keel.events.ResourceMissing
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.pause.ResourcePauser
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withResourceTracingContext
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.CannotResolveCurrentState
@@ -44,75 +45,77 @@ class ResourceActuator(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   suspend fun <T : ResourceSpec> checkResource(resource: Resource<T>) {
-    val id = resource.id
-    val plugin = handlers.supporting(resource.apiVersion, resource.kind)
+    withResourceTracingContext(resource) {
+      val id = resource.id
+      val plugin = handlers.supporting(resource.apiVersion, resource.kind)
 
-    if (resourcePauser.isPaused(resource)) {
-      log.debug("Actuation for resource {} is paused, skipping checks", id)
-      publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, "ActuationPaused"))
-      return
-    }
-
-    if (plugin.actuationInProgress(resource)) {
-      log.debug("Actuation for resource {} is already running, skipping checks", id)
-      publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, "ActuationInProgress"))
-      return
-    }
-
-    try {
-      val (desired, current) = plugin.resolve(resource)
-      val diff = ResourceDiff(desired, current)
-      if (diff.hasChanges()) {
-        diffFingerprintRepository.store(id, diff)
+      if (resourcePauser.isPaused(resource)) {
+        log.debug("Actuation for resource {} is paused, skipping checks", id)
+        publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, "ActuationPaused"))
+        return@withResourceTracingContext
       }
 
-      val response = vetoEnforcer.canCheck(resource)
-      if (!response.allowed) {
-        log.debug("Skipping actuation for resource {} because it was vetoed: {}", id, response.message)
-        publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, response.vetoName))
-        publishVetoedEvent(response, resource)
-        return
+      if (plugin.actuationInProgress(resource)) {
+        log.debug("Actuation for resource {} is already running, skipping checks", id)
+        publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, "ActuationInProgress"))
+        return@withResourceTracingContext
       }
 
-      log.debug("Checking resource {}", id)
-
-      when {
-        current == null -> {
-          log.warn("Resource {} is missing", id)
-          publisher.publishEvent(ResourceMissing(resource, clock))
-
-          plugin.create(resource, diff)
-            .also { tasks ->
-              publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
-            }
+      try {
+        val (desired, current) = plugin.resolve(resource)
+        val diff = ResourceDiff(desired, current)
+        if (diff.hasChanges()) {
+          diffFingerprintRepository.store(id, diff)
         }
-        diff.hasChanges() -> {
-          log.warn("Resource {} is invalid", id)
-          log.info("Resource {} delta: {}", id, diff.toDebug())
-          publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
 
-          plugin.update(resource, diff)
-            .also { tasks ->
-              publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
-            }
+        val response = vetoEnforcer.canCheck(resource)
+        if (!response.allowed) {
+          log.debug("Skipping actuation for resource {} because it was vetoed: {}", id, response.message)
+          publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, response.vetoName))
+          publishVetoedEvent(response, resource)
+          return@withResourceTracingContext
         }
-        else -> {
-          log.info("Resource {} is valid", id)
-          // TODO: not sure this logic belongs here
-          val lastEvent = resourceRepository.lastEvent(id)
-          if (lastEvent is ResourceDeltaDetected || lastEvent is ResourceActuationLaunched) {
-            publisher.publishEvent(ResourceDeltaResolved(resource, clock))
-          } else {
-            publisher.publishEvent(ResourceValid(resource, clock))
+
+        log.debug("Checking resource {}", id)
+
+        when {
+          current == null -> {
+            log.warn("Resource {} is missing", id)
+            publisher.publishEvent(ResourceMissing(resource, clock))
+
+            plugin.create(resource, diff)
+              .also { tasks ->
+                publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
+              }
+          }
+          diff.hasChanges() -> {
+            log.warn("Resource {} is invalid", id)
+            log.info("Resource {} delta: {}", id, diff.toDebug())
+            publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
+
+            plugin.update(resource, diff)
+              .also { tasks ->
+                publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
+              }
+          }
+          else -> {
+            log.info("Resource {} is valid", id)
+            // TODO: not sure this logic belongs here
+            val lastEvent = resourceRepository.lastEvent(id)
+            if (lastEvent is ResourceDeltaDetected || lastEvent is ResourceActuationLaunched) {
+              publisher.publishEvent(ResourceDeltaResolved(resource, clock))
+            } else {
+              publisher.publishEvent(ResourceValid(resource, clock))
+            }
           }
         }
+      } catch (e: ResourceCurrentlyUnresolvable) {
+        log.warn("Resource check for {} failed (hopefully temporarily) due to {}", id, e.message)
+        publisher.publishEvent(ResourceCheckUnresolvable(resource, e, clock))
+      } catch (e: Exception) {
+        log.error("Resource check for $id failed", e)
+        publisher.publishEvent(ResourceCheckError(resource, e, clock))
       }
-    } catch (e: ResourceCurrentlyUnresolvable) {
-      log.warn("Resource check for {} failed (hopefully temporarily) due to {}", id, e.message)
-      publisher.publishEvent(ResourceCheckUnresolvable(resource, e, clock))
-    } catch (e: Exception) {
-      log.error("Resource check for $id failed", e)
-      publisher.publishEvent(ResourceCheckError(resource, e, clock))
     }
   }
 

--- a/keel-core/keel-core.gradle.kts
+++ b/keel-core/keel-core.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
   api("com.netflix.frigga:frigga")
   api("com.netflix.spinnaker.kork:kork-core")
   api("net.swiftzer.semver:semver:1.1.0")
+  api("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+  api("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
+
 
   testImplementation(project(":keel-test"))
   testImplementation(project(":keel-core-test"))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Exportable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Exportable.kt
@@ -3,9 +3,13 @@ package com.netflix.spinnaker.keel.api
 import com.netflix.spinnaker.keel.model.Moniker
 
 data class Exportable(
+  val cloudProvider: String,
   val account: String,
   val serviceAccount: String,
   val moniker: Moniker,
   val regions: Set<String>,
   val kind: String
-)
+) {
+  fun toResourceId() =
+    "$cloudProvider:$kind:$account:${moniker.name}".let(::ResourceId)
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
@@ -17,21 +17,21 @@ class TracingSupport {
   companion object {
     const val X_SPINNAKER_RESOURCE_ID = "X-SPINNAKER-RESOURCE-ID"
 
-    suspend fun <T : ResourceSpec, R> withResourceTracingContext(
+    suspend fun <T : ResourceSpec, R> withTracingContext(
       resource: Resource<T>,
       block: suspend CoroutineScope.() -> R
     ): R {
-      return withResourceTracingContext(resource.id, block)
+      return withTracingContext(resource.id, block)
     }
 
-    suspend fun <R> withResourceTracingContext(
+    suspend fun <R> withTracingContext(
       exportable: Exportable,
       block: suspend CoroutineScope.() -> R
     ): R {
-      return withResourceTracingContext(exportable.toResourceId(), block)
+      return withTracingContext(exportable.toResourceId(), block)
     }
 
-    private suspend fun <R> withResourceTracingContext(
+    private suspend fun <R> withTracingContext(
       resourceId: ResourceId,
       block: suspend CoroutineScope.() -> R
     ): R {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
@@ -1,0 +1,42 @@
+package com.netflix.spinnaker.keel.logging
+
+import com.netflix.spinnaker.keel.api.Exportable
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceId
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.id
+import kotlinx.coroutines.CoroutineScope
+import org.slf4j.MDC
+import kotlinx.coroutines.slf4j.MDCContext
+import kotlinx.coroutines.withContext
+
+/**
+ * Support for tracing resources in log statements via MDC in coroutines.
+ */
+class TracingSupport {
+  companion object {
+    const val X_SPINNAKER_RESOURCE_ID = "X-SPINNAKER-RESOURCE-ID"
+
+    suspend fun <T : ResourceSpec, R> withResourceTracingContext(
+      resource: Resource<T>,
+      block: suspend CoroutineScope.() -> R
+    ): R {
+      return withResourceTracingContext(resource.id, block)
+    }
+
+    suspend fun <R> withResourceTracingContext(
+      exportable: Exportable,
+      block: suspend CoroutineScope.() -> R
+    ): R {
+      return withResourceTracingContext(exportable.toResourceId(), block)
+    }
+
+    private suspend fun <R> withResourceTracingContext(
+      resourceId: ResourceId,
+      block: suspend CoroutineScope.() -> R
+    ): R {
+      MDC.put(X_SPINNAKER_RESOURCE_ID, resourceId.toString())
+      return withContext(MDCContext(), block)
+    }
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
@@ -35,8 +35,12 @@ class TracingSupport {
       resourceId: ResourceId,
       block: suspend CoroutineScope.() -> R
     ): R {
-      MDC.put(X_SPINNAKER_RESOURCE_ID, resourceId.toString())
-      return withContext(MDCContext(), block)
+      try {
+        MDC.put(X_SPINNAKER_RESOURCE_ID, resourceId.toString())
+        return withContext(MDCContext(), block)
+      } finally {
+        MDC.remove(X_SPINNAKER_RESOURCE_ID)
+      }
     }
   }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
@@ -1,0 +1,71 @@
+package com.netflix.spinnaker.keel.logging
+
+import com.netflix.spinnaker.keel.api.Exportable
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withResourceTracingContext
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.X_SPINNAKER_RESOURCE_ID
+import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.keel.model.Moniker
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import org.slf4j.MDC
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+class TracingSupportTests : JUnit5Minutests {
+  val resource = resource()
+  val exportable = Exportable(
+    cloudProvider = "aws",
+    account = "test",
+    serviceAccount = "keel@spinnaker",
+    moniker = Moniker("keel"),
+    regions = emptySet(),
+    kind = resource.kind
+  )
+
+  fun tests() = rootContext {
+    before {
+      MDC.clear()
+    }
+
+    after {
+      MDC.clear()
+    }
+
+    test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from resource") {
+      runBlocking {
+        launch {
+          withResourceTracingContext(resource) {
+            expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+              .isEqualTo(resource.id.toString())
+          }
+        }
+      }
+    }
+
+    test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from exportable") {
+      runBlocking {
+        launch {
+          withResourceTracingContext(exportable) {
+            expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+              .isEqualTo(exportable.toResourceId().toString())
+          }
+        }
+      }
+    }
+
+    test("MDC context from outer scope propagates to the coroutine") {
+      runBlocking {
+        MDC.put("foo", "bar")
+        launch {
+          withResourceTracingContext(resource) {
+            expectThat(MDC.get("foo"))
+              .isEqualTo("bar")
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
@@ -8,11 +8,13 @@ import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.model.Moniker
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import kotlinx.coroutines.async
 import org.slf4j.MDC
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import strikt.assertions.isNull
 
 class TracingSupportTests : JUnit5Minutests {
   val resource = resource()
@@ -34,36 +36,64 @@ class TracingSupportTests : JUnit5Minutests {
       MDC.clear()
     }
 
-    test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from resource") {
-      runBlocking {
-        launch {
-          withResourceTracingContext(resource) {
-            expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
-              .isEqualTo(resource.id.toString())
+    context("running with tracing context") {
+      test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from resource") {
+        runBlocking {
+          launch {
+            withResourceTracingContext(resource) {
+              expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+                .isEqualTo(resource.id.toString())
+            }
           }
         }
       }
-    }
 
-    test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from exportable") {
-      runBlocking {
-        launch {
-          withResourceTracingContext(exportable) {
-            expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
-              .isEqualTo(exportable.toResourceId().toString())
+      test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from exportable") {
+        runBlocking {
+          launch {
+            withResourceTracingContext(exportable) {
+              expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+                .isEqualTo(exportable.toResourceId().toString())
+            }
           }
         }
       }
-    }
 
-    test("MDC context from outer scope propagates to the coroutine") {
-      runBlocking {
-        MDC.put("foo", "bar")
-        launch {
-          withResourceTracingContext(resource) {
-            expectThat(MDC.get("foo"))
-              .isEqualTo("bar")
+      test("removes X-SPINNAKER-RESOURCE-ID from MDC after block executes") {
+        runBlocking {
+          MDC.put("foo", "bar")
+          launch {
+            withResourceTracingContext(resource) {
+              expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+                .isEqualTo(resource.id.toString())
+            }
+          }.join()
+          expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+            .isNull()
+          expectThat(MDC.get("foo"))
+            .isEqualTo("bar")
+        }
+      }
+
+      test("does not mix up X-SPINNAKER-RESOURCE-ID between parallel coroutines") {
+        runBlocking {
+          val coroutine1 = async {
+            withResourceTracingContext(resource) {
+              println("X-SPINNAKER-RESOURCE-ID: ${MDC.get(X_SPINNAKER_RESOURCE_ID)}")
+              expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+                .isEqualTo(resource.id.toString())
+            }
           }
+          val coroutine2 = async {
+            val anotherResource = resource()
+            withResourceTracingContext(anotherResource) {
+              println("X-SPINNAKER-RESOURCE-ID: ${MDC.get(X_SPINNAKER_RESOURCE_ID)}")
+              expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
+                .isEqualTo(anotherResource.id.toString())
+            }
+          }
+          coroutine1.await()
+          coroutine2.await()
         }
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.logging
 
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withResourceTracingContext
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.X_SPINNAKER_RESOURCE_ID
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.model.Moniker
@@ -40,7 +40,7 @@ class TracingSupportTests : JUnit5Minutests {
       test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from resource") {
         runBlocking {
           launch {
-            withResourceTracingContext(resource) {
+            withTracingContext(resource) {
               expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
                 .isEqualTo(resource.id.toString())
             }
@@ -51,7 +51,7 @@ class TracingSupportTests : JUnit5Minutests {
       test("injects X-SPINNAKER-RESOURCE-ID to MDC in the coroutine context from exportable") {
         runBlocking {
           launch {
-            withResourceTracingContext(exportable) {
+            withTracingContext(exportable) {
               expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
                 .isEqualTo(exportable.toResourceId().toString())
             }
@@ -63,7 +63,7 @@ class TracingSupportTests : JUnit5Minutests {
         runBlocking {
           MDC.put("foo", "bar")
           launch {
-            withResourceTracingContext(resource) {
+            withTracingContext(resource) {
               expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
                 .isEqualTo(resource.id.toString())
             }
@@ -78,7 +78,7 @@ class TracingSupportTests : JUnit5Minutests {
       test("does not mix up X-SPINNAKER-RESOURCE-ID between parallel coroutines") {
         runBlocking {
           val coroutine1 = async {
-            withResourceTracingContext(resource) {
+            withTracingContext(resource) {
               println("X-SPINNAKER-RESOURCE-ID: ${MDC.get(X_SPINNAKER_RESOURCE_ID)}")
               expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
                 .isEqualTo(resource.id.toString())
@@ -86,7 +86,7 @@ class TracingSupportTests : JUnit5Minutests {
           }
           val coroutine2 = async {
             val anotherResource = resource()
-            withResourceTracingContext(anotherResource) {
+            withTracingContext(anotherResource) {
               println("X-SPINNAKER-RESOURCE-ID: ${MDC.get(X_SPINNAKER_RESOURCE_ID)}")
               expectThat(MDC.get(X_SPINNAKER_RESOURCE_ID))
                 .isEqualTo(anotherResource.id.toString())

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
 
   testImplementation(project(":keel-test"))
   testImplementation("io.strikt:strikt-jackson")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -228,6 +228,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
 
       test("export generates a valid spec for the deployed ALB") {
         val exportable = Exportable(
+          cloudProvider = "aws",
           account = "test",
           serviceAccount = "keel@spin.spin.spin",
           moniker = parseMoniker("testapp-managedogge-wow"),

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -272,6 +272,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
 
       test("export generates a valid spec for the deployed CLB") {
         val exportable = Exportable(
+          cloudProvider = "aws",
           account = "test",
           serviceAccount = "keel@spin.spin.spin",
           moniker = parseMoniker("testapp-managedogge-wow"),

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -155,6 +155,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val activeServerGroupResponseWest = serverGroupWest.toCloudDriverResponse(vpcWest, listOf(subnet1West, subnet2West, subnet3West), listOf(sg1West, sg2West))
 
   val exportable = Exportable(
+    cloudProvider = "aws",
     account = spec.locations.account,
     serviceAccount = "keel@spinnaker",
     moniker = spec.moniker,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -291,6 +291,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
       test("export generates a spec for the existing security group") {
         val exportable = Exportable(
+          cloudProvider = "aws",
           account = "prod",
           serviceAccount = "keel@spin.io",
           moniker = parseMoniker("keel-fnord"),

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -147,6 +147,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   )
 
   val exportable = Exportable(
+    cloudProvider = "titus",
     account = spec.locations.account,
     serviceAccount = "keel@spinnaker",
     moniker = spec.moniker,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withResourceTracingContext
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.supporting
@@ -70,10 +71,12 @@ class ExportController(
     @PathVariable("name") name: String,
     @RequestParam("serviceAccount") serviceAccount: String
   ): SubmittedResource<*> {
-    val apiVersion = SPINNAKER_API_V1.subApi(cloudProviderOverrides[cloudProvider] ?: cloudProvider)
+    val provider = cloudProviderOverrides[cloudProvider] ?: cloudProvider
+    val apiVersion = SPINNAKER_API_V1.subApi(provider)
     val kind = typeToKind.getOrDefault(type.toLowerCase(), type.toLowerCase())
     val handler = handlers.supporting(apiVersion, kind)
     val exportable = Exportable(
+      cloudProvider = provider,
       account = account,
       serviceAccount = serviceAccount,
       moniker = parseMoniker(name),
@@ -88,7 +91,10 @@ class ExportController(
     )
 
     return runBlocking {
-      handler.export(exportable)
+      withResourceTracingContext(exportable) {
+        log.info("Exporting resource ${exportable.toResourceId()}")
+        handler.export(exportable)
+      }
     }
   }
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
-import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withResourceTracingContext
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.supporting
@@ -91,7 +91,7 @@ class ExportController(
     )
 
     return runBlocking {
-      withResourceTracingContext(exportable) {
+      withTracingContext(exportable) {
         log.info("Exporting resource ${exportable.toResourceId()}")
         handler.export(exportable)
       }


### PR DESCRIPTION
As a follow-up to #645, this adds an `X-SPINNAKER-RESOURCE-ID` discrete field to the keel logs when the output is in JSON format, which can be helpful in narrowing down logs when troubleshooting.

Instrumentation is currently limited to only the resource checking loop in `ResourceActuator` and the resource export flow initiated by `ExportController`, but the helper methods defined in `TracingSupport` should be reusable elsewhere.

Perhaps of particular note in this PR, the resource ID is not propagated to calls executed in thread pools, such as those from the `okhttp3` HTTP client. It should be technically possible to wire those threads with MDC, but I feel like that should be left for a future PR.