### PR TITLE
refactor(plugins): Decouple jackson from core models

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spinnaker.keel.api.UID
+import com.netflix.spinnaker.keel.serialization.mixins.MixinModule
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
@@ -37,6 +38,7 @@ private fun <T : ObjectMapper> T.configureMe(): T =
     registerKotlinModule()
       .registerULIDModule()
       .registerModule(JavaTimeModule())
+      .registerModule(MixinModule())
       .configureSaneDateTimeRepresentation()
       .disable(FAIL_ON_UNKNOWN_PROPERTIES)
       .enable(ACCEPT_CASE_INSENSITIVE_ENUMS)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/mixins/ApiVersionMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/mixins/ApiVersionMixin.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2018 Netflix, Inc.
+ * Copyright 2020 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *    http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,23 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.netflix.spinnaker.keel.api
+package com.netflix.spinnaker.keel.serialization.mixins
 
+import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import com.netflix.spinnaker.keel.api.ApiVersion
 
-data class ApiVersion(
+@MixinFor(ApiVersion::class)
+@JsonSerialize(using = ToStringSerializer::class)
+abstract class ApiVersionMixin(
   val group: String,
   val version: String
 ) {
+
+  @JsonCreator
   constructor(value: String) :
     this(value.substringBefore("/"), value.substringAfter("/"))
 
-  override fun toString() = "$group/$version"
-
-  fun subApi(prefix: String) = copy(group = "$prefix.$group")
-
   @JsonIgnore
-  val prefix: String = group.substringBefore(".")
+  abstract fun getPrefix(): String
 }
-
-val SPINNAKER_API_V1 = ApiVersion("spinnaker.netflix.com", "v1")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/mixins/MixinFor.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/mixins/MixinFor.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.serialization.mixins
+
+import kotlin.reflect.KClass
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class MixinFor(
+  val value: KClass<*>
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/mixins/MixinModule.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/mixins/MixinModule.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.netflix.spinnaker.keel.serialization.mixins
+
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.netflix.spinnaker.keel.api.ApiVersion
+
+class MixinModule : SimpleModule("KeelMixinModule") {
+  init {
+    setMixInAnnotation(ApiVersion::class.java, ApiVersionMixin::class.java)
+
+    // TODO(rz): Scan for abstract classes with the `MixinFor` annotation. ClassPathScanningCandidateComponentProvider
+    //  does not have support (and will not support) for finding abstract classes. Until a real solution is added,
+    //  mappings would need to be manually defined like above.
+  }
+}


### PR DESCRIPTION
A little experiment around decoupling Jackson annotations from the core models. This would allow us to, for the most part, move existing models into a plugin API without bringing Jackson along for the ride!

Uses [Jackson Mixin Annotations](https://github.com/FasterXML/jackson-docs/wiki/JacksonMixInAnnotations), which is just an abstract class that you define with all of the constructors & methods that you need to put annotations on. Once the mixin class is created, an association is made between the mixin and the actual target class, voila. Nice thing is that it supports all annotations that Jackson knows about, so I believe things should "just work".

There's a little more boilerplate with this, but it's definitely less interruptive than other options I've found so far.

I see two initial drawbacks on this:

1. Boilerplate. For any class you want to do customization of serialization for, you'll need a mixin class.
1. Discoverability. This is a problem no matter the solution, I think, but with decoupling serde from the actual model, the codebase may be more difficult to reason about for new developers.

I went down the path of writing a helper to reduce boilerplate via the `@MixinFor` annotation which would automate the mapping of mixins to their target class, but I couldn't get it to work for a quick POC. What exists here works, however.