### PR TITLE
fix(resourceEvents): adding statuses to ResourceTaskSucceeded and ResourceTaskFailed

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -33,6 +33,8 @@ import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceMissing
+import com.netflix.spinnaker.keel.events.ResourceTaskFailed
+import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
@@ -157,7 +159,9 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
   }
 
   private fun List<ResourceEvent>.isActuating(): Boolean {
-    return first() is ResourceActuationLaunched
+    return first() is ResourceActuationLaunched || first() is ResourceTaskSucceeded ||
+      // we might want to move ResourceTaskFailed to isError later on
+      first() is ResourceTaskFailed
   }
 
   private fun List<ResourceEvent>.isError(): Boolean {


### PR DESCRIPTION
Adding ACTUATING status to both ResourceTaskSucceeded and ResourceTaskFailed events (events triggered based on statuses of orca tasks), as it currently implemented as informative tasks (meaning just provide info to the user, and we're not deciding upon them if there is an actual error).