### PR TITLE
refactor(export): Refactor export to simplify omitting defaults and creating overrides

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiff.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/ResourceDiff.kt
@@ -31,20 +31,17 @@ data class ResourceDiff<T : Any>(
   fun hasChanges(): Boolean = diff.hasChanges()
 
   val affectedRootPropertyTypes: List<Class<*>>
-    get() = mutableListOf<Class<*>>()
-      .also { types ->
-        diff.visitChildren { node, visit ->
-          visit.dontGoDeeper()
-          types += node.valueType
-        }
-      }
+    get() = children.map { it.valueType }.toList()
 
   val affectedRootPropertyNames: Set<String>
-    get() = mutableSetOf<String>()
-      .also { names ->
+    get() = children.map { it.propertyName }.toSet()
+
+  val children: Set<DiffNode>
+    get() = mutableSetOf<DiffNode>()
+      .also { nodes ->
         diff.visitChildren { node, visit ->
           visit.dontGoDeeper()
-          names += node.propertyName
+          nodes += node
         }
       }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATE_KEYS_AS_TI
 import com.fasterxml.jackson.databind.SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.USE_NATIVE_TYPE_ID
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
@@ -27,7 +28,9 @@ fun configuredObjectMapper(): ObjectMapper =
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
 fun configuredYamlMapper(): YAMLMapper =
-  YAMLMapper().configureMe()
+  YAMLMapper()
+    .configureMe()
+    .disable(USE_NATIVE_TYPE_ID)
 
 private fun <T : ObjectMapper> T.configureMe(): T =
   apply {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
@@ -67,6 +67,6 @@ internal class ResourceMetadataTests : JUnit5Minutests {
         expectThat(mapper.readValue<Map<String, Any?>>(this))
           .hasEntry("namespace", "default")
       }
-    }
+      }
   }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
@@ -67,6 +67,6 @@ internal class ResourceMetadataTests : JUnit5Minutests {
         expectThat(mapper.readValue<Map<String, Any?>>(this))
           .hasEntry("namespace", "default")
       }
-      }
+    }
   }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -756,8 +756,7 @@ class ClusterHandler(
       tags = tags
     )
 
-    // it's safe to assume a non-null result here because not all properties have defaults
-    return buildSpecFromDiff(defaults, thisSpec)!!
+    return checkNotNull(buildSpecFromDiff(defaults, thisSpec))
   }
 
   /**

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceSpecExportHelper.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceSpecExportHelper.kt
@@ -1,0 +1,83 @@
+package com.netflix.spinnaker.keel.plugin
+
+import com.netflix.spinnaker.keel.diff.ResourceDiff
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.full.primaryConstructor
+
+/**
+ * Given a base (a.k.a. "left") and a working (a.k.a. "right") objects of type T to compare, create a "diff" of those
+ * objects and use only the properties whose values are different between the two to create an instance of a
+ * ResourceSpec-like class of type S with the corresponding values from the working object.
+ *
+ * If all the diff properties have a null value in the working object, returns null.
+ */
+inline fun <reified T : Any, reified S : Any> buildSpecFromDiff(
+  base: T,
+  working: T,
+  allowedProperties: Set<String>? = null,
+  forcedProperties: Set<String> = emptySet()
+): S? {
+  val diff = ResourceDiff(working, base)
+
+  if (!diff.hasChanges()) {
+    return null
+  }
+
+  // for the purpose of building specs, we ignore removed values on the working object as the base will either
+  // be a baseline object with defaults or to calculate overrides from, so we let the base take precedence in
+  // that case
+  val addedOrChangedProps = diff.children
+    .filter { it.isAdded || it.isChanged }
+    .map { it.propertyName }
+    .toSet()
+
+  // build a map of constructor parameters including only those present in the diff that are allowed,
+  // unless they're forcefully included
+  var filteredParams = addedOrChangedProps
+    .also {
+      if (allowedProperties != null) {
+        it intersect allowedProperties
+      }
+      it union forcedProperties
+    }
+
+  if (filteredParams.isEmpty()) {
+    return null
+  }
+
+  val ctor = S::class.primaryConstructor!!
+  val params = ctor.parameters
+    .filter { param -> param.name in filteredParams }
+    .map { param ->
+      val prop = T::class.memberProperties.find { prop -> prop.name == param.name }
+      param to prop?.get(working)
+    }
+    .toMap()
+
+  return if (params.values.all { it == null }) {
+    null
+  } else {
+    ctor.callBy(params)
+  }
+}
+
+/**
+ * Given an input object of an arbitrary type I, and an output type O whose structure resembles that of the input
+ * object's class, convert the input object to the output type by building a map of constructor parameters for the
+ * output type matching properties with the same name in the input object. This is similar to Jackson's
+ * ObjectMapper.convertValue(from, to), but should be cheaper.
+ */
+inline fun <reified I : Any, reified O : Any> convert(obj: I): O {
+  val ctor = O::class.primaryConstructor!!
+  val params = ctor.parameters
+    .filter { param ->
+      I::class.memberProperties.any { prop -> prop.name == param.name }
+    }
+    .map { param ->
+      val prop = I::class.memberProperties.find { prop -> prop.name == param.name }
+      param to prop!!.get(obj)
+    }
+    .toMap()
+
+  return ctor.callBy(params)
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -436,8 +436,7 @@ class TitusClusterHandler(
       tags = tags
     )
 
-    // it's safe to assume a non-null result here because not all properties have defaults
-    return buildSpecFromDiff(defaults, thisSpec)!!
+    return checkNotNull(buildSpecFromDiff(defaults, thisSpec))
   }
 
   private fun Resources.exportSpec(): ResourcesSpec? {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -94,7 +94,7 @@ data class TitusClusterSpec(
 }
 
 data class TitusServerGroupSpec(
-  val container: Container,
+  val container: Container? = null,
   val capacity: Capacity? = null,
   val capacityGroup: String? = null,
   val constraints: Constraints? = null,
@@ -189,7 +189,7 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       capacity = resolveCapacity(it.name),
       capacityGroup = resolveCapacityGroup(it.name),
       constraints = resolveConstraints(it.name),
-      container = resolveContainer(defaults.container),
+      container = resolveContainer(defaults.container ?: error("Container image not specified or resolved")),
       dependencies = resolveDependencies(it.name),
       entryPoint = resolveEntryPoint(it.name),
       env = resolveEnv(it.name),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -49,7 +49,7 @@ class TitusImageResolver(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun getContainerFromSpec(resource: Resource<TitusClusterSpec>) =
-    resource.spec.defaults.container
+    resource.spec.defaults.container ?: error("Container not specified or resolved")
 
   override fun getAccountFromSpec(resource: Resource<TitusClusterSpec>) =
     resource.spec.deriveRegistry()

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -90,6 +90,7 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
+import strikt.assertions.isNull
 import strikt.assertions.isTrue
 import strikt.assertions.map
 
@@ -488,6 +489,27 @@ class TitusClusterHandlerTests : JUnit5Minutests {
               .hasSize(0)
           }
         }
+
+        test("has default values in defaults omitted") {
+          expectThat(spec.defaults.constraints)
+            .isNull()
+          expectThat(spec.defaults.entryPoint)
+            .isNull()
+          expectThat(spec.defaults.migrationPolicy)
+            .isNull()
+          expectThat(spec.defaults.resources)
+            .isNull()
+          expectThat(spec.defaults.iamProfile)
+            .isNull()
+          expectThat(spec.defaults.capacityGroup)
+            .isNull()
+          expectThat(spec.defaults.env)
+            .isNull()
+          expectThat(spec.defaults.containerAttributes)
+            .isNull()
+          expectThat(spec.defaults.tags)
+            .isNull()
+        }
       }
 
       context("export with overrides") {
@@ -512,8 +534,8 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
           test("has overrides matching differences in the server groups") {
             val overrideDiff = ResourceDiff(spec.overrides["us-west-2"]!!, spec.defaults)
-            val changedProps = overrideDiff.children
-              .filter { it.isChanged }
+            val addedOrChangedProps = overrideDiff.children
+              .filter { it.isAdded || it.isChanged }
               .map { it.propertyName }
               .toSet()
             expectThat(resource.kind)
@@ -528,12 +550,29 @@ class TitusClusterHandlerTests : JUnit5Minutests {
               .containsKey("us-west-2")
             expectThat(overrideDiff.hasChanges())
               .isTrue()
-            expectThat(changedProps)
+            expectThat(addedOrChangedProps)
               .isEqualTo(setOf("entryPoint", "capacity", "env"))
+          }
+
+          test("has default values in overrides omitted") {
+            val override = spec.overrides["us-west-2"]!!
+            expectThat(override.constraints)
+              .isNull()
+            expectThat(override.migrationPolicy)
+              .isNull()
+            expectThat(override.resources)
+              .isNull()
+            expectThat(override.iamProfile)
+              .isNull()
+            expectThat(override.capacityGroup)
+              .isNull()
+            expectThat(override.containerAttributes)
+              .isNull()
+            expectThat(override.tags)
+              .isNull()
           }
         }
       }
-      // TODO: test for defaults omitted from export
     }
 
     context("figuring out tagging strategy") {


### PR DESCRIPTION
This is my attempt at simplifying the process of omitting defaults and creating overrides when exporting resource specs. 

I'd originally envisioned being able to fully automate this process by comparing a baseline "dummy" spec with all resolvable fields resolved, but after running into several blockers (e.g. the fact that `Resolver` interfaces are defined in terms of `Resource` and not `ResourceSpec` and don't provide any feedback as to what they changed, the fact that the `resolve()` methods in `ResourceSpec` types operate on concrete resolved types and not specs, the fact that `ResourceSpec` types use a mix of spec-like data classes with all properties nullable and concrete types with no nullable properties, etc.) I gave up.

Instead, I've tried to turn 🍋into lemonade by simplifying the process to generate the spec objects for the following use cases:
1. When generating the `defaults` block in `ClusterSpec` and `TitusClusterSpec` from the corresponding server group and related objects returned from clouddriver, we had a lot of code to essentially translate from one type to another, and to omit defaults (static and dynamic) from the spec, generally by using lots of `if/else` conditions around constructor parameters, or using `copy` to modify the spec, or both. My approach was to use a bit of reflection and rely on certain assumptions (namely the availability of a primary constructor in the spec classes which receive all properties, and that property names in the clouddriver types and the spec types are the same) to automate the process of converting types. In addition, I relied on the diff library we were already using to simplify the process of omitting defaults.

2. When generating the `overrides` block in the specs, again it was convenient to just compare a spec for a region with the `defaults` object from step 1, basically using the same mechanism.

This still requires implementors to manually code in defaults/resolvables in certain places for comparison, but hopefully creates enough of a pattern to make the overall process easier. Going back to the blockers I found initially, I feel like our domain model for "concrete" resource representations and specs is too loose, which likely led to the mixed type usage I referenced above, but fixing that would be a massive and risky change set that is way beyond the scope of this PR.

Closes #640 (kinda).