### PR TITLE
fix(artifacts): don't approve a version with an invalid status

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -21,12 +21,6 @@ class EnvironmentPromotionChecker(
     .filterIsInstance<StatefulConstraintEvaluator<*>>()
   private val statelessEvaluators = constraints - statefulEvaluators
 
-  /**
-   * TODO (Critical): The EC2 ClusterSpec enables artifact filtering by ArtifactStatus. This is
-   *  currently handled in ImageResolver after artifacts are "approved" for an environment.
-   *  Instead, this needs to happen here or earlier. Otherwise we may deploy canary clusters or
-   *  request manual judgements for artifacts that should never be allowed in a given environemnt.
-   */
   suspend fun checkEnvironments(deliveryConfig: DeliveryConfig) {
     deliveryConfig
       .artifacts

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -30,11 +30,11 @@ interface ArtifactRepository {
   fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus?): Boolean
 
   /**
-   * @returns the versions we have for an artifact, optionally filtering by status if provided
+   * @returns the versions we have for an artifact, filtering by the artifact status information,
+   * and sorting with the artifact's sorting strategy
    */
   fun versions(
-    artifact: DeliveryArtifact,
-    statuses: List<ArtifactStatus> = emptyList()
+    artifact: DeliveryArtifact
   ): List<String>
 
   /**
@@ -46,14 +46,14 @@ interface ArtifactRepository {
   ): List<String>
 
   /**
-   * @return the latest version of [artifact] approved for use in [targetEnvironment],
-   * optionally filtering by status if provided.
+   * @return the latest version of [artifact] approved for use in [targetEnvironment]
+   *
+   * Only versions that meet the status requirements for an artifact can be approved
    */
   fun latestVersionApprovedIn(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
-    targetEnvironment: String,
-    statuses: List<ArtifactStatus> = emptyList()
+    targetEnvironment: String
   ): String?
 
   /**

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
@@ -26,4 +26,4 @@ class NoImageFoundForRegions(artifactName: String, regions: Collection<String>) 
   ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in regions ${regions.joinToString()}")
 
 class NoImageSatisfiesConstraints(artifactName: String, environment: String) :
-  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in $environment")
+  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in environment $environment")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -81,8 +81,7 @@ class ImageResolver(
     val artifactVersion = artifactRepository.latestVersionApprovedIn(
       deliveryConfig,
       artifact,
-      environment.name,
-      artifact.statuses // todo eb: this is kind of a change, since we used to pass statuses in from the artifact image provider
+      environment.name
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
     return imageService.getLatestNamedImageWithAllRegionsForAppVersion(
       appVersion = AppVersion.parseName(artifactVersion),

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.ec2.resolvers
 
 import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.ArtifactStatus.RELEASE
-import com.netflix.spinnaker.keel.api.ArtifactStatus.SNAPSHOT
 import com.netflix.spinnaker.keel.api.DebianArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
@@ -209,19 +208,6 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             artifactRepository.register(artifact)
             artifactRepository.store(artifact, "${artifact.name}-$version2", RELEASE)
-          }
-          test("throws an exception") {
-            expectCatching { resolve() }
-              .failed()
-              .isA<NoImageSatisfiesConstraints>()
-          }
-        }
-
-        context("only an artifact with the wrong status has been approved for the environment") {
-          before {
-            artifactRepository.register(artifact)
-            artifactRepository.store(artifact, "${artifact.name}-$version2", SNAPSHOT)
-            artifactRepository.approveVersionFor(deliveryConfig, artifact, "${artifact.name}-$version2", "test")
           }
           test("throws an exception") {
             expectCatching { resolve() }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.sql
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.ArtifactStatus
 import com.netflix.spinnaker.keel.api.ArtifactType
-import com.netflix.spinnaker.keel.api.ArtifactType.DEB
 import com.netflix.spinnaker.keel.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.api.ArtifactVersions
 import com.netflix.spinnaker.keel.api.DebianArtifact
@@ -157,15 +156,14 @@ class SqlArtifactRepository(
       .getValues(ARTIFACT_VERSIONS.VERSION)
   }
 
-  // todo eb: get status from artifact instead of function param?
-  override fun versions(artifact: DeliveryArtifact, statuses: List<ArtifactStatus>): List<String> {
+  override fun versions(artifact: DeliveryArtifact): List<String> {
     return if (isRegistered(artifact.name, artifact.type)) {
       jooq
         .select(ARTIFACT_VERSIONS.VERSION, ARTIFACT_VERSIONS.RELEASE_STATUS)
         .from(ARTIFACT_VERSIONS)
         .where(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
         .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type.value()))
-        .apply { if (artifact.type == DEB && statuses.isNotEmpty()) and(ARTIFACT_VERSIONS.RELEASE_STATUS.`in`(*statuses.map { it.toString() }.toTypedArray())) }
+        .apply { if (artifact is DebianArtifact && artifact.statuses.isNotEmpty()) and(ARTIFACT_VERSIONS.RELEASE_STATUS.`in`(*artifact.statuses.map { it.toString() }.toTypedArray())) }
         .fetch()
         .getValues(ARTIFACT_VERSIONS.VERSION)
         .sortedWith(artifact.versioningStrategy.comparator)
@@ -177,21 +175,16 @@ class SqlArtifactRepository(
   override fun latestVersionApprovedIn(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
-    targetEnvironment: String,
-    statuses: List<ArtifactStatus>
+    targetEnvironment: String
   ): String? {
     val environment = deliveryConfig.environmentNamed(targetEnvironment)
     val envUid = deliveryConfig.getUidFor(environment)
     val artifactId = artifact.uid
     val versions: List<String> = jooq
       .select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
-      .from(ENVIRONMENT_ARTIFACT_VERSIONS, ARTIFACT_VERSIONS)
+      .from(ENVIRONMENT_ARTIFACT_VERSIONS)
       .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envUid))
       .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifactId))
-      .and(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
-      .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type.name))
-      .and(ARTIFACT_VERSIONS.VERSION.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION))
-      .apply { if (statuses.isNotEmpty()) and(ARTIFACT_VERSIONS.RELEASE_STATUS.`in`(*statuses.map { it.toString() }.toTypedArray())) }
       .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.APPROVED_AT.desc())
       .fetch()
       .getValues(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)


### PR DESCRIPTION
Fixes https://github.com/spinnaker/keel/issues/690

When we ask for versions of an artifact, we now only get valid versions based on the artifact status information.

This means we can't approve a version for deployment that has an invalid status.