### PR TITLE
Optionally specify locations at the environment level

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.keel.api
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.netflix.spinnaker.keel.persistence.NoMatchingArtifactException
+import com.netflix.spinnaker.keel.serialization.SubmittedEnvironmentDeserializer
 
 const val DEFAULT_SERVICE_ACCOUNT = "keel@spinnaker.io"
 
@@ -18,11 +20,16 @@ data class SubmittedDeliveryConfig(
   val environments: Set<SubmittedEnvironment> = emptySet()
 )
 
+@JsonDeserialize(using = SubmittedEnvironmentDeserializer::class)
 data class SubmittedEnvironment(
   val name: String,
   val resources: Set<SubmittedResource<*>>,
   val constraints: Set<Constraint> = emptySet(),
-  val notifications: Set<NotificationConfig> = emptySet()
+  val notifications: Set<NotificationConfig> = emptySet(),
+  /**
+   * Optional locations that are propagated to any [resources] where they are not specified.
+   */
+  val locations: SubnetAwareLocations? = null
 )
 
 val DeliveryConfig.resources: Set<Resource<*>>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -17,10 +17,13 @@
  */
 package com.netflix.spinnaker.keel.api
 
+import com.fasterxml.jackson.annotation.JacksonInject
+
 /**
  * A resource spec which is located in an account and one or more regions.
  */
 interface Locatable<T : Locations<*>> : ResourceSpec {
+  @get:JacksonInject("locations")
   val locations: T
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/DeserializationContexts.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/DeserializationContexts.kt
@@ -1,0 +1,12 @@
+package com.netflix.spinnaker.keel.serialization
+
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.ObjectMapper
+
+internal val DeserializationContext.mapper: ObjectMapper
+  // Such an intuitive API. ObjectMapper is the only thing that implements ObjectCodec but useful
+  // methods like convertValue are not on that interface so we need to do a dirty type cast.
+  get() = parser.codec as ObjectMapper
+
+internal inline fun <reified T> DeserializationContext.instantiationException(cause: Throwable) =
+  instantiationException(T::class.java, cause)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedResourceDeserializer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedResourceDeserializer.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.serialization
 
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer
 import com.fasterxml.jackson.databind.introspect.AnnotatedClassResolver
 import com.fasterxml.jackson.databind.type.TypeFactory
@@ -48,13 +47,5 @@ class SubmittedResourceDeserializer : StdNodeBasedDeserializer<SubmittedResource
     }
   }
 }
-
-private val DeserializationContext.mapper: ObjectMapper
-  // Such an intuitive API. ObjectMapper is the only thing that implements ObjectCodec but useful
-  // methods like convertValue are not on that interface so we need to do a dirty type cast.
-  get() = parser.codec as ObjectMapper
-
-private inline fun <reified T> DeserializationContext.instantiationException(cause: Throwable) =
-  instantiationException(T::class.java, cause)
 
 private inline fun <reified T> TypeFactory.constructType() = constructType(T::class.java)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedEnvironmentDeserializerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedEnvironmentDeserializerTests.kt
@@ -1,0 +1,175 @@
+package com.netflix.spinnaker.keel.serialization
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.SubmittedEnvironment
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+class SubmittedEnvironmentDeserializerTests : JUnit5Minutests {
+
+  data class Fixture(
+    val json: String
+  ) {
+    val mapper = configuredYamlMapper()
+      .apply {
+        configure(DeserializationFeature.WRAP_EXCEPTIONS, true)
+        registerSubtypes(NamedType(TestLocatableResource::class.java, "test/v1/test-locatable"))
+      }
+  }
+
+  fun tests() = rootContext<Fixture> {
+    context("locations is specified on the resource spec") {
+      fixture {
+        Fixture("""
+          |---
+          |name: test
+          |resources:
+          |- apiVersion: test/v1
+          |  kind: test-locatable
+          |  metadata:
+          |    serviceAccount: mickey@disney.com
+          |  spec:
+          |    id: my-resource
+          |    application: whatever
+          |    locations:
+          |      account: prod
+          |      subnet: internal (vpc0)
+          |      vpc: vpc0
+          |      regions:
+          |      - name: us-east-1
+          |      - name: us-west-2
+          |locations:
+          |  account: test
+          |  subnet: internal (vpc0)
+          |  vpc: vpc0
+          |  regions:
+          |  - name: us-east-1
+          |  - name: us-west-2
+          """.trimMargin()
+        )
+      }
+
+      test("resource's locations corresponds to what was specified at the environment level") {
+        val environment = mapper.readValue<SubmittedEnvironment>(json)
+
+        expectThat(environment.resources.first().spec)
+          .isA<TestLocatableResource>()
+          .get { locations.account }
+          .isEqualTo("prod")
+      }
+    }
+
+    context("locations is omitted from the resource spec") {
+      fixture {
+        Fixture("""
+          |---
+          |name: test
+          |resources:
+          |- apiVersion: test/v1
+          |  kind: test-locatable
+          |  metadata:
+          |    serviceAccount: mickey@disney.com
+          |  spec:
+          |    id: my-resource
+          |    application: whatever
+          |locations:
+          |  account: test
+          |  subnet: internal (vpc0)
+          |  vpc: vpc0
+          |  regions:
+          |  - name: us-east-1
+          |  - name: us-west-2
+          """.trimMargin()
+        )
+      }
+
+      test("locations corresponds to what was specified on the resource") {
+        val environment = mapper.readValue<SubmittedEnvironment>(json)
+
+        expectThat(environment.resources.first().spec)
+          .isA<TestLocatableResource>()
+          .get { locations.account }
+          .isEqualTo("test")
+      }
+    }
+
+    context("locations appears in one environment but not another") {
+      fixture {
+        Fixture("""
+          |---
+          |- name: test
+          |  resources:
+          |  - apiVersion: test/v1
+          |    kind: test-locatable
+          |    metadata:
+          |      serviceAccount: mickey@disney.com
+          |    spec:
+          |      id: my-test-resource
+          |      application: whatever
+          |  locations:
+          |    account: test
+          |    subnet: internal (vpc0)
+          |    vpc: vpc0
+          |    regions:
+          |    - name: us-east-1
+          |    - name: us-west-2
+          |- name: prod
+          |  resources:
+          |  - apiVersion: test/v1
+          |    kind: test-locatable
+          |    metadata:
+          |      serviceAccount: mickey@disney.com
+          |    spec:
+          |      id: my-prod-resource
+          |      application: whatever
+          """.trimMargin()
+        )
+      }
+
+      test("locations does not leak from one environment to another") {
+        expectThrows<JsonProcessingException> {
+          mapper.readValue<List<SubmittedEnvironment>>(json)
+        }
+      }
+    }
+
+    context("locations is omitted from the resource spec and the environment") {
+      fixture {
+        Fixture("""
+          |---
+          |name: test
+          |resources:
+          |- apiVersion: test/v1
+          |  kind: test-locatable
+          |  metadata:
+          |    serviceAccount: mickey@disney.com
+          |  spec:
+          |    id: my-resource
+          |    application: whatever
+          """.trimMargin()
+        )
+      }
+
+      test("the resource cannot be parsed") {
+        expectThrows<JsonProcessingException> {
+          mapper.readValue<SubmittedEnvironment>(json)
+        }
+      }
+    }
+  }
+}
+
+private data class TestLocatableResource(
+  override val id: String,
+  override val application: String,
+  override val locations: SubnetAwareLocations
+) : Locatable<SubnetAwareLocations>


### PR DESCRIPTION
This allows all resources in an environment to omit their `locations` property in favor of the one set at the environment level. It relies on some Jackson JSON parsing trickery. The nice part is that the `locations` property on the resource spec does _not_ need to be nullable, and we don't need to keep looking up the environment in order to fetch the locations -- instead it's all handled when parsing the submitted delivery config.

Closes #445 