### PR TITLE
feat(ec2): support for declarative autoscale policies

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -13,6 +13,7 @@ data class ActiveServerGroup(
   val image: ActiveServerGroupImage,
   val launchConfig: LaunchConfig,
   val asg: AutoScalingGroup,
+  val scalingPolicies: List<ScalingPolicy>,
   val vpcId: String,
   val targetGroups: Set<String>,
   val loadBalancers: Set<String>,
@@ -68,6 +69,69 @@ data class AutoScalingGroup(
   val tags: Set<Tag>,
   val terminationPolicies: Set<String>,
   val vpczoneIdentifier: String
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_ScalingPolicy.html
+data class ScalingPolicy(
+  val autoScalingGroupName: String,
+  val policyName: String,
+  val policyType: String,
+  val estimatedInstanceWarmup: Int,
+  val adjustmentType: String? = null, // step scaling only
+  val minAdjustmentStep: Int? = null, // step scaling only
+  val minAdjustmentMagnitude: Int? = null, // step only
+  val stepAdjustments: List<StepAdjustmentModel>? = null,
+  val metricAggregationType: String? = null,
+  val targetTrackingConfiguration: TargetTrackingConfiguration? = null,
+  val alarms: List<ScalingPolicyAlarm>
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_StepAdjustment.html
+data class StepAdjustmentModel(
+  val metricIntervalLowerBound: Double? = null,
+  val metricIntervalUpperBound: Double? = null,
+  val scalingAdjustment: Int
+)
+
+// these are managed by EC2 for target tracking policies, but client provided for step policies
+data class ScalingPolicyAlarm(
+  val actionsEnabled: Boolean = true,
+  val comparisonOperator: String,
+  val dimensions: List<MetricDimensionModel>? = emptyList(),
+  val evaluationPeriods: Int,
+  val period: Int,
+  val threshold: Int,
+  val metricName: String,
+  val namespace: String,
+  val statistic: String
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_TargetTrackingConfiguration.html
+data class TargetTrackingConfiguration(
+  val targetValue: Double,
+  val disableScaleIn: Boolean? = null,
+  val customizedMetricSpecification: CustomizedMetricSpecificationModel? = null,
+  val predefinedMetricSpecification: PredefinedMetricSpecificationModel? = null
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_CustomizedMetricSpecification.html
+data class CustomizedMetricSpecificationModel(
+  val metricName: String,
+  val namespace: String,
+  val statistic: String,
+  val unit: String? = null,
+  val dimensions: List<MetricDimensionModel>? = emptyList()
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html
+data class PredefinedMetricSpecificationModel(
+  val predefinedMetricType: String,
+  val resourceLabel: String? = null
+)
+
+data class MetricDimensionModel(
+  val name: String,
+  val value: String
 )
 
 data class SuspendedProcess(

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
@@ -303,7 +303,57 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
     |    "serviceLinkedRoleARN": "arn:aws:iam::$owner:role/aws-service-role/autoscaling.amazonaws.com/AWSServiceRoleForAutoScaling",
     |    "vpczoneIdentifier": "${subnets.joinToString(",")}"
     |  },
-    |  "scalingPolicies": [],
+    |  "scalingPolicies": [
+    |   {
+    |     "autoScalingGroupName": "$app-v$seq",
+    |     "policyName": "$app-v$seq/ZZZ-RPS per instance-GreaterThanThreshold-560.0-3-60-1576009239950",
+    |     "policyARN": "arn:aws:autoscaling:$region:$owner:scalingPolicy:8d1f1cc2-a28a-481e-b3b0-6e9c4cfc8712:autoScalingGroupName/$app-v$seq:policyName/$app-v$seq/ZZZ-RPS per instance-GreaterThanThreshold-560.0-3-60-1576009239950",
+    |     "policyType": "TargetTrackingScaling",
+    |     "stepAdjustments": [],
+    |     "estimatedInstanceWarmup": 300,
+    |     "alarms": [
+    |       {
+    |         "alarmName": "TargetTracking-$app-v$seq-AlarmHigh-3d97edfc-dc29-4497-9203-20e2c0859db6",
+    |         "alarmArn": "arn:aws:cloudwatch:$region:$owner:alarm:TargetTracking-$app-v$seq-AlarmHigh-3d97edfc-dc29-4497-9203-20e2c0859db6",
+    |         "alarmDescription": "DO NOT EDIT OR DELETE. For TargetTrackingScaling policy...",
+    |         "actionsEnabled": true,
+    |         "alarmActions": [
+    |           "arn:aws:autoscaling:$region:$owner:scalingPolicy:8d1f1cc2-a28a-481e-b3b0-6e9c4cfc8712:autoScalingGroupName/$app-v$seq:policyName/$app-v$seq/ZZZ-RPS per instance-GreaterThanThreshold-560.0-3-60-1576009239950"
+    |         ],
+    |         "metricName": "RPS per instance",
+    |         "namespace": "ZZZ/EPIC",
+    |         "statistic": "Average",
+    |         "dimensions": [
+    |           {
+    |             "name": "AutoScalingGroupName",
+    |             "value": "$app-v$seq"
+    |           }
+    |         ],
+    |         "period": 60,
+    |         "evaluationPeriods": 3,
+    |         "threshold": 560.0,
+    |         "comparisonOperator": "GreaterThanThreshold",
+    |         "metrics": [],
+    |         "okactions": []
+    |       }
+    |     ],
+    |     "targetTrackingConfiguration": {
+    |       "customizedMetricSpecification": {
+    |         "metricName": "RPS per instance",
+    |         "namespace": "ZZZ/EPIC",
+    |         "statistic": "Average",
+    |         "dimensions": [
+    |           {
+    |             "name": "AutoScalingGroupName",
+    |             "value": "$app-v$seq"
+    |           }
+    |         ]
+    |       },
+    |       "targetValue": 560.0,
+    |       "disableScaleIn": true
+    |     }
+    |   }
+    |  ],
     |  "scheduledActions": [],
     |  "buildInfo": {
     |    "package_name": "$app",
@@ -384,6 +434,34 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
       tags = setOf(Tag("spinnaker:application", app)),
       terminationPolicies = setOf("Default"),
       vpczoneIdentifier = subnets.joinToString(",")
+    ),
+    scalingPolicies = listOf(
+      ScalingPolicy(
+        autoScalingGroupName = "$app-v$seq",
+        policyName = "$app-v$seq/ZZZ-RPS per instance-GreaterThanThreshold-560.0-3-60-1576009239950",
+        policyType = "TargetTrackingScaling",
+        stepAdjustments = emptyList(),
+        estimatedInstanceWarmup = 300,
+        targetTrackingConfiguration = TargetTrackingConfiguration(
+          targetValue = 560.0,
+          disableScaleIn = true,
+          customizedMetricSpecification = CustomizedMetricSpecificationModel(
+            metricName = "RPS per instance",
+            namespace = "ZZZ/EPIC",
+            statistic = "Average",
+            dimensions = listOf(MetricDimensionModel(name = "AutoScalingGroupName", value = "$app-v$seq"))
+          )
+        ),
+        alarms = listOf(ScalingPolicyAlarm(
+          comparisonOperator = "GreaterThanThreshold",
+          dimensions = listOf(MetricDimensionModel(name = "AutoScalingGroupName", value = "$app-v$seq")),
+          evaluationPeriods = 3,
+          period = 60,
+          threshold = 560,
+          metricName = "RPS per instance",
+          namespace = "ZZZ/EPIC",
+          statistic = "Average"))
+      )
     ),
     vpcId = vpc,
     loadBalancers = emptySet(),

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Capacity.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Capacity.kt
@@ -20,5 +20,5 @@ package com.netflix.spinnaker.keel.api
 data class Capacity(
   val min: Int,
   val max: Int,
-  val desired: Int
+  val desired: Int? = null
 )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Scaling.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/Scaling.kt
@@ -17,10 +17,170 @@
  */
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
+import de.danielbechler.diff.inclusion.Inclusion
+import de.danielbechler.diff.introspection.ObjectDiffProperty
+import java.time.Duration
 
+val DEFAULT_AUTOSCALE_INSTANCE_WARMUP: Duration = Duration.ofMinutes(5)
+
+@JsonInclude(NON_EMPTY)
 data class Scaling(
-  @JsonInclude(NON_EMPTY)
-  val suspendedProcesses: Set<ScalingProcess> = emptySet()
+  val suspendedProcesses: Set<ScalingProcess> = emptySet(),
+  val targetTrackingPolicies: Set<TargetTrackingPolicy> = emptySet(),
+  val stepScalingPolicies: Set<StepScalingPolicy> = emptySet()
+) {
+  @JsonIgnore
+  fun hasScalingPolicies(): Boolean =
+    targetTrackingPolicies.isNotEmpty() || stepScalingPolicies.isNotEmpty()
+}
+
+sealed class ScalingPolicy
+
+data class TargetTrackingPolicy(
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  @JsonIgnore
+  val name: String? = null,
+  val warmup: Duration = DEFAULT_AUTOSCALE_INSTANCE_WARMUP,
+  val targetValue: Double,
+  val disableScaleIn: Boolean? = null,
+  val predefinedMetricSpec: PredefinedMetricSpecification? = null,
+  val customMetricSpec: CustomizedMetricSpecification? = null
+) : ScalingPolicy() {
+  init {
+    require(customMetricSpec != null || predefinedMetricSpec != null) {
+      "a custom or predefined metric must be defined"
+    }
+
+    require(customMetricSpec == null || predefinedMetricSpec == null) {
+      "only one of customMetricSpec or predefinedMetricSpec can be defined"
+    }
+  }
+
+  // Excluding name, so we can remove policies from current asg when modifying
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as TargetTrackingPolicy
+
+    if (warmup != other.warmup) return false
+    if (targetValue != other.targetValue) return false
+    if (disableScaleIn != other.disableScaleIn) return false
+    if (predefinedMetricSpec != other.predefinedMetricSpec) return false
+    if (customMetricSpec != other.customMetricSpec) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = warmup.hashCode()
+    result = 31 * result + targetValue.hashCode()
+    result = 31 * result + disableScaleIn.hashCode()
+    result = 31 * result + predefinedMetricSpec.hashCode()
+    result = 31 * result + customMetricSpec.hashCode()
+    return result
+  }
+}
+
+@JsonInclude(NON_EMPTY)
+data class StepScalingPolicy(
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  @JsonIgnore
+  val name: String? = null,
+  val adjustmentType: String,
+  val actionsEnabled: Boolean,
+  val comparisonOperator: String,
+  val dimensions: Set<MetricDimension>? = emptySet(),
+  val evaluationPeriods: Int,
+  val period: Duration,
+  val threshold: Int,
+  val metricName: String,
+  val namespace: String,
+  val statistic: String,
+  val warmup: Duration = DEFAULT_AUTOSCALE_INSTANCE_WARMUP,
+  val metricAggregationType: String = "Average",
+  val stepAdjustments: Set<StepAdjustment>
+) : ScalingPolicy() {
+  init {
+    require(stepAdjustments.isNotEmpty()) { "at least one stepAdjustment is required" }
+    require(dimensions.isNullOrEmpty() || dimensions.none { it.name == "AutoScalingGroupName" }) {
+      "autoscale dimensions should not be scoped to a specific ASG name"
+    }
+    require(period.multipliedBy(evaluationPeriods.toLong()) <= Duration.ofDays(1)) {
+      "period * evaluationPeriods must be less than or equal to 1 day"
+    }
+  }
+
+  // Excluding name, so we can remove policies from current asg when modifying
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (javaClass != other?.javaClass) return false
+
+    other as StepScalingPolicy
+
+    if (adjustmentType != other.adjustmentType) return false
+    if (actionsEnabled != other.actionsEnabled) return false
+    if (comparisonOperator != other.comparisonOperator) return false
+    if (dimensions != other.dimensions) return false
+    if (evaluationPeriods != other.evaluationPeriods) return false
+    if (period != other.period) return false
+    if (threshold != other.threshold) return false
+    if (metricName != other.metricName) return false
+    if (namespace != other.namespace) return false
+    if (statistic != other.statistic) return false
+    if (warmup != other.warmup) return false
+    if (metricAggregationType != other.metricAggregationType) return false
+    if (stepAdjustments != other.stepAdjustments) return false
+
+    return true
+  }
+
+  override fun hashCode(): Int {
+    var result = adjustmentType.hashCode()
+    result = 31 * result + actionsEnabled.hashCode()
+    result = 31 * result + comparisonOperator.hashCode()
+    result = 31 * result + dimensions.hashCode()
+    result = 31 * result + evaluationPeriods.hashCode()
+    result = 31 * result + period.hashCode()
+    result = 31 * result + threshold.hashCode()
+    result = 31 * result + metricName.hashCode()
+    result = 31 * result + namespace.hashCode()
+    result = 31 * result + statistic.hashCode()
+    result = 31 * result + warmup.hashCode()
+    result = 31 * result + metricAggregationType.hashCode()
+    result = 31 * result + stepAdjustments.hashCode()
+    return result
+  }
+}
+
+data class MetricDimension(
+  val name: String,
+  val value: String
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_CustomizedMetricSpecification.html
+@JsonInclude(NON_EMPTY)
+data class CustomizedMetricSpecification(
+  val name: String,
+  val namespace: String,
+  val statistic: String,
+  val unit: String? = null,
+  val dimensions: Set<MetricDimension>? = emptySet()
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_PredefinedMetricSpecification.html
+data class PredefinedMetricSpecification(
+  val type: String,
+  val label: String? = null
+)
+
+// https://docs.aws.amazon.com/autoscaling/ec2/APIReference/API_StepAdjustment.html
+@JsonInclude(NON_EMPTY)
+data class StepAdjustment(
+  val lowerBound: Double? = null,
+  val upperBound: Double? = null,
+  val scalingAdjustment: Int
 )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -47,7 +47,16 @@ data class ServerGroup(
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = EXCLUDED)
   val buildInfo: BuildInfo? = null
-)
+) {
+  init {
+    require(
+      capacity.desired != null && !scaling.hasScalingPolicies() ||
+        capacity.desired == null && scaling.hasScalingPolicies()
+    ) {
+      "capacity.desired and auto-scaling policies are mutually exclusive"
+    }
+  }
+}
 
 val ServerGroup.moniker: Moniker
   get() = parseMoniker(name)

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
@@ -45,6 +45,18 @@ class TaskLauncher(
     description: String,
     correlationId: String,
     job: Map<String, Any?>
+  ): Task = submitJobToOrca(
+    resource = resource,
+    description = description,
+    correlationId = correlationId,
+    stages = listOf(job)
+  )
+
+  suspend fun submitJobToOrca(
+    resource: Resource<*>,
+    description: String,
+    correlationId: String,
+    stages: List<Map<String, Any?>>
   ): Task =
     orcaService
       .orchestrate(
@@ -53,7 +65,7 @@ class TaskLauncher(
           name = description,
           application = resource.application,
           description = description,
-          job = listOf(Job(job["type"].toString(), job)),
+          job = stages.map { Job(it["type"].toString(), it) },
           trigger = OrchestrationTrigger(
             correlationId = correlationId,
             notifications = resource.notifications

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -600,7 +600,7 @@ private fun TitusServerGroup.withDoubleCapacity(): TitusServerGroup =
     capacity = Capacity(
       min = capacity.min * 2,
       max = capacity.max * 2,
-      desired = capacity.desired * 2
+      desired = capacity.desired!! * 2
     )
   )
 
@@ -612,7 +612,7 @@ private fun TitusActiveServerGroup.withDoubleCapacity(): TitusActiveServerGroup 
     capacity = Capacity(
       min = capacity.min * 2,
       max = capacity.max * 2,
-      desired = capacity.desired * 2
+      desired = capacity.desired!! * 2
     )
   )
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -41,9 +41,23 @@ class ConvertExampleFilesTest : JUnit5Minutests {
 
   fun tests() = rootContext<Unit> {
 
-    context("cluster") {
+    context("ec2 cluster") {
       mapper.registerSubtypes(NamedType(ClusterSpec::class.java, "$SPINNAKER_EC2_API_V1/cluster"))
       val file = this.javaClass.getResource("/examples/cluster-example.yml").readText()
+
+      test("yaml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedResource<*>>(file)
+        }
+          .succeeded()
+          .get { spec }
+          .isA<ClusterSpec>()
+      }
+    }
+
+    context("ec2 cluster with scaling policies") {
+      mapper.registerSubtypes(NamedType(ClusterSpec::class.java, "$SPINNAKER_EC2_API_V1/cluster"))
+      val file = this.javaClass.getResource("/examples/ec2-cluster-with-autoscaling-example.yml").readText()
 
       test("yaml can be parsed") {
         expectCatching {

--- a/keel-web/src/test/resources/examples/ec2-cluster-with-autoscaling-example.yml
+++ b/keel-web/src/test/resources/examples/ec2-cluster-with-autoscaling-example.yml
@@ -1,0 +1,63 @@
+---
+apiVersion: ec2.spinnaker.netflix.com/v1
+kind: cluster
+metadata:
+  serviceAccount: my-email@spinnaker.io
+spec:
+  moniker:
+    app: keeldemo
+    stack: examples
+    detail: ec2v1
+  imageProvider:
+    deliveryArtifact:
+      name: keeldemo
+      type: deb
+  locations:
+    account: test
+    vpc: vpc0
+    subnet: internal (vpc0)
+    regions:
+      - name: us-west-2
+      - name: us-east-1
+  overrides: {}
+  launchConfiguration:
+    instanceType: m5.large
+    ebsOptimized: true
+    iamRole: keeldemoInstanceProfile
+    keyPair: nf-test-keypair-a
+  capacity:
+    min: 3
+    max: 10
+  scaling:
+    suspendedProcesses:
+    - "AZRebalance"
+    targetTrackingPolicies:
+    - warmup: "PT7M"
+      targetValue: 50.0
+      disableScaleIn: true
+      customMetricSpec:
+        name: "CPUUtilization"
+        namespace: "AWS/EC2"
+        statistic: "Average"
+    stepScalingPolicies:
+    - adjustmentType: "PercentChangeInCapacity"
+      actionsEnabled: true
+      comparisonOperator: "LessThanThreshold"
+      evaluationPeriods: 60
+      period: "PT1M"
+      threshold: 45
+      metricName: "CPUUtilization"
+      namespace: "AWS/EC2"
+      statistic: "Average"
+      warmup: "PT0S"
+      metricAggregationType: "Average"
+      stepAdjustments:
+      - upperBound: 0.0
+        scalingAdjustment: -4
+  dependencies:
+    loadBalancerNames: []
+    securityGroupNames:
+      - keeldemo
+      - nf-datacenter
+      - nf-infrastructure
+    targetGroups: []


### PR DESCRIPTION
- Adds support for EC2 target tracking and step scaling based autoscale policies.
- `Capacity.desired` is now ignored when clusters have at least one autoscale policy.
- Autoscale policies are added, updated, or removed without deploying new server groups if resource diffs only effect scaling policies or scaling policies and capacity.
- When a cluster with scaling policies is deployed for the first time (no `current` state), the server group is created and scaling policies applied via two stages within the same orchestration.
- Modified scaling policies are applied via two stages (delete + add) within the same orchestration.
- Export functionality is fully supported; the Spinnaker UI's Create Scaling Policy wizard can thus be used to assist with the creation of declarative scaling policies.
- Example resource usage at `keel-web/src/test/resources/examples/ec2-cluster-with-autoscaling-example.yml`.