### PR TITLE
feat(deliveryConfig): require delivery config, tie artifact to it

### DIFF
--- a/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
+++ b/keel-actuator/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersisterTests.kt
@@ -223,7 +223,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
 
         test("artifacts are persisted") {
           expectThat(artifactRepository.isRegistered("keel", DEB)).isTrue()
-          verify { publisher.publishEvent(ArtifactRegisteredEvent(DebianArtifact("keel"))) }
+          verify { publisher.publishEvent(ArtifactRegisteredEvent(DebianArtifact(name = "keel", deliveryConfigName = "keel-manifest"))) }
         }
 
         test("individual resources are persisted") {
@@ -239,7 +239,7 @@ internal class ResourcePersisterTests : JUnit5Minutests {
 
       context("a delivery config with existing artifacts and resources is persisted") {
         before {
-          val artifact = DebianArtifact(name = "keel")
+          val artifact = DebianArtifact(name = "keel", deliveryConfigName = "keel-manifest")
             .also {
               artifactRepository.register(it)
             }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -89,7 +89,7 @@ class ArtifactListener(
    * For each registered debian artifact, get the last version, and persist if it's newer than what we have.
    */
   // todo eb: should we fetch more than one version?
-  @Scheduled(initialDelay = 60000, fixedDelayString = "\${keel.artifact-refresh.frequency:PT6H}")
+  @Scheduled(fixedDelayString = "\${keel.artifact-refresh.frequency:PT6H}")
   fun syncArtifactVersions() =
     runBlocking {
       artifactRepository.getAll().forEach { artifact ->

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ArtifactSyncEvent
+import com.netflix.spinnaker.keel.exceptions.UnsupportedArtifactTypeException
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactVersionUpdated
 import com.netflix.spinnaker.kork.artifacts.model.Artifact
@@ -37,26 +38,25 @@ class ArtifactListener(
     event
       .artifacts
       .filter { it.type.toUpperCase() in artifactTypeNames }
-      .forEach { korkArtifact ->
-        if (artifactRepository.isRegistered(korkArtifact.name, korkArtifact.type())) {
-          val artifact = artifactRepository.get(korkArtifact.name, korkArtifact.type())
+      .forEach { artifact ->
+        if (artifactRepository.isRegistered(artifact.name, artifact.type())) {
           val version: String
           var status: ArtifactStatus? = null
-          when (artifact) {
-            is DebianArtifact -> {
-              version = "${korkArtifact.name}-${korkArtifact.version}"
-              status = debStatus(korkArtifact)
+          when (artifact.type()) {
+            DEB -> {
+              version = "${artifact.name}-${artifact.version}"
+              status = debStatus(artifact)
             }
-            is DockerArtifact -> {
-              version = korkArtifact.version
+            DOCKER -> {
+              version = artifact.version
             }
-            else -> throw UnsupportedArtifactTypeException(korkArtifact.type)
+            else -> throw UnsupportedArtifactTypeException(artifact.type)
           }
           log.info("Registering version {} ({}) of {} {}", version, status, artifact.name, artifact.type)
-          artifactRepository.store(artifact, version, status)
+          artifactRepository.store(artifact.name, artifact.type(), version, status)
             .also { wasAdded ->
               if (wasAdded) {
-                publisher.publishEvent(ArtifactVersionUpdated(artifact.name, artifact.type))
+                publisher.publishEvent(ArtifactVersionUpdated(artifact.name, artifact.type()))
               }
             }
         }
@@ -116,7 +116,7 @@ class ArtifactListener(
                 // todo eb: is there a better way to think of docker status?
                 DOCKER -> null
               }
-              artifactRepository.store(artifact, latestVersion, status)
+              artifactRepository.store(artifact.name, artifact.type, latestVersion, status)
             }
           }
         }
@@ -145,7 +145,7 @@ class ArtifactListener(
           val version = "${artifact.name}-$firstVersion"
           val status = debStatus(artifactService.getArtifact(artifact.name, firstVersion))
           log.debug("Storing latest version {} ({}) for registered artifact {}", version, status, artifact)
-          artifactRepository.store(artifact, version, status)
+          artifactRepository.store(artifact.name, artifact.type, version, status)
         }
     }
 
@@ -157,7 +157,7 @@ class ArtifactListener(
       getLatestDockerTag(artifact)
         ?.let { firstVersion ->
           log.debug("Storing latest version {} for registered artifact {}", firstVersion, artifact)
-          artifactRepository.store(artifact, firstVersion, null)
+          artifactRepository.store(artifact.name, artifact.type, firstVersion, null)
         }
     }
 

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -76,6 +76,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
       appVersion = "keel-0.161.0-h63.24d0843",
       regions = resource.spec.regions
     )
+
+    val artifact = DebianArtifact(name = "keel", deliveryConfigName = "delivery-config")
   }
 
   fun tests() = rootContext<Fixture> {
@@ -86,9 +88,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
     context("resolving desired and current state") {
       context("clouddriver has an image for the base AMI") {
         before {
-          val artifact = DebianArtifact("keel")
           artifactRepository.register(artifact)
-          artifactRepository.store(artifact, image.appVersion, FINAL)
+          artifactRepository.store(artifact.name, artifact.type, image.appVersion, FINAL)
 
           every {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
@@ -155,7 +156,6 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
       context("there are no known versions of the artifact") {
         before {
-          val artifact = DebianArtifact("keel")
           artifactRepository.register(artifact)
           every {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
@@ -172,9 +172,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
       context("there is only a version with the wrong status") {
         before {
-          val artifact = DebianArtifact("keel")
           artifactRepository.register(artifact)
-          artifactRepository.store(artifact, image.appVersion, FINAL)
+          artifactRepository.store(artifact.name, artifact.type, image.appVersion, FINAL)
           every {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
           } returns "xenialbase-x86_64-201904291721-ebs"
@@ -190,9 +189,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
       context("there is no cached base image") {
         before {
-          val artifact = DebianArtifact("keel")
           artifactRepository.register(artifact)
-          artifactRepository.store(artifact, image.appVersion, FINAL)
+          artifactRepository.store(artifact.name, artifact.type, image.appVersion, FINAL)
 
           every {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)
@@ -206,9 +204,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
       context("clouddriver can't find the base AMI") {
         before {
-          val artifact = DebianArtifact("keel")
           artifactRepository.register(artifact)
-          artifactRepository.store(artifact, image.appVersion, FINAL)
+          artifactRepository.store(artifact.name, artifact.type, image.appVersion, FINAL)
 
           every {
             baseImageCache.getBaseImage(resource.spec.baseOs, resource.spec.baseLabel)

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -210,7 +210,6 @@ class ImageServiceTests : JUnit5Minutests {
         }
       }
 
-      // todo eb: is this backwards now
       test("images are sorted by appversion, then creation date") {
         val sortedImages = listOf(image2, image3, image1, image5, image6).sortedWith(NamedImageComparator)
         val first = sortedImages[0]

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -40,15 +40,15 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
   data class Fixture<T : ArtifactRepository>(
     val subject: T
   ) {
-    val artifact1 = DebianArtifact("foo", statuses = listOf(SNAPSHOT))
-    val artifact2 = DebianArtifact("bar", statuses = listOf(SNAPSHOT))
-    val artifact3 = DockerArtifact("baz")
+    val artifact1 = DebianArtifact("foo", deliveryConfigName = "my-manifest", statuses = listOf(SNAPSHOT))
+    val artifact2 = DebianArtifact("bar", deliveryConfigName = "my-manifest", statuses = listOf(SNAPSHOT))
+    val artifact3 = DockerArtifact("baz", deliveryConfigName = "my-manifest")
     val environment1 = Environment("test")
     val environment2 = Environment("staging")
     val manifest = DeliveryConfig(
       name = "my-manifest",
       application = "fnord",
-      artifacts = setOf(artifact1, artifact2),
+      artifacts = setOf(artifact1, artifact2, artifact3),
       environments = setOf(environment1, environment2)
     )
     val version1 = "keeldemo-0.0.1~dev.8-h8.41595c4"
@@ -75,6 +75,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       setOf(version4, version5).forEach {
         store(artifact2, it, RELEASE)
       }
+      register(artifact3)
+      store(artifact3, version6, null)
     }
     persist(manifest)
   }
@@ -224,15 +226,23 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
           clock.incrementBy(Duration.ofHours(1))
           subject.approveVersionFor(manifest, artifact1, version1, environment1.name)
           subject.markAsDeployingTo(manifest, artifact1, version1, environment1.name)
+          subject.approveVersionFor(manifest, artifact3, version6, environment2.name)
+          subject.markAsDeployingTo(manifest, artifact3, version6, environment2.name)
         }
 
         test("the approved version for that environment matches") {
+          // debian
           expectThat(subject.latestVersionApprovedIn(manifest, artifact1, environment1.name))
             .isEqualTo(version1)
+          // docker
+          expectThat(subject.latestVersionApprovedIn(manifest, artifact3, environment2.name))
+            .isEqualTo(version6)
         }
 
         test("the version is not considered successfully deployed yet") {
           expectThat(subject.wasSuccessfullyDeployedTo(manifest, artifact1, version1, environment1.name))
+            .isFalse()
+          expectThat(subject.wasSuccessfullyDeployedTo(manifest, artifact3, version6, environment2.name))
             .isFalse()
         }
 
@@ -241,6 +251,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             get(ArtifactVersionStatus::pending).containsExactlyInAnyOrder(version2, version3)
             get(ArtifactVersionStatus::current).isNull()
             get(ArtifactVersionStatus::deploying).isEqualTo(version1)
+            get(ArtifactVersionStatus::previous).isEmpty()
+          }
+
+          expectThat(versionsIn(environment2, artifact3)) {
+            get(ArtifactVersionStatus::pending).isEmpty()
+            get(ArtifactVersionStatus::current).isNull()
+            get(ArtifactVersionStatus::deploying).isEqualTo(version6)
             get(ArtifactVersionStatus::previous).isEmpty()
           }
         }
@@ -266,10 +283,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         context("the version is marked as successfully deployed") {
           before {
             subject.markAsSuccessfullyDeployedTo(manifest, artifact1, version1, environment1.name)
+            subject.markAsSuccessfullyDeployedTo(manifest, artifact3, version6, environment2.name)
           }
 
           test("the version is now considered successfully deployed") {
             expectThat(subject.wasSuccessfullyDeployedTo(manifest, artifact1, version1, environment1.name))
+              .isTrue()
+            expectThat(subject.wasSuccessfullyDeployedTo(manifest, artifact3, version6, environment2.name))
               .isTrue()
           }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -427,7 +427,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     context("getting all filters by type") {
       before {
         persist()
-        subject.register(artifact3)
         subject.store(artifact1, version4, FINAL)
         subject.store(artifact3, version6, FINAL)
       }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -26,7 +26,6 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
-import strikt.assertions.isNotNull
 import strikt.assertions.succeeded
 
 abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : ResourceRepository, A : ArtifactRepository> :
@@ -168,7 +167,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         copy(
           deliveryConfig = deliveryConfig.copy(
             artifacts = setOf(
-              DebianArtifact(name = "keel")
+              DebianArtifact(name = "keel", deliveryConfigName = deliveryConfig.name)
             ),
             environments = setOf(
               Environment(
@@ -272,7 +271,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
 
           getEnvironment(resource)
             .succeeded()
-            .isNotNull()
             .isEqualTo(environment)
         }
 
@@ -281,7 +279,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
 
           getDeliveryConfig(resource)
             .succeeded()
-            .isNotNull()
             .isEqualTo(deliveryConfig)
         }
       }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -1,5 +1,8 @@
 package com.netflix.spinnaker.keel.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonProperty.Access
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -42,7 +45,7 @@ interface DeliveryArtifact {
 @JsonTypeName("deb")
 data class DebianArtifact(
   override val name: String,
-  override val deliveryConfigName: String? = null,
+  @JsonProperty(access = Access.WRITE_ONLY) override val deliveryConfigName: String? = null,
   override val reference: String = name,
   val statuses: List<ArtifactStatus> = emptyList(),
   override val versioningStrategy: VersioningStrategy = DebianSemVerVersioningStrategy
@@ -53,16 +56,17 @@ data class DebianArtifact(
 @JsonTypeName("docker")
 data class DockerArtifact(
   override val name: String,
-  override val deliveryConfigName: String? = null,
+  @JsonProperty(access = Access.WRITE_ONLY) override val deliveryConfigName: String? = null,
   override val reference: String = name,
   val tagVersionStrategy: TagVersionStrategy = SEMVER_TAG,
   val captureGroupRegex: String? = null,
-  override val versioningStrategy: VersioningStrategy = DockerVersioningStrategy(tagVersionStrategy, captureGroupRegex)
+  @JsonProperty(access = Access.WRITE_ONLY) override val versioningStrategy: VersioningStrategy = DockerVersioningStrategy(tagVersionStrategy, captureGroupRegex)
 ) : DeliveryArtifact {
   override val type = DOCKER
 
   val organization
-    get() = name.split("/").first()
+    @JsonIgnore get() = name.split("/").first()
+
   val image
-    get() = name.split("/").last()
+    @JsonIgnore get() = name.split("/").last()
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -35,11 +35,15 @@ interface DeliveryArtifact {
   val name: String
   val type: ArtifactType
   val versioningStrategy: VersioningStrategy
+  val reference: String // friendly reference to use within a delivery config
+  val deliveryConfigName: String? // the delivery config this artifact is a part of
 }
 
 @JsonTypeName("deb")
 data class DebianArtifact(
   override val name: String,
+  override val deliveryConfigName: String? = null,
+  override val reference: String = name,
   val statuses: List<ArtifactStatus> = emptyList(),
   override val versioningStrategy: VersioningStrategy = DebianSemVerVersioningStrategy
 ) : DeliveryArtifact {
@@ -49,9 +53,16 @@ data class DebianArtifact(
 @JsonTypeName("docker")
 data class DockerArtifact(
   override val name: String,
+  override val deliveryConfigName: String? = null,
+  override val reference: String = name,
   val tagVersionStrategy: TagVersionStrategy = SEMVER_TAG,
   val captureGroupRegex: String? = null,
   override val versioningStrategy: VersioningStrategy = DockerVersioningStrategy(tagVersionStrategy, captureGroupRegex)
 ) : DeliveryArtifact {
   override val type = DOCKER
+
+  val organization
+    get() = name.split("/").first()
+  val image
+    get() = name.split("/").last()
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/UnsupportedArtifactTypeException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/UnsupportedArtifactTypeException.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-package com.netflix.spinnaker.keel.artifact
+package com.netflix.spinnaker.keel.exceptions
 
 import com.netflix.spinnaker.keel.api.ArtifactType
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -23,15 +23,11 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
 
   /**
    * Retrieve the [Environment] a resource belongs to, by the resource [id].
-   *
-   * @return An [Environment] or `null` if the resource is not managed via an [Environment]
    */
   fun environmentFor(resourceId: ResourceId): Environment
 
   /**
    * Retrieve the [DeliveryConfig] a resource belongs to (the parent of its environment).
-   *
-   * @return A [DeliveryConfig] or `null` if the resource is not managed via a [DeliveryConfig].]
    */
   fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.persistence
 
+import com.netflix.spinnaker.keel.api.ArtifactType
 import com.netflix.spinnaker.keel.api.ConstraintState
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
@@ -21,24 +22,18 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun get(name: String): DeliveryConfig
 
   /**
-   * Check if the given application has a [DeliveryConfig].
-   * @return Boolean
-   */
-  fun hasDeliveryConfig(application: String): Boolean
-
-  /**
    * Retrieve the [Environment] a resource belongs to, by the resource [id].
    *
    * @return An [Environment] or `null` if the resource is not managed via an [Environment]
    */
-  fun environmentFor(resourceId: ResourceId): Environment?
+  fun environmentFor(resourceId: ResourceId): Environment
 
   /**
    * Retrieve the [DeliveryConfig] a resource belongs to (the parent of its environment).
    *
    * @return A [DeliveryConfig] or `null` if the resource is not managed via a [DeliveryConfig].]
    */
-  fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig?
+  fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig
 
   /**
    * @return All [DeliveryConfig] instances associated with [application], or an empty collection if
@@ -107,3 +102,8 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
 
 sealed class NoSuchDeliveryConfigException(message: String) : RuntimeException(message)
 class NoSuchDeliveryConfigName(name: String) : NoSuchDeliveryConfigException("No delivery config named $name exists in the repository")
+
+class NoMatchingArtifactException(deliveryConfigName: String, type: ArtifactType, reference: String) :
+  RuntimeException("No artifact with reference $reference and type $type found in delivery config $deliveryConfigName")
+
+class OrphanedResourceException(id: ResourceId) : RuntimeException("Resource $id exists without being a part of a delivery config")

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/ContainerProvider.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/ContainerProvider.kt
@@ -21,25 +21,29 @@ import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.netflix.spinnaker.keel.api.TagVersionStrategy
 
-@JsonDeserialize(using = ContainerDeserializer::class)
-sealed class Container(
-  open val organization: String,
-  open val image: String
-) {
+@JsonDeserialize(using = ContainerProviderDeserializer::class)
+sealed class ContainerProvider
+
+@JsonDeserialize(using = JsonDeserializer.None::class)
+data class ReferenceProvider(
+  val reference: String
+) : ContainerProvider()
+
+@JsonDeserialize(using = JsonDeserializer.None::class)
+data class DigestProvider(
+  val organization: String, // todo eb: should this be name = org/image instead, for consistency?
+  val image: String,
+  val digest: String
+) : ContainerProvider() {
   fun repository() = "$organization/$image"
 }
 
 @JsonDeserialize(using = JsonDeserializer.None::class)
-data class ContainerWithDigest(
-  override val organization: String,
-  override val image: String,
-  val digest: String
-) : Container(organization, image)
-
-@JsonDeserialize(using = JsonDeserializer.None::class)
-data class ContainerWithVersionedTag(
-  override val organization: String,
-  override val image: String,
+data class VersionedTagProvider(
+  val organization: String,
+  val image: String,
   val tagVersionStrategy: TagVersionStrategy,
   val captureGroupRegex: String? = null
-) : Container(organization, image)
+) : ContainerProvider() {
+  fun repository() = "$organization/$image"
+}

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/ContainerProviderDeserializer.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/ContainerProviderDeserializer.kt
@@ -19,11 +19,12 @@ package com.netflix.spinnaker.keel.docker
 
 import com.netflix.spinnaker.keel.serialization.PropertyNamePolymorphicDeserializer
 
-class ContainerDeserializer :
-  PropertyNamePolymorphicDeserializer<Container>(Container::class.java) {
-  override fun identifySubType(fieldNames: Collection<String>): Class<out Container> =
+class ContainerProviderDeserializer :
+  PropertyNamePolymorphicDeserializer<ContainerProvider>(ContainerProvider::class.java) {
+  override fun identifySubType(fieldNames: Collection<String>): Class<out ContainerProvider> =
     when {
-      "digest" in fieldNames -> ContainerWithDigest::class.java
-      else -> ContainerWithVersionedTag::class.java
+      "reference" in fieldNames -> ReferenceProvider::class.java
+      "tagVersionStrategy" in fieldNames -> VersionedTagProvider::class.java
+      else -> DigestProvider::class.java
     }
 }

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
@@ -41,7 +41,7 @@ class SampleDockerImageResolver(
   override fun getAccountFromSpec(resource: Resource<SampleSpecWithContainer>) =
     resource.spec.account
 
-  override fun updateContainerInSpec(resource: Resource<SampleSpecWithContainer>, container: Container) =
+  override fun updateContainerInSpec(resource: Resource<SampleSpecWithContainer>, container: ContainerProvider) =
     resource.copy(spec = resource.spec.copy(container = container))
 
   // this would normally call out to clouddriver
@@ -61,7 +61,7 @@ class SampleDockerImageResolver(
 }
 
 data class SampleSpecWithContainer(
-  val container: Container,
+  val container: ContainerProvider,
   val account: String
 ) : ResourceSpec {
   @JsonIgnore

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ImageProvider.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ImageProvider.kt
@@ -42,6 +42,14 @@ data class ArtifactImageProvider(
 ) : ImageProvider()
 
 /**
+ * Provides image id by referencing an artifact defined in the delivery config
+ */
+@JsonDeserialize(using = JsonDeserializer.None::class)
+data class ReferenceArtifactImageProvider(
+  val reference: String
+) : ImageProvider()
+
+/**
  * Provides an image by reference to a jenkins master, job, and job number
  */
 @JsonDeserialize(using = JsonDeserializer.None::class)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ImageProviderDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ImageProviderDeserializer.kt
@@ -21,12 +21,14 @@ import com.netflix.spinnaker.keel.api.InvalidPayload
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ImageProvider
 import com.netflix.spinnaker.keel.api.ec2.JenkinsImageProvider
+import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
 import com.netflix.spinnaker.keel.serialization.PropertyNamePolymorphicDeserializer
 
 internal class ImageProviderDeserializer :
   PropertyNamePolymorphicDeserializer<ImageProvider>(ImageProvider::class.java) {
   override fun identifySubType(fieldNames: Collection<String>): Class<out ImageProvider> =
     when {
+      "reference" in fieldNames -> ReferenceArtifactImageProvider::class.java
       "deliveryArtifact" in fieldNames -> ArtifactImageProvider::class.java
       "buildHost" in fieldNames -> JenkinsImageProvider::class.java
       else -> throw InvalidPayload("ImageProvider")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -62,88 +62,88 @@ internal class ImageResolverTests : JUnit5Minutests {
     val artifactRepository = InMemoryArtifactRepository()
     val imageService = mockk<ImageService>()
     private val subject = ImageResolver(
-        dynamicConfigService,
-        deliveryConfigRepository,
-        artifactRepository,
-        imageService
+      dynamicConfigService,
+      deliveryConfigRepository,
+      artifactRepository,
+      imageService
     )
     val images = listOf(
-        NamedImage(
-            imageName = "fnord-$version1",
-            attributes = mapOf(
-                "creationDate" to "2019-07-28T13:01:00.000Z"
-            ),
-            tagsByImageId = mapOf(
-                "ami-1" to mapOf("appversion" to "fnord-$version1", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
-            ),
-            accounts = setOf(account),
-            amis = mapOf(
-                imageRegion to listOf("ami-1")
-            )
+      NamedImage(
+        imageName = "fnord-$version1",
+        attributes = mapOf(
+          "creationDate" to "2019-07-28T13:01:00.000Z"
         ),
-        NamedImage(
-            imageName = "fnord-$version2",
-            attributes = mapOf(
-                "creationDate" to "2019-07-29T13:01:00.000Z"
-            ),
-            tagsByImageId = mapOf(
-                "ami-2" to mapOf("appversion" to "fnord-$version2", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
-            ),
-            accounts = setOf(account),
-            amis = mapOf(
-                imageRegion to listOf("ami-2")
-            )
+        tagsByImageId = mapOf(
+          "ami-1" to mapOf("appversion" to "fnord-$version1", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
         ),
-        NamedImage(
-            imageName = "fnord-$version3",
-            attributes = mapOf(
-                "creationDate" to "2019-07-30T13:01:00.000Z"
-            ),
-            tagsByImageId = mapOf(
-                "ami-3" to mapOf("appversion" to "fnord-$version3", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
-            ),
-            accounts = setOf(account),
-            amis = mapOf(
-                imageRegion to listOf("ami-3")
-            )
+        accounts = setOf(account),
+        amis = mapOf(
+          imageRegion to listOf("ami-1")
         )
+      ),
+      NamedImage(
+        imageName = "fnord-$version2",
+        attributes = mapOf(
+          "creationDate" to "2019-07-29T13:01:00.000Z"
+        ),
+        tagsByImageId = mapOf(
+          "ami-2" to mapOf("appversion" to "fnord-$version2", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
+        ),
+        accounts = setOf(account),
+        amis = mapOf(
+          imageRegion to listOf("ami-2")
+        )
+      ),
+      NamedImage(
+        imageName = "fnord-$version3",
+        attributes = mapOf(
+          "creationDate" to "2019-07-30T13:01:00.000Z"
+        ),
+        tagsByImageId = mapOf(
+          "ami-3" to mapOf("appversion" to "fnord-$version3", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
+        ),
+        accounts = setOf(account),
+        amis = mapOf(
+          imageRegion to listOf("ami-3")
+        )
+      )
     )
 
     val resource = resource(
-        apiVersion = SPINNAKER_EC2_API_V1,
-        kind = "cluster",
-        spec = ClusterSpec(
-            moniker = Moniker("fnord"),
-            imageProvider = imageProvider,
-            locations = SubnetAwareLocations(
-                account = account,
-                vpc = "vpc0",
-                subnet = "internal (vpc0)",
-                regions = setOf(
-                    SubnetAwareRegionSpec(
-                        name = resourceRegion,
-                        availabilityZones = setOf()
-                    )
-                )
-            ),
-            _defaults = ServerGroupSpec(
-                launchConfiguration = LaunchConfigurationSpec(
-                    instanceType = "m5.large",
-                    ebsOptimized = true,
-                    iamRole = "fnordIamRole",
-                    keyPair = "fnordKeyPair"
-                )
+      apiVersion = SPINNAKER_EC2_API_V1,
+      kind = "cluster",
+      spec = ClusterSpec(
+        moniker = Moniker("fnord"),
+        imageProvider = imageProvider,
+        locations = SubnetAwareLocations(
+          account = account,
+          vpc = "vpc0",
+          subnet = "internal (vpc0)",
+          regions = setOf(
+            SubnetAwareRegionSpec(
+              name = resourceRegion,
+              availabilityZones = setOf()
             )
+          )
+        ),
+        _defaults = ServerGroupSpec(
+          launchConfiguration = LaunchConfigurationSpec(
+            instanceType = "m5.large",
+            ebsOptimized = true,
+            iamRole = "fnordIamRole",
+            keyPair = "fnordKeyPair"
+          )
         )
+      )
     )
 
     val deliveryConfig = DeliveryConfig(
-        "my-manifest",
-        "fnord",
-        setOf(artifact),
-        setOf(
-            Environment(name = "test", resources = setOf(resource))
-        )
+      "my-manifest",
+      "fnord",
+      setOf(artifact),
+      setOf(
+        Environment(name = "test", resources = setOf(resource))
+      )
     )
 
     fun resolve(): Resource<ClusterSpec> = runBlocking {
@@ -157,7 +157,7 @@ internal class ImageResolverTests : JUnit5Minutests {
 
       test("returns the original spec unchanged") {
         expectThat(resolve())
-            .propertiesAreEqualTo(resource)
+          .propertiesAreEqualTo(resource)
       }
     }
 
@@ -165,7 +165,7 @@ internal class ImageResolverTests : JUnit5Minutests {
       val artifact = DebianArtifact(name = "fnord", deliveryConfigName = "my-manifest", statuses = listOf(RELEASE))
       fixture {
         Fixture(
-            ArtifactImageProvider(artifact, listOf(RELEASE))
+          ArtifactImageProvider(artifact, listOf(RELEASE))
         )
       }
 
@@ -197,11 +197,11 @@ internal class ImageResolverTests : JUnit5Minutests {
           test("returns the image id of the approved version") {
             val resolved = resolve()
             expectThat(resolved.spec.overrides[imageRegion]?.launchConfiguration?.image)
-                .isNotNull()
-                .and {
-                  get { appVersion }.isEqualTo("fnord-$version2")
-                  get { id }.isEqualTo("ami-2") // TODO: false moniker
-                }
+              .isNotNull()
+              .and {
+                get { appVersion }.isEqualTo("fnord-$version2")
+                get { id }.isEqualTo("ami-2") // TODO: false moniker
+              }
           }
         }
 
@@ -212,8 +212,8 @@ internal class ImageResolverTests : JUnit5Minutests {
           }
           test("throws an exception") {
             expectCatching { resolve() }
-                .failed()
-                .isA<NoImageSatisfiesConstraints>()
+              .failed()
+              .isA<NoImageSatisfiesConstraints>()
           }
         }
 
@@ -225,8 +225,8 @@ internal class ImageResolverTests : JUnit5Minutests {
           }
           test("throws an exception") {
             expectCatching { resolve() }
-                .failed()
-                .isA<NoImageSatisfiesConstraints>()
+              .failed()
+              .isA<NoImageSatisfiesConstraints>()
           }
         }
 
@@ -246,8 +246,8 @@ internal class ImageResolverTests : JUnit5Minutests {
 
           test("throws an exception") {
             expectCatching { resolve() }
-                .failed()
-                .isA<NoImageFoundForRegions>()
+              .failed()
+              .isA<NoImageFoundForRegions>()
           }
         }
 
@@ -282,8 +282,8 @@ internal class ImageResolverTests : JUnit5Minutests {
 
           test("throws an exception") {
             expectCatching { resolve() }
-                .failed()
-                .isA<NoImageFoundForRegions>()
+              .failed()
+              .isA<NoImageFoundForRegions>()
           }
         }
       }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -58,15 +58,15 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
     every { environmentFor(any()) } returns Environment("test")
   }
   private val taskLauncher = TaskLauncher(
-      orcaService,
-      deliveryConfigRepository
+    orcaService,
+    deliveryConfigRepository
   )
   private val mapper = ObjectMapper().registerKotlinModule()
   private val yamlMapper = configuredYamlMapper()
 
   private val normalizers: List<Resolver<*>> = listOf(
-      ApplicationLoadBalancerDefaultsResolver(),
-      ApplicationLoadBalancerNetworkResolver(cloudDriverCache))
+    ApplicationLoadBalancerDefaultsResolver(),
+    ApplicationLoadBalancerNetworkResolver(cloudDriverCache))
 
   private val yaml = """
     |---
@@ -93,9 +93,9 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
 
   private val spec = yamlMapper.readValue(yaml, ApplicationLoadBalancerSpec::class.java)
   private val resource = resource(
-      apiVersion = SPINNAKER_EC2_API_V1,
-      kind = "application-load-balancer",
-      spec = spec
+    apiVersion = SPINNAKER_EC2_API_V1,
+    kind = "application-load-balancer",
+    spec = spec
   )
 
   private val vpc = Network(CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
@@ -104,67 +104,67 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val sg1 = SecurityGroupSummary("testapp-elb", "sg-55555", "vpc-1")
 
   private val model = ApplicationLoadBalancerModel(
-      moniker = null,
-      loadBalancerName = "testapp-managedogge-wow",
-      availabilityZones = setOf("us-east-1c", "us-east-1d"),
-      vpcId = vpc.id,
-      subnets = setOf(sub1.id, sub2.id),
-      securityGroups = setOf(sg1.id),
-      scheme = "internal",
-      idleTimeout = 60,
-      ipAddressType = "ipv4",
-      listeners = listOf(
-          ApplicationLoadBalancerListener(
-              port = 80,
-              protocol = "HTTP",
-              certificates = null,
-              rules = emptyList(),
-              defaultActions = listOf(
-                  Action(
-                      order = 1,
-                      targetGroupName = "managedogge-wow-tg",
-                      type = "forward",
-                      redirectConfig = null)
-              )
-          )
-      ),
-      targetGroups = listOf(
-          TargetGroup(
-              targetGroupName = "managedogge-wow-tg",
-              loadBalancerNames = listOf("testapp-managedogge-wow"),
-              targetType = "instance",
-              matcher = TargetGroupMatcher(httpCode = "200-299"),
-              port = 7001,
-              protocol = "HTTP",
-              healthCheckEnabled = true,
-              healthCheckTimeoutSeconds = 5,
-              healthCheckPort = 7001,
-              healthCheckProtocol = "HTTP",
-              healthCheckPath = "/healthcheck",
-              healthCheckIntervalSeconds = 10,
-              healthyThresholdCount = 10,
-              unhealthyThresholdCount = 2,
-              vpcId = vpc.id,
-              attributes = TargetGroupAttributes(
-                  stickinessEnabled = false,
-                  deregistrationDelay = 300,
-                  stickinessType = "lb_cookie",
-                  stickinessDuration = 86400,
-                  slowStartDurationSeconds = 0
-              )
-          )
+    moniker = null,
+    loadBalancerName = "testapp-managedogge-wow",
+    availabilityZones = setOf("us-east-1c", "us-east-1d"),
+    vpcId = vpc.id,
+    subnets = setOf(sub1.id, sub2.id),
+    securityGroups = setOf(sg1.id),
+    scheme = "internal",
+    idleTimeout = 60,
+    ipAddressType = "ipv4",
+    listeners = listOf(
+      ApplicationLoadBalancerListener(
+        port = 80,
+        protocol = "HTTP",
+        certificates = null,
+        rules = emptyList(),
+        defaultActions = listOf(
+          Action(
+            order = 1,
+            targetGroupName = "managedogge-wow-tg",
+            type = "forward",
+            redirectConfig = null)
+        )
       )
+    ),
+    targetGroups = listOf(
+      TargetGroup(
+        targetGroupName = "managedogge-wow-tg",
+        loadBalancerNames = listOf("testapp-managedogge-wow"),
+        targetType = "instance",
+        matcher = TargetGroupMatcher(httpCode = "200-299"),
+        port = 7001,
+        protocol = "HTTP",
+        healthCheckEnabled = true,
+        healthCheckTimeoutSeconds = 5,
+        healthCheckPort = 7001,
+        healthCheckProtocol = "HTTP",
+        healthCheckPath = "/healthcheck",
+        healthCheckIntervalSeconds = 10,
+        healthyThresholdCount = 10,
+        unhealthyThresholdCount = 2,
+        vpcId = vpc.id,
+        attributes = TargetGroupAttributes(
+          stickinessEnabled = false,
+          deregistrationDelay = 300,
+          stickinessType = "lb_cookie",
+          stickinessDuration = 86400,
+          slowStartDurationSeconds = 0
+        )
+      )
+    )
   )
 
   fun tests() = rootContext<ApplicationLoadBalancerHandler> {
     fixture {
       ApplicationLoadBalancerHandler(
-          cloudDriverService,
-          cloudDriverCache,
-          orcaService,
-          taskLauncher,
-          mapper,
-          normalizers
+        cloudDriverService,
+        cloudDriverCache,
+        orcaService,
+        taskLauncher,
+        mapper,
+        normalizers
       )
     }
 
@@ -231,28 +231,28 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
 
       test("export generates a valid spec for the deployed ALB") {
         val exportable = Exportable(
-            cloudProvider = "aws",
-            account = "test",
-            serviceAccount = "keel@spin.spin.spin",
-            moniker = parseMoniker("testapp-managedogge-wow"),
-            regions = setOf("us-east-1"),
-            kind = supportedKind.kind
+          cloudProvider = "aws",
+          account = "test",
+          serviceAccount = "keel@spin.spin.spin",
+          moniker = parseMoniker("testapp-managedogge-wow"),
+          regions = setOf("us-east-1"),
+          kind = supportedKind.kind
         )
         val export = runBlocking {
           export(exportable)
         }
         expectThat(export.kind)
-            .isEqualTo("application-load-balancer")
+          .isEqualTo("application-load-balancer")
 
         runBlocking {
           // Export differs from the model prior to the application of resolvers
           val unresolvedDiff = ResourceDiff(resource, resource.copy(spec = export.spec))
           expectThat(unresolvedDiff.hasChanges())
-              .isTrue()
+            .isTrue()
           // But diffs cleanly after resolvers are applied
           val resolvedDiff = ResourceDiff(desired(resource), desired(normalize(export)))
           expectThat(resolvedDiff.hasChanges())
-              .isFalse()
+            .isFalse()
         }
       }
     }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
@@ -39,7 +40,6 @@ import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import java.time.Clock
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
@@ -53,17 +53,20 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverService = mockk<CloudDriverService>()
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
-  private val clock = Clock.systemDefaultZone()
+  private val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk() {
+    // we're just using this to get notifications
+    every { environmentFor(any()) } returns Environment("test")
+  }
   private val taskLauncher = TaskLauncher(
-    orcaService,
-    InMemoryDeliveryConfigRepository(clock)
+      orcaService,
+      deliveryConfigRepository
   )
   private val mapper = ObjectMapper().registerKotlinModule()
   private val yamlMapper = configuredYamlMapper()
 
   private val normalizers: List<Resolver<*>> = listOf(
-    ApplicationLoadBalancerDefaultsResolver(),
-    ApplicationLoadBalancerNetworkResolver(cloudDriverCache))
+      ApplicationLoadBalancerDefaultsResolver(),
+      ApplicationLoadBalancerNetworkResolver(cloudDriverCache))
 
   private val yaml = """
     |---
@@ -90,9 +93,9 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
 
   private val spec = yamlMapper.readValue(yaml, ApplicationLoadBalancerSpec::class.java)
   private val resource = resource(
-    apiVersion = SPINNAKER_EC2_API_V1,
-    kind = "application-load-balancer",
-    spec = spec
+      apiVersion = SPINNAKER_EC2_API_V1,
+      kind = "application-load-balancer",
+      spec = spec
   )
 
   private val vpc = Network(CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
@@ -101,67 +104,67 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val sg1 = SecurityGroupSummary("testapp-elb", "sg-55555", "vpc-1")
 
   private val model = ApplicationLoadBalancerModel(
-    moniker = null,
-    loadBalancerName = "testapp-managedogge-wow",
-    availabilityZones = setOf("us-east-1c", "us-east-1d"),
-    vpcId = vpc.id,
-    subnets = setOf(sub1.id, sub2.id),
-    securityGroups = setOf(sg1.id),
-    scheme = "internal",
-    idleTimeout = 60,
-    ipAddressType = "ipv4",
-    listeners = listOf(
-      ApplicationLoadBalancerListener(
-        port = 80,
-        protocol = "HTTP",
-        certificates = null,
-        rules = emptyList(),
-        defaultActions = listOf(
-          Action(
-            order = 1,
-            targetGroupName = "managedogge-wow-tg",
-            type = "forward",
-            redirectConfig = null)
-        )
+      moniker = null,
+      loadBalancerName = "testapp-managedogge-wow",
+      availabilityZones = setOf("us-east-1c", "us-east-1d"),
+      vpcId = vpc.id,
+      subnets = setOf(sub1.id, sub2.id),
+      securityGroups = setOf(sg1.id),
+      scheme = "internal",
+      idleTimeout = 60,
+      ipAddressType = "ipv4",
+      listeners = listOf(
+          ApplicationLoadBalancerListener(
+              port = 80,
+              protocol = "HTTP",
+              certificates = null,
+              rules = emptyList(),
+              defaultActions = listOf(
+                  Action(
+                      order = 1,
+                      targetGroupName = "managedogge-wow-tg",
+                      type = "forward",
+                      redirectConfig = null)
+              )
+          )
+      ),
+      targetGroups = listOf(
+          TargetGroup(
+              targetGroupName = "managedogge-wow-tg",
+              loadBalancerNames = listOf("testapp-managedogge-wow"),
+              targetType = "instance",
+              matcher = TargetGroupMatcher(httpCode = "200-299"),
+              port = 7001,
+              protocol = "HTTP",
+              healthCheckEnabled = true,
+              healthCheckTimeoutSeconds = 5,
+              healthCheckPort = 7001,
+              healthCheckProtocol = "HTTP",
+              healthCheckPath = "/healthcheck",
+              healthCheckIntervalSeconds = 10,
+              healthyThresholdCount = 10,
+              unhealthyThresholdCount = 2,
+              vpcId = vpc.id,
+              attributes = TargetGroupAttributes(
+                  stickinessEnabled = false,
+                  deregistrationDelay = 300,
+                  stickinessType = "lb_cookie",
+                  stickinessDuration = 86400,
+                  slowStartDurationSeconds = 0
+              )
+          )
       )
-    ),
-    targetGroups = listOf(
-      TargetGroup(
-        targetGroupName = "managedogge-wow-tg",
-        loadBalancerNames = listOf("testapp-managedogge-wow"),
-        targetType = "instance",
-        matcher = TargetGroupMatcher(httpCode = "200-299"),
-        port = 7001,
-        protocol = "HTTP",
-        healthCheckEnabled = true,
-        healthCheckTimeoutSeconds = 5,
-        healthCheckPort = 7001,
-        healthCheckProtocol = "HTTP",
-        healthCheckPath = "/healthcheck",
-        healthCheckIntervalSeconds = 10,
-        healthyThresholdCount = 10,
-        unhealthyThresholdCount = 2,
-        vpcId = vpc.id,
-        attributes = TargetGroupAttributes(
-          stickinessEnabled = false,
-          deregistrationDelay = 300,
-          stickinessType = "lb_cookie",
-          stickinessDuration = 86400,
-          slowStartDurationSeconds = 0
-        )
-      )
-    )
   )
 
   fun tests() = rootContext<ApplicationLoadBalancerHandler> {
     fixture {
       ApplicationLoadBalancerHandler(
-        cloudDriverService,
-        cloudDriverCache,
-        orcaService,
-        taskLauncher,
-        mapper,
-        normalizers
+          cloudDriverService,
+          cloudDriverCache,
+          orcaService,
+          taskLauncher,
+          mapper,
+          normalizers
       )
     }
 
@@ -228,28 +231,28 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
 
       test("export generates a valid spec for the deployed ALB") {
         val exportable = Exportable(
-          cloudProvider = "aws",
-          account = "test",
-          serviceAccount = "keel@spin.spin.spin",
-          moniker = parseMoniker("testapp-managedogge-wow"),
-          regions = setOf("us-east-1"),
-          kind = supportedKind.kind
+            cloudProvider = "aws",
+            account = "test",
+            serviceAccount = "keel@spin.spin.spin",
+            moniker = parseMoniker("testapp-managedogge-wow"),
+            regions = setOf("us-east-1"),
+            kind = supportedKind.kind
         )
         val export = runBlocking {
           export(exportable)
         }
         expectThat(export.kind)
-          .isEqualTo("application-load-balancer")
+            .isEqualTo("application-load-balancer")
 
         runBlocking {
           // Export differs from the model prior to the application of resolvers
           val unresolvedDiff = ResourceDiff(resource, resource.copy(spec = export.spec))
           expectThat(unresolvedDiff.hasChanges())
-            .isTrue()
+              .isTrue()
           // But diffs cleanly after resolvers are applied
           val resolvedDiff = ResourceDiff(desired(resource), desired(normalize(export)))
           expectThat(resolvedDiff.hasChanges())
-            .isFalse()
+              .isFalse()
         }
       }
     }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -68,15 +68,15 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
     every { environmentFor(any()) } returns Environment("test")
   }
   private val taskLauncher = TaskLauncher(
-      orcaService,
-      deliveryConfigRepository
+    orcaService,
+    deliveryConfigRepository
   )
   private val mapper = ObjectMapper().registerKotlinModule()
   private val yamlMapper = configuredYamlMapper()
 
   private val normalizers: List<Resolver<*>> = listOf(
-      ClassicLoadBalancerSecurityGroupsResolver(),
-      ClassicLoadBalancerNetworkResolver(cloudDriverCache))
+    ClassicLoadBalancerSecurityGroupsResolver(),
+    ClassicLoadBalancerNetworkResolver(cloudDriverCache))
 
   private val yaml = """
     |---
@@ -104,9 +104,9 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
 
   private val spec = yamlMapper.readValue(yaml, ClassicLoadBalancerSpec::class.java)
   private val resource = resource(
-      apiVersion = SPINNAKER_EC2_API_V1,
-      kind = "classic-load-balancer",
-      spec = spec
+    apiVersion = SPINNAKER_EC2_API_V1,
+    kind = "classic-load-balancer",
+    spec = spec
   )
 
   private val vpc = Network(CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
@@ -119,43 +119,43 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
   private val listener = spec.listeners.first()
 
   private val model = ClassicLoadBalancerModel(
-      loadBalancerName = spec.moniker.name,
-      availabilityZones = spec.locations.regions.first().availabilityZones,
-      vpcId = vpc.id,
-      subnets = setOf(sub1.id, sub2.id),
-      scheme = "internal",
-      securityGroups = setOf(sg1.id),
-      listenerDescriptions = listOf(
-          ClassicLoadBalancerListenerDescription(
-              ClassicLoadBalancerListener(
-                  protocol = listener.externalProtocol,
-                  loadBalancerPort = listener.externalPort,
-                  instanceProtocol = listener.internalProtocol,
-                  instancePort = listener.internalPort,
-                  sslcertificateId = null
-              )
-          )
-      ),
-      healthCheck = ClassicLoadBalancerHealthCheck(
-          target = spec.healthCheck.target,
-          interval = 10,
-          timeout = 5,
-          healthyThreshold = 5,
-          unhealthyThreshold = 2
-      ),
-      idleTimeout = 60,
-      moniker = null
+    loadBalancerName = spec.moniker.name,
+    availabilityZones = spec.locations.regions.first().availabilityZones,
+    vpcId = vpc.id,
+    subnets = setOf(sub1.id, sub2.id),
+    scheme = "internal",
+    securityGroups = setOf(sg1.id),
+    listenerDescriptions = listOf(
+      ClassicLoadBalancerListenerDescription(
+        ClassicLoadBalancerListener(
+          protocol = listener.externalProtocol,
+          loadBalancerPort = listener.externalPort,
+          instanceProtocol = listener.internalProtocol,
+          instancePort = listener.internalPort,
+          sslcertificateId = null
+        )
+      )
+    ),
+    healthCheck = ClassicLoadBalancerHealthCheck(
+      target = spec.healthCheck.target,
+      interval = 10,
+      timeout = 5,
+      healthyThreshold = 5,
+      unhealthyThreshold = 2
+    ),
+    idleTimeout = 60,
+    moniker = null
   )
 
   fun tests() = rootContext<ClassicLoadBalancerHandler> {
     fixture {
       ClassicLoadBalancerHandler(
-          cloudDriverService,
-          cloudDriverCache,
-          orcaService,
-          taskLauncher,
-          mapper,
-          normalizers
+        cloudDriverService,
+        cloudDriverCache,
+        orcaService,
+        taskLauncher,
+        mapper,
+        normalizers
       )
     }
 
@@ -255,15 +255,15 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
         }
 
         expectThat(diff.diff)
-            .and {
-              childCount().isEqualTo(1)
-              getChild(MapKeyElementSelector("us-east-1"), BeanPropertyElementSelector("dependencies"), BeanPropertyElementSelector("securityGroupNames"))
-                  .isNotNull()
-                  .and {
-                    state.isEqualTo(CHANGED)
-                    getChild(CollectionItemElementSelector("testapp-elb")).isNotNull().state.isEqualTo(REMOVED)
-                  }
-            }
+          .and {
+            childCount().isEqualTo(1)
+            getChild(MapKeyElementSelector("us-east-1"), BeanPropertyElementSelector("dependencies"), BeanPropertyElementSelector("securityGroupNames"))
+              .isNotNull()
+              .and {
+                state.isEqualTo(CHANGED)
+                getChild(CollectionItemElementSelector("testapp-elb")).isNotNull().state.isEqualTo(REMOVED)
+              }
+          }
 
         runBlocking {
           upsert(newResource, diff)
@@ -275,28 +275,28 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
 
       test("export generates a valid spec for the deployed CLB") {
         val exportable = Exportable(
-            cloudProvider = "aws",
-            account = "test",
-            serviceAccount = "keel@spin.spin.spin",
-            moniker = parseMoniker("testapp-managedogge-wow"),
-            regions = setOf("us-east-1"),
-            kind = supportedKind.kind
+          cloudProvider = "aws",
+          account = "test",
+          serviceAccount = "keel@spin.spin.spin",
+          moniker = parseMoniker("testapp-managedogge-wow"),
+          regions = setOf("us-east-1"),
+          kind = supportedKind.kind
         )
         val export = runBlocking {
           export(exportable)
         }
         expectThat(export.kind)
-            .isEqualTo("classic-load-balancer")
+          .isEqualTo("classic-load-balancer")
 
         runBlocking {
           // Export differs from the model prior to the application of resolvers
           val unresolvedDiff = ResourceDiff(resource, resource.copy(spec = export.spec))
           expectThat(unresolvedDiff.hasChanges())
-              .isTrue()
+            .isTrue()
           // But diffs cleanly after resolvers are applied
           val resolvedDiff = ResourceDiff(desired(resource), desired(normalize(export)))
           expectThat(resolvedDiff.hasChanges())
-              .isFalse()
+            .isFalse()
         }
       }
     }
@@ -304,17 +304,17 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
 }
 
 fun Assertion.Builder<DiffNode>.childCount(): Assertion.Builder<Int> =
-    get("child count") { childCount() }
+  get("child count") { childCount() }
 
 fun Assertion.Builder<DiffNode>.getChild(propertyName: String): Assertion.Builder<DiffNode?> =
-    get("child node with property name $propertyName") {
-      getChild(propertyName)
-    }
+  get("child node with property name $propertyName") {
+    getChild(propertyName)
+  }
 
 fun Assertion.Builder<DiffNode>.getChild(vararg selectors: ElementSelector): Assertion.Builder<DiffNode?> =
-    get("child node with path $path") {
-      getChild(selectors.toList())
-    }
+  get("child node with path $path") {
+    getChild(selectors.toList())
+  }
 
 val Assertion.Builder<DiffNode>.path: Assertion.Builder<NodePath>
   get() = get("path") { path }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -101,8 +101,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk()
   val taskLauncher = TaskLauncher(
-      orcaService,
-      deliveryConfigRepository
+    orcaService,
+    deliveryConfigRepository
   )
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
@@ -121,49 +121,49 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val targetTrackingPolicyName = "keel-test-target-tracking-policy"
 
   val spec = ClusterSpec(
-      moniker = Moniker(app = "keel", stack = "test"),
-      locations = SubnetAwareLocations(
-          account = vpcWest.account,
-          vpc = "vpc0",
-          subnet = subnet1West.purpose!!,
-          regions = listOf(vpcWest, vpcEast).map { subnet ->
-            SubnetAwareRegionSpec(
-                name = subnet.region,
-                availabilityZones = listOf("a", "b", "c").map { "${subnet.region}$it" }.toSet()
-            )
-          }.toSet()
+    moniker = Moniker(app = "keel", stack = "test"),
+    locations = SubnetAwareLocations(
+      account = vpcWest.account,
+      vpc = "vpc0",
+      subnet = subnet1West.purpose!!,
+      regions = listOf(vpcWest, vpcEast).map { subnet ->
+        SubnetAwareRegionSpec(
+          name = subnet.region,
+          availabilityZones = listOf("a", "b", "c").map { "${subnet.region}$it" }.toSet()
+        )
+      }.toSet()
+    ),
+    _defaults = ServerGroupSpec(
+      launchConfiguration = LaunchConfigurationSpec(
+        image = VirtualMachineImage(
+          id = "ami-123543254134",
+          appVersion = "keel-0.287.0-h208.fe2e8a1",
+          baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+        ),
+        instanceType = "r4.8xlarge",
+        ebsOptimized = false,
+        iamRole = LaunchConfiguration.defaultIamRoleFor("keel"),
+        keyPair = "nf-keypair-test-fake",
+        instanceMonitoring = false
       ),
-      _defaults = ServerGroupSpec(
-          launchConfiguration = LaunchConfigurationSpec(
-              image = VirtualMachineImage(
-                  id = "ami-123543254134",
-                  appVersion = "keel-0.287.0-h208.fe2e8a1",
-                  baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
-              ),
-              instanceType = "r4.8xlarge",
-              ebsOptimized = false,
-              iamRole = LaunchConfiguration.defaultIamRoleFor("keel"),
-              keyPair = "nf-keypair-test-fake",
-              instanceMonitoring = false
-          ),
-          capacity = Capacity(1, 6),
-          scaling = Scaling(
-              targetTrackingPolicies = setOf(TargetTrackingPolicy(
-                  name = targetTrackingPolicyName,
-                  targetValue = 560.0,
-                  disableScaleIn = true,
-                  customMetricSpec = CustomizedMetricSpecification(
-                      name = "RPS per instance",
-                      namespace = "SPIN/ACH",
-                      statistic = "Average"
-                  )
-              ))
-          ),
-          dependencies = ClusterDependencies(
-              loadBalancerNames = setOf("keel-test-frontend"),
-              securityGroupNames = setOf(sg1West.name, sg2West.name)
+      capacity = Capacity(1, 6),
+      scaling = Scaling(
+        targetTrackingPolicies = setOf(TargetTrackingPolicy(
+          name = targetTrackingPolicyName,
+          targetValue = 560.0,
+          disableScaleIn = true,
+          customMetricSpec = CustomizedMetricSpecification(
+            name = "RPS per instance",
+            namespace = "SPIN/ACH",
+            statistic = "Average"
           )
+        ))
+      ),
+      dependencies = ClusterDependencies(
+        loadBalancerNames = setOf("keel-test-frontend"),
+        securityGroupNames = setOf(sg1West.name, sg2West.name)
       )
+    )
   )
 
   val serverGroups = spec.resolve()
@@ -171,21 +171,21 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val serverGroupWest = serverGroups.first { it.location.region == "us-west-2" }
 
   val resource = resource(
-      apiVersion = SPINNAKER_API_V1,
-      kind = "cluster",
-      spec = spec
+    apiVersion = SPINNAKER_API_V1,
+    kind = "cluster",
+    spec = spec
   )
 
   val activeServerGroupResponseEast = serverGroupEast.toCloudDriverResponse(vpcEast, listOf(subnet1East, subnet2East, subnet3East), listOf(sg1East, sg2East))
   val activeServerGroupResponseWest = serverGroupWest.toCloudDriverResponse(vpcWest, listOf(subnet1West, subnet2West, subnet3West), listOf(sg1West, sg2West))
 
   val exportable = Exportable(
-      cloudProvider = "aws",
-      account = spec.locations.account,
-      serviceAccount = "keel@spinnaker",
-      moniker = spec.moniker,
-      regions = spec.locations.regions.map { it.name }.toSet(),
-      kind = "cluster"
+    cloudProvider = "aws",
+    account = spec.locations.account,
+    serviceAccount = "keel@spinnaker",
+    moniker = spec.moniker,
+    regions = spec.locations.regions.map { it.name }.toSet(),
+    kind = "cluster"
   )
 
   private fun ServerGroup.toCloudDriverResponse(
@@ -193,92 +193,92 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     subnets: List<Subnet>,
     securityGroups: List<SecurityGroupSummary>
   ): ActiveServerGroup =
-      randomNumeric(3).padStart(3, '0').let { sequence ->
-        ActiveServerGroup(
-            "$name-v$sequence",
-            location.region,
-            location.availabilityZones,
-            ActiveServerGroupImage(
-                launchConfiguration.imageId,
-                launchConfiguration.appVersion,
-                launchConfiguration.baseImageVersion
+    randomNumeric(3).padStart(3, '0').let { sequence ->
+      ActiveServerGroup(
+        "$name-v$sequence",
+        location.region,
+        location.availabilityZones,
+        ActiveServerGroupImage(
+          launchConfiguration.imageId,
+          launchConfiguration.appVersion,
+          launchConfiguration.baseImageVersion
+        ),
+        LaunchConfig(
+          launchConfiguration.ramdiskId,
+          launchConfiguration.ebsOptimized,
+          launchConfiguration.imageId,
+          launchConfiguration.instanceType,
+          launchConfiguration.keyPair,
+          launchConfiguration.iamRole,
+          InstanceMonitoring(launchConfiguration.instanceMonitoring)
+        ),
+        AutoScalingGroup(
+          "$name-v$sequence",
+          health.cooldown.seconds,
+          health.healthCheckType.let(HealthCheckType::toString),
+          health.warmup.seconds,
+          scaling.suspendedProcesses.map { SuspendedProcess(it.name) }.toSet(),
+          health.enabledMetrics.map(Metric::toString).toSet(),
+          tags.map { Tag(it.key, it.value) }.toSet(),
+          health.terminationPolicies.map(TerminationPolicy::toString).toSet(),
+          subnets.map(Subnet::id).joinToString(",")
+        ),
+        listOf(ScalingPolicy(
+          autoScalingGroupName = "$name-v$sequence",
+          policyName = "$name-target-tracking-policy",
+          policyType = "TargetTrackingScaling",
+          estimatedInstanceWarmup = 300,
+          adjustmentType = null,
+          minAdjustmentStep = null,
+          minAdjustmentMagnitude = null,
+          stepAdjustments = null,
+          metricAggregationType = null,
+          targetTrackingConfiguration = TargetTrackingConfiguration(
+            560.0,
+            true,
+            CustomizedMetricSpecificationModel(
+              "RPS per instance",
+              "SPIN/ACH",
+              "Average",
+              null,
+              listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence"))
             ),
-            LaunchConfig(
-                launchConfiguration.ramdiskId,
-                launchConfiguration.ebsOptimized,
-                launchConfiguration.imageId,
-                launchConfiguration.instanceType,
-                launchConfiguration.keyPair,
-                launchConfiguration.iamRole,
-                InstanceMonitoring(launchConfiguration.instanceMonitoring)
-            ),
-            AutoScalingGroup(
-                "$name-v$sequence",
-                health.cooldown.seconds,
-                health.healthCheckType.let(HealthCheckType::toString),
-                health.warmup.seconds,
-                scaling.suspendedProcesses.map { SuspendedProcess(it.name) }.toSet(),
-                health.enabledMetrics.map(Metric::toString).toSet(),
-                tags.map { Tag(it.key, it.value) }.toSet(),
-                health.terminationPolicies.map(TerminationPolicy::toString).toSet(),
-                subnets.map(Subnet::id).joinToString(",")
-            ),
-            listOf(ScalingPolicy(
-                autoScalingGroupName = "$name-v$sequence",
-                policyName = "$name-target-tracking-policy",
-                policyType = "TargetTrackingScaling",
-                estimatedInstanceWarmup = 300,
-                adjustmentType = null,
-                minAdjustmentStep = null,
-                minAdjustmentMagnitude = null,
-                stepAdjustments = null,
-                metricAggregationType = null,
-                targetTrackingConfiguration = TargetTrackingConfiguration(
-                    560.0,
-                    true,
-                    CustomizedMetricSpecificationModel(
-                        "RPS per instance",
-                        "SPIN/ACH",
-                        "Average",
-                        null,
-                        listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence"))
-                    ),
-                    null
-                ),
-                alarms = listOf(ScalingPolicyAlarm(
-                    true,
-                    "GreaterThanThreshold",
-                    listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence")),
-                    3,
-                    60,
-                    560,
-                    "RPS per instance",
-                    "SPIN/ACH",
-                    "Average"
-                ))
-            )),
-            vpc.id,
-            dependencies.targetGroups,
-            dependencies.loadBalancerNames,
-            capacity.let { Capacity(it.min, it.max, it.desired) },
-            CLOUD_PROVIDER,
-            securityGroups.map(SecurityGroupSummary::id).toSet(),
-            location.account,
-            parseMoniker("$name-v$sequence")
-        )
-      }
+            null
+          ),
+          alarms = listOf(ScalingPolicyAlarm(
+            true,
+            "GreaterThanThreshold",
+            listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence")),
+            3,
+            60,
+            560,
+            "RPS per instance",
+            "SPIN/ACH",
+            "Average"
+          ))
+        )),
+        vpc.id,
+        dependencies.targetGroups,
+        dependencies.loadBalancerNames,
+        capacity.let { Capacity(it.min, it.max, it.desired) },
+        CLOUD_PROVIDER,
+        securityGroups.map(SecurityGroupSummary::id).toSet(),
+        location.account,
+        parseMoniker("$name-v$sequence")
+      )
+    }
 
   fun tests() = rootContext<ClusterHandler> {
     fixture {
       ClusterHandler(
-          cloudDriverService,
-          cloudDriverCache,
-          orcaService,
-          taskLauncher,
-          clock,
-          publisher,
-          objectMapper,
-          normalizers
+        cloudDriverService,
+        cloudDriverCache,
+        orcaService,
+        taskLauncher,
+        clock,
+        publisher,
+        objectMapper,
+        normalizers
       )
     }
 
@@ -296,7 +296,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpcWest.account, vpcWest.region, sg1West.name) } returns sg1West
         every { securityGroupByName(vpcWest.account, vpcWest.region, sg2West.name) } returns sg2West
         every { availabilityZonesBy(vpcWest.account, vpcWest.id, subnet1West.purpose!!, vpcWest.region) } returns
-            setOf(subnet1West.availabilityZone)
+          setOf(subnet1West.availabilityZone)
 
         every { networkBy(vpcEast.id) } returns vpcEast
         every { subnetBy(subnet1East.id) } returns subnet1East
@@ -308,7 +308,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpcEast.account, vpcEast.region, sg1East.name) } returns sg1East
         every { securityGroupByName(vpcEast.account, vpcEast.region, sg2East.name) } returns sg2East
         every { availabilityZonesBy(vpcEast.account, vpcEast.id, subnet1East.purpose!!, vpcEast.region) } returns
-            setOf(subnet1East.availabilityZone)
+          setOf(subnet1East.availabilityZone)
       }
 
       coEvery { orcaService.orchestrate("keel@spinnaker", any()) } returns TaskRefResponse("/tasks/${randomUUID()}")
@@ -331,20 +331,20 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           current(resource)
         }
         expectThat(current)
-            .hasSize(1)
-            .not()
-            .containsKey("us-west-2")
+          .hasSize(1)
+          .not()
+          .containsKey("us-west-2")
       }
 
       test("annealing a new cluster only uses a createServerGroup stage if it has no scaling policies") {
         runBlocking {
           upsert(
-              resource,
-              ResourceDiff(
-                  serverGroups.map {
-                    it.copy(scaling = Scaling(), capacity = Capacity(2, 2, 2))
-                  }.byRegion(),
-                  emptyMap()))
+            resource,
+            ResourceDiff(
+              serverGroups.map {
+                it.copy(scaling = Scaling(), capacity = Capacity(2, 2, 2))
+              }.byRegion(),
+              emptyMap()))
         }
 
         val slot = slot<OrchestrationRequest>()
@@ -373,8 +373,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           get("type").isEqualTo("upsertScalingPolicy")
           get("refId").isEqualTo("2")
           get("requisiteStageRefIds")
-              .isA<List<String>>()
-              .isEqualTo(listOf("1"))
+            .isA<List<String>>()
+            .isEqualTo(listOf("1"))
         }
       }
     }
@@ -399,11 +399,11 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("the server group name is derived correctly") {
           expectThat(values)
-              .map { it.name }
-              .containsExactlyInAnyOrder(
-                  activeServerGroupResponseEast.name,
-                  activeServerGroupResponseWest.name
-              )
+            .map { it.name }
+            .containsExactlyInAnyOrder(
+              activeServerGroupResponseEast.name,
+              activeServerGroupResponseWest.name
+            )
         }
 
         test("an event is fired if all server groups have the same artifact version") {
@@ -420,20 +420,20 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("has the expected basic properties") {
           expectThat(kind)
-              .isEqualTo("cluster")
+            .isEqualTo("cluster")
           expectThat(apiVersion)
-              .isEqualTo(SPINNAKER_EC2_API_V1)
+            .isEqualTo(SPINNAKER_EC2_API_V1)
           expectThat(spec.locations.regions)
-              .hasSize(2)
+            .hasSize(2)
           expectThat(spec.defaults.scaling!!.targetTrackingPolicies)
-              .hasSize(1)
+            .hasSize(1)
           expectThat(spec.overrides)
-              .hasSize(0)
+            .hasSize(0)
         }
 
         test("omits complex fields altogether when all their properties have default values") {
           expectThat(spec.defaults.health)
-              .isNull()
+            .isNull()
         }
       }
 
@@ -441,8 +441,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         before {
           coEvery { cloudDriverService.activeServerGroup("us-east-1") } returns activeServerGroupResponseEast
           coEvery { cloudDriverService.activeServerGroup("us-west-2") } returns activeServerGroupResponseWest
-              .withNonDefaultHealthProps()
-              .withNonDefaultLaunchConfigProps()
+            .withNonDefaultHealthProps()
+            .withNonDefaultLaunchConfigProps()
         }
 
         test("export omits properties with default values from complex fields") {
@@ -450,34 +450,34 @@ internal class ClusterHandlerTests : JUnit5Minutests {
             export(exportable)
           }
           expectThat(exported.spec.locations.vpc)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.locations.subnet)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.health)
-              .isNotNull()
+            .isNotNull()
           expectThat(exported.spec.defaults.health!!.cooldown)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.health!!.warmup)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.health!!.healthCheckType)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.health!!.enabledMetrics)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.health!!.cooldown)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.health!!.terminationPolicies)
-              .isEqualTo(setOf(TerminationPolicy.NewestInstance))
+            .isEqualTo(setOf(TerminationPolicy.NewestInstance))
 
           expectThat(exported.spec.defaults.launchConfiguration!!.ebsOptimized)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.instanceMonitoring)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.ramdiskId)
-              .isNull()
+            .isNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.iamRole)
-              .isNotNull()
+            .isNotNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.keyPair)
-              .isNotNull()
+            .isNotNull()
         }
       }
     }
@@ -528,12 +528,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       test("applying the diff creates a server group in the region with missing tag") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withMissingAppVersion()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withMissingAppVersion()
         )
         val diff = ResourceDiff(
-            serverGroups.byRegion(),
-            modified.byRegion()
+          serverGroups.byRegion(),
+          modified.byRegion()
         )
         runBlocking {
           upsert(resource, diff)
@@ -552,12 +552,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     context("a diff has been detected") {
       context("the diff is only in capacity") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
         )
         val diff = ResourceDiff(
-            serverGroups.byRegion(),
-            modified.byRegion()
+          serverGroups.byRegion(),
+          modified.byRegion()
         )
 
         test("annealing resizes the current server group") {
@@ -571,13 +571,13 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("type").isEqualTo("resizeServerGroup")
             get("capacity").isEqualTo(
-                spec.resolveCapacity("us-west-2").let {
-                  mapOf(
-                      "min" to it.min,
-                      "max" to it.max,
-                      "desired" to it.desired
-                  )
-                }
+              spec.resolveCapacity("us-west-2").let {
+                mapOf(
+                  "min" to it.min,
+                  "max" to it.max,
+                  "desired" to it.desired
+                )
+              }
             )
             get("serverGroupName").isEqualTo(activeServerGroupResponseWest.asg.autoScalingGroupName)
           }
@@ -586,12 +586,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       context("the diff is only in scaling policies missing from current") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
         )
         val diff = ResourceDiff(
-            serverGroups.byRegion(),
-            modified.byRegion()
+          serverGroups.byRegion(),
+          modified.byRegion()
         )
 
         test("annealing only upserts scaling policies on the current server group") {
@@ -607,36 +607,36 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("type").isEqualTo("upsertScalingPolicy")
             get("targetTrackingConfiguration")
-                .isA<Map<String, Any?>>()
-                .get {
-                  expectThat(get("targetValue"))
-                      .isA<Double>()
-                      .isEqualTo(560.0)
-                  expectThat(get("disableScaleIn"))
-                      .isA<Boolean>()
-                      .isTrue()
-                  expectThat(get("customizedMetricSpecification"))
-                      .isA<CustomizedMetricSpecificationModel>()
-                      .isEqualTo(
-                          CustomizedMetricSpecificationModel(
-                              metricName = metricSpec.name,
-                              namespace = metricSpec.namespace,
-                              statistic = metricSpec.statistic
-                          )
-                      )
-                }
+              .isA<Map<String, Any?>>()
+              .get {
+                expectThat(get("targetValue"))
+                  .isA<Double>()
+                  .isEqualTo(560.0)
+                expectThat(get("disableScaleIn"))
+                  .isA<Boolean>()
+                  .isTrue()
+                expectThat(get("customizedMetricSpecification"))
+                  .isA<CustomizedMetricSpecificationModel>()
+                  .isEqualTo(
+                    CustomizedMetricSpecificationModel(
+                      metricName = metricSpec.name,
+                      namespace = metricSpec.namespace,
+                      statistic = metricSpec.statistic
+                    )
+                  )
+              }
           }
         }
       }
 
       context("the diff is only that deployed scaling policies are no longer desired") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
         )
         val diff = ResourceDiff(
-            modified.byRegion(),
-            serverGroups.byRegion()
+          modified.byRegion(),
+          serverGroups.byRegion()
         )
 
         test("annealing only deletes policies from the current server group") {
@@ -657,21 +657,21 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       context("only an existing scaling policy has been modified") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(
-                name = activeServerGroupResponseWest.name,
-                scaling = serverGroupWest.scaling.copy(
-                    targetTrackingPolicies = setOf(
-                        serverGroupWest.scaling.targetTrackingPolicies
-                            .first()
-                            .copy(targetValue = 42.0)
-                    )
-                )
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(
+            name = activeServerGroupResponseWest.name,
+            scaling = serverGroupWest.scaling.copy(
+              targetTrackingPolicies = setOf(
+                serverGroupWest.scaling.targetTrackingPolicies
+                  .first()
+                  .copy(targetValue = 42.0)
+              )
             )
+          )
         )
         val diff = ResourceDiff(
-            modified.byRegion(),
-            serverGroups.byRegion()
+          modified.byRegion(),
+          serverGroups.byRegion()
         )
 
         test("the modified policy is applied in two phases via one task") {
@@ -686,34 +686,34 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("refId").isEqualTo("1")
             get("requisiteStageRefIds")
-                .isA<List<String>>()
-                .isEqualTo(emptyList())
+              .isA<List<String>>()
+              .isEqualTo(emptyList())
             get("type").isEqualTo("deleteScalingPolicy")
             get("policyName").isEqualTo(targetTrackingPolicyName)
           }
           expectThat(slot.captured.job[1]) {
             get("refId").isEqualTo("2")
             get("requisiteStageRefIds")
-                .isA<List<String>>()
-                .isEqualTo(listOf("1"))
+              .isA<List<String>>()
+              .isEqualTo(listOf("1"))
             get("type").isEqualTo("upsertScalingPolicy")
             get("targetTrackingConfiguration")
-                .isA<Map<String, Any?>>()["targetValue"]
-                .isEqualTo(42.0)
+              .isA<Map<String, Any?>>()["targetValue"]
+              .isEqualTo(42.0)
           }
         }
       }
 
       context("the diff is only in capacity and scaling policies") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name)
-                .withDoubleCapacity()
-                .withNoScalingPolicies()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+            .withDoubleCapacity()
+            .withNoScalingPolicies()
         )
         val diff = ResourceDiff(
-            serverGroups.byRegion(),
-            modified.byRegion()
+          serverGroups.byRegion(),
+          modified.byRegion()
         )
 
         test("annealing resizes and modifies scaling policies in-place on the current server group") {
@@ -733,22 +733,22 @@ internal class ClusterHandlerTests : JUnit5Minutests {
             get("refId").isEqualTo("2")
             get("type").isEqualTo("upsertScalingPolicy")
             get("targetTrackingConfiguration")
-                .isA<Map<String, Any?>>()["targetValue"]
-                .isEqualTo(560.0)
+              .isA<Map<String, Any?>>()["targetValue"]
+              .isEqualTo(560.0)
           }
         }
       }
 
       context("the diff is something other than just capacity or scaling policies") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name)
-                .withDoubleCapacity()
-                .withDifferentInstanceType()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+            .withDoubleCapacity()
+            .withDifferentInstanceType()
         )
         val diff = ResourceDiff(
-            serverGroups.byRegion(),
-            modified.byRegion()
+          serverGroups.byRegion(),
+          modified.byRegion()
         )
 
         test("annealing clones the current server group") {
@@ -762,11 +762,11 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("type").isEqualTo("createServerGroup")
             get("source").isEqualTo(
-                mapOf(
-                    "account" to activeServerGroupResponseWest.accountName,
-                    "region" to activeServerGroupResponseWest.region,
-                    "asgName" to activeServerGroupResponseWest.asg.autoScalingGroupName
-                )
+              mapOf(
+                "account" to activeServerGroupResponseWest.accountName,
+                "region" to activeServerGroupResponseWest.region,
+                "asgName" to activeServerGroupResponseWest.asg.autoScalingGroupName
+              )
             )
           }
         }
@@ -792,10 +792,10 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("the deploy strategy is configured") {
           val deployWith = RedBlack(
-              resizePreviousToZero = true,
-              delayBeforeDisable = Duration.ofMinutes(1),
-              delayBeforeScaleDown = Duration.ofMinutes(5),
-              maxServerGroups = 3
+            resizePreviousToZero = true,
+            delayBeforeDisable = Duration.ofMinutes(1),
+            delayBeforeScaleDown = Duration.ofMinutes(5),
+            maxServerGroups = 3
           )
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
@@ -835,12 +835,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       context("multiple server groups have a diff") {
         val modified = setOf(
-            serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentInstanceType(),
-            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentInstanceType(),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
         )
         val diff = ResourceDiff(
-            serverGroups.byRegion(),
-            modified.byRegion()
+          serverGroups.byRegion(),
+          modified.byRegion()
         )
 
         before {
@@ -854,9 +854,9 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           coVerify { orcaService.orchestrate(any(), capture(tasks)) }
 
           expectThat(tasks)
-              .hasSize(2)
-              .map { it.job.first()["type"] }
-              .containsExactlyInAnyOrder("createServerGroup", "resizeServerGroup")
+            .hasSize(2)
+            .map { it.job.first()["type"] }
+            .containsExactlyInAnyOrder("createServerGroup", "resizeServerGroup")
         }
 
         test("each task has a distinct correlation id") {
@@ -864,92 +864,92 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           coVerify { orcaService.orchestrate(any(), capture(tasks)) }
 
           expectThat(tasks)
-              .hasSize(2)
-              .map { it.trigger.correlationId }
-              .containsDistinctElements()
+            .hasSize(2)
+            .map { it.trigger.correlationId }
+            .containsDistinctElements()
         }
       }
     }
   }
 
   private suspend fun CloudDriverService.activeServerGroup(region: String) = activeServerGroup(
-      serviceAccount = "keel@spinnaker",
-      app = spec.moniker.app,
-      account = spec.locations.account,
-      cluster = spec.moniker.name,
-      region = region,
-      cloudProvider = CLOUD_PROVIDER
+    serviceAccount = "keel@spinnaker",
+    app = spec.moniker.app,
+    account = spec.locations.account,
+    cluster = spec.moniker.name,
+    region = region,
+    cloudProvider = CLOUD_PROVIDER
   )
 }
 
 private fun <E, T : Iterable<E>> Assertion.Builder<T>.containsDistinctElements() =
-    assert("contains distinct elements") { subject ->
-      val duplicates = subject
-          .associateWith { elem -> subject.count { it == elem } }
-          .filterValues { it > 1 }
-          .keys
-      when (duplicates.size) {
-        0 -> pass()
-        1 -> fail(duplicates.first(), "The element %s occurs more than once")
-        else -> fail(duplicates, "The elements %s occur more than once")
-      }
+  assert("contains distinct elements") { subject ->
+    val duplicates = subject
+      .associateWith { elem -> subject.count { it == elem } }
+      .filterValues { it > 1 }
+      .keys
+    when (duplicates.size) {
+      0 -> pass()
+      1 -> fail(duplicates.first(), "The element %s occurs more than once")
+      else -> fail(duplicates, "The elements %s occur more than once")
     }
+  }
 
 private fun ServerGroup.withDoubleCapacity(): ServerGroup =
-    copy(
-        capacity = Capacity(
-            min = capacity.min * 2,
-            max = capacity.max * 2,
-            desired = when (capacity.desired) {
-              null -> null
-              else -> capacity.desired!! * 2
-            }
-        )
+  copy(
+    capacity = Capacity(
+      min = capacity.min * 2,
+      max = capacity.max * 2,
+      desired = when (capacity.desired) {
+        null -> null
+        else -> capacity.desired!! * 2
+      }
     )
+  )
 
 private fun ServerGroup.withNoScalingPolicies(): ServerGroup =
-    copy(scaling = Scaling(), capacity = capacity.copy(desired = capacity.max))
+  copy(scaling = Scaling(), capacity = capacity.copy(desired = capacity.max))
 
 private fun ServerGroup.withDifferentInstanceType(): ServerGroup =
-    copy(
-        launchConfiguration = launchConfiguration.copy(
-            instanceType = "r4.16xlarge"
-        )
+  copy(
+    launchConfiguration = launchConfiguration.copy(
+      instanceType = "r4.16xlarge"
     )
+  )
 
 private fun ServerGroup.withMissingAppVersion(): ServerGroup =
-    copy(
-        launchConfiguration = launchConfiguration.copy(
-            appVersion = null
-        )
+  copy(
+    launchConfiguration = launchConfiguration.copy(
+      appVersion = null
     )
+  )
 
 private fun ActiveServerGroup.withOlderAppVersion(): ActiveServerGroup =
-    copy(
-        image = image.copy(
-            imageId = "ami-573e1b2650a5",
-            appVersion = "keel-0.251.0-h167.9ea0465"
-        ),
-        launchConfig = launchConfig.copy(
-            imageId = "ami-573e1b2650a5"
-        )
+  copy(
+    image = image.copy(
+      imageId = "ami-573e1b2650a5",
+      appVersion = "keel-0.251.0-h167.9ea0465"
+    ),
+    launchConfig = launchConfig.copy(
+      imageId = "ami-573e1b2650a5"
     )
+  )
 
 private fun ActiveServerGroup.withNonDefaultHealthProps(): ActiveServerGroup =
-    copy(
-        asg = asg.copy(terminationPolicies = setOf(TerminationPolicy.NewestInstance.name)
-        )
+  copy(
+    asg = asg.copy(terminationPolicies = setOf(TerminationPolicy.NewestInstance.name)
     )
+  )
 
 private fun ActiveServerGroup.withNonDefaultLaunchConfigProps(): ActiveServerGroup =
-    copy(
-        launchConfig = launchConfig.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
-    )
+  copy(
+    launchConfig = launchConfig.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
+  )
 
 private fun ActiveServerGroup.withMissingAppVersion(): ActiveServerGroup =
-    copy(
-        image = ActiveServerGroupImage(
-            imageId = "ami-573e1b2650a5",
-            tags = emptyList()
-        )
+  copy(
+    image = ActiveServerGroupImage(
+      imageId = "ami-573e1b2650a5",
+      tags = emptyList()
     )
+  )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spinnaker.keel.api.Capacity
 import com.netflix.spinnaker.keel.api.ClusterDependencies
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Highlander
 import com.netflix.spinnaker.keel.api.RedBlack
@@ -96,11 +97,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val orcaService = mockk<OrcaService>()
   val objectMapper = ObjectMapper().registerKotlinModule()
   val normalizers = emptyList<Resolver<ClusterSpec>>()
-  val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   val clock = Clock.systemDefaultZone()
+  val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
+  val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk()
   val taskLauncher = TaskLauncher(
-    orcaService,
-    InMemoryDeliveryConfigRepository(clock)
+      orcaService,
+      deliveryConfigRepository
   )
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
@@ -119,49 +121,49 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val targetTrackingPolicyName = "keel-test-target-tracking-policy"
 
   val spec = ClusterSpec(
-    moniker = Moniker(app = "keel", stack = "test"),
-    locations = SubnetAwareLocations(
-      account = vpcWest.account,
-      vpc = "vpc0",
-      subnet = subnet1West.purpose!!,
-      regions = listOf(vpcWest, vpcEast).map { subnet ->
-        SubnetAwareRegionSpec(
-          name = subnet.region,
-          availabilityZones = listOf("a", "b", "c").map { "${subnet.region}$it" }.toSet()
-        )
-      }.toSet()
-    ),
-    _defaults = ServerGroupSpec(
-      launchConfiguration = LaunchConfigurationSpec(
-        image = VirtualMachineImage(
-          id = "ami-123543254134",
-          appVersion = "keel-0.287.0-h208.fe2e8a1",
-          baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
-        ),
-        instanceType = "r4.8xlarge",
-        ebsOptimized = false,
-        iamRole = LaunchConfiguration.defaultIamRoleFor("keel"),
-        keyPair = "nf-keypair-test-fake",
-        instanceMonitoring = false
+      moniker = Moniker(app = "keel", stack = "test"),
+      locations = SubnetAwareLocations(
+          account = vpcWest.account,
+          vpc = "vpc0",
+          subnet = subnet1West.purpose!!,
+          regions = listOf(vpcWest, vpcEast).map { subnet ->
+            SubnetAwareRegionSpec(
+                name = subnet.region,
+                availabilityZones = listOf("a", "b", "c").map { "${subnet.region}$it" }.toSet()
+            )
+          }.toSet()
       ),
-      capacity = Capacity(1, 6),
-      scaling = Scaling(
-        targetTrackingPolicies = setOf(TargetTrackingPolicy(
-          name = targetTrackingPolicyName,
-          targetValue = 560.0,
-          disableScaleIn = true,
-          customMetricSpec = CustomizedMetricSpecification(
-            name = "RPS per instance",
-            namespace = "SPIN/ACH",
-            statistic = "Average"
+      _defaults = ServerGroupSpec(
+          launchConfiguration = LaunchConfigurationSpec(
+              image = VirtualMachineImage(
+                  id = "ami-123543254134",
+                  appVersion = "keel-0.287.0-h208.fe2e8a1",
+                  baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+              ),
+              instanceType = "r4.8xlarge",
+              ebsOptimized = false,
+              iamRole = LaunchConfiguration.defaultIamRoleFor("keel"),
+              keyPair = "nf-keypair-test-fake",
+              instanceMonitoring = false
+          ),
+          capacity = Capacity(1, 6),
+          scaling = Scaling(
+              targetTrackingPolicies = setOf(TargetTrackingPolicy(
+                  name = targetTrackingPolicyName,
+                  targetValue = 560.0,
+                  disableScaleIn = true,
+                  customMetricSpec = CustomizedMetricSpecification(
+                      name = "RPS per instance",
+                      namespace = "SPIN/ACH",
+                      statistic = "Average"
+                  )
+              ))
+          ),
+          dependencies = ClusterDependencies(
+              loadBalancerNames = setOf("keel-test-frontend"),
+              securityGroupNames = setOf(sg1West.name, sg2West.name)
           )
-        ))
-      ),
-      dependencies = ClusterDependencies(
-        loadBalancerNames = setOf("keel-test-frontend"),
-        securityGroupNames = setOf(sg1West.name, sg2West.name)
       )
-    )
   )
 
   val serverGroups = spec.resolve()
@@ -169,21 +171,21 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val serverGroupWest = serverGroups.first { it.location.region == "us-west-2" }
 
   val resource = resource(
-    apiVersion = SPINNAKER_API_V1,
-    kind = "cluster",
-    spec = spec
+      apiVersion = SPINNAKER_API_V1,
+      kind = "cluster",
+      spec = spec
   )
 
   val activeServerGroupResponseEast = serverGroupEast.toCloudDriverResponse(vpcEast, listOf(subnet1East, subnet2East, subnet3East), listOf(sg1East, sg2East))
   val activeServerGroupResponseWest = serverGroupWest.toCloudDriverResponse(vpcWest, listOf(subnet1West, subnet2West, subnet3West), listOf(sg1West, sg2West))
 
   val exportable = Exportable(
-    cloudProvider = "aws",
-    account = spec.locations.account,
-    serviceAccount = "keel@spinnaker",
-    moniker = spec.moniker,
-    regions = spec.locations.regions.map { it.name }.toSet(),
-    kind = "cluster"
+      cloudProvider = "aws",
+      account = spec.locations.account,
+      serviceAccount = "keel@spinnaker",
+      moniker = spec.moniker,
+      regions = spec.locations.regions.map { it.name }.toSet(),
+      kind = "cluster"
   )
 
   private fun ServerGroup.toCloudDriverResponse(
@@ -191,92 +193,92 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     subnets: List<Subnet>,
     securityGroups: List<SecurityGroupSummary>
   ): ActiveServerGroup =
-    randomNumeric(3).padStart(3, '0').let { sequence ->
-      ActiveServerGroup(
-        "$name-v$sequence",
-        location.region,
-        location.availabilityZones,
-        ActiveServerGroupImage(
-          launchConfiguration.imageId,
-          launchConfiguration.appVersion,
-          launchConfiguration.baseImageVersion
-        ),
-        LaunchConfig(
-          launchConfiguration.ramdiskId,
-          launchConfiguration.ebsOptimized,
-          launchConfiguration.imageId,
-          launchConfiguration.instanceType,
-          launchConfiguration.keyPair,
-          launchConfiguration.iamRole,
-          InstanceMonitoring(launchConfiguration.instanceMonitoring)
-        ),
-        AutoScalingGroup(
-          "$name-v$sequence",
-          health.cooldown.seconds,
-          health.healthCheckType.let(HealthCheckType::toString),
-          health.warmup.seconds,
-          scaling.suspendedProcesses.map { SuspendedProcess(it.name) }.toSet(),
-          health.enabledMetrics.map(Metric::toString).toSet(),
-          tags.map { Tag(it.key, it.value) }.toSet(),
-          health.terminationPolicies.map(TerminationPolicy::toString).toSet(),
-          subnets.map(Subnet::id).joinToString(",")
-        ),
-        listOf(ScalingPolicy(
-          autoScalingGroupName = "$name-v$sequence",
-          policyName = "$name-target-tracking-policy",
-          policyType = "TargetTrackingScaling",
-          estimatedInstanceWarmup = 300,
-          adjustmentType = null,
-          minAdjustmentStep = null,
-          minAdjustmentMagnitude = null,
-          stepAdjustments = null,
-          metricAggregationType = null,
-          targetTrackingConfiguration = TargetTrackingConfiguration(
-            560.0,
-            true,
-            CustomizedMetricSpecificationModel(
-              "RPS per instance",
-              "SPIN/ACH",
-              "Average",
-              null,
-              listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence"))
+      randomNumeric(3).padStart(3, '0').let { sequence ->
+        ActiveServerGroup(
+            "$name-v$sequence",
+            location.region,
+            location.availabilityZones,
+            ActiveServerGroupImage(
+                launchConfiguration.imageId,
+                launchConfiguration.appVersion,
+                launchConfiguration.baseImageVersion
             ),
-            null
-          ),
-          alarms = listOf(ScalingPolicyAlarm(
-            true,
-            "GreaterThanThreshold",
-            listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence")),
-            3,
-            60,
-            560,
-            "RPS per instance",
-            "SPIN/ACH",
-            "Average"
-          ))
-        )),
-        vpc.id,
-        dependencies.targetGroups,
-        dependencies.loadBalancerNames,
-        capacity.let { Capacity(it.min, it.max, it.desired) },
-        CLOUD_PROVIDER,
-        securityGroups.map(SecurityGroupSummary::id).toSet(),
-        location.account,
-        parseMoniker("$name-v$sequence")
-      )
-    }
+            LaunchConfig(
+                launchConfiguration.ramdiskId,
+                launchConfiguration.ebsOptimized,
+                launchConfiguration.imageId,
+                launchConfiguration.instanceType,
+                launchConfiguration.keyPair,
+                launchConfiguration.iamRole,
+                InstanceMonitoring(launchConfiguration.instanceMonitoring)
+            ),
+            AutoScalingGroup(
+                "$name-v$sequence",
+                health.cooldown.seconds,
+                health.healthCheckType.let(HealthCheckType::toString),
+                health.warmup.seconds,
+                scaling.suspendedProcesses.map { SuspendedProcess(it.name) }.toSet(),
+                health.enabledMetrics.map(Metric::toString).toSet(),
+                tags.map { Tag(it.key, it.value) }.toSet(),
+                health.terminationPolicies.map(TerminationPolicy::toString).toSet(),
+                subnets.map(Subnet::id).joinToString(",")
+            ),
+            listOf(ScalingPolicy(
+                autoScalingGroupName = "$name-v$sequence",
+                policyName = "$name-target-tracking-policy",
+                policyType = "TargetTrackingScaling",
+                estimatedInstanceWarmup = 300,
+                adjustmentType = null,
+                minAdjustmentStep = null,
+                minAdjustmentMagnitude = null,
+                stepAdjustments = null,
+                metricAggregationType = null,
+                targetTrackingConfiguration = TargetTrackingConfiguration(
+                    560.0,
+                    true,
+                    CustomizedMetricSpecificationModel(
+                        "RPS per instance",
+                        "SPIN/ACH",
+                        "Average",
+                        null,
+                        listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence"))
+                    ),
+                    null
+                ),
+                alarms = listOf(ScalingPolicyAlarm(
+                    true,
+                    "GreaterThanThreshold",
+                    listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence")),
+                    3,
+                    60,
+                    560,
+                    "RPS per instance",
+                    "SPIN/ACH",
+                    "Average"
+                ))
+            )),
+            vpc.id,
+            dependencies.targetGroups,
+            dependencies.loadBalancerNames,
+            capacity.let { Capacity(it.min, it.max, it.desired) },
+            CLOUD_PROVIDER,
+            securityGroups.map(SecurityGroupSummary::id).toSet(),
+            location.account,
+            parseMoniker("$name-v$sequence")
+        )
+      }
 
   fun tests() = rootContext<ClusterHandler> {
     fixture {
       ClusterHandler(
-        cloudDriverService,
-        cloudDriverCache,
-        orcaService,
-        taskLauncher,
-        clock,
-        publisher,
-        objectMapper,
-        normalizers
+          cloudDriverService,
+          cloudDriverCache,
+          orcaService,
+          taskLauncher,
+          clock,
+          publisher,
+          objectMapper,
+          normalizers
       )
     }
 
@@ -294,7 +296,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpcWest.account, vpcWest.region, sg1West.name) } returns sg1West
         every { securityGroupByName(vpcWest.account, vpcWest.region, sg2West.name) } returns sg2West
         every { availabilityZonesBy(vpcWest.account, vpcWest.id, subnet1West.purpose!!, vpcWest.region) } returns
-          setOf(subnet1West.availabilityZone)
+            setOf(subnet1West.availabilityZone)
 
         every { networkBy(vpcEast.id) } returns vpcEast
         every { subnetBy(subnet1East.id) } returns subnet1East
@@ -306,10 +308,11 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpcEast.account, vpcEast.region, sg1East.name) } returns sg1East
         every { securityGroupByName(vpcEast.account, vpcEast.region, sg2East.name) } returns sg2East
         every { availabilityZonesBy(vpcEast.account, vpcEast.id, subnet1East.purpose!!, vpcEast.region) } returns
-          setOf(subnet1East.availabilityZone)
+            setOf(subnet1East.availabilityZone)
       }
 
       coEvery { orcaService.orchestrate("keel@spinnaker", any()) } returns TaskRefResponse("/tasks/${randomUUID()}")
+      every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
     }
 
     after {
@@ -328,20 +331,20 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           current(resource)
         }
         expectThat(current)
-          .hasSize(1)
-          .not()
-          .containsKey("us-west-2")
+            .hasSize(1)
+            .not()
+            .containsKey("us-west-2")
       }
 
       test("annealing a new cluster only uses a createServerGroup stage if it has no scaling policies") {
         runBlocking {
           upsert(
-            resource,
-            ResourceDiff(
-              serverGroups.map {
-                it.copy(scaling = Scaling(), capacity = Capacity(2, 2, 2))
-              }.byRegion(),
-              emptyMap()))
+              resource,
+              ResourceDiff(
+                  serverGroups.map {
+                    it.copy(scaling = Scaling(), capacity = Capacity(2, 2, 2))
+                  }.byRegion(),
+                  emptyMap()))
         }
 
         val slot = slot<OrchestrationRequest>()
@@ -370,8 +373,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           get("type").isEqualTo("upsertScalingPolicy")
           get("refId").isEqualTo("2")
           get("requisiteStageRefIds")
-            .isA<List<String>>()
-            .isEqualTo(listOf("1"))
+              .isA<List<String>>()
+              .isEqualTo(listOf("1"))
         }
       }
     }
@@ -396,11 +399,11 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("the server group name is derived correctly") {
           expectThat(values)
-            .map { it.name }
-            .containsExactlyInAnyOrder(
-              activeServerGroupResponseEast.name,
-              activeServerGroupResponseWest.name
-            )
+              .map { it.name }
+              .containsExactlyInAnyOrder(
+                  activeServerGroupResponseEast.name,
+                  activeServerGroupResponseWest.name
+              )
         }
 
         test("an event is fired if all server groups have the same artifact version") {
@@ -417,20 +420,20 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("has the expected basic properties") {
           expectThat(kind)
-            .isEqualTo("cluster")
+              .isEqualTo("cluster")
           expectThat(apiVersion)
-            .isEqualTo(SPINNAKER_EC2_API_V1)
+              .isEqualTo(SPINNAKER_EC2_API_V1)
           expectThat(spec.locations.regions)
-            .hasSize(2)
+              .hasSize(2)
           expectThat(spec.defaults.scaling!!.targetTrackingPolicies)
-            .hasSize(1)
+              .hasSize(1)
           expectThat(spec.overrides)
-            .hasSize(0)
+              .hasSize(0)
         }
 
         test("omits complex fields altogether when all their properties have default values") {
           expectThat(spec.defaults.health)
-            .isNull()
+              .isNull()
         }
       }
 
@@ -438,8 +441,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         before {
           coEvery { cloudDriverService.activeServerGroup("us-east-1") } returns activeServerGroupResponseEast
           coEvery { cloudDriverService.activeServerGroup("us-west-2") } returns activeServerGroupResponseWest
-            .withNonDefaultHealthProps()
-            .withNonDefaultLaunchConfigProps()
+              .withNonDefaultHealthProps()
+              .withNonDefaultLaunchConfigProps()
         }
 
         test("export omits properties with default values from complex fields") {
@@ -447,34 +450,34 @@ internal class ClusterHandlerTests : JUnit5Minutests {
             export(exportable)
           }
           expectThat(exported.spec.locations.vpc)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.locations.subnet)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.health)
-            .isNotNull()
+              .isNotNull()
           expectThat(exported.spec.defaults.health!!.cooldown)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.health!!.warmup)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.health!!.healthCheckType)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.health!!.enabledMetrics)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.health!!.cooldown)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.health!!.terminationPolicies)
-            .isEqualTo(setOf(TerminationPolicy.NewestInstance))
+              .isEqualTo(setOf(TerminationPolicy.NewestInstance))
 
           expectThat(exported.spec.defaults.launchConfiguration!!.ebsOptimized)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.instanceMonitoring)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.ramdiskId)
-            .isNull()
+              .isNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.iamRole)
-            .isNotNull()
+              .isNotNull()
           expectThat(exported.spec.defaults.launchConfiguration!!.keyPair)
-            .isNotNull()
+              .isNotNull()
         }
       }
     }
@@ -525,12 +528,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       test("applying the diff creates a server group in the region with missing tag") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withMissingAppVersion()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withMissingAppVersion()
         )
         val diff = ResourceDiff(
-          serverGroups.byRegion(),
-          modified.byRegion()
+            serverGroups.byRegion(),
+            modified.byRegion()
         )
         runBlocking {
           upsert(resource, diff)
@@ -549,12 +552,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     context("a diff has been detected") {
       context("the diff is only in capacity") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
         )
         val diff = ResourceDiff(
-          serverGroups.byRegion(),
-          modified.byRegion()
+            serverGroups.byRegion(),
+            modified.byRegion()
         )
 
         test("annealing resizes the current server group") {
@@ -568,13 +571,13 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("type").isEqualTo("resizeServerGroup")
             get("capacity").isEqualTo(
-              spec.resolveCapacity("us-west-2").let {
-                mapOf(
-                  "min" to it.min,
-                  "max" to it.max,
-                  "desired" to it.desired
-                )
-              }
+                spec.resolveCapacity("us-west-2").let {
+                  mapOf(
+                      "min" to it.min,
+                      "max" to it.max,
+                      "desired" to it.desired
+                  )
+                }
             )
             get("serverGroupName").isEqualTo(activeServerGroupResponseWest.asg.autoScalingGroupName)
           }
@@ -583,12 +586,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       context("the diff is only in scaling policies missing from current") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
         )
         val diff = ResourceDiff(
-          serverGroups.byRegion(),
-          modified.byRegion()
+            serverGroups.byRegion(),
+            modified.byRegion()
         )
 
         test("annealing only upserts scaling policies on the current server group") {
@@ -604,36 +607,36 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("type").isEqualTo("upsertScalingPolicy")
             get("targetTrackingConfiguration")
-              .isA<Map<String, Any?>>()
-              .get {
-                expectThat(get("targetValue"))
-                  .isA<Double>()
-                  .isEqualTo(560.0)
-                expectThat(get("disableScaleIn"))
-                  .isA<Boolean>()
-                  .isTrue()
-                expectThat(get("customizedMetricSpecification"))
-                  .isA<CustomizedMetricSpecificationModel>()
-                  .isEqualTo(
-                    CustomizedMetricSpecificationModel(
-                      metricName = metricSpec.name,
-                      namespace = metricSpec.namespace,
-                      statistic = metricSpec.statistic
-                    )
-                  )
-              }
+                .isA<Map<String, Any?>>()
+                .get {
+                  expectThat(get("targetValue"))
+                      .isA<Double>()
+                      .isEqualTo(560.0)
+                  expectThat(get("disableScaleIn"))
+                      .isA<Boolean>()
+                      .isTrue()
+                  expectThat(get("customizedMetricSpecification"))
+                      .isA<CustomizedMetricSpecificationModel>()
+                      .isEqualTo(
+                          CustomizedMetricSpecificationModel(
+                              metricName = metricSpec.name,
+                              namespace = metricSpec.namespace,
+                              statistic = metricSpec.statistic
+                          )
+                      )
+                }
           }
         }
       }
 
       context("the diff is only that deployed scaling policies are no longer desired") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withNoScalingPolicies()
         )
         val diff = ResourceDiff(
-          modified.byRegion(),
-          serverGroups.byRegion()
+            modified.byRegion(),
+            serverGroups.byRegion()
         )
 
         test("annealing only deletes policies from the current server group") {
@@ -654,21 +657,21 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       context("only an existing scaling policy has been modified") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(
-            name = activeServerGroupResponseWest.name,
-            scaling = serverGroupWest.scaling.copy(
-              targetTrackingPolicies = setOf(
-                serverGroupWest.scaling.targetTrackingPolicies
-                  .first()
-                  .copy(targetValue = 42.0)
-              )
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(
+                name = activeServerGroupResponseWest.name,
+                scaling = serverGroupWest.scaling.copy(
+                    targetTrackingPolicies = setOf(
+                        serverGroupWest.scaling.targetTrackingPolicies
+                            .first()
+                            .copy(targetValue = 42.0)
+                    )
+                )
             )
-          )
         )
         val diff = ResourceDiff(
-          modified.byRegion(),
-          serverGroups.byRegion()
+            modified.byRegion(),
+            serverGroups.byRegion()
         )
 
         test("the modified policy is applied in two phases via one task") {
@@ -683,34 +686,34 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("refId").isEqualTo("1")
             get("requisiteStageRefIds")
-              .isA<List<String>>()
-              .isEqualTo(emptyList())
+                .isA<List<String>>()
+                .isEqualTo(emptyList())
             get("type").isEqualTo("deleteScalingPolicy")
             get("policyName").isEqualTo(targetTrackingPolicyName)
           }
           expectThat(slot.captured.job[1]) {
             get("refId").isEqualTo("2")
             get("requisiteStageRefIds")
-              .isA<List<String>>()
-              .isEqualTo(listOf("1"))
+                .isA<List<String>>()
+                .isEqualTo(listOf("1"))
             get("type").isEqualTo("upsertScalingPolicy")
             get("targetTrackingConfiguration")
-              .isA<Map<String, Any?>>()["targetValue"]
-              .isEqualTo(42.0)
+                .isA<Map<String, Any?>>()["targetValue"]
+                .isEqualTo(42.0)
           }
         }
       }
 
       context("the diff is only in capacity and scaling policies") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
-            .withDoubleCapacity()
-            .withNoScalingPolicies()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+                .withDoubleCapacity()
+                .withNoScalingPolicies()
         )
         val diff = ResourceDiff(
-          serverGroups.byRegion(),
-          modified.byRegion()
+            serverGroups.byRegion(),
+            modified.byRegion()
         )
 
         test("annealing resizes and modifies scaling policies in-place on the current server group") {
@@ -730,22 +733,22 @@ internal class ClusterHandlerTests : JUnit5Minutests {
             get("refId").isEqualTo("2")
             get("type").isEqualTo("upsertScalingPolicy")
             get("targetTrackingConfiguration")
-              .isA<Map<String, Any?>>()["targetValue"]
-              .isEqualTo(560.0)
+                .isA<Map<String, Any?>>()["targetValue"]
+                .isEqualTo(560.0)
           }
         }
       }
 
       context("the diff is something other than just capacity or scaling policies") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
-            .withDoubleCapacity()
-            .withDifferentInstanceType()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+                .withDoubleCapacity()
+                .withDifferentInstanceType()
         )
         val diff = ResourceDiff(
-          serverGroups.byRegion(),
-          modified.byRegion()
+            serverGroups.byRegion(),
+            modified.byRegion()
         )
 
         test("annealing clones the current server group") {
@@ -759,11 +762,11 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           expectThat(slot.captured.job.first()) {
             get("type").isEqualTo("createServerGroup")
             get("source").isEqualTo(
-              mapOf(
-                "account" to activeServerGroupResponseWest.accountName,
-                "region" to activeServerGroupResponseWest.region,
-                "asgName" to activeServerGroupResponseWest.asg.autoScalingGroupName
-              )
+                mapOf(
+                    "account" to activeServerGroupResponseWest.accountName,
+                    "region" to activeServerGroupResponseWest.region,
+                    "asgName" to activeServerGroupResponseWest.asg.autoScalingGroupName
+                )
             )
           }
         }
@@ -789,10 +792,10 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("the deploy strategy is configured") {
           val deployWith = RedBlack(
-            resizePreviousToZero = true,
-            delayBeforeDisable = Duration.ofMinutes(1),
-            delayBeforeScaleDown = Duration.ofMinutes(5),
-            maxServerGroups = 3
+              resizePreviousToZero = true,
+              delayBeforeDisable = Duration.ofMinutes(1),
+              delayBeforeScaleDown = Duration.ofMinutes(5),
+              maxServerGroups = 3
           )
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
@@ -832,12 +835,12 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       context("multiple server groups have a diff") {
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentInstanceType(),
-          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+            serverGroupEast.copy(name = activeServerGroupResponseEast.name).withDifferentInstanceType(),
+            serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
         )
         val diff = ResourceDiff(
-          serverGroups.byRegion(),
-          modified.byRegion()
+            serverGroups.byRegion(),
+            modified.byRegion()
         )
 
         before {
@@ -851,9 +854,9 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           coVerify { orcaService.orchestrate(any(), capture(tasks)) }
 
           expectThat(tasks)
-            .hasSize(2)
-            .map { it.job.first()["type"] }
-            .containsExactlyInAnyOrder("createServerGroup", "resizeServerGroup")
+              .hasSize(2)
+              .map { it.job.first()["type"] }
+              .containsExactlyInAnyOrder("createServerGroup", "resizeServerGroup")
         }
 
         test("each task has a distinct correlation id") {
@@ -861,92 +864,92 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           coVerify { orcaService.orchestrate(any(), capture(tasks)) }
 
           expectThat(tasks)
-            .hasSize(2)
-            .map { it.trigger.correlationId }
-            .containsDistinctElements()
+              .hasSize(2)
+              .map { it.trigger.correlationId }
+              .containsDistinctElements()
         }
       }
     }
   }
 
   private suspend fun CloudDriverService.activeServerGroup(region: String) = activeServerGroup(
-    serviceAccount = "keel@spinnaker",
-    app = spec.moniker.app,
-    account = spec.locations.account,
-    cluster = spec.moniker.name,
-    region = region,
-    cloudProvider = CLOUD_PROVIDER
+      serviceAccount = "keel@spinnaker",
+      app = spec.moniker.app,
+      account = spec.locations.account,
+      cluster = spec.moniker.name,
+      region = region,
+      cloudProvider = CLOUD_PROVIDER
   )
 }
 
 private fun <E, T : Iterable<E>> Assertion.Builder<T>.containsDistinctElements() =
-  assert("contains distinct elements") { subject ->
-    val duplicates = subject
-      .associateWith { elem -> subject.count { it == elem } }
-      .filterValues { it > 1 }
-      .keys
-    when (duplicates.size) {
-      0 -> pass()
-      1 -> fail(duplicates.first(), "The element %s occurs more than once")
-      else -> fail(duplicates, "The elements %s occur more than once")
+    assert("contains distinct elements") { subject ->
+      val duplicates = subject
+          .associateWith { elem -> subject.count { it == elem } }
+          .filterValues { it > 1 }
+          .keys
+      when (duplicates.size) {
+        0 -> pass()
+        1 -> fail(duplicates.first(), "The element %s occurs more than once")
+        else -> fail(duplicates, "The elements %s occur more than once")
+      }
     }
-  }
 
 private fun ServerGroup.withDoubleCapacity(): ServerGroup =
-  copy(
-    capacity = Capacity(
-      min = capacity.min * 2,
-      max = capacity.max * 2,
-      desired = when (capacity.desired) {
-        null -> null
-        else -> capacity.desired!! * 2
-      }
+    copy(
+        capacity = Capacity(
+            min = capacity.min * 2,
+            max = capacity.max * 2,
+            desired = when (capacity.desired) {
+              null -> null
+              else -> capacity.desired!! * 2
+            }
+        )
     )
-  )
 
 private fun ServerGroup.withNoScalingPolicies(): ServerGroup =
-  copy(scaling = Scaling(), capacity = capacity.copy(desired = capacity.max))
+    copy(scaling = Scaling(), capacity = capacity.copy(desired = capacity.max))
 
 private fun ServerGroup.withDifferentInstanceType(): ServerGroup =
-  copy(
-    launchConfiguration = launchConfiguration.copy(
-      instanceType = "r4.16xlarge"
+    copy(
+        launchConfiguration = launchConfiguration.copy(
+            instanceType = "r4.16xlarge"
+        )
     )
-  )
 
 private fun ServerGroup.withMissingAppVersion(): ServerGroup =
-  copy(
-    launchConfiguration = launchConfiguration.copy(
-      appVersion = null
+    copy(
+        launchConfiguration = launchConfiguration.copy(
+            appVersion = null
+        )
     )
-  )
 
 private fun ActiveServerGroup.withOlderAppVersion(): ActiveServerGroup =
-  copy(
-    image = image.copy(
-      imageId = "ami-573e1b2650a5",
-      appVersion = "keel-0.251.0-h167.9ea0465"
-    ),
-    launchConfig = launchConfig.copy(
-      imageId = "ami-573e1b2650a5"
+    copy(
+        image = image.copy(
+            imageId = "ami-573e1b2650a5",
+            appVersion = "keel-0.251.0-h167.9ea0465"
+        ),
+        launchConfig = launchConfig.copy(
+            imageId = "ami-573e1b2650a5"
+        )
     )
-  )
 
 private fun ActiveServerGroup.withNonDefaultHealthProps(): ActiveServerGroup =
-  copy(
-    asg = asg.copy(terminationPolicies = setOf(TerminationPolicy.NewestInstance.name)
+    copy(
+        asg = asg.copy(terminationPolicies = setOf(TerminationPolicy.NewestInstance.name)
+        )
     )
-  )
 
 private fun ActiveServerGroup.withNonDefaultLaunchConfigProps(): ActiveServerGroup =
-  copy(
-    launchConfig = launchConfig.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
-  )
+    copy(
+        launchConfig = launchConfig.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
+    )
 
 private fun ActiveServerGroup.withMissingAppVersion(): ActiveServerGroup =
-  copy(
-    image = ActiveServerGroupImage(
-      imageId = "ami-573e1b2650a5",
-      tags = emptyList()
+    copy(
+        image = ActiveServerGroupImage(
+            imageId = "ami-573e1b2650a5",
+            tags = emptyList()
+        )
     )
-  )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SPINNAKER_API_V1
@@ -61,7 +62,6 @@ import io.mockk.coVerify
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
-import java.time.Clock
 import java.util.UUID.randomUUID
 import kotlinx.coroutines.runBlocking
 import strikt.api.Assertion
@@ -81,10 +81,13 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
   private val cloudDriverService: CloudDriverService = mockk()
   private val cloudDriverCache: CloudDriverCache = mockk()
   private val orcaService: OrcaService = mockk()
-  private val clock = Clock.systemDefaultZone()
+  private val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk() {
+    // we're just using this to get notifications
+    every { environmentFor(any()) } returns Environment("test")
+  }
   private val taskLauncher = TaskLauncher(
     orcaService,
-    InMemoryDeliveryConfigRepository(clock)
+    deliveryConfigRepository
   )
   private val objectMapper = configuredObjectMapper()
   private val normalizers = emptyList<Resolver<SecurityGroupSpec>>()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TaskLauncherTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TaskLauncherTests.kt
@@ -68,9 +68,9 @@ class TaskLauncherTests : JUnit5Minutests {
       before {
         val notification = NotificationConfig(SLACK, "#my-channel", QUIET)
         val env = Environment(
-            name = "test",
-            resources = setOf(resource),
-            notifications = setOf(notification)
+          name = "test",
+          resources = setOf(resource),
+          notifications = setOf(notification)
         )
         val deliveryConfig = DeliveryConfig(name = "keel", application = "keel", environments = setOf(env))
         deliveryConfigRepository.store(deliveryConfig)
@@ -86,7 +86,7 @@ class TaskLauncherTests : JUnit5Minutests {
           hasSize(1)
           first().get { `when` }.isEqualTo(listOf(ORCHESTRATION_FAILED.text()))
           first().get { message }.isEqualTo(
-              mapOf(ORCHESTRATION_FAILED.text() to ORCHESTRATION_FAILED.notificationMessage())
+            mapOf(ORCHESTRATION_FAILED.text() to ORCHESTRATION_FAILED.notificationMessage())
           )
         }
       }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TaskLauncherTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TaskLauncherTests.kt
@@ -42,7 +42,6 @@ import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.first
 import strikt.assertions.hasSize
-import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
 
@@ -65,25 +64,13 @@ class TaskLauncherTests : JUnit5Minutests {
       } returns TaskRefResponse("/tasks/${randomUID()}")
     }
 
-    context("no environments") {
-      before {
-        runBlocking {
-          taskLauncher.submitJobToOrca(resource, "task description", "correlate this", mapOf())
-        }
-      }
-
-      test("empty list gets returned") {
-        expectThat(request.captured.trigger.notifications).isEmpty()
-      }
-    }
-
     context("an environment exists") {
       before {
         val notification = NotificationConfig(SLACK, "#my-channel", QUIET)
         val env = Environment(
-          name = "test",
-          resources = setOf(resource),
-          notifications = setOf(notification)
+            name = "test",
+            resources = setOf(resource),
+            notifications = setOf(notification)
         )
         val deliveryConfig = DeliveryConfig(name = "keel", application = "keel", environments = setOf(env))
         deliveryConfigRepository.store(deliveryConfig)
@@ -99,7 +86,7 @@ class TaskLauncherTests : JUnit5Minutests {
           hasSize(1)
           first().get { `when` }.isEqualTo(listOf(ORCHESTRATION_FAILED.text()))
           first().get { message }.isEqualTo(
-            mapOf(ORCHESTRATION_FAILED.text() to ORCHESTRATION_FAILED.notificationMessage())
+              mapOf(ORCHESTRATION_FAILED.text() to ORCHESTRATION_FAILED.notificationMessage())
           )
         }
       }

--- a/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
+++ b/keel-plugin/src/main/kotlin/com/netflix/spinnaker/keel/plugin/TaskLauncher.kt
@@ -80,9 +80,8 @@ class TaskLauncher(
   private val Resource<*>.notifications: List<EchoNotification>
     get() = deliveryConfigRepository
       .environmentFor(id)
-      ?.notifications
-      ?.map { it.toEchoNotification() }
-      ?: emptyList()
+      .notifications
+      .map { it.toEchoNotification() }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
@@ -39,7 +39,9 @@ private val objectMapper: ObjectMapper = configuredObjectMapper()
 fun mapToArtifact(
   name: String,
   type: ArtifactType,
-  json: String
+  json: String,
+  reference: String,
+  deliveryConfigName: String
 ): DeliveryArtifact {
   try {
     val details = objectMapper.readValue<Map<String, Any>>(json)
@@ -54,7 +56,9 @@ fun mapToArtifact(
         } ?: emptyList()
         DebianArtifact(
           name = name,
-          statuses = statuses
+          statuses = statuses,
+          reference = reference,
+          deliveryConfigName = deliveryConfigName
         )
       }
       DOCKER -> {
@@ -62,7 +66,9 @@ fun mapToArtifact(
         DockerArtifact(
           name = name,
           tagVersionStrategy = objectMapper.convertValue(tagVersionStrategy),
-          captureGroupRegex = details["captureGroupRegex"]?.toString()
+          captureGroupRegex = details["captureGroupRegex"]?.toString(),
+          reference = reference,
+          deliveryConfigName = deliveryConfigName
         )
       }
     }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -119,11 +119,12 @@ class SqlArtifactRepository(
 
   override fun isRegistered(name: String, type: ArtifactType): Boolean =
     jooq
-      .selectOne()
+      .selectCount()
       .from(DELIVERY_ARTIFACT)
       .where(DELIVERY_ARTIFACT.NAME.eq(name))
       .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
-      .fetchOne() != null
+      .fetchOne()
+      .value1() > 0
 
   override fun getAll(type: ArtifactType?): List<DeliveryArtifact> =
     jooq

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.keel.api.PromotionStatus.PREVIOUS
 import com.netflix.spinnaker.keel.api.randomUID
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
-import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT_VERSION
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VERSIONS
@@ -46,8 +46,11 @@ class SqlArtifactRepository(
       .set(DELIVERY_ARTIFACT.UID, randomUID().toString())
       .set(DELIVERY_ARTIFACT.NAME, artifact.name)
       .set(DELIVERY_ARTIFACT.TYPE, artifact.type.name)
+      .set(DELIVERY_ARTIFACT.REFERENCE, artifact.reference)
+      .set(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME, artifact.deliveryConfigName)
       .set(DELIVERY_ARTIFACT.DETAILS, artifact.detailsAsJson())
       .onDuplicateKeyUpdate()
+      .set(DELIVERY_ARTIFACT.REFERENCE, artifact.reference)
       .set(DELIVERY_ARTIFACT.DETAILS, artifact.detailsAsJson())
       .execute()
   }
@@ -71,30 +74,45 @@ class SqlArtifactRepository(
       mapOf("statuses" to statuses)
     )
 
-  override fun get(name: String, type: ArtifactType): DeliveryArtifact {
+  override fun get(name: String, type: ArtifactType, deliveryConfigName: String): List<DeliveryArtifact> {
     return jooq
-      .select(DELIVERY_ARTIFACT.DETAILS)
+      .select(DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE)
       .from(DELIVERY_ARTIFACT)
       .where(DELIVERY_ARTIFACT.NAME.eq(name))
       .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
-      .fetchOne()
-      ?.let { (details) ->
-        mapToArtifact(name, type, details)
+      .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfigName))
+      .fetch { (details, reference) ->
+        mapToArtifact(name, type, details, reference, deliveryConfigName)
       } ?: throw NoSuchArtifactException(name, type)
   }
 
-  override fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus?): Boolean {
-    val uid = jooq.select(DELIVERY_ARTIFACT.UID)
+  override fun get(name: String, type: ArtifactType, reference: String, deliveryConfigName: String): DeliveryArtifact {
+    return jooq
+      .select(DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE)
       .from(DELIVERY_ARTIFACT)
-      .where(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
-      .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type.name))
+      .where(DELIVERY_ARTIFACT.NAME.eq(name))
+      .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
+      .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfigName))
+      .and(DELIVERY_ARTIFACT.REFERENCE.eq(reference))
       .fetchOne()
-      ?: throw NoSuchArtifactException(artifact)
+      ?.let { (details, reference) ->
+        mapToArtifact(name, type, details, reference, deliveryConfigName)
+      } ?: throw NoSuchArtifactException(name, type)
+  }
 
-    return jooq.insertInto(DELIVERY_ARTIFACT_VERSION)
-      .set(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID, uid.value1())
-      .set(DELIVERY_ARTIFACT_VERSION.VERSION, version)
-      .set(DELIVERY_ARTIFACT_VERSION.RELEASE_STATUS, status?.toString())
+  override fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus?): Boolean =
+    store(artifact.name, artifact.type, version, status)
+
+  override fun store(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): Boolean {
+    if (!isRegistered(name, type)) {
+      throw NoSuchArtifactException(name, type)
+    }
+
+    return jooq.insertInto(ARTIFACT_VERSIONS)
+      .set(ARTIFACT_VERSIONS.NAME, name)
+      .set(ARTIFACT_VERSIONS.TYPE, type.value())
+      .set(ARTIFACT_VERSIONS.VERSION, version)
+      .set(ARTIFACT_VERSIONS.RELEASE_STATUS, status?.toString())
       .onDuplicateKeyIgnore()
       .execute() == 1
   }
@@ -109,27 +127,33 @@ class SqlArtifactRepository(
 
   override fun getAll(type: ArtifactType?): List<DeliveryArtifact> =
     jooq
-      .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.TYPE, DELIVERY_ARTIFACT.DETAILS)
+      .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.TYPE, DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE, DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME)
       .from(DELIVERY_ARTIFACT)
       .apply { if (type != null) where(DELIVERY_ARTIFACT.TYPE.eq(type.toString())) }
-      .fetch { (name, storedType, details) ->
-        mapToArtifact(name, ArtifactType.valueOf(storedType), details)
+      .fetch { (name, storedType, details, reference, configName) ->
+        mapToArtifact(name, ArtifactType.valueOf(storedType), details, reference, configName)
       }
 
-  override fun versions(name: String, type: ArtifactType, statuses: List<ArtifactStatus>): List<String> =
-    versions(get(name, type), statuses)
+  override fun versions(name: String, type: ArtifactType): List<String> {
+    return jooq.select(ARTIFACT_VERSIONS.VERSION)
+      .from(ARTIFACT_VERSIONS)
+      .where(ARTIFACT_VERSIONS.NAME.eq(name))
+      .and(ARTIFACT_VERSIONS.TYPE.eq(type.value()))
+      .fetch()
+      .getValues(ARTIFACT_VERSIONS.VERSION)
+  }
 
+  // todo eb: get status from artifact instead of function param?
   override fun versions(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>): List<String> {
     return if (isRegistered(artifact.name, artifact.type)) {
       jooq
-        .select(DELIVERY_ARTIFACT_VERSION.VERSION)
-        .from(DELIVERY_ARTIFACT, DELIVERY_ARTIFACT_VERSION)
-        .where(DELIVERY_ARTIFACT.UID.eq(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID))
-        .and(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
-        .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type.name))
-        .apply { if (artifact.type == DEB && statuses.isNotEmpty()) and(DELIVERY_ARTIFACT_VERSION.RELEASE_STATUS.`in`(*statuses.map { it.toString() }.toTypedArray())) }
+        .select(ARTIFACT_VERSIONS.VERSION, ARTIFACT_VERSIONS.RELEASE_STATUS)
+        .from(ARTIFACT_VERSIONS)
+        .where(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
+        .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type.value()))
+        .apply { if (artifact.type == DEB && statuses.isNotEmpty()) and(ARTIFACT_VERSIONS.RELEASE_STATUS.`in`(*statuses.map { it.toString() }.toTypedArray())) }
         .fetch()
-        .getValues(DELIVERY_ARTIFACT_VERSION.VERSION)
+        .getValues(ARTIFACT_VERSIONS.VERSION)
         .sortedWith(artifact.versioningStrategy.comparator)
     } else {
       throw NoSuchArtifactException(artifact)
@@ -145,18 +169,20 @@ class SqlArtifactRepository(
     val environment = deliveryConfig.environmentNamed(targetEnvironment)
     val envUid = deliveryConfig.getUidFor(environment)
     val artifactId = artifact.uid
-    return jooq
-      .select(DELIVERY_ARTIFACT_VERSION.VERSION)
-      .from(ENVIRONMENT_ARTIFACT_VERSIONS
-        .innerJoin(DELIVERY_ARTIFACT_VERSION)
-        .on(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID)))
+    val versions: List<String> = jooq
+      .select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
+      .from(ENVIRONMENT_ARTIFACT_VERSIONS, ARTIFACT_VERSIONS)
       .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envUid))
-      .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(DELIVERY_ARTIFACT_VERSION.VERSION))
       .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifactId))
-      .apply { if (statuses.isNotEmpty()) and(DELIVERY_ARTIFACT_VERSION.RELEASE_STATUS.`in`(*statuses.map { it.toString() }.toTypedArray())) }
+      .and(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
+      .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type.name))
+      .and(ARTIFACT_VERSIONS.VERSION.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION))
+      .apply { if (statuses.isNotEmpty()) and(ARTIFACT_VERSIONS.RELEASE_STATUS.`in`(*statuses.map { it.toString() }.toTypedArray())) }
       .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.APPROVED_AT.desc())
-      .limit(1)
-      .fetchOne(0, String::class.java)
+      .fetch()
+      .getValues(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
+
+    return versions.firstOrNull()
   }
 
   override fun approveVersionFor(
@@ -264,12 +290,12 @@ class SqlArtifactRepository(
         val versionsInEnvironment = jooq
           .select(
             ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION,
-            DELIVERY_ARTIFACT_VERSION.RELEASE_STATUS,
+            ARTIFACT_VERSIONS.RELEASE_STATUS,
             ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS
           )
           .from(
             ENVIRONMENT_ARTIFACT_VERSIONS,
-            DELIVERY_ARTIFACT_VERSION,
+            ARTIFACT_VERSIONS,
             DELIVERY_ARTIFACT,
             ENVIRONMENT,
             DELIVERY_CONFIG
@@ -277,43 +303,50 @@ class SqlArtifactRepository(
           .where(DELIVERY_ARTIFACT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID))
           .and(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
           .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type.name))
-          .and(DELIVERY_ARTIFACT.UID.eq(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID))
-          .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(DELIVERY_ARTIFACT_VERSION.VERSION))
+          .and(DELIVERY_ARTIFACT.REFERENCE.eq(artifact.reference))
+          .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(ARTIFACT_VERSIONS.VERSION))
           .and(ENVIRONMENT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID))
           .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
-          .and(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
           .and(ENVIRONMENT.NAME.eq(environment.name))
+          .and(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
+          .and(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
+          .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type.name))
         val pendingVersions = jooq
           .select(
-            DELIVERY_ARTIFACT_VERSION.VERSION,
-            DELIVERY_ARTIFACT_VERSION.RELEASE_STATUS,
+            ARTIFACT_VERSIONS.VERSION,
+            ARTIFACT_VERSIONS.RELEASE_STATUS,
             DSL.`val`(PENDING.name)
           )
           .from(
-            DELIVERY_ARTIFACT_VERSION,
+            ARTIFACT_VERSIONS,
             DELIVERY_ARTIFACT,
             ENVIRONMENT,
             DELIVERY_CONFIG
           )
-          .where(DELIVERY_ARTIFACT.UID.eq(DELIVERY_ARTIFACT_VERSION.DELIVERY_ARTIFACT_UID))
-          .and(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
+          .where(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
           .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type.name))
+          .and(DELIVERY_ARTIFACT.REFERENCE.eq(artifact.reference))
+          .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
           .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
           .and(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
           .and(ENVIRONMENT.NAME.eq(environment.name))
+          .and(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
+          .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type.name))
           .andNotExists(
             selectOne()
               .from(ENVIRONMENT_ARTIFACT_VERSIONS)
-              .where(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(DELIVERY_ARTIFACT_VERSION.VERSION))
+              .where(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(ARTIFACT_VERSIONS.VERSION))
               .and(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
+              .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(DELIVERY_ARTIFACT.UID))
           )
         val versions = versionsInEnvironment
           .unionAll(pendingVersions)
           .fetch { (version, releaseStatus, promotionStatus) ->
             Triple(version, releaseStatus, PromotionStatus.valueOf(promotionStatus))
           }
-          .filter { (_, artifactStatus, _) ->
-            artifact !is DebianArtifact || artifact.statuses.isEmpty() || ArtifactStatus.valueOf(artifactStatus) in artifact.statuses
+          .filter { (_, releaseStatus, _) ->
+            artifact !is DebianArtifact || artifact.statuses.isEmpty() || ArtifactStatus.valueOf(releaseStatus) in artifact.statuses
           }
           .sortedWith(compareBy(artifact.versioningStrategy.comparator) { (version, _, _) -> version })
           .groupBy({ (_, _, promotionStatus) ->
@@ -351,7 +384,9 @@ class SqlArtifactRepository(
     get() = select(DELIVERY_ARTIFACT.UID)
       .from(DELIVERY_ARTIFACT)
       .where(DELIVERY_ARTIFACT.NAME.eq(name)
-        .and(DELIVERY_ARTIFACT.TYPE.eq(type.name)))
+        .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
+        .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfigName))
+        .and(DELIVERY_ARTIFACT.REFERENCE.eq(reference)))
 
   private val DeliveryConfig.uid: Select<Record1<String>>
     get() = select(DELIVERY_CONFIG.UID)

--- a/keel-sql/src/main/resources/db/changelog/20200106-tie-artifacts-to-delivery-configs.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200106-tie-artifacts-to-delivery-configs.yml
@@ -9,13 +9,13 @@ databaseChangeLog:
               - column:
                   name: delivery_config_name
                   type: varchar(255)
-                  value: "keel"
+                  value: "_pending"
                   constraints:
                     nullable: false
               - column:
                   name: reference
                   type: varchar(255)
-                  value: "keel"
+                  value: "_pending"
                   constraints:
                     nullable: false
       rollback:

--- a/keel-sql/src/main/resources/db/changelog/20200106-tie-artifacts-to-delivery-configs.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200106-tie-artifacts-to-delivery-configs.yml
@@ -1,0 +1,91 @@
+databaseChangeLog:
+  - changeSet:
+      id: tie-artifacts-to-delivery-configs
+      author: emjburns
+      changes:
+        - addColumn:
+            tableName: delivery_artifact
+            columns:
+              - column:
+                  name: delivery_config_name
+                  type: varchar(255)
+                  value: "keel"
+                  constraints:
+                    nullable: false
+              - column:
+                  name: reference
+                  type: varchar(255)
+                  value: "keel"
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: delivery_artifact
+            columnName: delivery_config_name
+        - dropColumn:
+            tableName: delivery_artifact
+            columnName: reference
+  - changeSet:
+      id: create-new-artifacts-table
+      author: emjburns
+      changes:
+        - createTable:
+            tableName: artifact_versions
+            columns:
+              - column:
+                  name: name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: type
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: version
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: release_status
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - modifySql:
+                  dbms: mysql
+                  append:
+                    value: " engine innodb"
+            rollback:
+              - dropTable:
+                  tableName: artifact_versions
+  - changeSet:
+      id: create-artifact-version-indicies
+      author: emjburns
+      changes:
+        - addPrimaryKey:
+            tableName: artifact_versions
+            constraintName: artifact_versions_pk
+            columnNames: name, type, version
+        - createIndex:
+            tableName: artifact_versions
+            indexName: artifact_versions_artifact_idx
+            columns:
+              - column:
+                  name: name
+              - column:
+                  name: type
+      rollback:
+        - dropPrimaryKey:
+            constraintName: artifact_versions_pk
+            tableName: artifact_versions
+        - dropIndex:
+            indexName: artifact_versions_artifact_idx
+            tableName: artifact_versions
+
+#  - changeSet:
+#      id: drop-delivery-artifact-versions
+#      author: emjburns
+#      changes:
+#        - dropTable:
+#            tableName: delivery_artifact_versions

--- a/keel-sql/src/main/resources/db/changelog/20200106-tie-artifacts-to-delivery-configs.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200106-tie-artifacts-to-delivery-configs.yml
@@ -83,9 +83,9 @@ databaseChangeLog:
             indexName: artifact_versions_artifact_idx
             tableName: artifact_versions
 
-#  - changeSet:
-#      id: drop-delivery-artifact-versions
-#      author: emjburns
-#      changes:
-#        - dropTable:
-#            tableName: delivery_artifact_versions
+  - changeSet:
+      id: drop-delivery-artifact-version
+      author: emjburns
+      changes:
+        - dropTable:
+            tableName: delivery_artifact_version

--- a/keel-sql/src/main/resources/db/changelog/20200108-update-delivery-artifact-indicies.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200108-update-delivery-artifact-indicies.yml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: update-delivery-artifact-indicies
+      author: emjburns
+      changes:
+        - dropIndex:
+            indexName: delivery_artifact_name_type_idx
+            tableName: delivery_artifact
+        - createIndex:
+            indexName: delivery_artifact_name_type_idx
+            tableName: delivery_artifact
+            unique: false
+            columns:
+              - column:
+                  name: name
+              - column:
+                  name: type

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -71,3 +71,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200106-tie-artifacts-to-delivery-configs.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200108-update-delivery-artifact-indicies.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -68,3 +68,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200107-default-promotion-status.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200106-tie-artifacts-to-delivery-configs.yml
+      relativeToChangelogFile: true

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
@@ -1,0 +1,44 @@
+package com.netflix.spinnaker.keel.test
+
+import com.netflix.spinnaker.keel.api.DebianArtifact
+import com.netflix.spinnaker.keel.api.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+
+/**
+ * Helper functions for working with delivery configs
+ */
+
+fun deliveryConfig(
+  resource: Resource<*> = resource(),
+  env: Environment = Environment("test", setOf(resource)),
+  configName: String = "myconfig",
+  artifact: DeliveryArtifact = DebianArtifact(name = "fnord", deliveryConfigName = configName),
+  deliveryConfig: DeliveryConfig = DeliveryConfig(
+    name = configName,
+    application = "fnord",
+    artifacts = setOf(artifact),
+    environments = setOf(env)
+  )
+): DeliveryConfig {
+  return deliveryConfig
+}
+
+fun saveDeliveryConfig(
+  deliveryConfig: DeliveryConfig,
+  artifactRepository: InMemoryArtifactRepository,
+  resourceRepository: InMemoryResourceRepository,
+  deliveryConfigRepository: InMemoryDeliveryConfigRepository
+) {
+  deliveryConfigRepository.store(deliveryConfig)
+  deliveryConfig.environments.flatMap { it.resources }.forEach {
+    resourceRepository.store(it)
+  }
+  deliveryConfig.artifacts.forEach {
+    artifactRepository.register(it)
+  }
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -31,8 +31,8 @@ import com.netflix.spinnaker.keel.api.titus.exceptions.ErrorResolvingContainerEx
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
-import com.netflix.spinnaker.keel.docker.Container
-import com.netflix.spinnaker.keel.docker.ContainerWithDigest
+import com.netflix.spinnaker.keel.docker.ContainerProvider
+import com.netflix.spinnaker.keel.docker.DigestProvider
 import com.netflix.spinnaker.keel.model.Moniker
 
 /**
@@ -58,7 +58,7 @@ data class TitusClusterSpec(
     moniker: Moniker,
     deployWith: ClusterDeployStrategy = RedBlack(),
     locations: SimpleLocations,
-    container: Container,
+    container: ContainerProvider,
     capacity: Capacity?,
     constraints: Constraints?,
     env: Map<String, String>?,
@@ -94,7 +94,7 @@ data class TitusClusterSpec(
 }
 
 data class TitusServerGroupSpec(
-  val container: Container? = null,
+  val container: ContainerProvider? = null,
   val capacity: Capacity? = null,
   val capacityGroup: String? = null,
   val constraints: Constraints? = null,
@@ -158,8 +158,8 @@ internal fun TitusClusterSpec.resolveCapacityGroup(region: String) =
 internal fun TitusClusterSpec.resolveConstraints(region: String) =
   overrides[region]?.constraints ?: defaults.constraints ?: Constraints()
 
-internal fun resolveContainer(container: Container): ContainerWithDigest {
-  if (container is ContainerWithDigest) {
+internal fun resolveContainerProvider(container: ContainerProvider): DigestProvider {
+  if (container is DigestProvider) {
     return container
   } else {
     // The spec container should be replaced with a resolved container by now.
@@ -189,7 +189,7 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       capacity = resolveCapacity(it.name),
       capacityGroup = resolveCapacityGroup(it.name),
       constraints = resolveConstraints(it.name),
-      container = resolveContainer(defaults.container ?: error("Container image not specified or resolved")),
+      container = resolveContainerProvider(defaults.container ?: error("Container image not specified or resolved")),
       dependencies = resolveDependencies(it.name),
       entryPoint = resolveEntryPoint(it.name),
       env = resolveEnv(it.name),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
-import com.netflix.spinnaker.keel.docker.Container
+import com.netflix.spinnaker.keel.docker.ContainerProvider
 import com.netflix.spinnaker.keel.docker.DockerImageResolver
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
@@ -54,7 +54,7 @@ class TitusImageResolver(
   override fun getAccountFromSpec(resource: Resource<TitusClusterSpec>) =
     resource.spec.deriveRegistry()
 
-  override fun updateContainerInSpec(resource: Resource<TitusClusterSpec>, container: Container) =
+  override fun updateContainerInSpec(resource: Resource<TitusClusterSpec>, container: ContainerProvider) =
     resource.copy(spec = resource.spec.copy(_defaults = resource.spec.defaults.copy(container = container)))
 
   override fun getTags(account: String, organization: String, image: String) =

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.keel.api.ClusterDependencies
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
-import com.netflix.spinnaker.keel.docker.ContainerWithDigest
+import com.netflix.spinnaker.keel.docker.DigestProvider
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.parseMoniker
 import de.danielbechler.diff.inclusion.Inclusion
@@ -39,7 +39,7 @@ data class TitusServerGroup(
    */
   @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
   val name: String,
-  val container: ContainerWithDigest,
+  val container: DigestProvider,
   val location: Location,
   val env: Map<String, String> = emptyMap(),
   val containerAttributes: Map<String, String> = emptyMap(),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ErrorResolvingContainerException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ErrorResolvingContainerException.kt
@@ -17,8 +17,8 @@
  */
 package com.netflix.spinnaker.keel.api.titus.exceptions
 
-import com.netflix.spinnaker.keel.docker.Container
+import com.netflix.spinnaker.keel.docker.ContainerProvider
 
 class ErrorResolvingContainerException(
-  val container: Container
+  val container: ContainerProvider
 ) : RuntimeException("There was an error resolving the correct docker container (current container: $container)")

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -48,8 +48,6 @@ class ApplicationController(
     @PathVariable("application") application: String,
     @RequestParam("includeDetails", required = false, defaultValue = "false") includeDetails: Boolean
   ): Map<String, Any> {
-    val hasDeliveryConfig = deliveryConfigRepository.hasDeliveryConfig(application)
-
     if (includeDetails) {
       var resources = resourceRepository.getSummaryByApplication(application)
       resources = resources.map { summary ->
@@ -61,24 +59,19 @@ class ApplicationController(
           summary
         }
       }
-      val constraintStates = if (hasDeliveryConfig) {
-        deliveryConfigRepository.constraintStateFor(application)
-      } else {
-        emptyList()
-      }
+      val constraintStates = deliveryConfigRepository.constraintStateFor(application)
 
       return mapOf(
         "applicationPaused" to resourcePauser.applicationIsPaused(application),
         "hasManagedResources" to resources.isNotEmpty(),
         "resources" to resources,
-        "hasDeliveryConfig" to hasDeliveryConfig,
         "currentEnvironmentConstraints" to constraintStates
       )
     }
     return mapOf(
       "applicationPaused" to resourcePauser.applicationIsPaused(application),
-      "hasManagedResources" to resourceRepository.hasManagedResources(application),
-      "hasDeliveryConfig" to hasDeliveryConfig)
+      "hasManagedResources" to resourceRepository.hasManagedResources(application)
+    )
   }
 
   @PostMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -51,6 +51,7 @@ class DeliveryConfigController(
   fun get(@PathVariable("name") name: String): DeliveryConfig =
     deliveryConfigRepository.get(name)
 
+  // todo eb: make this work with artifact references
   @PostMapping(
     path = ["/diff"],
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -94,17 +94,6 @@ class ResourceController(
     resourcePauser.resumeResource(id)
   }
 
-  @Deprecated("Individual resource creation is deprecated. Please use a delivery config.")
-  @PostMapping(
-    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  @PreAuthorize("@authorizationSupport.userCanModifySpec(#resource.metadata[serviceAccount], #resource.spec)")
-  fun upsert(@RequestBody resource: SubmittedResource<*>): Resource<*> {
-    log.debug("Upserting: $resource")
-    return resourcePersister.upsert(resource)
-  }
-
   @PostMapping(
     path = ["/diff"],
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
@@ -114,17 +103,6 @@ class ResourceController(
   fun diff(@RequestBody resource: SubmittedResource<*>): DiffResult {
     log.debug("Diffing: $resource")
     return runBlocking { adHocDiffer.calculate(resource) }
-  }
-
-  @Deprecated("Individual resource deletion is deprecated. Please use a delivery config.")
-  @DeleteMapping(
-    path = ["/{id}"],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  @PreAuthorize("@authorizationSupport.userCanModifyResource(#id)")
-  fun delete(@PathVariable("id") id: ResourceId): Resource<*> {
-    log.debug("Deleting: $id")
-    return resourcePersister.delete(id)
   }
 
   @ExceptionHandler(NoSuchResourceException::class)

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -24,8 +24,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [KeelApplication::class, MockEurekaConfiguration::class],
-  webEnvironment = MOCK
+    classes = [KeelApplication::class, MockEurekaConfiguration::class],
+    webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ApplicationControllerTests {
@@ -50,33 +50,31 @@ internal class ApplicationControllerTests {
     resourceRepository.appendHistory(ResourceCreated(res))
 
     var request = get("/application/${res.application}")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
     mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andExpect(content().json(
-        """
+        .perform(request)
+        .andExpect(status().isOk)
+        .andExpect(content().json(
+            """
           {
-            "hasManagedResources":true,
-            "hasDeliveryConfig":false
+            "hasManagedResources":true
           }
         """.trimIndent()
-      ))
+        ))
 
     request = get("/application/${res.application}?includeDetails=true")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
+        .accept(MediaType.APPLICATION_JSON_VALUE)
     mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andExpect(content().json(
-        """
+        .perform(request)
+        .andExpect(status().isOk)
+        .andExpect(content().json(
+            """
           |{
           |"hasManagedResources":true,
           |"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}],
-          |"hasDeliveryConfig":false,
           |"currentEnvironmentConstraints":[]
           |}
         """.trimMargin()
-      ))
+        ))
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -24,8 +24,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-    classes = [KeelApplication::class, MockEurekaConfiguration::class],
-    webEnvironment = MOCK
+  classes = [KeelApplication::class, MockEurekaConfiguration::class],
+  webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ApplicationControllerTests {
@@ -50,31 +50,31 @@ internal class ApplicationControllerTests {
     resourceRepository.appendHistory(ResourceCreated(res))
 
     var request = get("/application/${res.application}")
-        .accept(MediaType.APPLICATION_JSON_VALUE)
+      .accept(MediaType.APPLICATION_JSON_VALUE)
     mvc
-        .perform(request)
-        .andExpect(status().isOk)
-        .andExpect(content().json(
-            """
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().json(
+        """
           {
             "hasManagedResources":true
           }
         """.trimIndent()
-        ))
+      ))
 
     request = get("/application/${res.application}?includeDetails=true")
-        .accept(MediaType.APPLICATION_JSON_VALUE)
+      .accept(MediaType.APPLICATION_JSON_VALUE)
     mvc
-        .perform(request)
-        .andExpect(status().isOk)
-        .andExpect(content().json(
-            """
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().json(
+        """
           |{
           |"hasManagedResources":true,
           |"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}],
           |"currentEnvironmentConstraints":[]
           |}
         """.trimMargin()
-        ))
+      ))
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -21,8 +21,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [KeelApplication::class, MockEurekaConfiguration::class],
-  webEnvironment = MOCK
+    classes = [KeelApplication::class, MockEurekaConfiguration::class],
+    webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ArtifactControllerTests {
@@ -39,34 +39,37 @@ internal class ArtifactControllerTests {
 
   @Test
   fun `can get the versions of an artifact`() {
-    val artifact = DebianArtifact("fnord")
+    val artifact = DebianArtifact(name = "fnord", deliveryConfigName = "myconfig")
     with(artifactRepository) {
       register(artifact)
-      store(artifact, "fnord-1.0.0-41595c4", FINAL)
-      store(artifact, "fnord-2.0.0-608bd90", FINAL)
       store(artifact, "fnord-2.1.0-18ed1dc", FINAL)
+      store(artifact, "fnord-2.0.0-608bd90", FINAL)
+      store(artifact, "fnord-1.0.0-41595c4", FINAL)
     }
 
     val request = get("/artifacts/${artifact.name}/${artifact.type}")
-      .accept(APPLICATION_YAML)
+        .accept(APPLICATION_YAML)
     mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andExpect(content().string(
-        """---
+        .perform(request)
+        .andExpect(status().isOk)
+        .andExpect(content().string(
+            """---
           |- "fnord-2.1.0-18ed1dc"
           |- "fnord-2.0.0-608bd90"
           |- "fnord-1.0.0-41595c4"
         """.trimMargin()
-      ))
+        ))
   }
 
   @Test
-  fun `unregistered artifact is not found when requesting versions`() {
+  fun `versions empty for an artifact we're not tracking`() {
     val request = get("/artifacts/unregistered/DEB")
-      .accept(APPLICATION_YAML)
+        .accept(APPLICATION_YAML)
     mvc
-      .perform(request)
-      .andExpect(status().isNotFound)
+        .perform(request)
+        .andExpect(status().isOk)
+        .andExpect(content().string(
+            """--- []""".trimMargin()
+        ))
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -21,8 +21,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-    classes = [KeelApplication::class, MockEurekaConfiguration::class],
-    webEnvironment = MOCK
+  classes = [KeelApplication::class, MockEurekaConfiguration::class],
+  webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ArtifactControllerTests {
@@ -48,28 +48,28 @@ internal class ArtifactControllerTests {
     }
 
     val request = get("/artifacts/${artifact.name}/${artifact.type}")
-        .accept(APPLICATION_YAML)
+      .accept(APPLICATION_YAML)
     mvc
-        .perform(request)
-        .andExpect(status().isOk)
-        .andExpect(content().string(
-            """---
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().string(
+        """---
           |- "fnord-2.1.0-18ed1dc"
           |- "fnord-2.0.0-608bd90"
           |- "fnord-1.0.0-41595c4"
         """.trimMargin()
-        ))
+      ))
   }
 
   @Test
   fun `versions empty for an artifact we're not tracking`() {
     val request = get("/artifacts/unregistered/DEB")
-        .accept(APPLICATION_YAML)
+      .accept(APPLICATION_YAML)
     mvc
-        .perform(request)
-        .andExpect(status().isOk)
-        .andExpect(content().string(
-            """--- []""".trimMargin()
-        ))
+      .perform(request)
+      .andExpect(status().isOk)
+      .andExpect(content().string(
+        """--- []""".trimMargin()
+      ))
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -32,8 +32,8 @@ import strikt.assertions.isNotNull
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-    classes = [KeelApplication::class, MockEurekaConfiguration::class, DummyResourceConfiguration::class],
-    webEnvironment = MOCK
+  classes = [KeelApplication::class, MockEurekaConfiguration::class, DummyResourceConfiguration::class],
+  webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ResourceControllerTests {
@@ -64,10 +64,10 @@ internal class ResourceControllerTests {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns false
 
     val request = post("/resources/diff")
-        .accept(APPLICATION_JSON)
-        .contentType(APPLICATION_JSON)
-        .content(
-            """{
+      .accept(APPLICATION_JSON)
+      .contentType(APPLICATION_JSON)
+      .content(
+        """{
           |  "apiVersion": "test.spinnaker.netflix.com/v1",
           |  "kind": "whatever",
           |  "metadata": {
@@ -77,32 +77,32 @@ internal class ResourceControllerTests {
           |    "data": "o hai"
           |  }
           |}"""
-                .trimMargin()
-        )
+          .trimMargin()
+      )
     mvc
-        .perform(request)
-        .andExpect(status().isForbidden)
+      .perform(request)
+      .andExpect(status().isForbidden)
   }
 
   @Test
   fun `an invalid request body results in an HTTP 400`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
     val request = post("/resources/diff")
-        .accept(APPLICATION_YAML)
-        .contentType(APPLICATION_YAML)
-        .content(
-            """---
+      .accept(APPLICATION_YAML)
+      .contentType(APPLICATION_YAML)
+      .content(
+        """---
           |apiVersion: test.spinnaker.netflix.com/v1
           |kind: whatever
           |metadata:
           |  name: i-forgot-my-service-account
           |spec:
           |  data: o hai"""
-                .trimMargin()
-        )
+          .trimMargin()
+      )
     mvc
-        .perform(request)
-        .andExpect(status().isBadRequest)
+      .perform(request)
+      .andExpect(status().isBadRequest)
   }
 
   @Test
@@ -110,25 +110,25 @@ internal class ResourceControllerTests {
     resourceRepository.store(resource)
 
     val request = get("/resources/${resource.id}")
-        .accept(APPLICATION_YAML)
+      .accept(APPLICATION_YAML)
     val result = mvc
-        .perform(request)
-        .andExpect(status().isOk)
-        .andReturn()
+      .perform(request)
+      .andExpect(status().isOk)
+      .andReturn()
     expectThat(result.response)
-        .contentType
-        .isNotNull()
-        .isCompatibleWith(APPLICATION_YAML)
+      .contentType
+      .isNotNull()
+      .isCompatibleWith(APPLICATION_YAML)
   }
 
   @Test
   fun `unknown resource name results in a 404`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
     val request = get("/resources/i-do-not-exist")
-        .accept(APPLICATION_YAML)
+      .accept(APPLICATION_YAML)
     mvc
-        .perform(request)
-        .andExpect(status().isNotFound)
+      .perform(request)
+      .andExpect(status().isNotFound)
   }
 }
 
@@ -137,6 +137,6 @@ private val Assertion.Builder<MockHttpServletResponse>.contentType: Describeable
 
 @Suppress("UNCHECKED_CAST")
 private fun <T : MediaType?> Assertion.Builder<T>.isCompatibleWith(expected: MediaType): Assertion.Builder<MediaType> =
-    assertThat("is compatible with $expected") {
-      it?.isCompatibleWith(expected) ?: false
-    } as Assertion.Builder<MediaType>
+  assertThat("is compatible with $expected") {
+    it?.isCompatibleWith(expected) ?: false
+  } as Assertion.Builder<MediaType>

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -4,15 +4,12 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.actuation.ResourcePersister
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.diff.AdHocDiffer
-import com.netflix.spinnaker.keel.persistence.NoSuchResourceId
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
-import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
-import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -25,7 +22,6 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.mock.web.MockHttpServletResponse
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -36,8 +32,8 @@ import strikt.assertions.isNotNull
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [KeelApplication::class, MockEurekaConfiguration::class, DummyResourceConfiguration::class],
-  webEnvironment = MOCK
+    classes = [KeelApplication::class, MockEurekaConfiguration::class, DummyResourceConfiguration::class],
+    webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ResourceControllerTests {
@@ -64,77 +60,14 @@ internal class ResourceControllerTests {
   }
 
   @Test
-  fun `can create a resource as YAML`() {
-    every { resourcePersister.upsert<DummyResourceSpec>(any()) } returns resource
-    every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
-
-    val request = post("/resources")
-      .accept(APPLICATION_YAML)
-      .contentType(APPLICATION_YAML)
-      .content(
-        """---
-          |apiVersion: test.spinnaker.netflix.com/v1
-          |metadata:
-          |  serviceAccount: keel@spinnaker
-          |kind: whatever
-          |spec:
-          |  data: o hai"""
-          .trimMargin()
-      )
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-
-    verify {
-      resourcePersister
-        .upsert<DummyResourceSpec>(match {
-          it.spec.data == "o hai"
-        })
-    }
-  }
-
-  @Test
-  fun `can create a resource as JSON`() {
-    every { resourcePersister.upsert<DummyResourceSpec>(any()) } returns resource
-    every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
-
-    val request = post("/resources")
-      .accept(APPLICATION_JSON)
-      .contentType(APPLICATION_JSON)
-      .content(
-        """{
-          |  "apiVersion": "test.spinnaker.netflix.com/v1",
-          |  "kind": "whatever",
-          |  "metadata": {
-          |    "serviceAccount": "keel@spinnaker"
-          |  },
-          |  "spec": {
-          |    "data": "o hai"
-          |  }
-          |}"""
-          .trimMargin()
-      )
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-
-    verify {
-      resourcePersister
-        .upsert<DummyResourceSpec>(match {
-          it.spec.data == "o hai"
-        })
-    }
-  }
-
-  @Test
-  fun `can't create a resource when unauthorized`() {
+  fun `can't diff a resource when unauthorized`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns false
 
-    val request = post("/resources")
-      .accept(APPLICATION_JSON)
-      .contentType(APPLICATION_JSON)
-      .content(
-        """{
+    val request = post("/resources/diff")
+        .accept(APPLICATION_JSON)
+        .contentType(APPLICATION_JSON)
+        .content(
+            """{
           |  "apiVersion": "test.spinnaker.netflix.com/v1",
           |  "kind": "whatever",
           |  "metadata": {
@@ -144,85 +77,32 @@ internal class ResourceControllerTests {
           |    "data": "o hai"
           |  }
           |}"""
-          .trimMargin()
-      )
+                .trimMargin()
+        )
     mvc
-      .perform(request)
-      .andExpect(status().isForbidden)
-  }
-
-  @Test
-  fun `can update a resource`() {
-    every { resourcePersister.upsert<DummyResourceSpec>(any()) } returns resource
-    every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
-
-    val request = post("/resources")
-      .accept(APPLICATION_YAML)
-      .contentType(APPLICATION_YAML)
-      .content(
-        """---
-          |apiVersion: test.spinnaker.netflix.com/v1
-          |metadata:
-          |  serviceAccount: keel@spinnaker
-          |kind: whatever
-          |spec:
-          |  data: kthxbye"""
-          .trimMargin()
-      )
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-
-    verify {
-      resourcePersister
-        .upsert<DummyResourceSpec>(match {
-          it.spec.data == "kthxbye"
-        })
-    }
-  }
-
-  @Test
-  fun `attempting to update an unknown resource results in a 404`() {
-    every { resourcePersister.upsert<DummyResourceSpec>(any()) } throws NoSuchResourceId(resource.id)
-    every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
-
-    val request = post("/resources")
-      .accept(APPLICATION_YAML)
-      .contentType(APPLICATION_YAML)
-      .content(
-        """---
-          |apiVersion: test.spinnaker.netflix.com/v1
-          |metadata:
-          |  serviceAccount: keel@spinnaker
-          |kind: whatever
-          |spec:
-          |  data: kthxbye"""
-          .trimMargin()
-      )
-    mvc
-      .perform(request)
-      .andExpect(status().isNotFound)
+        .perform(request)
+        .andExpect(status().isForbidden)
   }
 
   @Test
   fun `an invalid request body results in an HTTP 400`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
-    val request = post("/resources")
-      .accept(APPLICATION_YAML)
-      .contentType(APPLICATION_YAML)
-      .content(
-        """---
+    val request = post("/resources/diff")
+        .accept(APPLICATION_YAML)
+        .contentType(APPLICATION_YAML)
+        .content(
+            """---
           |apiVersion: test.spinnaker.netflix.com/v1
           |kind: whatever
           |metadata:
           |  name: i-forgot-my-service-account
           |spec:
           |  data: o hai"""
-          .trimMargin()
-      )
+                .trimMargin()
+        )
     mvc
-      .perform(request)
-      .andExpect(status().isBadRequest)
+        .perform(request)
+        .andExpect(status().isBadRequest)
   }
 
   @Test
@@ -230,43 +110,25 @@ internal class ResourceControllerTests {
     resourceRepository.store(resource)
 
     val request = get("/resources/${resource.id}")
-      .accept(APPLICATION_YAML)
+        .accept(APPLICATION_YAML)
     val result = mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andReturn()
+        .perform(request)
+        .andExpect(status().isOk)
+        .andReturn()
     expectThat(result.response)
-      .contentType
-      .isNotNull()
-      .isCompatibleWith(APPLICATION_YAML)
-  }
-
-  @Test
-  fun `can delete a resource`() {
-    every { resourcePersister.delete(resource.id) } returns resource
-    every { authorizationSupport.userCanModifyResource(resource.id.toString()) } returns true
-    resourceRepository.store(resource)
-
-    val request = delete("/resources/${resource.id}")
-      .accept(APPLICATION_YAML)
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-
-    verify { resourcePersister.delete(resource.id) }
-
-    // clean up after the test
-    resourceRepository.delete(resource.id)
+        .contentType
+        .isNotNull()
+        .isCompatibleWith(APPLICATION_YAML)
   }
 
   @Test
   fun `unknown resource name results in a 404`() {
     every { authorizationSupport.userCanModifySpec("keel@spinnaker", any()) } returns true
     val request = get("/resources/i-do-not-exist")
-      .accept(APPLICATION_YAML)
+        .accept(APPLICATION_YAML)
     mvc
-      .perform(request)
-      .andExpect(status().isNotFound)
+        .perform(request)
+        .andExpect(status().isNotFound)
   }
 }
 
@@ -275,6 +137,6 @@ private val Assertion.Builder<MockHttpServletResponse>.contentType: Describeable
 
 @Suppress("UNCHECKED_CAST")
 private fun <T : MediaType?> Assertion.Builder<T>.isCompatibleWith(expected: MediaType): Assertion.Builder<MediaType> =
-  assertThat("is compatible with $expected") {
-    it?.isCompatibleWith(expected) ?: false
-  } as Assertion.Builder<MediaType>
+    assertThat("is compatible with $expected") {
+      it?.isCompatibleWith(expected) ?: false
+    } as Assertion.Builder<MediaType>


### PR DESCRIPTION
(closes https://github.com/spinnaker/keel/issues/655) This is a big PR with a major change: resources are required to be associated with a delivery config.
This PR also introduces artifact references for both aws and titus. That looks like this:

```json
"artifacts": [
    {
      "name": "emburns/spin-titus-demo",
      "type": "docker",
      "tagVersionStrategy": "branch-job-commit-by-job",
      "reference": "my-docker-artifact"
    },
   {
      "name": "deb-sample-app-server",
      "type": "deb",
      "reference": "my-deb"
    }
  ]
```
and a ec2 cluster in the same delivery config could define:
```json
{
          "apiVersion": "ec2.spinnaker.netflix.com/v1",
          "kind": "cluster",
          "spec": {
...
            "imageProvider": {
              "reference": "my-deb"
            }
...
          }
```
and a titus cluster in the same delivery config could define:
```json
{
	  "apiVersion": "titus.spinnaker.netflix.com/v1",
	  "kind": "cluster",
          "spec": {
...
            "container": {
              "reference": "my-docker-artifact"
            }
...
          }
```
