### PR TITLE
feat(sql): add retries to most places

### DIFF
--- a/keel-sql/keel-sql.gradle.kts
+++ b/keel-sql/keel-sql.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("org.jooq:jooq:3.11.11")
   implementation("com.zaxxer:HikariCP")
   implementation("org.liquibase:liquibase-core")
+  implementation("com.netflix.spinnaker.kork:kork-sql")
 
   runtimeOnly("mysql:mysql-connector-java")
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -8,8 +8,10 @@ import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
 import com.netflix.spinnaker.keel.sql.SqlDiffFingerprintRepository
 import com.netflix.spinnaker.keel.sql.SqlPausedRepository
 import com.netflix.spinnaker.keel.sql.SqlResourceRepository
+import com.netflix.spinnaker.keel.sql.SqlRetry
 import com.netflix.spinnaker.keel.sql.SqlUnhappyVetoRepository
 import com.netflix.spinnaker.kork.sql.config.DefaultSqlConfiguration
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import java.time.Clock
 import javax.annotation.PostConstruct
 import org.jooq.DSLContext
@@ -22,11 +24,14 @@ import org.springframework.context.annotation.Import
 
 @Configuration
 @ConditionalOnProperty("sql.enabled")
-@Import(DefaultSqlConfiguration::class)
+@Import(DefaultSqlConfiguration::class, SqlRetryProperties::class)
 class SqlConfiguration {
 
   @Autowired
   lateinit var jooqConfiguration: DefaultConfiguration
+
+  @Autowired
+  lateinit var sqlRetryProperties: SqlRetryProperties
 
   // This allows us to run tests with a testcontainers database that has a different schema name to
   // the real one used by the JOOQ code generator. It _is_ possible to change the schema used by
@@ -44,11 +49,11 @@ class SqlConfiguration {
     resourceTypeIdentifier: ResourceTypeIdentifier,
     objectMapper: ObjectMapper
   ) =
-    SqlResourceRepository(jooq, clock, resourceTypeIdentifier, objectMapper)
+    SqlResourceRepository(jooq, clock, resourceTypeIdentifier, objectMapper, SqlRetry(sqlRetryProperties))
 
   @Bean
   fun artifactRepository(jooq: DSLContext, clock: Clock, objectMapper: ObjectMapper) =
-    SqlArtifactRepository(jooq, clock, objectMapper)
+    SqlArtifactRepository(jooq, clock, objectMapper, SqlRetry(sqlRetryProperties))
 
   @Bean
   fun deliveryConfigRepository(
@@ -56,22 +61,22 @@ class SqlConfiguration {
     clock: Clock,
     resourceTypeIdentifier: ResourceTypeIdentifier
   ) =
-    SqlDeliveryConfigRepository(jooq, clock, resourceTypeIdentifier)
+    SqlDeliveryConfigRepository(jooq, clock, resourceTypeIdentifier, SqlRetry(sqlRetryProperties))
 
   @Bean
   fun diffFingerprintRepository(
     jooq: DSLContext,
     clock: Clock
-  ) = SqlDiffFingerprintRepository(jooq, clock)
+  ) = SqlDiffFingerprintRepository(jooq, clock, SqlRetry(sqlRetryProperties))
 
   @Bean
   fun unhappyVetoRepository(
     jooq: DSLContext
   ) =
-    SqlUnhappyVetoRepository(clock, jooq)
+    SqlUnhappyVetoRepository(clock, jooq, SqlRetry(sqlRetryProperties))
 
   @Bean
   fun pausedRepository(
     jooq: DSLContext
-  ) = SqlPausedRepository(jooq)
+  ) = SqlPausedRepository(jooq, SqlRetry(sqlRetryProperties))
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -26,6 +26,8 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOU
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.keel.sql.RetryCategory.READ
+import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -40,23 +42,26 @@ import org.jooq.util.mysql.MySQLDSL
 class SqlDeliveryConfigRepository(
   private val jooq: DSLContext,
   private val clock: Clock,
-  private val resourceTypeIdentifier: ResourceTypeIdentifier
+  private val resourceTypeIdentifier: ResourceTypeIdentifier,
+  private val sqlRetry: SqlRetry
 ) : DeliveryConfigRepository {
 
   private val mapper = configuredObjectMapper()
 
   override fun getByApplication(application: String): Collection<DeliveryConfig> =
-    jooq
-      .select(
-        DELIVERY_CONFIG.UID,
-        DELIVERY_CONFIG.NAME,
-        DELIVERY_CONFIG.APPLICATION
-      )
-      .from(DELIVERY_CONFIG)
-      .where(DELIVERY_CONFIG.APPLICATION.eq(application))
-      .fetch { (uid, name, application) ->
-        DeliveryConfig(name, application).attachDependents(uid)
-      }
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          DELIVERY_CONFIG.UID,
+          DELIVERY_CONFIG.NAME,
+          DELIVERY_CONFIG.APPLICATION
+        )
+        .from(DELIVERY_CONFIG)
+        .where(DELIVERY_CONFIG.APPLICATION.eq(application))
+        .fetch { (uid, name, application) ->
+          DeliveryConfig(name, application).attachDependents(uid)
+        }
+    }
 
   override fun deleteByApplication(application: String): Int {
 
@@ -64,46 +69,62 @@ class SqlDeliveryConfigRepository(
     val environmentUIDs = getEnvironmentUIDs(deliveryConfigUIDs)
 
     deliveryConfigUIDs.forEach { uid ->
-      jooq.deleteFrom(DELIVERY_CONFIG)
-        .where(DELIVERY_CONFIG.UID.eq(uid))
-        .execute()
-      jooq.deleteFrom(DELIVERY_CONFIG_ARTIFACT)
-        .where(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(uid))
-        .execute()
-      jooq.deleteFrom(DELIVERY_CONFIG_LAST_CHECKED)
-        .where(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID.eq(uid))
-        .execute()
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(DELIVERY_CONFIG)
+          .where(DELIVERY_CONFIG.UID.eq(uid))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(DELIVERY_CONFIG_ARTIFACT)
+          .where(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(uid))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(DELIVERY_CONFIG_LAST_CHECKED)
+          .where(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID.eq(uid))
+          .execute()
+      }
     }
     environmentUIDs.forEach { uid ->
-      jooq.deleteFrom(ENVIRONMENT)
-        .where(ENVIRONMENT.UID.eq(uid))
-        .execute()
-      jooq.deleteFrom(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(uid))
-        .execute()
-      jooq.deleteFrom(ENVIRONMENT_RESOURCE)
-        .where(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
-        .execute()
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(ENVIRONMENT)
+          .where(ENVIRONMENT.UID.eq(uid))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(ENVIRONMENT_ARTIFACT_VERSIONS)
+          .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(uid))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(ENVIRONMENT_RESOURCE)
+          .where(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
+          .execute()
+      }
     }
     return deliveryConfigUIDs.size
   }
 
-  private fun getUIDsByApplication(application: String): List<String> {
-    return jooq
-      .select(DELIVERY_CONFIG.UID)
-      .from(DELIVERY_CONFIG)
-      .where(DELIVERY_CONFIG.APPLICATION.eq(application))
-      .fetch(DELIVERY_CONFIG.UID)
-  }
+  private fun getUIDsByApplication(application: String): List<String> =
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_CONFIG.UID)
+        .from(DELIVERY_CONFIG)
+        .where(DELIVERY_CONFIG.APPLICATION.eq(application))
+        .fetch(DELIVERY_CONFIG.UID)
+    }
 
-  private fun getEnvironmentUIDs(deliveryConfigUIDs: List<String>): List<String> {
-    return jooq
-      .select(ENVIRONMENT.UID)
-      .from(ENVIRONMENT)
-      .where(ENVIRONMENT.DELIVERY_CONFIG_UID.`in`(deliveryConfigUIDs))
-      .fetch(ENVIRONMENT.UID)
-  }
+  private fun getEnvironmentUIDs(deliveryConfigUIDs: List<String>): List<String> =
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(ENVIRONMENT.UID)
+        .from(ENVIRONMENT)
+        .where(ENVIRONMENT.DELIVERY_CONFIG_UID.`in`(deliveryConfigUIDs))
+        .fetch(ENVIRONMENT.UID)
+    }
 
+  // todo: queries in this function aren't inherently retryable because of the cross-repository interactions
+  // from where this is called: https://github.com/spinnaker/keel/issues/740
   override fun store(deliveryConfig: DeliveryConfig) {
     with(deliveryConfig) {
       val uid = jooq
@@ -165,129 +186,142 @@ class SqlDeliveryConfigRepository(
   }
 
   override fun get(name: String): DeliveryConfig =
-    jooq
-      .select(
-        DELIVERY_CONFIG.UID,
-        DELIVERY_CONFIG.NAME,
-        DELIVERY_CONFIG.APPLICATION
-      )
-      .from(DELIVERY_CONFIG)
-      .where(DELIVERY_CONFIG.NAME.eq(name))
-      .fetchOne { (uid, name, application) ->
-        uid to DeliveryConfig(name, application)
-      }
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          DELIVERY_CONFIG.UID,
+          DELIVERY_CONFIG.NAME,
+          DELIVERY_CONFIG.APPLICATION
+        )
+        .from(DELIVERY_CONFIG)
+        .where(DELIVERY_CONFIG.NAME.eq(name))
+        .fetchOne { (uid, name, application) ->
+          uid to DeliveryConfig(name, application)
+        }
+    }
       ?.let { (uid, deliveryConfig) ->
         deliveryConfig.attachDependents(uid)
       }
       ?: throw NoSuchDeliveryConfigName(name)
 
   private fun DeliveryConfig.attachDependents(uid: String): DeliveryConfig =
-    jooq
-      .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.TYPE, DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE, DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME)
-      .from(DELIVERY_ARTIFACT, DELIVERY_CONFIG_ARTIFACT)
-      .where(DELIVERY_CONFIG_ARTIFACT.ARTIFACT_UID.eq(DELIVERY_ARTIFACT.UID))
-      .and(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(uid))
-      .fetch { (name, type, details, reference, configName) ->
-        mapToArtifact(name, ArtifactType.valueOf(type), details, reference, configName)
-      }
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.TYPE, DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE, DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME)
+        .from(DELIVERY_ARTIFACT, DELIVERY_CONFIG_ARTIFACT)
+        .where(DELIVERY_CONFIG_ARTIFACT.ARTIFACT_UID.eq(DELIVERY_ARTIFACT.UID))
+        .and(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(uid))
+        .fetch { (name, type, details, reference, configName) ->
+          mapToArtifact(name, ArtifactType.valueOf(type), details, reference, configName)
+        }
+    }
       .toSet()
       .let { artifacts ->
-        jooq
-          .select(ENVIRONMENT.UID, ENVIRONMENT.NAME, ENVIRONMENT.CONSTRAINTS, ENVIRONMENT.NOTIFICATIONS)
-          .from(ENVIRONMENT)
-          .where(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
-          .fetch { (environmentUid, name, constraintsJson, notificationsJson) ->
-            Environment(
-              name = name,
-              resources = resourcesForEnvironment(environmentUid),
-              constraints = mapper.readValue(constraintsJson),
-              notifications = mapper.readValue(notificationsJson ?: "[]")
-            )
-          }
-          .let { environments ->
-            copy(
-              artifacts = artifacts,
-              environments = environments.toSet()
-            )
-          }
+        sqlRetry.withRetry(READ) {
+          jooq
+            .select(ENVIRONMENT.UID, ENVIRONMENT.NAME, ENVIRONMENT.CONSTRAINTS, ENVIRONMENT.NOTIFICATIONS)
+            .from(ENVIRONMENT)
+            .where(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
+            .fetch { (environmentUid, name, constraintsJson, notificationsJson) ->
+              Environment(
+                name = name,
+                resources = resourcesForEnvironment(environmentUid),
+                constraints = mapper.readValue(constraintsJson),
+                notifications = mapper.readValue(notificationsJson ?: "[]")
+              )
+            }
+            .let { environments ->
+              copy(
+                artifacts = artifacts,
+                environments = environments.toSet()
+              )
+            }
+        }
       }
 
   override fun environmentFor(resourceId: ResourceId): Environment =
-    jooq
-      .select(ENVIRONMENT.UID, ENVIRONMENT.NAME, ENVIRONMENT.CONSTRAINTS, ENVIRONMENT.NOTIFICATIONS)
-      .from(ENVIRONMENT, ENVIRONMENT_RESOURCE, RESOURCE)
-      .where(RESOURCE.ID.eq(resourceId.value))
-      .and(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(RESOURCE.UID))
-      .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
-      .fetchOne { (uid, name, constraintsJson, notificationsJson) ->
-        Environment(
-          name = name,
-          resources = resourcesForEnvironment(uid),
-          constraints = mapper.readValue(constraintsJson),
-          notifications = mapper.readValue(notificationsJson ?: "[]")
-        )
-      } ?: throw OrphanedResourceException(resourceId)
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(ENVIRONMENT.UID, ENVIRONMENT.NAME, ENVIRONMENT.CONSTRAINTS, ENVIRONMENT.NOTIFICATIONS)
+        .from(ENVIRONMENT, ENVIRONMENT_RESOURCE, RESOURCE)
+        .where(RESOURCE.ID.eq(resourceId.value))
+        .and(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(RESOURCE.UID))
+        .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
+        .fetchOne { (uid, name, constraintsJson, notificationsJson) ->
+          Environment(
+            name = name,
+            resources = resourcesForEnvironment(uid),
+            constraints = mapper.readValue(constraintsJson),
+            notifications = mapper.readValue(notificationsJson ?: "[]")
+          )
+        }
+    } ?: throw OrphanedResourceException(resourceId)
 
   override fun deliveryConfigFor(resourceId: ResourceId): DeliveryConfig =
     // TODO: this implementation could be more efficient by sharing code with get(name)
-    jooq
-      .select(DELIVERY_CONFIG.NAME)
-      .from(ENVIRONMENT, ENVIRONMENT_RESOURCE, RESOURCE, DELIVERY_CONFIG)
-      .where(RESOURCE.ID.eq(resourceId.value))
-      .and(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(RESOURCE.UID))
-      .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
-      .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
-      .fetchOne { (name) ->
-        get(name)
-      } ?: throw OrphanedResourceException(resourceId)
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_CONFIG.NAME)
+        .from(ENVIRONMENT, ENVIRONMENT_RESOURCE, RESOURCE, DELIVERY_CONFIG)
+        .where(RESOURCE.ID.eq(resourceId.value))
+        .and(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(RESOURCE.UID))
+        .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
+        .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+        .fetchOne { (name) ->
+          get(name)
+        }
+    } ?: throw OrphanedResourceException(resourceId)
 
   override fun storeConstraintState(state: ConstraintState) {
     environmentUidByName(state.deliveryConfigName, state.environmentName)
       ?.also { envUid ->
-        val uid = jooq
-          .select(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID)
-          .from(ENVIRONMENT_ARTIFACT_CONSTRAINT)
-          .where(
-            ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(envUid),
-            ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(state.type),
-            ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(state.artifactVersion)
-          )
-          .fetchOne(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID)
-          ?: randomUID().toString()
+        val uid = sqlRetry.withRetry(READ) {
+          jooq
+            .select(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID)
+            .from(ENVIRONMENT_ARTIFACT_CONSTRAINT)
+            .where(
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(envUid),
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(state.type),
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(state.artifactVersion)
+            )
+            .fetchOne(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID)
+        } ?: randomUID().toString()
 
         val application = applicationByDeliveryConfigName(state.deliveryConfigName)
 
-        jooq.transaction { config ->
-          val txn = DSL.using(config)
-          txn
-            .insertInto(ENVIRONMENT_ARTIFACT_CONSTRAINT)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID, uid)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID, envUid)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION, state.artifactVersion)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE, state.type)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT, state.createdAt.toLocal())
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS, state.status.toString())
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY, state.judgedBy)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT, state.judgedAt?.toLocal())
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT, state.comment)
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES, mapper.writeValueAsString(state.attributes))
-            .onDuplicateKeyUpdate()
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS))
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY))
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT))
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT))
-            .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES))
-            .execute()
+        sqlRetry.withRetry(WRITE) {
+          jooq.transaction { config ->
+            val txn = DSL.using(config)
+            txn
+              .insertInto(ENVIRONMENT_ARTIFACT_CONSTRAINT)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID, uid)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID, envUid)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION, state.artifactVersion)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE, state.type)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT, state.createdAt.toLocal())
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS, state.status.toString())
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY, state.judgedBy)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT, state.judgedAt?.toLocal())
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT, state.comment)
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES, mapper.writeValueAsString(state.attributes))
+              .onDuplicateKeyUpdate()
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS))
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY))
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT))
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT))
+              .set(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES, MySQLDSL.values(ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES))
+              .execute()
 
-          txn
-            .insertInto(CURRENT_CONSTRAINT)
-            .set(CURRENT_CONSTRAINT.APPLICATION, application)
-            .set(CURRENT_CONSTRAINT.ENVIRONMENT_UID, envUid)
-            .set(CURRENT_CONSTRAINT.TYPE, state.type)
-            .set(CURRENT_CONSTRAINT.CONSTRAINT_UID, uid)
-            .onDuplicateKeyUpdate()
-            .set(CURRENT_CONSTRAINT.CONSTRAINT_UID, MySQLDSL.values(CURRENT_CONSTRAINT.CONSTRAINT_UID))
-            .execute()
+            txn
+              .insertInto(CURRENT_CONSTRAINT)
+              .set(CURRENT_CONSTRAINT.APPLICATION, application)
+              .set(CURRENT_CONSTRAINT.ENVIRONMENT_UID, envUid)
+              .set(CURRENT_CONSTRAINT.TYPE, state.type)
+              .set(CURRENT_CONSTRAINT.CONSTRAINT_UID, uid)
+              .onDuplicateKeyUpdate()
+              .set(CURRENT_CONSTRAINT.CONSTRAINT_UID, MySQLDSL.values(CURRENT_CONSTRAINT.CONSTRAINT_UID))
+              .execute()
+          }
         }
       }
   }
@@ -300,92 +334,98 @@ class SqlDeliveryConfigRepository(
   ): ConstraintState? {
     val environmentUID = environmentUidByName(deliveryConfigName, environmentName)
       ?: return null
-    return jooq
-      .select(
-        inline(deliveryConfigName).`as`("deliveryConfigName"),
-        inline(environmentName).`as`("environmentName"),
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES
-      )
-      .from(ENVIRONMENT_ARTIFACT_CONSTRAINT)
-      .where(
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(environmentUID),
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(artifactVersion),
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(type)
-      )
-      .fetchOne { (deliveryConfigName,
-                    environmentName,
-                    artifactVersion,
-                    constraintType,
-                    status,
-                    createdAt,
-                    judgedBy,
-                    judgedAt,
-                    comment,
-                    attributes) ->
-        ConstraintState(
-          deliveryConfigName,
-          environmentName,
-          artifactVersion,
-          constraintType,
-          ConstraintStatus.valueOf(status),
-          createdAt.toInstant(ZoneOffset.UTC),
-          judgedBy,
-          when (judgedAt) {
-            null -> null
-            else -> judgedAt.toInstant(ZoneOffset.UTC)
-          },
-          comment,
-          mapper.readValue(attributes)
+    return sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          inline(deliveryConfigName).`as`("deliveryConfigName"),
+          inline(environmentName).`as`("environmentName"),
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES
         )
-      }
+        .from(ENVIRONMENT_ARTIFACT_CONSTRAINT)
+        .where(
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(environmentUID),
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(artifactVersion),
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(type)
+        )
+        .fetchOne { (deliveryConfigName,
+                      environmentName,
+                      artifactVersion,
+                      constraintType,
+                      status,
+                      createdAt,
+                      judgedBy,
+                      judgedAt,
+                      comment,
+                      attributes) ->
+          ConstraintState(
+            deliveryConfigName,
+            environmentName,
+            artifactVersion,
+            constraintType,
+            ConstraintStatus.valueOf(status),
+            createdAt.toInstant(ZoneOffset.UTC),
+            judgedBy,
+            when (judgedAt) {
+              null -> null
+              else -> judgedAt.toInstant(ZoneOffset.UTC)
+            },
+            comment,
+            mapper.readValue(attributes)
+          )
+        }
+    }
   }
 
   override fun constraintStateFor(application: String): List<ConstraintState> {
     val environmentNames = mutableMapOf<String, String>()
     val deliveryConfigsByEnv = mutableMapOf<String, String>()
-    val constraintResult = jooq
-      .select(
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES
-      )
-      .from(CURRENT_CONSTRAINT)
-      .innerJoin(ENVIRONMENT_ARTIFACT_CONSTRAINT)
-      .on(CURRENT_CONSTRAINT.CONSTRAINT_UID.eq(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID))
-      .fetch()
+    val constraintResult = sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES
+        )
+        .from(CURRENT_CONSTRAINT)
+        .innerJoin(ENVIRONMENT_ARTIFACT_CONSTRAINT)
+        .on(CURRENT_CONSTRAINT.CONSTRAINT_UID.eq(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID))
+        .fetch()
+    }
 
     if (constraintResult.isEmpty()) {
       return emptyList()
     }
 
-    jooq
-      .select(
-        CURRENT_CONSTRAINT.ENVIRONMENT_UID,
-        ENVIRONMENT.NAME,
-        DELIVERY_CONFIG.NAME)
-      .from(CURRENT_CONSTRAINT)
-      .innerJoin(ENVIRONMENT)
-      .on(ENVIRONMENT.UID.eq(CURRENT_CONSTRAINT.ENVIRONMENT_UID))
-      .innerJoin(DELIVERY_CONFIG)
-      .on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
-      .where(CURRENT_CONSTRAINT.APPLICATION.eq(application))
-      .fetch { (envId, envName, dcName) ->
-        environmentNames[envId] = envName
-        deliveryConfigsByEnv[envId] = dcName
-      }
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          CURRENT_CONSTRAINT.ENVIRONMENT_UID,
+          ENVIRONMENT.NAME,
+          DELIVERY_CONFIG.NAME)
+        .from(CURRENT_CONSTRAINT)
+        .innerJoin(ENVIRONMENT)
+        .on(ENVIRONMENT.UID.eq(CURRENT_CONSTRAINT.ENVIRONMENT_UID))
+        .innerJoin(DELIVERY_CONFIG)
+        .on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
+        .where(CURRENT_CONSTRAINT.APPLICATION.eq(application))
+        .fetch { (envId, envName, dcName) ->
+          environmentNames[envId] = envName
+          deliveryConfigsByEnv[envId] = dcName
+        }
+    }
 
     return constraintResult.map { (envId,
                                     artifactVersion,
@@ -421,118 +461,128 @@ class SqlDeliveryConfigRepository(
   ): List<ConstraintState> {
     val environmentUID = environmentUidByName(deliveryConfigName, environmentName)
       ?: return emptyList()
-    return jooq
-      .select(
-        inline(deliveryConfigName).`as`("deliveryConfigName"),
-        inline(environmentName).`as`("environmentName"),
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
-        ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES
-      )
-      .from(ENVIRONMENT_ARTIFACT_CONSTRAINT)
-      .where(ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(environmentUID))
-      .orderBy(ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT.desc())
-      .limit(limit)
-      .fetch { (deliveryConfigName,
-                 environmentName,
-                 artifactVersion,
-                 constraintType,
-                 status,
-                 createdAt,
-                 judgedBy,
-                 judgedAt,
-                 comment,
-                 attributes) ->
-        ConstraintState(
-          deliveryConfigName,
-          environmentName,
-          artifactVersion,
-          constraintType,
-          ConstraintStatus.valueOf(status),
-          createdAt.toInstant(ZoneOffset.UTC),
-          judgedBy,
-          when (judgedAt) {
-            null -> null
-            else -> judgedAt.toInstant(ZoneOffset.UTC)
-          },
-          comment,
-          mapper.readValue(attributes)
+    return sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          inline(deliveryConfigName).`as`("deliveryConfigName"),
+          inline(environmentName).`as`("environmentName"),
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.STATUS,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_BY,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.JUDGED_AT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.COMMENT,
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ATTRIBUTES
         )
-      }
+        .from(ENVIRONMENT_ARTIFACT_CONSTRAINT)
+        .where(ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(environmentUID))
+        .orderBy(ENVIRONMENT_ARTIFACT_CONSTRAINT.CREATED_AT.desc())
+        .limit(limit)
+        .fetch { (deliveryConfigName,
+                   environmentName,
+                   artifactVersion,
+                   constraintType,
+                   status,
+                   createdAt,
+                   judgedBy,
+                   judgedAt,
+                   comment,
+                   attributes) ->
+          ConstraintState(
+            deliveryConfigName,
+            environmentName,
+            artifactVersion,
+            constraintType,
+            ConstraintStatus.valueOf(status),
+            createdAt.toInstant(ZoneOffset.UTC),
+            judgedBy,
+            when (judgedAt) {
+              null -> null
+              else -> judgedAt.toInstant(ZoneOffset.UTC)
+            },
+            comment,
+            mapper.readValue(attributes)
+          )
+        }
+    }
   }
 
   private fun resourcesForEnvironment(uid: String) =
-    jooq
-      .select(
-        RESOURCE.API_VERSION,
-        RESOURCE.KIND,
-        RESOURCE.METADATA,
-        RESOURCE.SPEC
-      )
-      .from(RESOURCE, ENVIRONMENT_RESOURCE)
-      .where(RESOURCE.UID.eq(ENVIRONMENT_RESOURCE.RESOURCE_UID))
-      .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
-      .fetch { (apiVersion, kind, metadata, spec) ->
-        Resource(
-          ApiVersion(apiVersion),
-          kind,
-          mapper.readValue<Map<String, Any?>>(metadata).asResourceMetadata(),
-          mapper.readValue(spec, resourceTypeIdentifier.identify(ApiVersion(apiVersion), kind))
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(
+          RESOURCE.API_VERSION,
+          RESOURCE.KIND,
+          RESOURCE.METADATA,
+          RESOURCE.SPEC
         )
-      }
+        .from(RESOURCE, ENVIRONMENT_RESOURCE)
+        .where(RESOURCE.UID.eq(ENVIRONMENT_RESOURCE.RESOURCE_UID))
+        .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
+        .fetch { (apiVersion, kind, metadata, spec) ->
+          Resource(
+            ApiVersion(apiVersion),
+            kind,
+            mapper.readValue<Map<String, Any?>>(metadata).asResourceMetadata(),
+            mapper.readValue(spec, resourceTypeIdentifier.identify(ApiVersion(apiVersion), kind))
+          )
+        }
+    }
       .toSet()
 
   override fun itemsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig> {
     val now = clock.instant()
     val cutoff = now.minus(minTimeSinceLastCheck).toLocal()
-    return jooq.inTransaction {
-      select(DELIVERY_CONFIG.UID, DELIVERY_CONFIG.NAME)
-        .from(DELIVERY_CONFIG, DELIVERY_CONFIG_LAST_CHECKED)
-        .where(DELIVERY_CONFIG.UID.eq(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID))
-        .and(DELIVERY_CONFIG_LAST_CHECKED.AT.lessOrEqual(cutoff))
-        .orderBy(DELIVERY_CONFIG_LAST_CHECKED.AT)
-        .limit(limit)
-        .forUpdate()
-        .fetch()
-        .also {
-          it.forEach { (uid, _) ->
-            insertInto(DELIVERY_CONFIG_LAST_CHECKED)
-              .set(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID, uid)
-              .set(DELIVERY_CONFIG_LAST_CHECKED.AT, now.toLocal())
-              .onDuplicateKeyUpdate()
-              .set(DELIVERY_CONFIG_LAST_CHECKED.AT, now.toLocal())
-              .execute()
+    return sqlRetry.withRetry(WRITE) {
+      jooq.inTransaction {
+        select(DELIVERY_CONFIG.UID, DELIVERY_CONFIG.NAME)
+          .from(DELIVERY_CONFIG, DELIVERY_CONFIG_LAST_CHECKED)
+          .where(DELIVERY_CONFIG.UID.eq(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID))
+          .and(DELIVERY_CONFIG_LAST_CHECKED.AT.lessOrEqual(cutoff))
+          .orderBy(DELIVERY_CONFIG_LAST_CHECKED.AT)
+          .limit(limit)
+          .forUpdate()
+          .fetch()
+          .also {
+            it.forEach { (uid, _) ->
+              insertInto(DELIVERY_CONFIG_LAST_CHECKED)
+                .set(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID, uid)
+                .set(DELIVERY_CONFIG_LAST_CHECKED.AT, now.toLocal())
+                .onDuplicateKeyUpdate()
+                .set(DELIVERY_CONFIG_LAST_CHECKED.AT, now.toLocal())
+                .execute()
+            }
           }
-        }
-        .map { (_, name) ->
-          get(name)
-        }
+          .map { (_, name) ->
+            get(name)
+          }
+      }
     }
   }
 
   private fun environmentUidByName(deliveryConfigName: String, environmentName: String): String? =
-    jooq
-      .select(ENVIRONMENT.UID)
-      .from(DELIVERY_CONFIG)
-      .innerJoin(ENVIRONMENT).on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
-      .where(
-        DELIVERY_CONFIG.NAME.eq(deliveryConfigName),
-        ENVIRONMENT.NAME.eq(environmentName)
-      )
-      .fetchOne(ENVIRONMENT.UID)
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(ENVIRONMENT.UID)
+        .from(DELIVERY_CONFIG)
+        .innerJoin(ENVIRONMENT).on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
+        .where(
+          DELIVERY_CONFIG.NAME.eq(deliveryConfigName),
+          ENVIRONMENT.NAME.eq(environmentName)
+        )
+        .fetchOne(ENVIRONMENT.UID)
+    }
       ?: null
 
   private fun applicationByDeliveryConfigName(name: String): String =
-    jooq
-      .select(DELIVERY_CONFIG.APPLICATION)
-      .from(DELIVERY_CONFIG)
-      .where(DELIVERY_CONFIG.NAME.eq(name))
-      .fetchOne(DELIVERY_CONFIG.APPLICATION)
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_CONFIG.APPLICATION)
+        .from(DELIVERY_CONFIG)
+        .where(DELIVERY_CONFIG.NAME.eq(name))
+        .fetchOne(DELIVERY_CONFIG.APPLICATION)
+    }
       ?: throw NoSuchDeliveryConfigName(name)
 
   private fun Instant.toLocal() = atZone(clock.zone).toLocalDateTime()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlRetry.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlRetry.kt
@@ -1,0 +1,42 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import io.github.resilience4j.retry.Retry
+import io.github.resilience4j.retry.RetryConfig
+import io.vavr.control.Try
+import java.time.Duration
+import org.jooq.exception.SQLDialectNotSupportedException
+
+class SqlRetry(
+  private val sqlRetryProperties: SqlRetryProperties
+) {
+  fun <T> withRetry(category: RetryCategory, action: () -> T): T {
+    return if (category == RetryCategory.WRITE) {
+      val retry = Retry.of(
+        "sqlWrite",
+        RetryConfig.custom<T>()
+          .maxAttempts(sqlRetryProperties.transactions.maxRetries)
+          .waitDuration(Duration.ofMillis(sqlRetryProperties.transactions.backoffMs))
+          .ignoreExceptions(SQLDialectNotSupportedException::class.java)
+          .build()
+      )
+
+      Try.ofSupplier(Retry.decorateSupplier(retry, action)).get()
+    } else {
+      val retry = Retry.of(
+        "sqlRead",
+        RetryConfig.custom<T>()
+          .maxAttempts(sqlRetryProperties.reads.maxRetries)
+          .waitDuration(Duration.ofMillis(sqlRetryProperties.reads.backoffMs))
+          .ignoreExceptions(SQLDialectNotSupportedException::class.java)
+          .build()
+      )
+
+      Try.ofSupplier(Retry.decorateSupplier(retry, action)).get()
+    }
+  }
+}
+
+enum class RetryCategory {
+  WRITE, READ
+}

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
@@ -3,6 +3,8 @@ package com.netflix.spinnaker.keel.sql
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.persistence.ArtifactRepositoryTests
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
 
@@ -10,15 +12,18 @@ class SqlArtifactRepositoryTests : ArtifactRepositoryTests<SqlArtifactRepository
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectmapper = configuredObjectMapper()
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   private val deliveryConfigRepository = SqlDeliveryConfigRepository(
     jooq,
     Clock.systemDefaultZone(),
-    DummyResourceTypeIdentifier
+    DummyResourceTypeIdentifier,
+    sqlRetry
   )
 
   override fun factory(clock: Clock): SqlArtifactRepository =
-    SqlArtifactRepository(jooq, clock, objectmapper)
+    SqlArtifactRepository(jooq, clock, objectmapper, sqlRetry)
 
   override fun SqlArtifactRepository.flush() {
     cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepositoryPeriodicallyCheckedTests
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
@@ -10,9 +12,11 @@ internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
 
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override val factory: (Clock) -> SqlDeliveryConfigRepository = { clock ->
-    SqlDeliveryConfigRepository(jooq, clock, DummyResourceTypeIdentifier)
+    SqlDeliveryConfigRepository(jooq, clock, DummyResourceTypeIdentifier, sqlRetry)
   }
 
   override fun flush() {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
@@ -3,6 +3,8 @@ package com.netflix.spinnaker.keel.sql
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepositoryTests
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
@@ -11,15 +13,17 @@ internal object SqlDeliveryConfigRepositoryTests : DeliveryConfigRepositoryTests
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectmapper = configuredObjectMapper()
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun createDeliveryConfigRepository(resourceTypeIdentifier: ResourceTypeIdentifier): SqlDeliveryConfigRepository =
-    SqlDeliveryConfigRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier)
+    SqlDeliveryConfigRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, sqlRetry)
 
   override fun createResourceRepository(): SqlResourceRepository =
-    SqlResourceRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, configuredObjectMapper())
+    SqlResourceRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, configuredObjectMapper(), sqlRetry)
 
   override fun createArtifactRepository(): SqlArtifactRepository =
-    SqlArtifactRepository(jooq, Clock.systemDefaultZone(), objectmapper)
+    SqlArtifactRepository(jooq, Clock.systemDefaultZone(), objectmapper, sqlRetry)
 
   override fun flush() {
     cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepositoryTests.kt
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepositoryTests
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
@@ -25,9 +27,11 @@ import org.junit.jupiter.api.AfterAll
 internal object SqlDiffFingerprintRepositoryTests : DiffFingerprintRepositoryTests<SqlDiffFingerprintRepository>() {
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun factory(clock: Clock): SqlDiffFingerprintRepository {
-    return SqlDiffFingerprintRepository(jooq, clock)
+    return SqlDiffFingerprintRepository(jooq, clock, sqlRetry)
   }
 
   override fun SqlDiffFingerprintRepository.flush() {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepositoryTests.kt
@@ -18,15 +18,19 @@
 package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.persistence.PausedRepositoryTests
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import org.junit.jupiter.api.AfterAll
 
 internal object SqlPausedRepositoryTests : PausedRepositoryTests<SqlPausedRepository>() {
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun factory(): SqlPausedRepository =
-    SqlPausedRepository(jooq)
+    SqlPausedRepository(jooq, sqlRetry)
 
   override fun SqlPausedRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -7,6 +7,8 @@ import com.netflix.spinnaker.keel.persistence.ResourceRepositoryPeriodicallyChec
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import dev.minutest.rootContext
 import java.time.Clock
@@ -24,9 +26,11 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
 
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override val factory: (clock: Clock) -> SqlResourceRepository = { clock ->
-    SqlResourceRepository(jooq, clock, DummyResourceTypeIdentifier, configuredObjectMapper())
+    SqlResourceRepository(jooq, clock, DummyResourceTypeIdentifier, configuredObjectMapper(), sqlRetry)
   }
 
   override fun flush() {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -2,6 +2,8 @@ package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.persistence.ResourceRepositoryTests
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
@@ -9,13 +11,16 @@ import org.junit.jupiter.api.AfterAll
 internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun factory(clock: Clock): SqlResourceRepository {
     return SqlResourceRepository(
       jooq,
       clock,
       DummyResourceTypeIdentifier,
-      configuredObjectMapper()
+      configuredObjectMapper(),
+      sqlRetry
     )
   }
 

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepositoryTests.kt
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepositoryTests
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
@@ -26,11 +28,14 @@ internal object SqlUnhappyVetoRepositoryTests : UnhappyVetoRepositoryTests<SqlUn
 
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun factory(clock: Clock): SqlUnhappyVetoRepository {
     return SqlUnhappyVetoRepository(
       clock,
-      jooq
+      jooq,
+      sqlRetry
     )
   }
 


### PR DESCRIPTION
Added retries to most places. One exception: persisting a delivery config. Because of the created spring transaction which operates across many tables and repositories it was impossible to add retries to those specific methods. I opened this issue (https://github.com/spinnaker/keel/issues/740) to track where we need to rethink things before being able to apply retries.

**View this w/o whitespace changes** for best experience. I wrap a lot of methods.