### PR TITLE
feat(debug): a way to add debugging context to resources

### DIFF
--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.ArtifactStatus.FINAL
 import com.netflix.spinnaker.keel.api.ArtifactStatus.SNAPSHOT
 import com.netflix.spinnaker.keel.api.DebianArtifact
 import com.netflix.spinnaker.keel.api.NoKnownArtifactVersions
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.bakery.UnknownBaseImage
 import com.netflix.spinnaker.keel.bakery.api.BaseLabel.RELEASE
@@ -224,7 +225,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
       context("the image already exists in more regions than desired") {
         before {
           coEvery {
-            imageService.getLatestImageWithAllRegions("keel", "test", image.regions.toList())
+            imageService.getLatestImageWithAllRegions(resource.id, "keel", "test", image.regions.toList())
           } returns image.copy(regions = image.regions + "eu-west-1")
         }
         test("current should filter the undesireable regions out of the image") {

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.BeanCreationException
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import retrofit2.Retrofit
@@ -61,6 +62,7 @@ class ClouddriverConfiguration {
 
   @Bean
   fun imageService(
-    cloudDriverService: CloudDriverService
-  ) = ImageService(cloudDriverService)
+    cloudDriverService: CloudDriverService,
+    publisher: ApplicationEventPublisher
+  ) = ImageService(cloudDriverService, publisher)
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryArtifact.kt
@@ -48,7 +48,7 @@ data class DebianArtifact(
   @JsonProperty(access = Access.WRITE_ONLY) override val deliveryConfigName: String? = null,
   override val reference: String = name,
   val statuses: List<ArtifactStatus> = emptyList(),
-  override val versioningStrategy: VersioningStrategy = DebianSemVerVersioningStrategy
+  @JsonProperty(access = Access.WRITE_ONLY) override val versioningStrategy: VersioningStrategy = DebianSemVerVersioningStrategy
 ) : DeliveryArtifact {
   override val type = DEB
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/DebugEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/DebugEvent.kt
@@ -1,0 +1,25 @@
+package com.netflix.spinnaker.keel.events
+
+import com.netflix.spinnaker.keel.api.ResourceId
+import java.time.Clock
+
+/**
+ * An event for tracking information about a resource that's used to make actuation decisions
+ */
+data class DebugEvent(
+  val resourceId: ResourceId,
+  val context: String,
+  val message: String,
+  val timestamp: Long
+) {
+  companion object {
+    val clock: Clock = Clock.systemDefaultZone()
+  }
+
+  constructor(resourceId: ResourceId, context: String, message: String, clock: Clock = Companion.clock) : this(
+    resourceId,
+    context,
+    message,
+    clock.instant().toEpochMilli()
+  )
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/DebugEventListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/DebugEventListener.kt
@@ -1,0 +1,14 @@
+package com.netflix.spinnaker.keel.events
+
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class DebugEventListener(private val resourceRepository: ResourceRepository) {
+
+  @EventListener(DebugEvent::class)
+  fun onDebugEvent(event: DebugEvent) {
+    resourceRepository.appendDebugLog(event)
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -34,8 +34,6 @@ import com.netflix.spinnaker.keel.events.ResourceState.Ok
 import java.time.Clock
 import java.time.Instant
 
-// todo emjburns: use the common class in kork, but refactor so you can also set the time in those.
-// todo emjburns: maybe only do ^ once the api stabilizes, for now we're using maps in gate.
 @JsonTypeInfo(
   use = Id.NAME,
   property = "type",

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.api.ResourceSummary
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.events.DebugEvent
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
@@ -129,6 +130,19 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
    * Records an event associated with a resource.
    */
   fun appendHistory(event: ResourceEvent)
+
+  /**
+   * Records a debug log associated with a resource
+   */
+  fun appendDebugLog(event: DebugEvent)
+
+  /**
+   * Retrieves the debug log for the resource represented by [uid].
+   *
+   * @param id the resource id.
+   * @param limit the maximum number of events to return.
+   */
+  fun debugLog(id: ResourceId, limit: Int = DEFAULT_MAX_EVENTS): List<DebugEvent>
 
   /**
    * Returns between zero and [limit] resources that have not been checked (i.e. returned by this

--- a/keel-sql/src/main/resources/db/changelog/20201011-resource-debug-log.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201011-resource-debug-log.yml
@@ -1,0 +1,60 @@
+databaseChangeLog:
+  - changeSet:
+      id: resource-debug-log
+      author: emjburns
+      changes:
+        - createTable:
+            tableName: resource_debug
+            columns:
+              - column:
+                  name: uid
+                  type: char(26)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: timestamp
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: context
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: json
+                  type: longtext
+                  constraints:
+                    nullable: false
+              - modifySql:
+                  dbms: mysql
+                  append:
+                    value: " engine innodb"
+      rollback:
+        - dropTable:
+            tableName: resource_debug
+  - changeSet:
+      id: create-resource-debug-indicies
+      author: emjburns
+      changes:
+        - createIndex:
+            indexName: resource_debug_uid_idx
+            tableName: resource_debug
+            columns:
+              - column:
+                  name: uid
+        - createIndex:
+            indexName: resource_debug_uid_timestamp_idx
+            tableName: resource_debug
+            columns:
+              - column:
+                  name: uid
+              - column:
+                  name: timestamp
+      rollback:
+        - dropIndex:
+            indexName: resource_debug_uid_idx
+            tableName: resource_debug
+        - dropIndex:
+            indexName: resource_debug_uid_timestamp_idx
+            tableName: resource_debug

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -77,3 +77,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200109-fix-delivery-artifact-uniqueness.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20201011-resource-debug-log.yml
+      relativeToChangelogFile: true

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -21,10 +21,12 @@ import com.netflix.spinnaker.keel.api.ResourceId
 import com.netflix.spinnaker.keel.api.SubmittedResource
 import com.netflix.spinnaker.keel.diff.AdHocDiffer
 import com.netflix.spinnaker.keel.diff.DiffResult
+import com.netflix.spinnaker.keel.events.DebugEvent
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
 import com.netflix.spinnaker.keel.pause.ResourcePauser
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
 import com.netflix.spinnaker.keel.plugin.UnsupportedKind
@@ -44,6 +46,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -77,6 +80,17 @@ class ResourceController(
     } else {
       resourceRepository.getStatus(id)
     }
+
+  @GetMapping(
+    path = ["/{id}/debug"],
+    produces = [APPLICATION_JSON_VALUE]
+  )
+  fun getDebugLog(
+    @PathVariable("id") id: ResourceId,
+    @RequestParam("limit") limit: Int?
+  ): List<DebugEvent> {
+    return resourceRepository.debugLog(id, limit ?: DEFAULT_MAX_EVENTS)
+  }
 
   @PostMapping(
     path = ["/{id}/pause"],


### PR DESCRIPTION
I've been frustrated when I've had to debug resource actuation decisions and I haven't been able to get a lot of information about why something happened. For example, why does my image keep rebaking? 

I thought it might be useful to create a way to attach debug messages to resources - sort of like the way we have context on clouddriver tasks which tell the steps taken. I didn't want to just log messages, because then you have to rely on remembering what to search for. So, I created a "debug log" for each resource. 

To use it, all you have to do is emit an event with the resource id (a `DebugEvent`). These will get collected and surfaced from the endpoint `resources/{id}/debug`.

The idea is that this will mostly be used for us to figure out what is going wrong, but it could be available for a user to get more information about why we did something. This will provide a lot more detail than the current event log - and that's good! I think they should stay separate.

A sample:

```json

[{
    "resourceId": "bakery:image:deb-sample-app-server",
    "context": "Finding current image",
    "message": "current image is Image(baseAmiVersion=nflx-base-5x, appVersion=deb-sample-app-server-0.69.0, regions=[us-east-1, us-west-2])",
    "timestamp": 1578765130641
  },
  {
    "resourceId": "bakery:image:deb-sample-app-server",
    "context": "Finding latest qualifying named image for deb-sample-app-server",
    "message": "rejected images={deb-sample-app-server-0.73.0-h303.1=[image is only in regions [us-west-2], not all required regions ([us-east-1, us-west-2])], deb-sample-app-server-0.73.0-h303.1=[image is only in regions [us-east-1, us-west-1], not all required regions ([us-east-1, us-west-2])]}",
    "timestamp": 1578765130640
  },
  {
    "resourceId": "bakery:image:deb-sample-app-server",
    "context": "Finding latest qualifying named image for deb-sample-app-server",
    "message": "selected image=NamedImage(imageName=deb-sample-app-server-0.69.0-h299.b ... blah blah)",
    "timestamp": 1578765130640
  },
  {
    "resourceId": "bakery:image:deb-sample-app-server",
    "context": "Resolving type",
    "message": "baseimage=xenialbase-x",
    "timestamp": 1578765130534
  },
  {
    "resourceId": "bakery:image:deb-sample-app-server",
    "context": "Finding latest version of deb-sample-app-server",
    "message": "latest known version = deb-sample-app-server-0.73.0-h303.1",
    "timestamp": 1578765129929
  }]
```