### PR TITLE
feat(constraint): kayenta canary constraint with ec2 implementation

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.keel.clouddriver.model
 import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.model.Moniker
 
 // todo eb: this should be more general so that it works for all server groups, not just ec2
@@ -24,6 +25,13 @@ data class ActiveServerGroup(
   val moniker: Moniker,
   val buildInfo: BuildInfo? = null
 )
+
+fun ActiveServerGroup.subnet(cloudDriverCache: CloudDriverCache): String =
+  asg.vpczoneIdentifier.substringBefore(",").let { subnetId ->
+    cloudDriverCache
+      .subnetBy(subnetId)
+      .purpose ?: error("Subnet $subnetId has no purpose!")
+  }
 
 data class ActiveServerGroupImage(
   val imageId: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Constraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Constraint.kt
@@ -18,7 +18,8 @@ import java.time.zone.ZoneRulesException
   Type(value = DependsOnConstraint::class, name = "depends-on"),
   Type(value = TimeWindowConstraint::class, name = "allowed-times"),
   Type(value = ManualJudgementConstraint::class, name = "manual-judgement"),
-  Type(value = PipelineConstraint::class, name = "pipeline")
+  Type(value = PipelineConstraint::class, name = "pipeline"),
+  Type(value = CanaryConstraint::class, name = "canary")
 )
 abstract class Constraint(val type: String)
 
@@ -68,6 +69,34 @@ data class PipelineConstraint(
   val retries: Int = 0,
   val parameters: Map<String, Any?> = emptyMap()
 ) : StatefulConstraint("pipeline")
+
+// TODO: doesn't support sliding look-back, custom metric scope, or extended scope parameters (will default to asg)
+data class CanaryConstraint(
+  val serviceAccount: String = "anonymous",
+  val timeout: Duration = Duration.ofHours(24),
+  // TODO: resolve config name -> id via kayenta/canaryConfig?application=application
+  val canaryConfigId: String,
+  val beginAnalysisAfter: Duration = Duration.ofMinutes(10),
+  val canaryAnalysisInterval: Duration = Duration.ofMinutes(30),
+  val cleanupDelay: Duration = Duration.ZERO,
+  val lifetime: Duration,
+  // TODO: this default is only for testing; we need a configurable way to resolve constraint defaults -af
+  val metricsAccountName: String = "atlas-global.prod",
+  val storageAccount: String? = null,
+  val marginalScore: Int,
+  val passScore: Int,
+  val source: CanarySource,
+  val regions: Set<String>,
+  val capacity: Int,
+  // If true, the failure of a canary in one region triggers the immediate cancellation of other regions
+  val failureCancelsRunningRegions: Boolean = true
+) : StatefulConstraint("canary")
+
+data class CanarySource(
+  val account: String,
+  val cloudProvider: String,
+  val cluster: String
+)
 
 data class TimeWindow(
   val days: String? = null,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ConstraintState.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ConstraintState.kt
@@ -42,7 +42,8 @@ enum class ConstraintStatus(private val passed: Boolean, private val failed: Boo
   use = JsonTypeInfo.Id.NAME,
   property = "type")
 @JsonSubTypes(
-  Type(value = PipelineConstraintStateAttributes::class, name = "pipeline")
+  Type(value = PipelineConstraintStateAttributes::class, name = "pipeline"),
+  Type(value = CanaryConstraintAttributes::class, name = "canary")
 )
 abstract class ConstraintStateAttributes(val type: String)
 
@@ -52,3 +53,22 @@ data class PipelineConstraintStateAttributes(
   val latestAttempt: Instant,
   val lastExecutionStatus: String? = null
 ) : ConstraintStateAttributes("pipeline")
+
+data class CanaryConstraintAttributes(
+  val executions: Set<RegionalExecutionId> = emptySet(),
+  val startAttempt: Int = 0,
+  val status: Set<CanaryStatus> = emptySet()
+) : ConstraintStateAttributes("canary")
+
+data class RegionalExecutionId(
+  val region: String,
+  val executionId: String
+)
+
+data class CanaryStatus(
+  val executionId: String,
+  val region: String,
+  val executionStatus: String,
+  val scores: List<Double> = emptyList(),
+  val scoreMessage: String?
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintDeployHandler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintDeployHandler.kt
@@ -19,7 +19,7 @@ interface CanaryConstraintDeployHandler {
    *
    * @return A map where values are [Task]'s pointing to regional orca canary tasks, keyed by region
    */
-  fun deployCanary(
+  suspend fun deployCanary(
     constraint: CanaryConstraint,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintDeployHandler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintDeployHandler.kt
@@ -1,0 +1,29 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.CanaryConstraint
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.events.Task
+
+interface CanaryConstraintDeployHandler {
+  val supportedClouds: Set<String>
+
+  /**
+   * Deploy and analyze a canary using cloud provider specific logic.
+   *
+   * @param constraint The canary constraint configuration
+   * @param version Artifact to be canaried
+   * @param deliveryConfig The [DeliveryConfig] containing the environment gated by this canary
+   * @param targetEnvironment The [Environment] gated by this canary
+   * @param regions Regions that need a canary deployment, may be a subset of regions defined in [constraint]
+   *
+   * @return A map where values are [Task]'s pointing to regional orca canary tasks, keyed by region
+   */
+  fun deployCanary(
+    constraint: CanaryConstraint,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    regions: Set<String>
+  ): Map<String, Task>
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -19,6 +19,9 @@ package com.netflix.spinnaker.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.ImageService
+import com.netflix.spinnaker.keel.constraints.CanaryConstraintDeployHandler
+import com.netflix.spinnaker.keel.ec2.constraints.Ec2CanaryConstraintDeployHandler
 import com.netflix.spinnaker.keel.ec2.resource.ApplicationLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
@@ -110,5 +113,19 @@ class EC2Config {
       taskLauncher,
       objectMapper,
       normalizers
+    )
+
+  @Bean
+  fun ec2CanaryDeployHandler(
+    taskLauncher: TaskLauncher,
+    cloudDriverService: CloudDriverService,
+    cloudDriverCache: CloudDriverCache,
+    imageService: ImageService
+  ): CanaryConstraintDeployHandler =
+    Ec2CanaryConstraintDeployHandler(
+      taskLauncher,
+      cloudDriverService,
+      cloudDriverCache,
+      imageService
     )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -1,0 +1,166 @@
+package com.netflix.spinnaker.keel.ec2.constraints
+
+import com.netflix.frigga.ami.AppVersion
+import com.netflix.spinnaker.keel.api.CanaryConstraint
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.ImageService
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.subnet
+import com.netflix.spinnaker.keel.constraints.CanaryConstraintDeployHandler
+import com.netflix.spinnaker.keel.constraints.toStageBase
+import com.netflix.spinnaker.keel.events.Task
+import com.netflix.spinnaker.keel.model.parseMoniker
+import com.netflix.spinnaker.keel.model.toEchoNotification
+import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import com.netflix.spinnaker.keel.retrofit.isNotFound
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import retrofit2.HttpException
+
+class Ec2CanaryConstraintDeployHandler(
+  private val taskLauncher: TaskLauncher,
+  private val cloudDriverService: CloudDriverService,
+  private val cloudDriverCache: CloudDriverCache,
+  private val imageService: ImageService
+) : CanaryConstraintDeployHandler {
+  companion object {
+    const val DEFAULT_KAYENTA_STORAGE_ACCOUNT = "s3-objects"
+    private val log by lazy { LoggerFactory.getLogger(Ec2CanaryConstraintDeployHandler::class.java) }
+  }
+
+  // TODO: The rest of Spinnaker should be refactored to refer to ec2 as ec2 instead of aws.
+  //  But for now, `CanaryConstraint.source` points to a source cluster (including cloud
+  //  provider) as Orca and Clouddriver would - that is, with "aws" as the provider when ec2
+  //  is intended.
+  override val supportedClouds = setOf("ec2", "aws")
+
+  override fun deployCanary(
+    constraint: CanaryConstraint,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    regions: Set<String>
+  ): Map<String, Task> {
+
+    val judge = "canary:${deliveryConfig.application}:${targetEnvironment.name}:${constraint.canaryConfigId}"
+
+    val image = runBlocking {
+      imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+        appVersion = AppVersion.parseName(version.replace("~", "_")),
+        account = "test", // TODO: update when we have "default image account" configuration
+        regions = constraint.regions.toList())
+    }
+      ?.imageName ?: error("Image not found for $version in all requested regions ($regions)")
+
+    val regionalJobs = runBlocking {
+      val source = getSourceServerGroups(deliveryConfig.application, constraint)
+      require(regions.all { source.containsKey(it) }) {
+        "Source cluster ${constraint.source.cluster} not available in all canary regions"
+      }
+
+      regions.associateWith { region ->
+        val sourceServerGroup = source.getValue(region)
+        constraint.toStageBase(
+          cloudDriverCache = cloudDriverCache,
+          storageAccount = constraint.storageAccount ?: DEFAULT_KAYENTA_STORAGE_ACCOUNT,
+          app = deliveryConfig.application,
+          control = sourceServerGroup.toKayentaStageServerGroup(constraint.capacity, "baseline", image),
+          experiment = sourceServerGroup.toKayentaStageServerGroup(constraint.capacity, "canary", image)
+        )
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return regionalJobs.map { (region, task) ->
+      val description = "Canary $version for ${deliveryConfig.application}/environment " +
+        "${targetEnvironment.name} in $region"
+
+      region to
+        try {
+          runBlocking {
+            taskLauncher.submitJobToOrca(
+              serviceAccount = constraint.serviceAccount,
+              application = deliveryConfig.application,
+              notifications = targetEnvironment.notifications.map { it.toEchoNotification() },
+              subject = description,
+              description = description,
+              correlationId = "$judge:$region",
+              stages = listOf(task)
+            )
+          }
+        } catch (e: Exception) {
+          log.error("Error launching orca canary for: ${description.toLowerCase()}")
+          null
+        }
+    }
+      .filter { it.second != null }
+      .toMap() as Map<String, Task>
+  }
+
+  private suspend fun getSourceServerGroups(
+    app: String,
+    constraint: CanaryConstraint
+  ): Map<String, ActiveServerGroup> =
+    coroutineScope {
+      constraint.regions.map { region ->
+        async {
+          try {
+            cloudDriverService.activeServerGroup(
+              serviceAccount = constraint.serviceAccount,
+              app = app,
+              account = constraint.source.account,
+              cluster = constraint.source.cluster,
+              region = region,
+              cloudProvider = constraint.source.cloudProvider
+            )
+          } catch (e: HttpException) {
+            when (e.isNotFound) {
+              true -> null
+              else -> throw e
+            }
+          }
+        }
+      }
+        .mapNotNull { it.await() }
+        .associateBy { it.region }
+    }
+
+  private fun ActiveServerGroup.toKayentaStageServerGroup(
+    capacity: Int,
+    type: String,
+    image: String
+  ): Map<String, Any?> {
+    val moniker = parseMoniker(name)
+    return mutableMapOf(
+      "application" to moniker.app,
+      "stack" to moniker.stack,
+      "freeFormDetails" to "${moniker.detail}-$type",
+      "region" to region,
+      "account" to accountName,
+      "cloudProvider" to cloudProvider,
+      "amiName" to image,
+      "availabilityZones" to mapOf(region to zones),
+      "capacity" to Capacity(capacity, capacity, capacity),
+      "ebsOptimized" to launchConfig.ebsOptimized,
+      "healthCheckGracePeriod" to asg.healthCheckGracePeriod,
+      "healthCheckType" to asg.healthCheckType,
+      "iamRole" to launchConfig.iamInstanceProfile,
+      "instanceMonitoring" to launchConfig.instanceMonitoring.enabled,
+      "instanceType" to launchConfig.instanceType,
+      "keyPair" to launchConfig.keyName,
+      "loadBalancers" to loadBalancers,
+      "targetGroups" to targetGroups,
+      "securityGroups" to securityGroups,
+      "strategy" to "redblack",
+      "subnetType" to subnet(cloudDriverCache),
+      "suspendedProcesses" to asg.suspendedProcesses,
+      "useSourceCapacity" to false
+    )
+  }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -42,6 +42,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.PredefinedMetricSpecificatio
 import com.netflix.spinnaker.keel.clouddriver.model.ScalingPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.StepAdjustmentModel
 import com.netflix.spinnaker.keel.clouddriver.model.Tag
+import com.netflix.spinnaker.keel.clouddriver.model.subnet
 import com.netflix.spinnaker.keel.diff.ResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
@@ -583,7 +584,7 @@ class ClusterHandler(
         account = accountName,
         region = region,
         vpc = cloudDriverCache.networkBy(vpcId).name ?: error("VPC with id $vpcId has no name!"),
-        subnet = subnet,
+        subnet = subnet(cloudDriverCache),
         availabilityZones = zones
       ),
       launchConfiguration = launchConfig.run {
@@ -714,13 +715,6 @@ class ClusterHandler(
       .map {
         cloudDriverCache.securityGroupByName(location.account, location.region, it).id
       }
-
-  private val ActiveServerGroup.subnet: String
-    get() = asg.vpczoneIdentifier.substringBefore(",").let { subnetId ->
-      cloudDriverCache
-        .subnetBy(subnetId)
-        .purpose ?: throw IllegalStateException("Subnet $subnetId has no purpose!")
-    }
 
   private val ActiveServerGroup.securityGroupNames: Set<String>
     get() = securityGroups.map {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -1,0 +1,221 @@
+package com.netflix.spinnaker.keel.api.ec2.constraints
+
+import com.netflix.frigga.ami.AppVersion
+import com.netflix.spinnaker.keel.api.CanaryConstraint
+import com.netflix.spinnaker.keel.api.CanarySource
+import com.netflix.spinnaker.keel.api.Capacity
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
+import com.netflix.spinnaker.keel.api.randomUID
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.ImageService
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
+import com.netflix.spinnaker.keel.clouddriver.model.AutoScalingGroup
+import com.netflix.spinnaker.keel.clouddriver.model.Credential
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
+import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
+import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
+import com.netflix.spinnaker.keel.clouddriver.model.Subnet
+import com.netflix.spinnaker.keel.clouddriver.model.SuspendedProcess
+import com.netflix.spinnaker.keel.ec2.constraints.Ec2CanaryConstraintDeployHandler
+import com.netflix.spinnaker.keel.events.Task
+import com.netflix.spinnaker.keel.model.parseMoniker
+import com.netflix.spinnaker.keel.plugin.TaskLauncher
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.CapturingSlot
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.slot
+import java.time.Clock
+import java.time.Duration
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.getValue
+import strikt.assertions.hasSize
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
+
+  companion object {
+    val clock: Clock = Clock.systemUTC()
+    val taskLauncher: TaskLauncher = mockk()
+    val cloudDriverService: CloudDriverService = mockk()
+    val cloudDriverCache: CloudDriverCache = mockk()
+    val imageService: ImageService = mockk()
+  }
+
+  data class Fixture(
+    val constraint: CanaryConstraint,
+    val version: String,
+    val deliveryConfig: DeliveryConfig,
+    val targetEnvironment: Environment,
+    val regions: Set<String>
+  ) {
+    constructor() : this(
+      constraint = CanaryConstraint(
+        canaryConfigId = randomUID().toString(),
+        lifetime = Duration.ofMinutes(60),
+        marginalScore = 75,
+        passScore = 90,
+        source = CanarySource(
+          account = "test",
+          cloudProvider = "aws",
+          cluster = "fnord-prod"
+        ),
+        regions = setOf("us-west-1", "us-west-2"),
+        capacity = 1
+      ),
+      version = "fnord-42.0.0-h42",
+      deliveryConfig = DeliveryConfig(name = "fnord-manifest", application = "fnord"),
+      targetEnvironment = Environment("prod"),
+      regions = setOf("us-west-1", "us-west-2")
+    )
+
+    val subject = Ec2CanaryConstraintDeployHandler(taskLauncher, cloudDriverService, cloudDriverCache, imageService)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("need to launch canaries in two regions") {
+      before {
+        coEvery {
+          imageService.getLatestNamedImageWithAllRegionsForAppVersion(any(), any(), any())
+        } returns NamedImage("fnord-42.0.0-h42", emptyMap(), emptyMap(), emptySet(), emptyMap())
+
+        coEvery {
+          cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-1", any())
+        } returns sourceServerGroup("us-west-1")
+
+        coEvery {
+          cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-2", any())
+        } returns sourceServerGroup("us-west-2")
+
+        coEvery {
+          taskLauncher.submitJobToOrca(any(), any(), any(), any(), any(), any(), any())
+        } returns Task(randomUID().toString(), "fnord canary")
+
+        coEvery {
+          cloudDriverCache.subnetBy(any())
+        } returns Subnet(
+          id = "subnet-42",
+          account = "test",
+          region = "us-west-1",
+          availabilityZone = "us-west-1a",
+          vpcId = "vpc-123",
+          purpose = "internal"
+        )
+
+        coEvery {
+          cloudDriverCache.credentialBy("test")
+        } returns Credential(
+          name = "test",
+          type = "aws",
+          attributes = mapOf(
+            "attributes" to mapOf(
+              "environment" to "test")))
+      }
+
+      test("generates and submits an orca task per regions") {
+        val slot: CapturingSlot<List<Map<String, Any>>> = slot()
+        val tasks = subject.deployCanary(constraint, version, deliveryConfig, targetEnvironment, regions)
+
+        coVerify(exactly = 1) {
+          imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName(version), "test", any())
+          cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-1", any())
+          cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-2", any())
+        }
+        coVerify(exactly = 2) {
+          taskLauncher.submitJobToOrca(any(), any(), any(), any(), any(), any(), capture(slot))
+        }
+
+        expectThat(tasks)
+          .hasSize(2)
+          .get { keys }
+          .containsExactlyInAnyOrder("us-west-1", "us-west-2")
+
+        expectThat(slot.captured)
+          .hasSize(1)
+          .and {
+            get { first() }
+              .and {
+                getValue("type").isEqualTo("kayentaCanary")
+                getValue("refId").isEqualTo("canary")
+                getValue("canaryConfig")
+                  .isA<Map<String, Any?>>()
+                  .and {
+                    getValue("canaryConfigId")
+                      .isEqualTo(constraint.canaryConfigId)
+                    getValue("canaryAnalysisIntervalMins")
+                      .isEqualTo(constraint.canaryAnalysisInterval.toMinutes())
+                  }
+                getValue("deployments")
+                  .isA<Map<String, Any?>>()
+                  .and {
+                    getValue("serverGroupPairs")
+                      .isA<List<Map<String, Any?>>>()
+                      .hasSize(1)
+                      .and {
+                        get { first() }
+                          .and {
+                            hasSize(2)
+                            getValue("experiment")
+                              .isA<Map<String, Any?>>()
+                              .and {
+                                getValue("application")
+                                  .isEqualTo(deliveryConfig.application)
+                                getValue("freeFormDetails")
+                                  .isEqualTo(
+                                    "${parseMoniker(constraint.source.cluster).detail}-canary")
+                              }
+                          }
+                      }
+                  }
+              }
+          }
+      }
+    }
+  }
+
+  private fun sourceServerGroup(region: String) = ActiveServerGroup(
+    name = "fnord-prod",
+    region = region,
+    zones = emptySet(),
+    image = ActiveServerGroupImage("ami-42b", null, null),
+    launchConfig = LaunchConfig(
+      ramdiskId = null,
+      ebsOptimized = true,
+      imageId = "ami-42b",
+      instanceType = "m5.2xlarge",
+      keyName = "nosecrets",
+      iamInstanceProfile = "fnordInstanceProfile",
+      instanceMonitoring = InstanceMonitoring(false)
+    ),
+    asg = AutoScalingGroup(
+      autoScalingGroupName = "fnord-prod-v042",
+      defaultCooldown = 300,
+      healthCheckType = "ec2",
+      healthCheckGracePeriod = 300,
+      suspendedProcesses = setOf(SuspendedProcess(processName = "AZRebalance")),
+      enabledMetrics = emptySet(),
+      tags = emptySet(),
+      terminationPolicies = setOf(TerminationPolicy.OldestInstance.toString()),
+      vpczoneIdentifier = "subnet-42,subnet-123"
+    ),
+    scalingPolicies = emptyList(),
+    vpcId = "vpc-123",
+    targetGroups = emptySet(),
+    loadBalancers = emptySet(),
+    capacity = Capacity(10, 10, 10),
+    cloudProvider = "aws",
+    securityGroups = setOf("fnord"),
+    accountName = "test",
+    moniker = parseMoniker("fnord-prod")
+  )
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -33,6 +33,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import java.time.Clock
 import java.time.Duration
+import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.getValue
@@ -124,7 +125,9 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
 
       test("generates and submits an orca task per regions") {
         val slot: CapturingSlot<List<Map<String, Any>>> = slot()
-        val tasks = subject.deployCanary(constraint, version, deliveryConfig, targetEnvironment, regions)
+        val tasks = runBlocking {
+          subject.deployCanary(constraint, version, deliveryConfig, targetEnvironment, regions)
+        }
 
         coVerify(exactly = 1) {
           imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName(version), "test", any())

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluator.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluator.kt
@@ -1,0 +1,332 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.CanaryConstraint
+import com.netflix.spinnaker.keel.api.CanaryConstraintAttributes
+import com.netflix.spinnaker.keel.api.CanaryStatus
+import com.netflix.spinnaker.keel.api.ConstraintState
+import com.netflix.spinnaker.keel.api.ConstraintStatus
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.RegionalExecutionId
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import java.time.Clock
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * An environment promotion constraint that deploys control (baseline) and experiment (canary)
+ * clusters which are evaluated by Kayenta using a constraint-provided canary config.
+ *
+ * When the constraint specifies a multi-region canary, the Kayenta ACA must pass in all
+ * regions for promotion to be allowed. Kayenta false positives can be overridden to
+ * allow promotion via the `DeliveryConfigController.updateConstraintStatus` REST method.
+ *
+ * Example constraint:
+ *
+ * constraints:
+ *  - type: canary
+ *    serviceAccount: "keel@keel.io" // Will move to the Delivery Config root
+ *    canaryConfigId: b11b739d-7b1d-47c7-8430-d8ddffafb645 // Will later support named configs
+ *    beginAnalysisAfter: PT3M
+ *    canaryAnalysisInterval: PT10M
+ *    lifetime: PT30M
+ *    marginalScore: 50
+ *    passScore: 90
+ *    capacity: 1
+ *    source:
+ *      account: test
+ *      cloudProvider: aws
+ *      cluster: afeldmantest-test-c
+ *    regions:
+ *      - us-east-1
+ *      - us-west-2
+ */
+@Component
+class CanaryConstraintEvaluator(
+  private val handlers: List<CanaryConstraintDeployHandler>,
+  private val orcaService: OrcaService,
+  override val deliveryConfigRepository: DeliveryConfigRepository,
+  private val clock: Clock
+) : StatefulConstraintEvaluator<CanaryConstraint>() {
+  override val constraintType = CanaryConstraint::class.java
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+  private val correlatedMessagePrefix = "Correlated canary tasks found"
+
+  override fun canPromote(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    constraint: CanaryConstraint,
+    state: ConstraintState
+  ): Boolean {
+    val deployHandler = handlers.firstOrNull {
+      it.supportedClouds.contains(constraint.source.cloudProvider)
+    } ?: error("No canary constraint deploy handler found for ${constraint.source.cloudProvider}")
+
+    val judge = "canary:${deliveryConfig.application}:${targetEnvironment.name}:${constraint.canaryConfigId}"
+    var attributes = state.attributes as CanaryConstraintAttributes? ?: CanaryConstraintAttributes()
+    val status = canaryStatus(attributes)
+
+    if (status.anyFailed()) {
+      val stillRunning = status.getRunning()
+      if (stillRunning.isNotEmpty() && constraint.failureCancelsRunningRegions) {
+        runBlocking {
+          stillRunning.forEach {
+            log.warn("Cancelling still running canary $judge:${it.region} as at least one region has failed.")
+            orcaService.cancelOrchestration(it.executionId)
+          }
+        }
+      }
+      deliveryConfigRepository.storeConstraintState(
+        state.copy(
+          status = ConstraintStatus.FAIL,
+          judgedBy = judge,
+          judgedAt = clock.instant(),
+          comment = "Canary failed: ${status.summary()}"))
+
+      return false
+    }
+
+    if (status.allPassed() && status.regions() == constraint.regions) {
+      deliveryConfigRepository.storeConstraintState(
+        state.copy(
+          status = ConstraintStatus.PASS,
+          judgedBy = judge,
+          judgedAt = clock.instant(),
+          comment = "Canary passed: ${status.summary()}"))
+
+      return true
+    }
+
+    val regionsToTrigger = shouldTrigger(constraint, attributes)
+    val regionsWithCorrelatedExecutions = runBlocking {
+      constraint.regionsWithCorrelatedExecutions(judge)
+    }
+    val unknownExecutions = regionsWithCorrelatedExecutions.filter {
+      regionsToTrigger.contains(it.key)
+    }
+      .toSortedMap()
+
+    if (unknownExecutions.isNotEmpty() && attributes.executions.isEmpty()) {
+      val message = "$correlatedMessagePrefix ($unknownExecutions), " +
+        "another artifact version may still be under evaluation."
+
+      if (state.comment != message) {
+        deliveryConfigRepository.storeConstraintState(state.copy(comment = message))
+      }
+
+      return false
+    }
+
+    if (regionsToTrigger.isEmpty()) {
+      if (!status.anyRunning()) {
+        deliveryConfigRepository.storeConstraintState(
+          state.copy(
+            status = ConstraintStatus.FAIL,
+            judgedBy = judge,
+            judgedAt = clock.instant(),
+            attributes = attributes.copy(status = status),
+            comment = "Failure encountered launching canaries"))
+      } else if (attributes.status != status) {
+        deliveryConfigRepository.storeConstraintState(
+          state.copy(
+            attributes = attributes.copy(status = status)))
+      }
+
+      return false
+    }
+
+    attributes = attributes.copy(startAttempt = attributes.startAttempt + 1)
+
+    val tasks = deployHandler.deployCanary(
+      constraint = constraint,
+      version = version,
+      deliveryConfig = deliveryConfig,
+      targetEnvironment = targetEnvironment,
+      regions = regionsToTrigger)
+
+    attributes = attributes.copy(
+      executions = tasks.map { (region, task) ->
+        RegionalExecutionId(region, task.id)
+      }
+        .toSet())
+
+    deliveryConfigRepository.storeConstraintState(
+      state.copy(
+        attributes = attributes,
+        comment = "Running canaries in ${attributes.launchedRegions}"))
+
+    return false
+  }
+
+  @Suppress("UNCHECKED_CAST")
+  private fun canaryStatus(attributes: CanaryConstraintAttributes?): Set<CanaryStatus> {
+    if (attributes == null || attributes.executions.isNullOrEmpty()) {
+      return emptySet()
+    }
+
+    return attributes.executions
+      .associate {
+        it.region to runBlocking {
+          orcaService
+            .getOrchestrationExecution(it.executionId)
+        }
+      }
+      .map { (region, detail) ->
+        val context = detail.execution.stages.canaryContext()
+
+        CanaryStatus(
+          executionId = detail.id,
+          region = region,
+          executionStatus = detail.status.toString(),
+          scores = context.getOrDefault("canaryScores", emptyList<Double>()) as List<Double>,
+          scoreMessage = context["canaryScoreMessage"] as String?
+        )
+      }
+      .toSet()
+  }
+
+  private fun Set<CanaryStatus>.summary(): Map<String, Any> =
+    associate { status ->
+      status.region to mutableMapOf(
+        "executionStatus" to status.executionStatus
+      ).also {
+        if (status.scoreMessage != null) {
+          it["message"] = status.scoreMessage!!
+        }
+      }
+    }
+
+  private fun Set<CanaryStatus>.allPassed(): Boolean =
+    all {
+      OrcaExecutionStatus.valueOf(it.executionStatus).isSuccess()
+    }
+
+  private fun Set<CanaryStatus>.anyFailed(): Boolean =
+    any {
+      OrcaExecutionStatus.valueOf(it.executionStatus).isFailure()
+    }
+
+  private fun Set<CanaryStatus>.anyRunning(): Boolean =
+    isNotEmpty() && getRunning().isNotEmpty()
+
+  private fun Set<CanaryStatus>.getRunning(): Set<CanaryStatus> =
+    filter {
+      OrcaExecutionStatus.valueOf(it.executionStatus).isIncomplete()
+    }
+      .toSet()
+
+  private fun Set<CanaryStatus>.regions(): Set<String> =
+    map { it.region }
+      .toSet()
+
+  suspend fun CanaryConstraint.regionsWithCorrelatedExecutions(prefix: String): Map<String, String> =
+    regions.mapNotNull { region ->
+      val correlated = orcaService.getCorrelatedExecutions("$prefix:$region")
+      if (correlated.isNotEmpty()) {
+        region to correlated.first()
+      } else {
+        null
+      }
+    }
+      .toMap()
+
+  /**
+   * @return Set of regions (as strings) that still need a canary deploy.
+   *
+   * Supports triggering a subset of regions specified in the constraint.
+   * If a constraint specifies 2 regions and on the first eval, Orca
+   * successfully receives the task submission for one region, but the
+   * second fails due to a network issue, the second constraint eval
+   * will only attempt to trigger for the failed region.
+   */
+  private fun shouldTrigger(
+    constraint: CanaryConstraint,
+    attributes: CanaryConstraintAttributes?
+  ): Set<String> =
+    when {
+      attributes == null -> constraint.regions
+      constraint.regions.size == attributes.executions.size -> emptySet()
+      attributes.startAttempt >= 3 -> emptySet()
+      else -> constraint.regions - attributes.executions
+        .map { it.region }
+        .toSet()
+    }
+
+  private val CanaryConstraintAttributes.launchedRegions: Set<String>
+    get() = executions
+      .map { it.region }
+      .toSet()
+
+  private fun List<Map<String, Any>>?.canaryContext(): Map<String, Any> {
+    if (this.isNullOrEmpty()) {
+      return emptyMap()
+    }
+
+    val stage = find { it["refId"] == "canary" }
+      ?: return emptyMap()
+
+    @Suppress("UNCHECKED_CAST")
+    return stage.getOrDefault("context", emptyMap<String, Any>()) as Map<String, Any>
+  }
+}
+
+fun CanaryConstraint.toStageBase(
+  cloudDriverCache: CloudDriverCache,
+  storageAccount: String,
+  app: String,
+  control: Map<String, Any?>,
+  experiment: Map<String, Any?>
+): Map<String, Any> =
+  mapOf(
+    "type" to "kayentaCanary",
+    "user" to "Spinnaker",
+    "name" to "Canary Analysis",
+    "refId" to "canary",
+    "analysisType" to "realTimeAutomatic",
+    "canaryConfig" to mapOf(
+      "beginCanaryAnalysisAfterMins" to beginAnalysisAfter.toMinutes(),
+      "canaryAnalysisIntervalMins" to canaryAnalysisInterval.toMinutes(),
+      "canaryConfigId" to canaryConfigId,
+      "lifetimeDuration" to lifetime,
+      "metricsAccountName" to metricsAccountName,
+      "scopes" to listOf(
+        mapOf(
+          "extendedScopeParams" to mapOf(
+            "dataset" to "regional",
+            "type" to "asg",
+            "environment" to cloudDriverCache
+              .credentialBy(source.account)
+              .attributes
+              .getOrDefault("environment", "test")
+          )
+        )
+      ),
+      "scoreThresholds" to mapOf(
+        "marginal" to marginalScore,
+        "pass" to passScore
+      ),
+      "storageAccountName" to storageAccount
+    ),
+    "deployments" to mapOf(
+      "delayBeforeCleanup" to cleanupDelay,
+      "baseline" to mapOf(
+        "account" to source.account,
+        "cloudProvider" to source.cloudProvider,
+        "cluster" to source.cluster,
+        "application" to app
+      ),
+      "serverGroupPairs" to listOf(
+        mapOf(
+          "control" to control,
+          "experiment" to experiment
+        )
+      )
+    )
+  )

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -23,6 +23,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Headers
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface OrcaService {
@@ -46,6 +47,12 @@ interface OrcaService {
   @GET("/pipelines/{id}")
   suspend fun getPipelineExecution(@Path("id") id: String): ExecutionDetailResponse
 
+  @GET("/tasks/{id}")
+  suspend fun getOrchestrationExecution(@Path("id") id: String): ExecutionDetailResponse
+
+  @PUT("/tasks/{id}/cancel")
+  suspend fun cancelOrchestration(@Path("id") id: String)
+
   @GET("/executions/correlated/{correlationId}")
   suspend fun getCorrelatedExecutions(@Path("correlationId") correlationId: String): List<String>
 }
@@ -63,5 +70,10 @@ data class ExecutionDetailResponse(
   val buildTime: Instant,
   val startTime: Instant?,
   val endTime: Instant?,
-  val status: OrcaExecutionStatus
+  val status: OrcaExecutionStatus,
+  val execution: OrcaExecutionStages = OrcaExecutionStages(emptyList())
+)
+
+data class OrcaExecutionStages(
+  val stages: List<Map<String, Any>>?
 )

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
@@ -1,0 +1,415 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.CanaryConstraint
+import com.netflix.spinnaker.keel.api.CanaryConstraintAttributes
+import com.netflix.spinnaker.keel.api.CanarySource
+import com.netflix.spinnaker.keel.api.ConstraintStatus
+import com.netflix.spinnaker.keel.api.DebianArtifact
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.RegionalExecutionId
+import com.netflix.spinnaker.keel.api.randomUID
+import com.netflix.spinnaker.keel.events.Task
+import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStages
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.Runs
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import java.time.Clock
+import java.time.Duration
+import strikt.api.expectThat
+import strikt.assertions.all
+import strikt.assertions.contains
+import strikt.assertions.hasSize
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
+import strikt.assertions.isTrue
+
+internal class CanaryConstraintEvaluatorTests : JUnit5Minutests {
+
+  companion object {
+    val clock: Clock = Clock.systemUTC()
+    val deliveryConfigRepository = InMemoryDeliveryConfigRepository(clock)
+    val orcaService: OrcaService = mockk(relaxed = true)
+    val type: String = "canary"
+  }
+
+  private val defaultConstraint: CanaryConstraint = CanaryConstraint(
+    canaryConfigId = randomUID().toString(),
+    lifetime = Duration.ofMinutes(60),
+    marginalScore = 75,
+    passScore = 90,
+    source = CanarySource(
+      account = "test",
+      cloudProvider = "aws",
+      cluster = "fnord-prod"
+    ),
+    regions = setOf("us-west-1", "us-west-2"),
+    capacity = 1
+  )
+
+  private val defaultTargetEnvironment: Environment = Environment(
+    name = "prod",
+    resources = setOf(resource(spec = DummyResourceSpec())),
+    constraints = setOf(defaultConstraint)
+  )
+
+  data class Fixture(
+    val constraint: CanaryConstraint,
+    val artifact: DeliveryArtifact = DebianArtifact(name = "fnord"),
+    val version: String = "fnord-1.42.0",
+    val targetEnvironment: Environment,
+    val handlers: List<CanaryConstraintDeployHandler> = listOf(DummyCanaryConstraintDeployHandler())
+  ) {
+    val deliveryConfig: DeliveryConfig = DeliveryConfig(
+      name = "fnord-manifest",
+      application = "fnord",
+      environments = setOf(
+        Environment(
+          name = "test",
+          resources = setOf(resource(spec = DummyResourceSpec()))),
+        targetEnvironment
+      )
+    )
+
+    val judge = "canary:${deliveryConfig.application}:${targetEnvironment.name}:${constraint.canaryConfigId}"
+
+    val subject = CanaryConstraintEvaluator(
+      handlers = handlers,
+      orcaService = orcaService,
+      deliveryConfigRepository = deliveryConfigRepository,
+      clock = clock
+    )
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture(constraint = defaultConstraint, targetEnvironment = defaultTargetEnvironment)
+    }
+
+    context("promotion is gated on launching a canary and its status") {
+      before {
+        deliveryConfigRepository.store(deliveryConfig)
+      }
+
+      after {
+        clearMocks(orcaService)
+      }
+
+      test("first pass persists state and launches canaries") {
+        coEvery {
+          orcaService.getCorrelatedExecutions(any())
+        } returns emptyList()
+
+        expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+          .isFalse()
+
+        coVerify(exactly = 2) {
+          orcaService.getCorrelatedExecutions(any())
+        }
+
+        val state = deliveryConfigRepository.getConstraintState(
+          deliveryConfig.name,
+          targetEnvironment.name,
+          version,
+          type)
+
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.PENDING)
+            get { attributes }
+              .isA<CanaryConstraintAttributes>()
+              .and {
+                get { executions }.hasSize(2)
+                get { startAttempt }.isEqualTo(1)
+                // Canary status is only checked on post-launch constraint evals
+                get { status }.hasSize(0)
+              }
+          }
+      }
+
+      test("the next pass checks canary status") {
+        before {
+          clearMocks(orcaService)
+        }
+
+        coEvery {
+          orcaService.getOrchestrationExecution(any())
+        } returns ExecutionDetailResponse(
+          id = randomUID().toString(),
+          name = "fnord",
+          application = "fnord",
+          buildTime = clock.instant(),
+          startTime = clock.instant(),
+          endTime = null,
+          status = OrcaExecutionStatus.RUNNING
+        )
+
+        coEvery {
+          orcaService.getCorrelatedExecutions(any())
+        } returns listOf(randomUID().toString())
+
+        expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+          .isFalse()
+
+        coVerify(exactly = 2) {
+          orcaService.getOrchestrationExecution(any())
+          orcaService.getCorrelatedExecutions(any())
+        }
+
+        val state = deliveryConfigRepository.getConstraintState(
+          deliveryConfig.name,
+          targetEnvironment.name,
+          version,
+          type)
+
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.PENDING)
+            get { attributes }
+              .isA<CanaryConstraintAttributes>()
+              .and {
+                get { executions }.hasSize(2)
+                get { startAttempt }.isEqualTo(1)
+                get { status }
+                  .hasSize(2)
+                  .all {
+                    get { executionStatus }
+                      .isEqualTo(OrcaExecutionStatus.RUNNING.toString())
+                  }
+              }
+          }
+      }
+
+      test("promotion is allowed when all canaries pass") {
+        coEvery {
+          orcaService.getCorrelatedExecutions(any())
+        } returns emptyList()
+
+        coEvery {
+          orcaService.getOrchestrationExecution(any())
+        } returns ExecutionDetailResponse(
+          id = randomUID().toString(),
+          name = "fnord",
+          application = "fnord",
+          buildTime = clock.instant(),
+          startTime = clock.instant(),
+          endTime = clock.instant(),
+          status = OrcaExecutionStatus.SUCCEEDED,
+          execution = OrcaExecutionStages(
+            stages = listOf(
+              mapOf(
+                "refId" to "canary",
+                "context" to mapOf(
+                  "canaryScoreMessage" to "Final canary score 100.0 met or exceeded the pass score threshold."
+                )))))
+
+        expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+          .isTrue()
+
+        coVerify(exactly = 2) {
+          orcaService.getOrchestrationExecution(any())
+        }
+
+        coVerify(exactly = 0) {
+          orcaService.getCorrelatedExecutions(any())
+        }
+
+        val state = deliveryConfigRepository.getConstraintState(
+          deliveryConfig.name,
+          targetEnvironment.name,
+          version,
+          type)
+
+        expectThat(state!!.comment)
+          .isNotNull()
+          .contains("canary score 100.0")
+      }
+    }
+
+    context("the canary fails early in one region but is still running in another") {
+      val west1Id = randomUID().toString()
+      val west2Id = randomUID().toString()
+
+      before {
+        deliveryConfigRepository.dropAll()
+        deliveryConfigRepository.store(deliveryConfig)
+
+        coEvery {
+          orcaService.getCorrelatedExecutions(any())
+        } returns emptyList()
+
+        expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+          .isFalse()
+
+        coVerify(exactly = 2) {
+          orcaService.getCorrelatedExecutions(any())
+        }
+
+        val state = deliveryConfigRepository.getConstraintState(
+          deliveryConfig.name,
+          targetEnvironment.name,
+          version,
+          type)
+
+        var attributes = state!!.attributes!! as CanaryConstraintAttributes
+
+        attributes = attributes.copy(
+          executions = setOf(
+            RegionalExecutionId(region = "us-west-1", executionId = west1Id),
+            RegionalExecutionId(region = "us-west-2", executionId = west2Id)))
+
+        deliveryConfigRepository.storeConstraintState(state.copy(attributes = attributes))
+      }
+
+      test("one region failed, another is still running and is cancelled") {
+        coEvery {
+          orcaService.getCorrelatedExecutions("$judge:us-west-1")
+        } returns listOf(west1Id)
+
+        coEvery {
+          orcaService.getCorrelatedExecutions("$judge:us-west-2")
+        } returns emptyList()
+
+        coEvery {
+          orcaService.getOrchestrationExecution(west1Id)
+        } returns ExecutionDetailResponse(
+          id = west1Id,
+          name = "fnord",
+          application = "fnord",
+          buildTime = clock.instant(),
+          startTime = clock.instant(),
+          endTime = null,
+          status = OrcaExecutionStatus.RUNNING)
+
+        coEvery {
+          orcaService.getOrchestrationExecution(west2Id)
+        } returns ExecutionDetailResponse(
+          id = west2Id,
+          name = "fnord",
+          application = "fnord",
+          buildTime = clock.instant(),
+          startTime = clock.instant(),
+          endTime = clock.instant(),
+          status = OrcaExecutionStatus.TERMINAL)
+
+        coEvery {
+          orcaService.cancelOrchestration(any())
+        } just Runs
+
+        expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+          .isFalse()
+
+        coVerify(exactly = 1) {
+          orcaService.cancelOrchestration(west1Id)
+        }
+      }
+    }
+
+    context("orca task submissions fail") {
+      deriveFixture {
+        copy(handlers = listOf(FailCanaryConstraintDeployHandler()))
+      }
+
+      before {
+        deliveryConfigRepository.dropAll()
+        deliveryConfigRepository.store(deliveryConfig)
+      }
+
+      test("retryable failures increments start attempts and remains pending") {
+        coEvery {
+          orcaService.getCorrelatedExecutions(any())
+        } returns emptyList()
+
+        repeat(3) {
+          expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+            .isFalse()
+        }
+
+        val state = deliveryConfigRepository.getConstraintState(
+          deliveryConfig.name,
+          targetEnvironment.name,
+          version,
+          type)
+
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.PENDING)
+            get { attributes }
+              .isA<CanaryConstraintAttributes>()
+              .and {
+                get { executions }.hasSize(0)
+                get { startAttempt }.isEqualTo(3)
+              }
+          }
+      }
+
+      test("constraint fails when task launches fail and retries are exhausted") {
+        coEvery {
+          orcaService.getCorrelatedExecutions(any())
+        } returns emptyList()
+
+        repeat(4) {
+          expectThat(subject.canPromote(artifact, version, deliveryConfig, targetEnvironment))
+            .isFalse()
+        }
+
+        val state = deliveryConfigRepository.getConstraintState(
+          deliveryConfig.name,
+          targetEnvironment.name,
+          version,
+          type)
+
+        expectThat(state)
+          .isNotNull()
+          .and {
+            get { status }.isEqualTo(ConstraintStatus.FAIL)
+          }
+      }
+    }
+  }
+}
+
+class DummyCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
+  override val supportedClouds = setOf("aws", "ec2")
+
+  override fun deployCanary(
+    constraint: CanaryConstraint,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    regions: Set<String>
+  ): Map<String, Task> {
+    return regions.associateWith {
+      Task(id = randomUID().toString(), name = "Canary $version in region $it")
+    }
+  }
+}
+
+class FailCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
+  override val supportedClouds = setOf("aws", "ec2")
+
+  override fun deployCanary(
+    constraint: CanaryConstraint,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    regions: Set<String>
+  ): Map<String, Task> = emptyMap()
+}

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
@@ -389,7 +389,7 @@ internal class CanaryConstraintEvaluatorTests : JUnit5Minutests {
 class DummyCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
   override val supportedClouds = setOf("aws", "ec2")
 
-  override fun deployCanary(
+  override suspend fun deployCanary(
     constraint: CanaryConstraint,
     version: String,
     deliveryConfig: DeliveryConfig,
@@ -405,7 +405,7 @@ class DummyCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
 class FailCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
   override val supportedClouds = setOf("aws", "ec2")
 
-  override fun deployCanary(
+  override suspend fun deployCanary(
     constraint: CanaryConstraint,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
@@ -58,22 +58,41 @@ class TaskLauncher(
     correlationId: String,
     stages: List<Map<String, Any?>>
   ): Task =
+    submitJobToOrca(
+      serviceAccount = resource.serviceAccount,
+      application = resource.application,
+      notifications = resource.notifications,
+      subject = resource.id.value,
+      description = description,
+      correlationId = correlationId,
+      stages = stages
+    )
+
+  suspend fun submitJobToOrca(
+    serviceAccount: String,
+    application: String,
+    notifications: List<EchoNotification>,
+    subject: String,
+    description: String,
+    correlationId: String,
+    stages: List<Map<String, Any?>>
+  ): Task =
     orcaService
       .orchestrate(
-        resource.serviceAccount,
+        serviceAccount,
         OrchestrationRequest(
           name = description,
-          application = resource.application,
+          application = application,
           description = description,
           job = stages.map { Job(it["type"].toString(), it) },
           trigger = OrchestrationTrigger(
             correlationId = correlationId,
-            notifications = resource.notifications
+            notifications = notifications
           )
         )
       )
       .let {
-        log.info("Started task {} to upsert {}", it.ref, resource.id)
+        log.info("Started task {} to upsert {}", it.ref, subject)
         Task(id = it.taskId, name = description)
       }
 

--- a/keel-sql/src/main/resources/db/changelog/20191108-environment-artifact-constraint.yml
+++ b/keel-sql/src/main/resources/db/changelog/20191108-environment-artifact-constraint.yml
@@ -163,3 +163,16 @@ databaseChangeLog:
             columns:
               - column:
                   name: constraint_uid
+
+  - changeSet:
+      id: wider-envconstraint-columns
+      author: asher
+      changes:
+        - modifyDataType:
+            tableName: environment_artifact_constraint
+            columnName: judged_by
+            newDataType: varchar(512)
+        - modifyDataType:
+            tableName: environment_artifact_constraint
+            columnName: comment
+            newDataType: varchar(1024)


### PR DESCRIPTION
 An environment promotion constraint that deploys control (baseline) and experiment (canary)
 clusters which are evaluated by Kayenta using a constraint-provided canary config.

 When the constraint specifies a multi-region canary, the Kayenta ACA must pass in all
 regions for promotion to be allowed. Kayenta false positives can be overridden to
 allow promotion via the `DeliveryConfigController.updateConstraintStatus` REST method.

 Example constraint:
 ```
 constraints:
  - type: canary
    serviceAccount: "keel@keel.io" // Will soon move to the Delivery Config root
    canaryConfigId: b11b739d-7b1d-47c7-8430-d8ddffafb645 // Will later support named configs
    beginAnalysisAfter: PT3M
    canaryAnalysisInterval: PT10M
    lifetime: PT30M
    marginalScore: 50
    passScore: 90
    capacity: 1
    source:
      account: test
      cloudProvider: aws
      cluster: app-test-web
    regions:
      - us-east-1
      - us-west-2
 ```