### PR TITLE
fix(events): add resume events so status isn't stale

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -149,7 +149,11 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         }
 
         test("one resource is returned for the application") {
-          expectThat(subject.getByApplication("toast")).hasSize(1)
+          expectThat(subject.getResourceIdsByApplication("toast")).hasSize(1)
+        }
+
+        test("full resource returned for the application") {
+          expectThat(subject.getResourcesByApplication("toast")).hasSize(1)
         }
 
         test("resource summary is formatted correctly") {
@@ -292,7 +296,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
 
         test("deleting a non-existent application throws an exception") {
           expectThat(subject.deleteByApplication(resource.application)).isEqualTo(0)
-          }
+        }
       }
 
       context("fetching event history for the resource") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -80,7 +80,12 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
   /**
    * Fetches resources for a given application.
    */
-  fun getByApplication(application: String): List<String>
+  fun getResourceIdsByApplication(application: String): List<String>
+
+  /**
+   * Fetches resources for a given application.
+   */
+  fun getResourcesByApplication(application: String): List<Resource<*>>
 
   /**
    * Fetches resource summary, including the status

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
@@ -67,10 +67,16 @@ class InMemoryResourceRepository(
   override fun hasManagedResources(application: String): Boolean =
     resources.any { it.value.application == application }
 
-  override fun getByApplication(application: String): List<String> =
+  override fun getResourceIdsByApplication(application: String): List<String> =
     resources
       .filterValues { it.application == application }
       .map { it.value.id.toString() }
+
+  override fun getResourcesByApplication(application: String): List<Resource<*>> =
+    resources
+      .filterValues { it.application == application }
+      .map { it.value }
+      .toList()
 
   override fun getSummaryByApplication(application: String): List<ResourceSummary> =
     resources


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/668.

Now that pause is so quick, the paused status gets cleared immediately and the status icon is stale. This is worrisome and creates confusion when you pause while keel was doing something, stop that action and fix the resource, then unpause and still have the "we're doing something" icon.

This PR adds back in the `RESUMED` events and status. This is done via events. If the events don't make it (say, the instance gets killed mid-event) it's not a big deal. The resource will just have a stale status for < 1 minute.