### PR TITLE
feat(configs): add api version to delivery configs

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -11,7 +11,8 @@ data class DeliveryConfig(
   val application: String,
   val serviceAccount: String,
   val artifacts: Set<DeliveryArtifact> = emptySet(),
-  val environments: Set<Environment> = emptySet()
+  val environments: Set<Environment> = emptySet(),
+  val apiVersion: ApiVersion = ApiVersion("delivery.config.spinnaker.netflix.com", "v1")
 )
 
 data class SubmittedDeliveryConfig(

--- a/keel-sql/src/main/resources/db/changelog/20200122-delivery-config-api-version.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200122-delivery-config-api-version.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: delivery-config-api-version
+      author: emjburns
+      changes:
+        - addColumn:
+            tableName: delivery_config
+            columns:
+              - column:
+                  name: api_version
+                  type: varchar(255)
+                  defaultValue: delivery.config.spinnaker.netflix.com/v1
+                  constraints:
+                    nullable: false
+      rollback:
+        - dropColumn:
+            tableName: delivery_config
+            columnName: api_version

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -83,3 +83,7 @@ databaseChangeLog:
   - include:
       file: changelog/20200122-service-account-on-delivery-config.yml
       relativeToChangelogFile: true
+  - include:
+     file: changelog/20200122-delivery-config-api-version.yml
+     relativeToChangelogFile: true
+


### PR DESCRIPTION
Adding api version to delivery configs so that we can make versioned changes to delivery configs. Not required for submission, we will default the value to v1.
