### PR TITLE
Optionally specify locations at the environment level, inherited by all resources

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.api
 
 data class Environment(
   val name: String,
+  val locations: SubnetAwareLocations? = null, // TODO: does it make sense to enforce subnet aware? I think so. Also long term we may want non-EC2 conceptions of locations
   val resources: Set<Resource<*>> = emptySet(),
   val constraints: Set<Constraint> = emptySet(),
   val notifications: Set<NotificationConfig> = emptySet() // applies to each resource

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -21,7 +21,11 @@ package com.netflix.spinnaker.keel.api
  * A resource spec which is located in an account and one or more regions.
  */
 interface Locatable<T : Locations<*>> : ResourceSpec {
-  val locations: T
+  /**
+   * If not specified, the locations are inherited from the [Environment]. Locations must be
+   * specified in one place or the other.
+   */
+  val locations: T?
 }
 
 interface Locations<T : RegionSpec> {
@@ -68,6 +72,15 @@ data class SimpleLocations(
 
 fun defaultVPC(subnet: String?) =
   subnet?.let { Regex("""^.+\((.+)\)$""").find(it)?.groupValues?.get(1) } ?: "vpc0"
+
+fun SubnetAwareLocations.toSimpleLocations() =
+  SimpleLocations(
+    account,
+    vpc,
+    regions
+      .map { SimpleRegionSpec(it.name) }
+      .toSet()
+  )
 
 object LocationConstants {
   const val DEFAULT_VPC_NAME = "vpc0"

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -210,14 +210,12 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
       } else {
         null
       },
-      locations = if (spec is Locatable<*> && spec.locations != null) {
+      locations = (spec as? Locatable<*>)?.locations?.let { locations ->
         SimpleLocations(
-          account = spec.locations!!.account,
-          vpc = spec.locations!!.vpc,
-          regions = spec.locations!!.regions.map { SimpleRegionSpec(it.name) }.toSet()
+          account = locations.account,
+          vpc = locations.vpc,
+          regions = locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
         )
-      } else {
-        null
       }
     )
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -210,11 +210,11 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
       } else {
         null
       },
-      locations = if (spec is Locatable<*>) {
+      locations = if (spec is Locatable<*> && spec.locations != null) {
         SimpleLocations(
-          account = spec.locations.account,
-          vpc = spec.locations.vpc,
-          regions = spec.locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
+          account = spec.locations!!.account,
+          vpc = spec.locations!!.vpc,
+          regions = spec.locations!!.regions.map { SimpleRegionSpec(it.name) }.toSet()
         )
       } else {
         null

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -74,6 +74,7 @@ class EC2Config {
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
     taskLauncher: TaskLauncher,
+    deliveryConfigRepository: DeliveryConfigRepository,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>
   ): SecurityGroupHandler =
@@ -82,6 +83,7 @@ class EC2Config {
       cloudDriverCache,
       orcaService,
       taskLauncher,
+      deliveryConfigRepository,
       objectMapper,
       normalizers
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import java.time.Clock
@@ -52,7 +53,8 @@ class EC2Config {
     clock: Clock,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>,
-    publisher: ApplicationEventPublisher
+    publisher: ApplicationEventPublisher,
+    deliveryConfigRepository: DeliveryConfigRepository
   ): ClusterHandler =
     ClusterHandler(
       cloudDriverService,
@@ -61,6 +63,7 @@ class EC2Config {
       taskLauncher,
       clock,
       publisher,
+      deliveryConfigRepository,
       objectMapper,
       normalizers
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -94,6 +94,7 @@ class EC2Config {
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
     taskLauncher: TaskLauncher,
+    deliveryConfigRepository: DeliveryConfigRepository,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>
   ): ClassicLoadBalancerHandler =
@@ -102,6 +103,7 @@ class EC2Config {
       cloudDriverCache,
       orcaService,
       taskLauncher,
+      deliveryConfigRepository,
       objectMapper,
       normalizers
     )
@@ -112,6 +114,7 @@ class EC2Config {
     cloudDriverCache: CloudDriverCache,
     orcaService: OrcaService,
     taskLauncher: TaskLauncher,
+    deliveryConfigRepository: DeliveryConfigRepository,
     objectMapper: ObjectMapper,
     normalizers: List<Resolver<*>>
   ): ApplicationLoadBalancerHandler =
@@ -120,6 +123,7 @@ class EC2Config {
       cloudDriverCache,
       orcaService,
       taskLauncher,
+      deliveryConfigRepository,
       objectMapper,
       normalizers
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
@@ -13,7 +13,7 @@ import java.time.Duration
 
 data class ApplicationLoadBalancerSpec(
   override val moniker: Moniker,
-  override val locations: SubnetAwareLocations,
+  override val locations: SubnetAwareLocations?,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),
@@ -33,7 +33,7 @@ data class ApplicationLoadBalancerSpec(
   override val loadBalancerType: LoadBalancerType = APPLICATION
 
   @JsonIgnore
-  override val id: String = "${locations.account}:${moniker.name}"
+  override val id: String = "${locations?.account}:${moniker.name}"
 
   data class Listener(
     val port: Int,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpec.kt
@@ -10,7 +10,7 @@ import java.time.Duration
 
 data class ClassicLoadBalancerSpec(
   override val moniker: Moniker,
-  override val locations: SubnetAwareLocations,
+  override val locations: SubnetAwareLocations?,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),
@@ -30,7 +30,7 @@ data class ClassicLoadBalancerSpec(
   override val loadBalancerType: LoadBalancerType = CLASSIC
 
   @JsonIgnore
-  override val id: String = "${locations.account}:${moniker.name}"
+  override val id: String = "${locations?.account}:${moniker.name}"
 }
 
 data class ClassicLoadBalancerOverride(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -21,7 +21,8 @@ import java.time.Duration
  * Transforms a [ClusterSpec] into a concrete model of server group desired states.
  */
 fun ClusterSpec.resolve(): Set<ServerGroup> =
-  locations.regions.map {
+  // TODO: fall back to environment's locations
+  locations!!.regions.map {
     ServerGroup(
       name = moniker.name,
       location = Location(
@@ -102,13 +103,13 @@ data class ClusterSpec(
   override val moniker: Moniker,
   val imageProvider: ImageProvider? = null,
   val deployWith: ClusterDeployStrategy = RedBlack(),
-  override val locations: SubnetAwareLocations,
+  override val locations: SubnetAwareLocations?,
   private val _defaults: ServerGroupSpec,
   @JsonInclude(NON_EMPTY)
   val overrides: Map<String, ServerGroupSpec> = emptyMap()
 ) : Monikered, Locatable<SubnetAwareLocations> {
   @JsonIgnore
-  override val id = "${locations.account}:${moniker.name}"
+  override val id = "${locations?.account}:${moniker.name}"
 
   /**
    * I have no idea why, but if I annotate the constructor property with @get:JsonUnwrapped, the

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LoadBalancerSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/LoadBalancerSpec.kt
@@ -7,7 +7,7 @@ import java.time.Duration
 
 interface LoadBalancerSpec : Monikered, Locatable<SubnetAwareLocations> {
   val loadBalancerType: LoadBalancerType
-  override val locations: SubnetAwareLocations
+  override val locations: SubnetAwareLocations?
   val internal: Boolean
   val dependencies: LoadBalancerDependencies
   val idleTimeout: Duration

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
@@ -27,14 +27,14 @@ import de.danielbechler.diff.introspection.ObjectDiffProperty
 
 data class SecurityGroupSpec(
   override val moniker: Moniker,
-  override val locations: SimpleLocations,
+  override val locations: SimpleLocations?,
   val description: String?,
   val inboundRules: Set<SecurityGroupRule> = emptySet(),
   @JsonInclude(NON_EMPTY)
   val overrides: Map<String, SecurityGroupOverride> = emptyMap()
 ) : Monikered, Locatable<SimpleLocations> {
   @JsonIgnore
-  override val id = "${locations.account}:${moniker.name}"
+  override val id = "${locations?.account}:${moniker.name}"
 }
 
 data class SecurityGroupOverride(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/KeyPairResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/KeyPairResolver.kt
@@ -22,7 +22,8 @@ class KeyPairResolver(private val cloudDriverCache: CloudDriverCache) : Resolver
   override fun invoke(resource: Resource<ClusterSpec>): Resource<ClusterSpec> =
     resource.run {
       copy(
-        spec = spec.withResolvedKeyPairs(spec.locations.account)
+        // TODO: fall back to environment's locations
+        spec = spec.withResolvedKeyPairs(spec.locations!!.account)
       )
     }
 
@@ -36,7 +37,8 @@ class KeyPairResolver(private val cloudDriverCache: CloudDriverCache) : Resolver
     if (defaultKeyPair.contains(REGION_PLACEHOLDER)) {
       // if the default key pair in clouddriver is templated, we can't use that as a default but can try and apply it
       // to the overrides, if necessary.
-      locations.regions.forEach { region ->
+      // TODO: fall back to environment's locations
+      locations?.regions?.forEach { region ->
         val override = overrides[region.name]
         if (override?.launchConfiguration != null) {
           if (override.launchConfiguration.keyPair == null) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
@@ -50,7 +50,8 @@ class ClusterNetworkResolver(cloudDriverCache: CloudDriverCache) : NetworkResolv
       copy(
         spec = spec.run {
           copy(
-            locations = locations.withResolvedNetwork()
+            // TODO: fall back to environment's locations
+            locations = locations!!.withResolvedNetwork()
           )
         }
       )
@@ -67,7 +68,8 @@ class ClassicLoadBalancerNetworkResolver(cloudDriverCache: CloudDriverCache) : N
       copy(
         spec = spec.run {
           copy(
-            locations = locations.withResolvedNetwork()
+            // TODO: fall back to environment's locations
+            locations = locations!!.withResolvedNetwork()
           )
         }
       )
@@ -84,7 +86,8 @@ class ApplicationLoadBalancerNetworkResolver(cloudDriverCache: CloudDriverCache)
       copy(
         spec = spec.run {
           copy(
-            locations = locations.withResolvedNetwork()
+            // TODO: fall back to environment's locations
+            locations = locations!!.withResolvedNetwork()
           )
         }
       )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -48,7 +48,8 @@ class ApplicationLoadBalancerHandler(
   override suspend fun toResolvedType(resource: Resource<ApplicationLoadBalancerSpec>):
     Map<String, ApplicationLoadBalancer> =
     with(resource.spec) {
-      locations.regions.map { region ->
+      // TODO: fall back to environment's locations
+      locations!!.regions.map { region ->
         ApplicationLoadBalancer(
           moniker,
           Location(
@@ -173,7 +174,8 @@ class ApplicationLoadBalancerHandler(
   override suspend fun actuationInProgress(resource: Resource<ApplicationLoadBalancerSpec>): Boolean =
     resource
       .spec
-      .locations
+      // TODO: fall back to environment's locations
+      .locations!!
       .regions
       .map { it.name }
       .any { region ->
@@ -186,9 +188,11 @@ class ApplicationLoadBalancerHandler(
     spec: ApplicationLoadBalancerSpec,
     serviceAccount: String
   ) = getApplicationLoadBalancer(
-    account = spec.locations.account,
+    // TODO: fall back to environment's locations
+    account = spec.locations!!.account,
     name = spec.moniker.name,
-    regions = spec.locations.regions.map { it.name }.toSet(),
+    // TODO: fall back to environment's locations
+    regions = spec.locations!!.regions.map { it.name }.toSet(),
     serviceAccount = serviceAccount
   )
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.resolveLocations
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
@@ -41,6 +43,7 @@ class ClassicLoadBalancerHandler(
   private val cloudDriverCache: CloudDriverCache,
   private val orcaService: OrcaService,
   private val taskLauncher: TaskLauncher,
+  private val deliveryConfigRepository: DeliveryConfigRepository,
   objectMapper: ObjectMapper,
   resolvers: List<Resolver<*>>
 ) : ResourceHandler<ClassicLoadBalancerSpec, Map<String, ClassicLoadBalancer>>(objectMapper, resolvers) {
@@ -50,29 +53,34 @@ class ClassicLoadBalancerHandler(
 
   override suspend fun toResolvedType(resource: Resource<ClassicLoadBalancerSpec>): Map<String, ClassicLoadBalancer> =
     with(resource.spec) {
-      // TODO: fall back to environment's locations
-      locations!!.regions.map { region ->
-        ClassicLoadBalancer(
-          moniker,
-          Location(
-            account = locations.account,
-            region = region.name,
-            vpc = locations.vpc ?: error("No vpc supplied or resolved"),
-            subnet = locations.subnet ?: error("No subnet purpose supplied or resolved"),
-            availabilityZones = region.availabilityZones
-          ),
-          internal,
-          overrides[region.name]?.dependencies ?: dependencies,
-          overrides[region.name]?.listeners ?: listeners,
-          overrides[region.name]?.healthCheck ?: healthCheck,
-          idleTimeout
-        )
+      deliveryConfigRepository.resolveLocations(resource).let { locations ->
+        locations.regions.map { region ->
+          ClassicLoadBalancer(
+            moniker,
+            Location(
+              account = locations.account,
+              region = region.name,
+              vpc = locations.vpc ?: error("No vpc supplied or resolved"),
+              subnet = locations.subnet ?: error("No subnet purpose supplied or resolved"),
+              availabilityZones = region.availabilityZones
+            ),
+            internal,
+            overrides[region.name]?.dependencies ?: dependencies,
+            overrides[region.name]?.listeners ?: listeners,
+            overrides[region.name]?.healthCheck ?: healthCheck,
+            idleTimeout
+          )
+        }
+          .associateBy { it.location.region }
       }
-        .associateBy { it.location.region }
     }
 
   override suspend fun current(resource: Resource<ClassicLoadBalancerSpec>): Map<String, ClassicLoadBalancer> =
-    cloudDriverService.getClassicLoadBalancer(resource.spec, resource.serviceAccount)
+    cloudDriverService.getClassicLoadBalancer(
+      resource.spec,
+      deliveryConfigRepository.resolveLocations(resource),
+      resource.serviceAccount
+    )
 
   override suspend fun upsert(
     resource: Resource<ClassicLoadBalancerSpec>,
@@ -174,10 +182,8 @@ class ClassicLoadBalancerHandler(
   }
 
   override suspend fun actuationInProgress(resource: Resource<ClassicLoadBalancerSpec>): Boolean =
-    resource
-      .spec
-      // TODO: fall back to environment's locations
-      .locations!!
+    deliveryConfigRepository
+      .resolveLocations(resource)
       .regions
       .map { it.name }
       .any { region ->
@@ -188,13 +194,13 @@ class ClassicLoadBalancerHandler(
 
   private suspend fun CloudDriverService.getClassicLoadBalancer(
     spec: ClassicLoadBalancerSpec,
+    locations: SubnetAwareLocations,
     serviceAccount: String
   ) = getClassicLoadBalancer(
-    // TODO: fall back to environment's locations
-    account = spec.locations!!.account,
+    account = locations.account,
     name = spec.moniker.name,
     // TODO: fall back to environment's locations
-    regions = spec.locations!!.regions.map { it.name }.toSet(),
+    regions = locations.regions.map { it.name }.toSet(),
     serviceAccount = serviceAccount
   )
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -50,7 +50,8 @@ class ClassicLoadBalancerHandler(
 
   override suspend fun toResolvedType(resource: Resource<ClassicLoadBalancerSpec>): Map<String, ClassicLoadBalancer> =
     with(resource.spec) {
-      locations.regions.map { region ->
+      // TODO: fall back to environment's locations
+      locations!!.regions.map { region ->
         ClassicLoadBalancer(
           moniker,
           Location(
@@ -175,7 +176,8 @@ class ClassicLoadBalancerHandler(
   override suspend fun actuationInProgress(resource: Resource<ClassicLoadBalancerSpec>): Boolean =
     resource
       .spec
-      .locations
+      // TODO: fall back to environment's locations
+      .locations!!
       .regions
       .map { it.name }
       .any { region ->
@@ -188,9 +190,11 @@ class ClassicLoadBalancerHandler(
     spec: ClassicLoadBalancerSpec,
     serviceAccount: String
   ) = getClassicLoadBalancer(
-    account = spec.locations.account,
+    // TODO: fall back to environment's locations
+    account = spec.locations!!.account,
     name = spec.moniker.name,
-    regions = spec.locations.regions.map { it.name }.toSet(),
+    // TODO: fall back to environment's locations
+    regions = spec.locations!!.regions.map { it.name }.toSet(),
     serviceAccount = serviceAccount
   )
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -49,6 +49,7 @@ import com.netflix.spinnaker.keel.ec2.image.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.events.Task
 import com.netflix.spinnaker.keel.model.Moniker
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.ResourceHandler
 import com.netflix.spinnaker.keel.plugin.SupportedKind
@@ -73,6 +74,7 @@ class ClusterHandler(
   private val taskLauncher: TaskLauncher,
   private val clock: Clock,
   private val publisher: ApplicationEventPublisher,
+  private val deliveryConfigRepository: DeliveryConfigRepository,
   objectMapper: ObjectMapper,
   resolvers: List<Resolver<*>>
 ) : ResourceHandler<ClusterSpec, Map<String, ServerGroup>>(objectMapper, resolvers) {
@@ -82,7 +84,7 @@ class ClusterHandler(
 
   override suspend fun toResolvedType(resource: Resource<ClusterSpec>): Map<String, ServerGroup> =
     with(resource.spec) {
-      resolve().byRegion()
+      resolve(deliveryConfigRepository.environmentFor(resource.id)).byRegion()
     }
 
   override suspend fun current(resource: Resource<ClusterSpec>): Map<String, ServerGroup> =

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -224,7 +224,8 @@ class ClusterHandler(
   override suspend fun actuationInProgress(resource: Resource<ClusterSpec>) =
     resource
       .spec
-      .locations
+      // TODO: fall back to environment's locations
+      .locations!!
       .regions
       .map { it.name }
       .any { region ->
@@ -528,9 +529,11 @@ class ClusterHandler(
 
   private suspend fun CloudDriverService.getServerGroups(resource: Resource<ClusterSpec>): Iterable<ServerGroup> =
     getServerGroups(
-      account = resource.spec.locations.account,
+      // TODO: fall back to environment's locations
+      account = resource.spec.locations!!.account,
       moniker = resource.spec.moniker,
-      regions = resource.spec.locations.regions.map { it.name }.toSet(),
+      // TODO: fall back to environment's locations
+      regions = resource.spec.locations!!.regions.map { it.name }.toSet(),
       serviceAccount = resource.serviceAccount
     )
       .also { them ->

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -67,7 +67,8 @@ class SecurityGroupHandler(
 
   override suspend fun toResolvedType(resource: Resource<SecurityGroupSpec>): Map<String, SecurityGroup> =
     with(resource.spec) {
-      locations.regions.map { region ->
+      // TODO: fall back to environment's locations
+      locations!!.regions.map { region ->
         region.name to SecurityGroup(
           moniker = Moniker(app = moniker.app, stack = moniker.stack, detail = moniker.detail),
           location = SecurityGroup.Location(
@@ -208,7 +209,8 @@ class SecurityGroupHandler(
       val inboundDiff =
         ResourceDiff(securityGroup.inboundRules, this.inboundRules)
           .hasChanges()
-      val vpcDiff = securityGroup.location.vpc != this.locations.vpc
+      // TODO: fall back to environment's locations
+      val vpcDiff = securityGroup.location.vpc != this.locations!!.vpc
       val descriptionDiff = securityGroup.description != this.description
 
       if (inboundDiff || vpcDiff || descriptionDiff) {
@@ -235,7 +237,8 @@ class SecurityGroupHandler(
   override suspend fun actuationInProgress(resource: Resource<SecurityGroupSpec>): Boolean =
     resource
       .spec
-      .locations
+      // TODO: fall back to environment's locations
+      .locations!!
       .regions
       .map { it.name }
       .any { region ->
@@ -249,7 +252,8 @@ class SecurityGroupHandler(
     serviceAccount: String
   ): Map<String, SecurityGroup> =
     coroutineScope {
-      spec.locations.regions.map { region ->
+      // TODO: fall back to environment's locations
+      spec.locations!!.regions.map { region ->
         async {
           try {
             getSecurityGroup(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
@@ -43,7 +43,8 @@ internal class ClusterSpecTests : JUnit5Minutests {
       }
 
       test("there is one server group per region specified in the cluster") {
-        expectThat(result).hasSize(spec.locations.regions.size)
+        // TODO: fall back to environment's locations
+        expectThat(result).hasSize(spec.locations!!.regions.size)
       }
 
       test("image resolution is applied to all server groups") {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
-import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
@@ -53,7 +53,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverService = mockk<CloudDriverService>()
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
-  private val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk() {
+  private val deliveryConfigRepository: DeliveryConfigRepository = mockk() {
     // we're just using this to get notifications
     every { environmentFor(any()) } returns Environment("test")
   }
@@ -163,6 +163,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
         cloudDriverCache,
         orcaService,
         taskLauncher,
+        deliveryConfigRepository,
         mapper,
         normalizers
       )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -120,7 +120,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
 
   private val model = ClassicLoadBalancerModel(
     loadBalancerName = spec.moniker.name,
-    availabilityZones = spec.locations.regions.first().availabilityZones,
+    availabilityZones = spec.locations!!.regions.first().availabilityZones,
     vpcId = vpc.id,
     subnets = setOf(sub1.id, sub2.id),
     scheme = "internal",

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
-import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
@@ -63,7 +63,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverService = mockk<CloudDriverService>()
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
-  private val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk() {
+  private val deliveryConfigRepository: DeliveryConfigRepository = mockk() {
     // we're just using this to get notifications
     every { environmentFor(any()) } returns Environment("test")
   }
@@ -154,6 +154,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
         cloudDriverCache,
         orcaService,
         taskLauncher,
+        deliveryConfigRepository,
         mapper,
         normalizers
       )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -120,6 +120,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
   val targetTrackingPolicyName = "keel-test-target-tracking-policy"
 
+  val environment = Environment(name = "test")
+
   val spec = ClusterSpec(
     moniker = Moniker(app = "keel", stack = "test"),
     locations = SubnetAwareLocations(
@@ -166,7 +168,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     )
   )
 
-  val serverGroups = spec.resolve()
+  val serverGroups = spec.resolve(environment)
   val serverGroupEast = serverGroups.first { it.location.region == "us-east-1" }
   val serverGroupWest = serverGroups.first { it.location.region == "us-west-2" }
 
@@ -279,6 +281,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         taskLauncher,
         clock,
         publisher,
+        deliveryConfigRepository,
         objectMapper,
         normalizers
       )
@@ -314,7 +317,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
       }
 
       coEvery { orcaService.orchestrate("keel@spinnaker", any()) } returns TaskRefResponse("/tasks/${randomUUID()}")
-      every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
+      every { deliveryConfigRepository.environmentFor(any()) } returns environment
     }
 
     after {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -308,7 +308,9 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           .isEqualTo("security-group")
         expectThat(export.apiVersion)
           .isEqualTo(SPINNAKER_EC2_API_V1)
-        expectThat(export.spec.locations.regions)
+        expectThat(export.spec.locations)
+          .isNotNull()
+          .get { regions }
           .hasSize(2)
         expectThat(export.spec.overrides)
           .hasSize(0)
@@ -450,7 +452,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           }
 
           before {
-            securityGroupSpec.locations.regions.forEach { region ->
+            // TODO: fall back to environment's locations
+            securityGroupSpec.locations!!.regions.forEach { region ->
               Network(CLOUD_PROVIDER, randomUUID().toString(), "vpc1", "test", region.name)
                 .also {
                   every { cloudDriverCache.networkBy(it.id) } returns it
@@ -702,8 +705,9 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
             .copy(
               spec = resource.spec.copy(
                 locations = SimpleLocations(
-                  account = securityGroupSpec.locations.account,
-                  vpc = securityGroupSpec.locations.vpc,
+                  // TODO: fall back to environment's locations
+                  account = securityGroupSpec.locations!!.account,
+                  vpc = securityGroupSpec.locations!!.vpc,
                   regions = setOf(SimpleRegionSpec("us-east-17"))
                 )
               )

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
@@ -15,7 +15,7 @@ import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 
 fun deliveryConfig(
   resource: Resource<*> = resource(),
-  env: Environment = Environment("test", setOf(resource)),
+  env: Environment = Environment(name = "test", resources = setOf(resource)),
   configName: String = "myconfig",
   artifact: DeliveryArtifact = DebianArtifact(name = "fnord", deliveryConfigName = configName),
   deliveryConfig: DeliveryConfig = DeliveryConfig(

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -123,7 +123,7 @@ data class DummyLocatableResourceSpec(
   override val id: String = randomString(),
   val data: String = randomString(),
   override val application: String = "fnord",
-  override val locations: SimpleLocations = SimpleLocations(
+  override val locations: SimpleLocations? = SimpleLocations(
     account = "test",
     vpc = "vpc0",
     regions = setOf(SimpleRegionSpec("us-west-1"))

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import java.time.Clock
@@ -40,6 +41,7 @@ class TitusConfig {
     orcaService: OrcaService,
     clock: Clock,
     taskLauncher: TaskLauncher,
+    deliveryConfigRepository: DeliveryConfigRepository,
     publisher: ApplicationEventPublisher,
     objectMapper: ObjectMapper,
     resolvers: List<Resolver<*>>
@@ -49,7 +51,7 @@ class TitusConfig {
     orcaService,
     clock,
     taskLauncher,
-    publisher,
+    deliveryConfigRepository,
     objectMapper,
     resolvers
   )

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -97,7 +97,8 @@ class TitusClusterHandler(
   override suspend fun actuationInProgress(resource: Resource<TitusClusterSpec>): Boolean =
     resource
       .spec
-      .locations
+      // TODO: fall back to environment's locations
+      .locations!!
       .regions
       .map { it.name }
       .any { region ->
@@ -314,9 +315,12 @@ class TitusClusterHandler(
     }
 
   private suspend fun CloudDriverService.getServerGroups(resource: Resource<TitusClusterSpec>): Iterable<TitusServerGroup> =
-    getServerGroups(resource.spec.locations.account,
+    getServerGroups(
+      // TODO: fall back to environment's locations
+      resource.spec.locations!!.account,
       resource.spec.moniker,
-      resource.spec.locations.regions.map { it.name }.toSet(),
+      // TODO: fall back to environment's locations
+      resource.spec.locations!!.regions.map { it.name }.toSet(),
       resource.serviceAccount
     )
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -42,13 +42,14 @@ import com.netflix.spinnaker.keel.model.Moniker
 data class TitusClusterSpec(
   override val moniker: Moniker,
   val deployWith: ClusterDeployStrategy = RedBlack(),
-  override val locations: SimpleLocations,
+  override val locations: SimpleLocations?,
   private val _defaults: TitusServerGroupSpec,
   val overrides: Map<String, TitusServerGroupSpec> = emptyMap()
 ) : Monikered, Locatable<SimpleLocations> {
 
   @JsonIgnore
-  override val id = "${locations.account}:${moniker.name}"
+  // TODO: fall back to environment's locations
+  override val id = "${locations!!.account}:${moniker.name}"
 
   val defaults: TitusServerGroupSpec
     @JsonUnwrapped get() = _defaults
@@ -179,7 +180,8 @@ internal fun TitusClusterSpec.resolveDependencies(region: String): ClusterDepend
   )
 
 fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
-  locations.regions.map {
+  // TODO: fall back to environment's locations
+  locations!!.regions.map {
     TitusServerGroup(
       name = moniker.name,
       location = Location(

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -72,6 +72,7 @@ class TitusImageResolver(
     }
 
   protected fun TitusClusterSpec.deriveRegistry(): String =
-    cloudDriverCache.credentialBy(locations.account).attributes["registry"]?.toString()
+    // TODO: fall back to environment's locations
+    cloudDriverCache.credentialBy(locations!!.account).attributes["registry"]?.toString()
       ?: throw RegistryNotFound(locations.account)
 }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -91,6 +91,7 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
+import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
 import strikt.assertions.map
@@ -119,12 +120,13 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   val titusAccount = "titustest"
   val awsAccount = "test"
 
+  val locations = SimpleLocations(
+    account = titusAccount,
+    regions = setOf(SimpleRegionSpec("us-east-1"), SimpleRegionSpec("us-west-2"))
+  )
   val spec = TitusClusterSpec(
     moniker = Moniker(app = "keel", stack = "test"),
-    locations = SimpleLocations(
-      account = titusAccount,
-      regions = setOf(SimpleRegionSpec("us-east-1"), SimpleRegionSpec("us-west-2"))
-    ),
+    locations = locations,
     _defaults = TitusServerGroupSpec(
       container = DigestProvider(
         organization = "spinnaker",
@@ -154,10 +156,10 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
   val exportable = Exportable(
     cloudProvider = "titus",
-    account = spec.locations.account,
+    account = locations.account,
     serviceAccount = "keel@spinnaker",
     moniker = spec.moniker,
-    regions = spec.locations.regions.map { it.name }.toSet(),
+    regions = locations.regions.map { it.name }.toSet(),
     kind = "cluster"
   )
 
@@ -489,7 +491,9 @@ class TitusClusterHandlerTests : JUnit5Minutests {
               .isEqualTo("cluster")
             expectThat(resource.apiVersion)
               .isEqualTo(SPINNAKER_TITUS_API_V1)
-            expectThat(spec.locations.regions)
+            expectThat(spec.locations)
+              .isNotNull()
+              .get { regions }
               .hasSize(2)
             expectThat(spec.overrides)
               .hasSize(0)
@@ -548,7 +552,9 @@ class TitusClusterHandlerTests : JUnit5Minutests {
               .isEqualTo("cluster")
             expectThat(resource.apiVersion)
               .isEqualTo(SPINNAKER_TITUS_API_V1)
-            expectThat(spec.locations.regions)
+            expectThat(spec.locations)
+              .isNotNull()
+              .get { regions }
               .hasSize(2)
             expectThat(spec.overrides)
               .hasSize(1)
@@ -635,7 +641,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   private suspend fun CloudDriverService.titusActiveServerGroup(region: String) = titusActiveServerGroup(
     serviceAccount = "keel@spinnaker",
     app = spec.moniker.app,
-    account = spec.locations.account,
+    account = locations.account,
     cluster = spec.moniker.name,
     region = region,
     cloudProvider = CLOUD_PROVIDER

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -58,7 +58,7 @@ import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.model.parseMoniker
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
-import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.plugin.Resolver
 import com.netflix.spinnaker.keel.plugin.TaskLauncher
 import com.netflix.spinnaker.keel.test.resource
@@ -104,7 +104,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   val orcaService = mockk<OrcaService>()
   val objectMapper = ObjectMapper().registerKotlinModule()
   val resolvers = emptyList<Resolver<TitusClusterSpec>>()
-  val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk()
+  val deliveryConfigRepository: DeliveryConfigRepository = mockk()
   val taskLauncher = TaskLauncher(
     orcaService,
     deliveryConfigRepository
@@ -214,7 +214,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         orcaService,
         clock,
         taskLauncher,
-        publisher,
+        deliveryConfigRepository,
         objectMapper,
         resolvers
       )


### PR DESCRIPTION
Still to-do:

- [ ] Fix resources that use `locations` in their `id`
- [ ] Add optional `locations` to `SubmittedEnvironment` and wire it up