### PR TITLE
fix(docker): persist the correct image version

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -48,7 +48,7 @@ class ArtifactListener(
               status = debStatus(korkArtifact)
             }
             is DockerArtifact -> {
-              version = "${korkArtifact.name}:${korkArtifact.version}"
+              version = korkArtifact.version
             }
             else -> throw UnsupportedArtifactTypeException(korkArtifact.type)
           }


### PR DESCRIPTION
We were inconsistently registering docker versions. Fixing.