### PR TITLE
wip(api): Refactoring core models for plugins into java

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,7 @@ allprojects {
 }
 
 subprojects {
-  if (name != "keel-bom") {
+  if (name != "keel-bom" && name != "keel-api") {
     apply(plugin = "nebula.kotlin")
 
     repositories {

--- a/keel-actuator/keel-actuator.gradle.kts
+++ b/keel-actuator/keel-actuator.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":keel-api"))
   api(project(":keel-core"))
   api(project(":keel-plugin"))
   api(project(":keel-veto"))

--- a/keel-api/keel-api.gradle.kts
+++ b/keel-api/keel-api.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  java
+}
+
+repositories {
+  jcenter()
+  if (property("korkVersion").toString().endsWith("-SNAPSHOT")) {
+    mavenLocal()
+  }
+}
+
+dependencies {
+  "implementation"(platform("com.netflix.spinnaker.kork:kork-bom:${property("korkVersion")}"))
+
+  "implementation"("com.netflix.spinnaker.kork:kork-plugins-api")
+
+  "compileOnly"("org.projectlombok:lombok")
+  "annotationProcessor"("org.projectlombok:lombok")
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ApiAssertions.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ApiAssertions.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+import static com.netflix.spinnaker.keel.util.Assert.isNotBlank;
+
+/** TODO(rz): Document. */
+class ApiAssertions {
+
+  /** TODO(rz): Document. */
+  static boolean isValidId(Object value) {
+    if (value instanceof String) {
+      return isNotBlank((String) value);
+    }
+    return false;
+  }
+
+  /** TODO(rz): Document. */
+  static boolean isValidServiceAccount(Object value) {
+    if (value instanceof String) {
+      return isNotBlank((String) value);
+    }
+    return false;
+  }
+
+  /** TODO(rz): Document. */
+  static boolean isValidApplication(Object value) {
+    if (value instanceof String) {
+      return isNotBlank((String) value);
+    }
+    return false;
+  }
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ApiVersion.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ApiVersion.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+import static java.lang.String.format;
+
+import java.util.Arrays;
+import lombok.Value;
+
+/** TODO(rz): Document. */
+@Value
+public class ApiVersion {
+  /** TODO(rz): Document. */
+  private String group;
+
+  /** TODO(rz): Document. */
+  private String version;
+
+  /** TODO(rz): Document. */
+  private String prefix;
+
+  public ApiVersion(String value) {
+    String[] parts = value.split("/");
+    String[] lastParts = Arrays.copyOfRange(parts, 1, parts.length - 1);
+    this.group = parts[0];
+    this.version = String.join("/", lastParts);
+    this.prefix = group.split("\\.")[0];
+  }
+
+  public ApiVersion(String group, String version) {
+    this.group = group;
+    this.version = version;
+    this.prefix = group.split("\\.")[0];
+  }
+
+  public ApiVersion subApi(String prefix) {
+    return new ApiVersion(format("%s.%s", prefix, group), version);
+  }
+
+  @Override
+  public String toString() {
+    return format("%s/%s", group, version);
+  }
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/Resource.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/Resource.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+import static com.netflix.spinnaker.keel.api.ApiAssertions.isValidApplication;
+import static com.netflix.spinnaker.keel.api.ApiAssertions.isValidId;
+import static com.netflix.spinnaker.keel.api.ApiAssertions.isValidServiceAccount;
+import static com.netflix.spinnaker.keel.util.Assert.isNotEmpty;
+import static com.netflix.spinnaker.keel.util.Assert.require;
+
+import java.util.Map;
+import lombok.Value;
+
+/** TODO(rz): Document. */
+@Value
+public class Resource<T extends ResourceSpec> {
+  /** TODO(rz): Document. */
+  private ApiVersion apiVersion;
+
+  /** TODO(rz): Document. */
+  private String kind;
+
+  /** TODO(rz): Document. */
+  private Map<String, Object> metadata;
+
+  /** TODO(rz): Document. */
+  private T spec;
+
+  public Resource(ApiVersion apiVersion, String kind, Map<String, Object> metadata, T spec) {
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+    this.metadata = metadata;
+    this.spec = spec;
+  }
+
+  public Resource(SubmittedResource<T> resource, Map<String, Object> metadata) {
+    this(resource.getApiVersion(), resource.getKind(), metadata, resource.getSpec());
+  }
+
+  private void validate() {
+    require(isNotEmpty(kind), "resource kind must be defined");
+    require(isValidId(metadata.get("id")), "resource id must be a valid id");
+    require(
+        isValidServiceAccount(metadata.get("serviceAccount")),
+        "serviceAccount must be a valid service account");
+    require(
+        isValidApplication(metadata.get("application")), "application must be a valid application");
+  }
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ResourceId.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ResourceId.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+import lombok.Value;
+
+/**
+ * TODO(rz): Document.
+ *
+ * <p>Note: You cannot reliably parse the application name from the resource id. The application is
+ * a property on the resource spec.
+ */
+@Value
+public class ResourceId {
+  private String value;
+
+  @Override
+  public String toString() {
+    return value;
+  }
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ResourceSpec.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/ResourceSpec.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+/** Implemented by all resource specs. */
+public interface ResourceSpec {
+
+  /**
+   * The formal resource name. This is combined with the resource's API version prefix and kind to
+   * form the fully-qualified [ResourceId].
+   *
+   * <p>This can be a property that is part of the spec, or derived from other properties. If the
+   * latter remember to annotate the overridden property with
+   * [com.fasterxml.jackson.annotation.JsonIgnore].
+   */
+  String getId();
+
+  /**
+   * The Spinnaker application this resource belongs to.
+   *
+   * <p>This can be a property that is part of the spec, or derived from other properties. If the
+   * latter remember to annotate the overridden property with
+   * [com.fasterxml.jackson.annotation.JsonIgnore].
+   */
+  String getApplication();
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/SubmittedResource.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/SubmittedResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+import static com.netflix.spinnaker.keel.api.ApiAssertions.isValidServiceAccount;
+import static com.netflix.spinnaker.keel.util.Assert.require;
+
+import java.util.Map;
+import lombok.Value;
+
+/** External representation of a resource that would be submitted to the API. */
+@Value
+public class SubmittedResource<T extends ResourceSpec> {
+
+  /** TODO(rz): Document. */
+  private Map<String, Object> metadata;
+
+  /** TODO(rz): Document. */
+  private ApiVersion apiVersion;
+
+  /** TODO(rz): Document. */
+  private String kind;
+
+  /** TODO(rz): Document. */
+  private T spec;
+
+  public SubmittedResource(
+      Map<String, Object> metadata, ApiVersion apiVersion, String kind, T spec) {
+    this.metadata = metadata;
+    this.apiVersion = apiVersion;
+    this.kind = kind;
+    this.spec = spec;
+
+    require(
+        isValidServiceAccount(metadata.get("serviceAccount")),
+        "serviceAccount must be a valid service account");
+  }
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/api/Task.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/api/Task.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.api;
+
+import lombok.Value;
+
+/** TODO(rz): Document. */
+@Value
+public class Task {
+  /** TODO(rz): Document. */
+  private String id;
+
+  /** TODO(rz): Document. */
+  private String name;
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/plugin/KeelPlugin.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/plugin/KeelPlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.plugin;
+
+import org.pf4j.ExtensionPoint;
+
+/** A marker interface for various Keel plugin extension points. */
+public interface KeelPlugin extends ExtensionPoint {
+
+  /** Get the name of the plugin. This is for internal use only. */
+  default String getName() {
+    return getClass().getSimpleName();
+  }
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/plugin/Resolver.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/plugin/Resolver.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.plugin;
+
+import com.netflix.spinnaker.keel.api.ApiVersion;
+import com.netflix.spinnaker.keel.api.Resource;
+import com.netflix.spinnaker.keel.api.ResourceSpec;
+import java.util.function.Function;
+
+/**
+ * Implementations apply changes to a {@link ResourceSpec} such as adding default values, applying
+ * opinions, or resolving references.
+ */
+public interface Resolver<T extends ResourceSpec> extends Function<Resource<T>, Resource<T>> {
+
+  /** TODO(rz): Document. */
+  ApiVersion getApiVersion();
+
+  /** TODO(rz): Document. */
+  String getSupportedKind();
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/plugin/TaskLauncher.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/plugin/TaskLauncher.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.plugin;
+
+import com.netflix.spinnaker.keel.api.Resource;
+import com.netflix.spinnaker.keel.api.Task;
+import java.util.Map;
+
+/**
+ * TODO(rz): Document. TODO(rz): Also an issue of the original [OrcaTaskLauncher] exposing a
+ * suspendable method. What are we supposed to do about these types? Perhaps expose a @Suspendable
+ * annotation? Return a Future?
+ */
+public interface TaskLauncher {
+
+  /** TODO(rz): Document. */
+  Task submitJobToOrca(
+      Resource<?> resource, String description, String correlationId, Map<String, Object> job);
+}

--- a/keel-api/src/main/java/com/netflix/spinnaker/keel/util/Assert.java
+++ b/keel-api/src/main/java/com/netflix/spinnaker/keel/util/Assert.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.util;
+
+public class Assert {
+
+  /**
+   * Requires that {@code condition} is true, otherwise a {@link IllegalArgumentException} will be
+   * thrown.
+   *
+   * @param condition The condition to assert on.
+   * @param message The message that will be thrown if the condition is false.
+   */
+  public static void require(boolean condition, String message) {
+    if (condition) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  public static boolean isNotEmpty(String value) {
+    return value.length() > 0;
+  }
+
+  public static boolean isNotBlank(String value) {
+    return value.trim().length() > 0;
+  }
+}

--- a/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
+++ b/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+  implementation(project(":keel-api"))
   implementation(project(":keel-core"))
   implementation(project(":keel-plugin"))
   implementation(project(":keel-clouddriver"))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -384,8 +384,3 @@ data class ResourceCheckError(
     exception.message
   )
 }
-
-data class Task(
-  val id: String,
-  val name: String
-)

--- a/keel-docker/keel-docker.gradle.kts
+++ b/keel-docker/keel-docker.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+  implementation(project(":keel-api"))
   implementation(project(":keel-core"))
   implementation(project(":keel-igor"))
   implementation(project(":keel-plugin"))

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
   api(project(":keel-plugin"))
+  implementation(project(":keel-api"))
   implementation(project(":keel-clouddriver"))
   implementation(project(":keel-orca"))
   implementation(project(":keel-retrofit"))

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
@@ -41,7 +41,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
-    taskLauncher: TaskLauncher,
+    taskLauncher: OrcaTaskLauncher,
     clock: Clock,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>,
@@ -63,7 +63,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
-    taskLauncher: TaskLauncher,
+    taskLauncher: OrcaTaskLauncher,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>
   ): SecurityGroupHandler =
@@ -81,7 +81,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
-    taskLauncher: TaskLauncher,
+    taskLauncher: OrcaTaskLauncher,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>
   ): ClassicLoadBalancerHandler =
@@ -99,7 +99,7 @@ class EC2Config {
     cloudDriverService: CloudDriverService,
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
-    taskLauncher: TaskLauncher,
+    taskLauncher: OrcaTaskLauncher,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>
   ): ApplicationLoadBalancerHandler =

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
@@ -38,7 +38,7 @@ class ApplicationLoadBalancerHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
-  private val taskLauncher: TaskLauncher,
+  private val taskLauncher: OrcaTaskLauncher,
   objectMapper: ObjectMapper,
   resolvers: List<Resolver<*>>
 ) : ResourceHandler<ApplicationLoadBalancerSpec, Map<String, ApplicationLoadBalancer>>(objectMapper, resolvers) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -27,7 +27,7 @@ import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
@@ -41,7 +41,7 @@ class ClassicLoadBalancerHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
-  private val taskLauncher: TaskLauncher,
+  private val taskLauncher: OrcaTaskLauncher,
   objectMapper: ObjectMapper,
   resolvers: List<Resolver<*>>
 ) : ResourceHandler<ClassicLoadBalancerSpec, Map<String, ClassicLoadBalancer>>(objectMapper, resolvers) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -41,7 +41,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -57,7 +57,7 @@ class ClusterHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
-  private val taskLauncher: TaskLauncher,
+  private val taskLauncher: OrcaTaskLauncher,
   private val clock: Clock,
   private val publisher: ApplicationEventPublisher,
   objectMapper: ObjectMapper,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -45,7 +45,7 @@ import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
@@ -58,7 +58,7 @@ class SecurityGroupHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
-  private val taskLauncher: TaskLauncher,
+  private val taskLauncher: OrcaTaskLauncher,
   objectMapper: ObjectMapper,
   resolvers: List<Resolver<*>>
 ) : ResourceHandler<SecurityGroupSpec, Map<String, SecurityGroup>>(objectMapper, resolvers) {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.test.resource
@@ -54,7 +54,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
   private val clock = Clock.systemDefaultZone()
-  private val taskLauncher = TaskLauncher(
+  private val taskLauncher = OrcaTaskLauncher(
     orcaService,
     InMemoryDeliveryConfigRepository(clock)
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.test.resource
@@ -64,7 +64,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
   private val clock = Clock.systemDefaultZone()
-  private val taskLauncher = TaskLauncher(
+  private val taskLauncher = OrcaTaskLauncher(
     orcaService,
     InMemoryDeliveryConfigRepository(clock)
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -46,7 +46,7 @@ import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -89,7 +89,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val normalizers = emptyList<Resolver<ClusterSpec>>()
   val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   val clock = Clock.systemDefaultZone()
-  val taskLauncher = TaskLauncher(
+  val taskLauncher = OrcaTaskLauncher(
     orcaService,
     InMemoryDeliveryConfigRepository(clock)
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -48,7 +48,7 @@ import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.test.resource
@@ -82,7 +82,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
   private val cloudDriverCache: CloudDriverCache = mockk()
   private val orcaService: OrcaService = mockk()
   private val clock = Clock.systemDefaultZone()
-  private val taskLauncher = TaskLauncher(
+  private val taskLauncher = OrcaTaskLauncher(
     orcaService,
     InMemoryDeliveryConfigRepository(clock)
   )
@@ -94,7 +94,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
     val cloudDriverService: CloudDriverService
     val cloudDriverCache: CloudDriverCache
     val orcaService: OrcaService
-    val taskLauncher: TaskLauncher
+    val taskLauncher: OrcaTaskLauncher
     val objectMapper: ObjectMapper
     val normalizers: List<Resolver<SecurityGroupSpec>>
     val vpcRegion1: Network
@@ -109,7 +109,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
     override val cloudDriverService: CloudDriverService,
     override val cloudDriverCache: CloudDriverCache,
     override val orcaService: OrcaService,
-    override val taskLauncher: TaskLauncher,
+    override val taskLauncher: OrcaTaskLauncher,
     override val objectMapper: ObjectMapper,
     override val normalizers: List<Resolver<SecurityGroupSpec>>,
     override val vpcRegion1: Network =
@@ -197,7 +197,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
     override val cloudDriverService: CloudDriverService,
     override val cloudDriverCache: CloudDriverCache,
     override val orcaService: OrcaService,
-    override val taskLauncher: TaskLauncher,
+    override val taskLauncher: OrcaTaskLauncher,
     override val objectMapper: ObjectMapper,
     override val normalizers: List<Resolver<SecurityGroupSpec>>,
     override val vpcRegion1: Network =

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TaskLauncherTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TaskLauncherTests.kt
@@ -29,7 +29,7 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -51,7 +51,7 @@ class TaskLauncherTests : JUnit5Minutests {
     val clock = Clock.systemDefaultZone()
     val orcaService: OrcaService = mockk()
     val deliveryConfigRepository = InMemoryDeliveryConfigRepository(clock)
-    val taskLauncher = TaskLauncher(orcaService, deliveryConfigRepository)
+    val taskLauncher = OrcaTaskLauncher(orcaService, deliveryConfigRepository)
     val resource: Resource<DummyResourceSpec> = resource()
     val request = slot<OrchestrationRequest>()
   }

--- a/keel-orca/keel-orca.gradle.kts
+++ b/keel-orca/keel-orca.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
   api("com.fasterxml.jackson.module:jackson-module-kotlin")
   api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 
+  implementation(project(":keel-api"))
   implementation(project(":keel-clouddriver"))
   implementation(project(":keel-core"))
   implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/keel-plugin/keel-plugin.gradle.kts
+++ b/keel-plugin/keel-plugin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":keel-api"))
   api(project(":keel-core"))
   implementation(project(":keel-orca"))
 

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/OrcaTaskLauncher.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/OrcaTaskLauncher.kt
@@ -18,10 +18,10 @@
 package com.netflix.spinnaker.keel.plugin
 
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.Task
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.serviceAccount
-import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.EchoNotification
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component
  * Wraps [OrcaService] to make it easier to launch tasks in a standard way.
  */
 @Component
-class TaskLauncher(
+class OrcaTaskLauncher(
   private val orcaService: OrcaService,
   private val deliveryConfigRepository: DeliveryConfigRepository
 ) {
@@ -62,7 +62,7 @@ class TaskLauncher(
       )
       .let {
         log.info("Started task {} to upsert {}", it.ref, resource.id)
-        Task(id = it.taskId, name = description)
+        Task(it.taskId, description)
       }
 
   private val Resource<*>.notifications: List<EchoNotification>

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/Resolver.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/Resolver.kt
@@ -19,8 +19,8 @@
 package com.netflix.spinnaker.keel.plugin
 
 import com.netflix.spinnaker.keel.api.ApiVersion
-import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
 
 /**
  * Implementations apply changes to a [ResourceSpec] such as adding default values, applying

--- a/keel-test/keel-test.gradle.kts
+++ b/keel-test/keel-test.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":keel-api"))
   api(project(":keel-core"))
   api(project(":keel-plugin"))
 }

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":keel-api"))
   api(project(":keel-plugin"))
   implementation(project(":keel-clouddriver"))
   implementation(project(":keel-orca"))

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.plugin.Resolver
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.ApplicationEventPublisher
@@ -39,7 +39,7 @@ class TitusConfig {
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
     clock: Clock,
-    taskLauncher: TaskLauncher,
+    taskLauncher: OrcaTaskLauncher,
     publisher: ApplicationEventPublisher,
     objectMapper: ObjectMapper,
     resolvers: List<Resolver<*>>

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -53,7 +53,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -72,7 +72,7 @@ class TitusClusterHandler(
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
   private val clock: Clock,
-  private val taskLauncher: TaskLauncher,
+  private val taskLauncher: OrcaTaskLauncher,
   private val publisher: ApplicationEventPublisher,
   objectMapper: ObjectMapper,
   resolvers: List<Resolver<*>>

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -59,7 +59,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
-import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.plugin.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -101,7 +101,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   val orcaService = mockk<OrcaService>()
   val objectMapper = ObjectMapper().registerKotlinModule()
   val resolvers = emptyList<Resolver<TitusClusterSpec>>()
-  val taskLauncher = TaskLauncher(orcaService, InMemoryDeliveryConfigRepository())
+  val taskLauncher = OrcaTaskLauncher(orcaService, InMemoryDeliveryConfigRepository())
   val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   val clock = Clock.systemDefaultZone()
 

--- a/keel-veto/keel-veto.gradle.kts
+++ b/keel-veto/keel-veto.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
 
   testImplementation(project(":keel-test"))
   testImplementation(project(":keel-core-test"))
+  testImplementation(project(":keel-api"))
   testImplementation(project(":keel-plugin"))
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")

--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":keel-api"))
   api(project(":keel-actuator"))
   api(project(":keel-plugin"))
   api(project(":keel-clouddriver"))


### PR DESCRIPTION
This is far from being complete, but I wanted to put _something_ out there. I'm targeting `Resolver` as the scope for this initial change.

Things that need to be done:

- [ ] Documentation of all public interfaces and methods.
- [ ] Removal of Kotlin classes that still exist in `keel-core`.
- [ ] Kotlin DSL methods for compatibility where `val` interfaces were changed to methods.
- [ ] Shimming of Jackson usage in `keel-core`, since Jackson can't come for the ride in `keel-api`
- [ ] ... Probably other stuff, too.