### PR TITLE
fix(diff): allow top level service account in dc diff

### DIFF
--- a/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
+++ b/keel-actuator/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
@@ -64,7 +64,9 @@ class AdHocDiffer(
     submittedDeliveryConfig.environments.map { env ->
       val resourceDiffs = runBlocking {
         env.resources.map { resource ->
-          calculate(resource)
+          val metadata = resource.metadata.toMutableMap()
+          metadata["serviceAccount"] = submittedDeliveryConfig.serviceAccount
+          calculate(resource.copy(metadata = metadata))
         }
       }
 


### PR DESCRIPTION
This allows diffs of delivery configs that have the service account defined at the top level.