### PR TITLE
fix(config): add validation that resource names are unique

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourcePersister.kt
@@ -14,6 +14,7 @@ import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import com.netflix.spinnaker.keel.core.api.id
 import com.netflix.spinnaker.keel.core.api.normalize
+import com.netflix.spinnaker.keel.core.api.resources
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ResourceCreated
@@ -77,8 +78,10 @@ class ResourcePersister(
     try {
       validate(new)
     } catch (e: ValidationException) {
-      log.warn("Validation of ${new.name} failed, deleting delivery config")
-      deleteDeliveryConfig(new.name)
+      log.warn("Validation of ${new.name} failed, deleting already persisted resources")
+      new.resources.forEach { resource ->
+        resourceRepository.delete(resource.id)
+      }
       throw e
     }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateResourceIdException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateResourceIdException.kt
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.keel.exceptions
+
+open class ValidationException(
+  val msg: String
+) : RuntimeException(msg)
+
+class DuplicateResourceIdException(
+  val ids: List<String>,
+  val envsToResources: Map<String, List<String>>
+) : ValidationException(
+  "Resources with ids $ids exist in more than one environment ($envsToResources). " +
+    "Please ensure each resource has a unique id."
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateResourceIdException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateResourceIdException.kt
@@ -8,6 +8,6 @@ class DuplicateResourceIdException(
   val ids: List<String>,
   val envsToResources: Map<String, List<String>>
 ) : ValidationException(
-  "Resources with ids $ids exist in more than one environment ($envsToResources). " +
+  "Resource(s) with ids $ids exist in more than one environment ($envsToResources). " +
     "Please ensure each resource has a unique id."
 )

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
+import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
 import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
@@ -46,6 +47,13 @@ class ExceptionHandler {
   @ExceptionHandler(ArtifactAlreadyRegistered::class)
   @ResponseStatus(CONFLICT)
   fun onAlreadyRegistered(e: ArtifactAlreadyRegistered): ApiError {
+    log.error(e.message)
+    return ApiError(e)
+  }
+
+  @ExceptionHandler(DuplicateResourceIdException::class)
+  @ResponseStatus(BAD_REQUEST)
+  fun onDuplicateResourceIds(e: DuplicateResourceIdException): ApiError {
     log.error(e.message)
     return ApiError(e)
   }


### PR DESCRIPTION
We currently don't validate that you can't have the same resource in more than one env. This PR adds validation based on resource id. 

If the resource is present in more than one env, we throw an exception with a detailed error message and delete the delivery config. We do it in this order because we only calculate the resource id once it's been normalized and saved.