### PR TITLE
fix(artifact): fixing uniqueness

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20200109-fix-delivery-artifact-uniqueness.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200109-fix-delivery-artifact-uniqueness.yml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: shorten-artifact-type
+      author: emjburns
+      changes:
+        - modifyDataType:
+            tableName: delivery_artifact
+            columnName: type
+            newDataType: varchar(25)
+        - modifyDataType:
+            tableName: delivery_artifact
+            columnName: reference
+            newDataType: varchar(50)
+        - modifyDataType:
+            tableName: delivery_artifact
+            columnName: name
+            newDataType: varchar(50)
+  - changeSet:
+      id: fix-delivery-artifact-uniqueness
+      author: emjburns
+      changes:
+        - createIndex:
+            indexName: delivery_artifact_unique_idx
+            tableName: delivery_artifact
+            unique: true
+            columns:
+              - column:
+                  name: name
+              - column:
+                  name: type
+              - column:
+                  name: delivery_config_name
+              - column:
+                  name: reference

--- a/keel-sql/src/main/resources/db/changelog/20200109-fix-delivery-artifact-uniqueness.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200109-fix-delivery-artifact-uniqueness.yml
@@ -1,34 +1,14 @@
 databaseChangeLog:
   - changeSet:
-      id: shorten-artifact-type
-      author: emjburns
-      changes:
-        - modifyDataType:
-            tableName: delivery_artifact
-            columnName: type
-            newDataType: varchar(25)
-        - modifyDataType:
-            tableName: delivery_artifact
-            columnName: reference
-            newDataType: varchar(50)
-        - modifyDataType:
-            tableName: delivery_artifact
-            columnName: name
-            newDataType: varchar(50)
-  - changeSet:
       id: fix-delivery-artifact-uniqueness
       author: emjburns
       changes:
-        - createIndex:
-            indexName: delivery_artifact_unique_idx
+        - addColumn:
             tableName: delivery_artifact
-            unique: true
             columns:
               - column:
-                  name: name
-              - column:
-                  name: type
-              - column:
-                  name: delivery_config_name
-              - column:
-                  name: reference
+                  name: fingerprint
+                  type: char(40)
+                  afterColumn: uid
+                  constraints:
+                    nullable: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -74,3 +74,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200108-update-delivery-artifact-indicies.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200109-fix-delivery-artifact-uniqueness.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Turns out we obviously needed a unique constraint for artifacts. Making a delivery artifact unique on name, type, delivery config, and reference. This means that you can care about the same exact artifact in more than one way (i.e. snapshot status for feature branch env, release status for prod flow) as long as you give it a different "reference".