### PR TITLE
feat(environments): automated blacklisting of versions from environments

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -20,7 +20,7 @@ data class DebianArtifact(
   override val name: String,
   override val deliveryConfigName: String? = null,
   override val reference: String = name,
-  val statuses: List<ArtifactStatus> = emptyList(),
+  val statuses: Set<ArtifactStatus> = emptySet(),
   override val versioningStrategy: VersioningStrategy = DebianSemVerVersioningStrategy
 ) : DeliveryArtifact() {
   override val type = ArtifactType.deb

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/api/ImageSpec.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/api/ImageSpec.kt
@@ -10,7 +10,7 @@ data class ImageSpec(
   val baseOs: String,
   val regions: Set<String>,
   val storeType: StoreType,
-  val artifactStatuses: List<ArtifactStatus> = enumValues<ArtifactStatus>().toList(),
+  val artifactStatuses: Set<ArtifactStatus> = enumValues<ArtifactStatus>().toSet(),
   override val application: String // the application an image is baked in
 ) : ResourceSpec {
   @JsonIgnore

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandlerTests.kt
@@ -71,7 +71,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
         application = "keel"
       )
     )
-    val resourceOnlySnapshot = resource.copy(spec = resource.spec.copy(artifactStatuses = listOf(SNAPSHOT)))
+    val resourceOnlySnapshot = resource.copy(spec = resource.spec.copy(artifactStatuses = setOf(SNAPSHOT)))
 
     val image = Image(
       baseAmiVersion = "nflx-base-5.378.0-h1230.8808866",

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -44,9 +44,9 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     val subject: T
   ) {
     // the artifact built off a feature branch
-    val artifact1 = DebianArtifact("keeldemo", deliveryConfigName = "my-manifest", reference = "candidate", statuses = listOf(SNAPSHOT))
+    val artifact1 = DebianArtifact("keeldemo", deliveryConfigName = "my-manifest", reference = "candidate", statuses = setOf(SNAPSHOT))
     // the artifact built off of master
-    val artifact2 = DebianArtifact("keeldemo", deliveryConfigName = "my-manifest", reference = "master", statuses = listOf(RELEASE))
+    val artifact2 = DebianArtifact("keeldemo", deliveryConfigName = "my-manifest", reference = "master", statuses = setOf(RELEASE))
     val artifact3 = DockerArtifact("docker", deliveryConfigName = "my-manifest", reference = "docker-artifact")
     val environment1 = Environment("test")
     val environment2 = Environment("staging")
@@ -108,7 +108,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       .artifacts
       .first {
         if (artifact is DebianArtifact) {
-          it.name == artifact.name && it.type == artifact.type && artifact.statuses == it.statuses.toList()
+          it.name == artifact.name && it.type == artifact.type && artifact.statuses == it.statuses
         } else {
           it.name == artifact.name && it.type == artifact.type
         }
@@ -210,7 +210,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         }
 
         test("querying for all returns all") {
-          val artifactWithAll = artifact1.copy(statuses = emptyList())
+          val artifactWithAll = artifact1.copy(statuses = emptySet())
           expectThat(subject.versions(artifactWithAll)).containsExactly(version5, version4, version3, version2, version1)
         }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -105,7 +106,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       .versionsByEnvironment(manifest)
       .first { it.name == environment.name }
       .artifacts
-      .first { it.name == artifact.name && it.type == artifact.type }
+      .first {
+        if (artifact is DebianArtifact) {
+          it.name == artifact.name && it.type == artifact.type && artifact.statuses == it.statuses.toList()
+        } else {
+          it.name == artifact.name && it.type == artifact.type
+        }
+      }
       .versions
   }
 
@@ -431,6 +438,12 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             .isEqualTo(version4)
             .isEqualTo(pin1.version)
         }
+
+        test("pinned version cannot be vetoed") {
+          subject.pinEnvironment(manifest, pin1)
+          expectThat(subject.markAsVetoedIn(manifest, artifact2, pin1.version!!, pin1.targetEnvironment))
+            .isFalse()
+        }
       }
     }
 
@@ -463,6 +476,53 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
           that(subject.getAll().size).isEqualTo(3)
           that(subject.getAll(docker).size).isEqualTo(1)
           that(subject.getAll(deb).size).isEqualTo(2)
+        }
+      }
+    }
+
+    context("the latest version is vetoed") {
+      before {
+        subject.flush()
+        persist()
+        subject.approveVersionFor(manifest, artifact2, version4, environment2.name)
+        subject.approveVersionFor(manifest, artifact2, version5, environment2.name)
+        subject.markAsVetoedIn(manifest, artifact2, version5, environment2.name)
+      }
+
+      test("latestVersionApprovedIn reflects the veto") {
+        expectThat(subject.latestVersionApprovedIn(manifest, artifact2, environment2.name))
+          .isEqualTo(version4)
+      }
+
+      test("vetoedEnvironmentVersions reflects the veto") {
+        expectThat(subject.vetoedEnvironmentVersions(manifest))
+          .isEqualTo(
+            listOf(
+              EnvironmentArtifactVetoes(
+                deliveryConfigName = manifest.name,
+                targetEnvironment = environment2.name,
+                artifact = artifact2,
+                versions = mutableSetOf(version5)
+              )
+            )
+          )
+      }
+
+      test("version status reflects the veto") {
+        expectThat(versionsIn(environment2, artifact2)) {
+          get(ArtifactVersionStatus::vetoed).containsExactly(version5)
+          get(ArtifactVersionStatus::approved).containsExactly(version4)
+        }
+      }
+
+      test("unveto the vetoed version") {
+        subject.deleteVeto(manifest, artifact2, version5, environment2.name)
+
+        expectThat(subject.latestVersionApprovedIn(manifest, artifact2, environment2.name))
+          .isEqualTo(version5)
+        expectThat(versionsIn(environment2, artifact2)) {
+          get(ArtifactVersionStatus::vetoed).isEmpty()
+          get(ArtifactVersionStatus::approved).containsExactlyInAnyOrder(version4, version5)
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -1,11 +1,11 @@
 package com.netflix.spinnaker.keel.actuation
 
-import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.VersionedArtifact
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
@@ -79,24 +79,24 @@ class ResourceActuator(
         val response = vetoEnforcer.canCheck(resource)
         if (!response.allowed) {
           /**
-           * [ArtifactVersioned] is a special [resource] sub-type. When a veto response sets
+           * [VersionedArtifact] is a special [resource] sub-type. When a veto response sets
            * [VetoResponse.vetoArtifact] and the resource under evaluation is of type
-           * [ArtifactVersioned], blacklist the desired artifact version from the environment
+           * [VersionedArtifact], blacklist the desired artifact version from the environment
            * containing [resource]. This ensures that the environment will be fully restored to
            * a prior good-state.
            */
-          if (response.vetoArtifact && resource.spec is ArtifactVersioned) {
+          if (response.vetoArtifact && resource.spec is VersionedArtifact) {
             try {
               val (version, artifact) = when (desired) {
                 is Map<*, *> -> {
                   if (desired.size > 0) {
-                    val versioned = (desired as Map<String, ArtifactVersioned>).values.first()
+                    val versioned = (desired as Map<String, VersionedArtifact>).values.first()
                     Pair(versioned.artifactVersion, versioned.deliveryArtifact)
                   } else {
                     Pair(null, null)
                   }
                 }
-                is ArtifactVersioned -> Pair(desired.artifactVersion, desired.deliveryArtifact)
+                is VersionedArtifact -> Pair(desired.artifactVersion, desired.deliveryArtifact)
                 else -> Pair(null, null)
               }
               if (version != null && artifact != null) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -1,5 +1,8 @@
 package com.netflix.spinnaker.keel.actuation
 
+import com.netflix.spinnaker.keel.api.ArtifactVersioned
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.ResourceSpec
@@ -19,6 +22,8 @@ import com.netflix.spinnaker.keel.events.ResourceMissing
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.pause.ResourcePauser
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.CannotResolveCurrentState
@@ -36,6 +41,8 @@ import org.springframework.stereotype.Component
 @Component
 class ResourceActuator(
   private val resourceRepository: ResourceRepository,
+  private val artifactRepository: ArtifactRepository,
+  private val deliveryConfigRepository: DeliveryConfigRepository,
   private val diffFingerprintRepository: DiffFingerprintRepository,
   private val handlers: List<ResourceHandler<*, *>>,
   private val resourcePauser: ResourcePauser,
@@ -71,6 +78,45 @@ class ResourceActuator(
 
         val response = vetoEnforcer.canCheck(resource)
         if (!response.allowed) {
+          /**
+           * [ArtifactVersioned] is a special [resource] sub-type. When a veto response sets
+           * [VetoResponse.vetoArtifact] and the resource under evaluation is of type
+           * [ArtifactVersioned], blacklist the desired artifact version from the environment
+           * containing [resource]. This ensures that the environment will be fully restored to
+           * a prior good-state.
+           */
+          if (response.vetoArtifact && resource.spec is ArtifactVersioned) {
+            try {
+              val (version, artifact) = when (desired) {
+                is Map<*, *> -> {
+                  if (desired.size > 0) {
+                    val versioned = (desired as Map<String, ArtifactVersioned>).values.first()
+                    Pair(versioned.artifactVersion, versioned.deliveryArtifact)
+                  } else {
+                    Pair(null, null)
+                  }
+                }
+                is ArtifactVersioned -> Pair(desired.artifactVersion, desired.deliveryArtifact)
+                else -> Pair(null, null)
+              }
+              if (version != null && artifact != null) {
+                val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
+                val environment = deliveryConfig.environmentFor(resource)?.name
+                  ?: error("Failed to find environment for ${resource.id} in deliveryConfig ${deliveryConfig.name} " +
+                    "while attempting to veto artifact ${artifact.name} version $version")
+
+                artifactRepository.markAsVetoedIn(
+                  deliveryConfig = deliveryConfig,
+                  artifact = artifact,
+                  version = version,
+                  targetEnvironment = environment)
+                // TODO: emit event + metric
+              }
+            } catch (e: Exception) {
+              log.warn("Failed to veto presumed bad artifact version for ${resource.id}", e)
+              // TODO: emit metric
+            }
+          }
           log.debug("Skipping actuation for resource {} because it was vetoed: {}", id, response.message)
           publisher.publishEvent(ResourceCheckSkipped(resource.apiVersion, resource.kind, id, response.vetoName))
           publishVetoedEvent(response, resource)
@@ -120,7 +166,7 @@ class ResourceActuator(
     }
   }
 
-  private suspend fun ResourceHandler<*, *>.resolve(resource: Resource<out ResourceSpec>): Pair<Any, Any?> =
+  private suspend fun <T : Any> ResourceHandler<*, T>.resolve(resource: Resource<out ResourceSpec>): Pair<T, T?> =
     supervisorScope {
       val desired = async {
         try {
@@ -159,6 +205,9 @@ class ResourceActuator(
           response.message,
           clock.instant()))
     }
+
+  private fun DeliveryConfig.environmentFor(resource: Resource<*>): Environment? =
+    environments.firstOrNull { it.resources.contains(resource) }
 
   // These extensions get round the fact tht we don't know the spec type of the resource from
   // the repository. I don't want the `ResourceHandler` interface to be untyped though.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ArtifactVersioned.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/ArtifactVersioned.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.api
+
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+
+interface ArtifactVersioned {
+  val deliveryArtifact: DeliveryArtifact?
+  val artifactVersion: String?
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/UnhappyControl.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/UnhappyControl.kt
@@ -1,0 +1,17 @@
+package com.netflix.spinnaker.keel.api
+
+import java.time.Duration
+
+interface UnhappyControl {
+  /**
+   * [maxDiffCount] allows customization of how many times keel will attempt to
+   * actuate a given resource diff before `UnhappyVeto` is engaged.
+   */
+  val maxDiffCount: Int?
+  /**
+   * [unhappyWaitTime] allows customization of how often actuation of an unhappy
+   * resource can be attempted. An [unhappyWaitTime] of Duration.ZERO is treated as:
+   * "Wait forever or until the diff changes, whichever comes first."
+   */
+  val unhappyWaitTime: Duration?
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/VersionedArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/VersionedArtifact.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.api
 
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 
-interface ArtifactVersioned {
+interface VersionedArtifact {
   val deliveryArtifact: DeliveryArtifact?
   val artifactVersion: String?
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
@@ -18,3 +18,18 @@ data class PinnedEnvironment(
   val artifact: DeliveryArtifact,
   val version: String
 )
+
+data class EnvironmentArtifactVeto(
+  val deliveryConfigName: String,
+  val targetEnvironment: String,
+  val reference: String,
+  val type: String,
+  val version: String
+)
+
+data class EnvironmentArtifactVetoes(
+  val deliveryConfigName: String,
+  val targetEnvironment: String,
+  val artifact: DeliveryArtifact,
+  val versions: MutableSet<String>
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactsSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactsSummary.kt
@@ -11,7 +11,7 @@ data class EnvironmentArtifactsSummary(
 data class ArtifactVersions(
   val name: String,
   val type: ArtifactType,
-  val statuses: Collection<ArtifactStatus>,
+  val statuses: Set<ArtifactStatus>,
   val versions: ArtifactVersionStatus
 )
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactsSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactsSummary.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.core.api
 
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 
 data class EnvironmentArtifactsSummary(
@@ -10,6 +11,7 @@ data class EnvironmentArtifactsSummary(
 data class ArtifactVersions(
   val name: String,
   val type: ArtifactType,
+  val statuses: Collection<ArtifactStatus>,
   val versions: ArtifactVersionStatus
 )
 
@@ -17,5 +19,7 @@ data class ArtifactVersionStatus(
   val current: String?,
   val deploying: String?,
   val pending: List<String>,
-  val previous: List<String>
+  val approved: List<String>,
+  val previous: List<String>,
+  val vetoed: List<String>
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 
@@ -117,6 +118,42 @@ interface ArtifactRepository {
    * [wasSuccessfullyDeployedTo] will return `true` for that version.
    */
   fun markAsSuccessfullyDeployedTo(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String
+  )
+
+  /**
+   * @return list of [EnvironmentArtifactVetoes] for all environments and artifacts defined
+   * in the [deliveryConfig].
+   */
+  fun vetoedEnvironmentVersions(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactVetoes>
+
+  /**
+   * Marks [version] as vetoed from consideration for deployment to [targetEnvironment].
+   * When run against the latest approved version, the effect is a rollback to the last
+   * previously deployed version. This is in contrast to [pinEnvironment], which forces
+   * resolution of the desired artifact version to what is pinned. Only a single
+   * (artifact, artifact_version) can be pinned per environment but many can be vetoed.
+   *
+   * @param force when set, the version will be vetoed even if it became the desired
+   *  version due to a prior, potentially automated, veto.
+   *
+   * @return `true` if the veto was successfully persisted.
+   */
+  fun markAsVetoedIn(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String,
+    force: Boolean = false
+  ): Boolean
+
+  /**
+   * Removes any veto of [version] in [targetEnvironment]]
+   */
+  fun deleteVeto(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
     version: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PromotionStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PromotionStatus.kt
@@ -1,5 +1,5 @@
 package com.netflix.spinnaker.keel.persistence
 
 enum class PromotionStatus {
-  PENDING, APPROVED, DEPLOYING, CURRENT, PREVIOUS
+  PENDING, APPROVED, DEPLOYING, CURRENT, PREVIOUS, VETOED
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
@@ -37,7 +37,11 @@ abstract class UnhappyVetoRepository(
   /**
    * Marks [resourceId] as unhappy for [waitingTime]
    */
-  abstract fun markUnhappyForWaitingTime(resourceId: String, application: String)
+  abstract fun markUnhappyForWaitingTime(
+    resourceId: String,
+    application: String,
+    wait: Duration = Duration.parse(waitingTime)
+  )
 
   /**
    * Clears unhappy marking for [resourceId]
@@ -59,8 +63,11 @@ abstract class UnhappyVetoRepository(
    */
   abstract fun getAllForApp(application: String): Set<String>
 
-  fun calculateExpirationTime(): Instant =
-    clock.instant().plus(Duration.parse(waitingTime))
+  fun calculateExpirationTime(wait: Duration): Instant =
+    when (wait) {
+      Duration.ZERO -> Instant.MAX
+      else -> clock.instant().plus(wait)
+    }
 
   data class UnhappyVetoStatus(
     val shouldSkip: Boolean = false,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.comparator
@@ -16,9 +17,11 @@ import com.netflix.spinnaker.keel.persistence.ArtifactReferenceNotFoundException
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
 import com.netflix.spinnaker.keel.persistence.PromotionStatus
+import com.netflix.spinnaker.keel.persistence.PromotionStatus.APPROVED
 import com.netflix.spinnaker.keel.persistence.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.persistence.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.persistence.PromotionStatus.PREVIOUS
+import com.netflix.spinnaker.keel.persistence.PromotionStatus.VETOED
 import java.util.UUID
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -32,8 +35,10 @@ class InMemoryArtifactRepository : ArtifactRepository {
 
   private val approvedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
   private val deployedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
+  private val vetoedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
   private val pinnedVersions = mutableMapOf<EnvironmentVersionsKey, EnvironmentArtifactPin>()
   private val statusByEnvironment = mutableMapOf<EnvironmentVersionsKey, MutableMap<String, PromotionStatus>>()
+  private val vetoReference = mutableMapOf<EnvironmentVersionsKey, MutableMap<String, String>>()
   private val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
 
   private data class VersionsKey(
@@ -164,6 +169,8 @@ class InMemoryArtifactRepository : ArtifactRepository {
     val isNew = !versions.contains(version)
     versions.add(version)
     approvedVersions[key] = versions
+    val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
+    statuses[version] = APPROVED
     return isNew
   }
 
@@ -223,6 +230,109 @@ class InMemoryArtifactRepository : ArtifactRepository {
     statuses[version] = CURRENT
   }
 
+  override fun vetoedEnvironmentVersions(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactVetoes> {
+    val vetoes: MutableMap<EnvironmentVersionsKey, EnvironmentArtifactVetoes> = mutableMapOf()
+
+    deliveryConfig.environments.forEach { environment ->
+      deliveryConfig.artifacts.forEach { artifact ->
+        getId(artifact)
+          ?.let { artifactId ->
+            val key = EnvironmentVersionsKey(artifactId, deliveryConfig, environment.name)
+            statusByEnvironment[key]
+              ?.filter { it.value == VETOED }
+              ?.map {
+                val version = it.key
+                vetoes.getOrPut(key, {
+                  EnvironmentArtifactVetoes(
+                    deliveryConfigName = deliveryConfig.name,
+                    targetEnvironment = environment.name,
+                    artifact = artifact,
+                    versions = mutableSetOf()
+                  )
+                })
+                  .versions.add(version)
+              }
+          }
+      }
+    }
+
+    return vetoes.values.toList()
+  }
+
+  override fun markAsVetoedIn(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String,
+    force: Boolean
+  ): Boolean {
+    val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
+    val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
+    pinnedVersions[key]?.let {
+      if (it.version == version) {
+        log.warn(
+          "Pinned artifact version cannot be vetoed: " +
+            "deliveryConfig=${deliveryConfig.name}, " +
+            "environment=$targetEnvironment, " +
+            "artifactVersion=$version")
+        return false
+      }
+    }
+
+    val ref = vetoReference.getOrPut(key, ::mutableMapOf)
+    if (ref.containsKey(version) && !force) {
+      log.warn(
+        "Not vetoing artifact version as it appears to have already been an automated rollback target: " +
+          "deliveryConfig=${deliveryConfig.name}, " +
+          "environment=$targetEnvironment, " +
+          "artifactVersion=$version, " +
+          "priorVersionReference=${ref[version]}")
+      return false
+    }
+
+    val prior = approvedVersions
+      .getOrDefault(key, mutableListOf())
+      .asSequence()
+      .filter { it != version }
+      .sortedWith(artifact.versioningStrategy.comparator)
+      .firstOrNull()
+
+    if (prior != null) {
+      ref[version] = prior
+      ref[prior] = version
+    } else {
+      ref[version] = version
+    }
+
+    approvedVersions.getOrPut(key, ::mutableListOf).remove(version)
+    deployedVersions.getOrPut(key, ::mutableListOf).remove(version)
+    vetoedVersions.getOrPut(key, ::mutableListOf).add(version)
+
+    val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
+    statuses[version] = VETOED
+    return true
+  }
+
+  override fun deleteVeto(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String
+  ) {
+    val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
+    val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
+    vetoedVersions.getOrPut(key, ::mutableListOf).remove(version)
+    val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
+    statuses[version] = APPROVED
+    approvedVersions.getOrPut(key, ::mutableListOf).add(version)
+    val ref = vetoReference.getOrPut(key, ::mutableMapOf)
+    val prior = ref[version]
+    if (prior != version && ref[prior] == version) {
+      ref.remove(prior)
+    }
+    ref.remove(version)
+  }
+
   override fun markAsDeployingTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String) {
     val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
     val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
@@ -244,6 +354,10 @@ class InMemoryArtifactRepository : ArtifactRepository {
             ArtifactVersions(
               name = artifact.name,
               type = artifact.type,
+              statuses = when (artifact) {
+                is DebianArtifact -> artifact.statuses
+                else -> emptyList()
+              },
               versions = ArtifactVersionStatus(
                 current = statuses.filterValues { it == CURRENT }.keys.firstOrNull(),
                 deploying = statuses.filterValues { it == DEPLOYING }.keys.firstOrNull(),
@@ -255,7 +369,9 @@ class InMemoryArtifactRepository : ArtifactRepository {
                   ?.map { it.version }
                   ?.filter { it !in statuses.keys }
                   ?: emptyList(),
-                previous = statuses.filterValues { it == PREVIOUS }.keys.toList()
+                approved = statuses.filterValues { it == APPROVED }.keys.toList(),
+                previous = statuses.filterValues { it == PREVIOUS }.keys.toList(),
+                vetoed = statuses.filterValues { it == VETOED }.keys.toList()
               )
             )
           }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -356,7 +356,7 @@ class InMemoryArtifactRepository : ArtifactRepository {
               type = artifact.type,
               statuses = when (artifact) {
                 is DebianArtifact -> artifact.statuses
-                else -> emptyList()
+                else -> emptySet()
               },
               versions = ArtifactVersionStatus(
                 current = statuses.filterValues { it == CURRENT }.keys.firstOrNull(),

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryUnhappyVetoRepository.kt
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.keel.persistence.memory
 
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 
 class InMemoryUnhappyVetoRepository(
@@ -27,8 +28,8 @@ class InMemoryUnhappyVetoRepository(
 
   private val resources: MutableMap<String, Record> = mutableMapOf()
 
-  override fun markUnhappyForWaitingTime(resourceId: String, application: String) {
-    resources[resourceId] = Record(application, calculateExpirationTime())
+  override fun markUnhappyForWaitingTime(resourceId: String, application: String, wait: Duration) {
+    resources[resourceId] = Record(application, calculateExpirationTime(wait))
   }
 
   override fun markHappy(resourceId: String) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
@@ -38,13 +38,6 @@ interface Veto {
   fun check(resource: Resource<*>): VetoResponse
 
   /**
-   * Check whether the resource can be checked according to this veto,
-   * by id and application. Application is not always calculable from the resourceId,
-   * so it needs to be passed in
-   */
-  fun check(resourceId: String, application: String): VetoResponse
-
-  /**
    * The message format a veto accepts
    */
   fun messageFormat(): Map<String, Any>
@@ -67,12 +60,13 @@ interface Veto {
   fun allowedResponse(): VetoResponse =
     VetoResponse(allowed = true, vetoName = name())
 
-  fun deniedResponse(message: String): VetoResponse =
-    VetoResponse(allowed = false, vetoName = name(), message = message)
+  fun deniedResponse(message: String, vetoArtifact: Boolean = true): VetoResponse =
+    VetoResponse(allowed = false, vetoName = name(), vetoArtifact = vetoArtifact, message = message)
 }
 
 data class VetoResponse(
   val allowed: Boolean,
   val vetoName: String,
+  val vetoArtifact: Boolean = false,
   val message: String? = null
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.keel.veto.unhappy
 
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
@@ -26,6 +28,7 @@ import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
 import com.netflix.spinnaker.keel.veto.Veto
 import com.netflix.spinnaker.keel.veto.VetoResponse
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import java.time.Duration
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
@@ -47,29 +50,29 @@ class UnhappyVeto(
   @Value("veto.unhappy.waiting-time")
   private var configuredWaitingTime: String = "PT10M"
 
-  override fun check(resource: Resource<*>) =
-    check(resource.id, resource.spec.application)
+  override fun check(resource: Resource<*>): VetoResponse {
+    val resourceId = resource.id
+    val application = resource.application
 
-  override fun check(resourceId: String, application: String): VetoResponse {
-    if (diffFingerprintRepository.diffCount(resourceId) <= maxDiffCount()) {
+    if (diffFingerprintRepository.diffCount(resourceId) <= maxDiffCount(resource)) {
       // if we haven't generated the same diff 10 times, we should keep trying
       return allowedResponse()
     }
 
     val vetoStatus = unhappyVetoRepository.getVetoStatus(resourceId)
     if (vetoStatus.shouldSkip) {
-      return deniedResponse(unhappyMessage())
+      return deniedResponse(unhappyMessage(resource))
     }
 
     // allow for a check every [waitingTime] even if the resource is unhappy
     if (vetoStatus.shouldRecheck) {
-      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application)
+      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application, waitingTime(resource))
       return allowedResponse()
     }
 
     return if (resourceRepository.getStatus(resourceId) == UNHAPPY) {
-      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application)
-      deniedResponse(unhappyMessage())
+      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application, waitingTime(resource))
+      deniedResponse(unhappyMessage(resource))
     } else {
       unhappyVetoRepository.markHappy(resourceId)
       allowedResponse()
@@ -90,15 +93,37 @@ class UnhappyVeto(
   override fun currentRejectionsByApp(application: String) =
     unhappyVetoRepository.getAllForApp(application).toList()
 
+  private fun maxDiffCount(resource: Resource<*>) =
+    when (resource.spec) {
+      is UnhappyControl -> (resource.spec as UnhappyControl).maxDiffCount ?: maxDiffCount()
+      else -> maxDiffCount()
+    }
+
   private fun maxDiffCount() =
     dynamicConfigService.getConfig(Int::class.java, "veto.unhappy.max-diff-count", 5)
 
-  private fun waitingTime() =
-    dynamicConfigService.getConfig(String::class.java, "veto.unhappy.waiting-time", configuredWaitingTime)
+  private fun waitingTime(resource: Resource<*>) =
+    when (resource.spec) {
+      is UnhappyControl -> (resource.spec as UnhappyControl).unhappyWaitTime ?: waitingTime()
+      else -> waitingTime()
+    }
 
-  private fun unhappyMessage(): String {
-    val maxDiffs = maxDiffCount()
-    val waitingTime = waitingTime()
-    return "Resource is unhappy and our $maxDiffs actions have not fixed it. We will try again after $waitingTime, or if the diff changes."
+  private fun waitingTime() =
+    Duration
+      .parse(
+        dynamicConfigService.getConfig(
+          String::class.java,
+          "veto.unhappy.waiting-time",
+          configuredWaitingTime))
+
+  private fun unhappyMessage(resource: Resource<*>): String {
+    val maxDiffs = maxDiffCount(resource)
+    val waitingTime = waitingTime(resource)
+    if (waitingTime == Duration.ZERO) {
+      return "Resource is unhappy and our $maxDiffs actions have not fixed it. " +
+        "Resource will remain paused until the diff changes or manually unpaused."
+    }
+    return "Resource is unhappy and our $maxDiffs actions have not fixed it. We will try again after " +
+      "$waitingTime, or if the diff changes."
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -121,7 +121,7 @@ class UnhappyVeto(
     val waitingTime = waitingTime(resource)
     if (waitingTime == Duration.ZERO) {
       return "Resource is unhappy and our $maxDiffs actions have not fixed it. " +
-        "Resource will remain paused until the diff changes or manually unpaused."
+        "Resource will remain paused until the diff changes or the resource is manually unpaused."
     }
     return "Resource is unhappy and our $maxDiffs actions have not fixed it. We will try again after " +
       "$waitingTime, or if the diff changes."

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -66,8 +66,13 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
         every {
           artifactRepository.versions(artifact)
         } returns emptyList()
+
         every {
           artifactRepository.pinnedEnvironments(any())
+        } returns emptyList()
+
+        every {
+          artifactRepository.vetoedEnvironmentVersions(any())
         } returns emptyList()
       }
 
@@ -92,6 +97,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
         every {
           artifactRepository.pinnedEnvironments(any())
         } returns emptyList()
+
+        every {
+          artifactRepository.vetoedEnvironmentVersions(any())
+        } returns emptyList()
       }
 
       context("there are no constraints on the environment") {
@@ -99,6 +108,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           runBlocking {
             subject.checkEnvironments(deliveryConfig)
           }
+
+          every {
+            artifactRepository.vetoedEnvironmentVersions(any())
+          } returns emptyList()
         }
 
         test("the environment is assigned the latest version of an artifact") {
@@ -126,6 +139,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           every {
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
           } returns false
+
+          every {
+            artifactRepository.vetoedEnvironmentVersions(any())
+          } returns emptyList()
 
           runBlocking {
             subject.checkEnvironments(deliveryConfig)
@@ -159,6 +176,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           every {
             artifactRepository.approveVersionFor(deliveryConfig, artifact, "1.1", environment.name)
           } returns true
+
+          every {
+            artifactRepository.vetoedEnvironmentVersions(any())
+          } returns emptyList()
 
           every {
             artifactRepository.pinnedEnvironments(any())
@@ -241,6 +262,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           } returns true
 
           every {
+            artifactRepository.vetoedEnvironmentVersions(any())
+          } returns emptyList()
+
+          every {
             artifactRepository.pinnedEnvironments(any())
           } returns listOf(PinnedEnvironment(deliveryConfig.name, environment.name, artifact, "1.1"))
 
@@ -275,6 +300,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           every {
             artifactRepository.versions(artifact)
           } returns listOf("1.0")
+
+          every {
+            artifactRepository.vetoedEnvironmentVersions(any())
+          } returns emptyList()
 
           every { artifactRepository.pinnedEnvironments(any()) } returns emptyList()
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/veto/DummyVeto.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/veto/DummyVeto.kt
@@ -18,16 +18,11 @@
 package com.netflix.spinnaker.keel.veto
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 
 class DummyVeto(
   private val allowAll: Boolean
 ) : Veto {
   override fun check(resource: Resource<*>): VetoResponse =
-    check(resource.id, resource.application)
-
-  override fun check(resourceId: String, application: String): VetoResponse =
     if (allowAll) {
       allowedResponse()
     } else {

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
@@ -55,7 +55,12 @@ abstract class DockerImageResolver<T : ResourceSpec>(
   /**
    * Replace exiting container with resolved container
    */
-  abstract fun updateContainerInSpec(resource: Resource<T>, container: ContainerProvider): Resource<T>
+  abstract fun updateContainerInSpec(
+    resource: Resource<T>,
+    container: ContainerProvider,
+    artifact: DockerArtifact,
+    tag: String
+  ): Resource<T>
 
   /**
    * Get all available the tags for an image
@@ -79,7 +84,7 @@ abstract class DockerImageResolver<T : ResourceSpec>(
     val tag: String = findTagGivenDeliveryConfig(deliveryConfig, environment, artifact)
 
     val newContainer = getContainer(account, artifact, tag)
-    return updateContainerInSpec(resource, newContainer)
+    return updateContainerInSpec(resource, newContainer, artifact, tag)
   }
 
   fun getArtifact(container: ContainerProvider, deliveryConfig: DeliveryConfig): DockerArtifact =

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.keel.docker
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 
@@ -40,7 +41,12 @@ class SampleDockerImageResolver(
   override fun getAccountFromSpec(resource: Resource<SampleSpecWithContainer>) =
     resource.spec.account
 
-  override fun updateContainerInSpec(resource: Resource<SampleSpecWithContainer>, container: ContainerProvider) =
+  override fun updateContainerInSpec(
+    resource: Resource<SampleSpecWithContainer>,
+    container: ContainerProvider,
+    artifact: DockerArtifact,
+    tag: String
+  ) =
     resource.copy(spec = resource.spec.copy(container = container))
 
   // this would normally call out to clouddriver

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
 import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Moniker
@@ -13,6 +12,7 @@ import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.VersionedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
@@ -122,7 +122,7 @@ data class ClusterSpec(
   @JsonIgnore
   // Once clusters go unhappy, only retry when the diff changes, or if manually unvetoed
   override val unhappyWaitTime: Duration? = Duration.ZERO
-) : Monikered, Locatable<SubnetAwareLocations>, ArtifactVersioned, UnhappyControl {
+) : Monikered, Locatable<SubnetAwareLocations>, VersionedArtifact, UnhappyControl {
   @JsonIgnore
   override val id = "${locations.account}:$moniker"
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -18,9 +18,9 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.VersionedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.clouddriver.model.BuildInfo
 import com.netflix.spinnaker.keel.core.api.Capacity
@@ -61,7 +61,7 @@ data class ServerGroup(
   override val maxDiffCount: Int? = null,
   @get:ObjectDiffProperty(inclusion = EXCLUDED)
   override val unhappyWaitTime: Duration? = null
-) : ArtifactVersioned, UnhappyControl {
+) : VersionedArtifact, UnhappyControl {
   init {
     require(
       capacity.desired != null && !scaling.hasScalingPolicies() ||

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -18,13 +18,17 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.clouddriver.model.BuildInfo
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
 import com.netflix.spinnaker.keel.core.parseMoniker
 import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
 import de.danielbechler.diff.introspection.ObjectDiffProperty
+import java.time.Duration
 
 data class ServerGroup(
   /**
@@ -46,8 +50,18 @@ data class ServerGroup(
   val tags: Map<String, String> = emptyMap(),
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = EXCLUDED)
-  val buildInfo: BuildInfo? = null
-) {
+  val buildInfo: BuildInfo? = null,
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  override val deliveryArtifact: DeliveryArtifact? = null,
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  override val artifactVersion: String? = null,
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  override val maxDiffCount: Int? = null,
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  override val unhappyWaitTime: Duration? = null
+) : ArtifactVersioned, UnhappyControl {
   init {
     require(
       capacity.desired != null && !scaling.hasScalingPolicies() ||

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -67,7 +67,7 @@ class ImageResolver(
   private suspend fun resolveFromReference(
     resource: Resource<ClusterSpec>,
     imageProvider: ReferenceArtifactImageProvider
-  ): VersionedNameImage {
+  ): VersionedNamedImage {
     val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
     val artifact = deliveryConfig.artifacts.find { it.reference == imageProvider.reference && it.type == deb }
       ?: throw NoMatchingArtifactException(deliveryConfig.name, deb, imageProvider.reference)
@@ -78,7 +78,7 @@ class ImageResolver(
   private suspend fun resolveFromArtifact(
     resource: Resource<ClusterSpec>,
     artifact: DebianArtifact
-  ): VersionedNameImage {
+  ): VersionedNamedImage {
     val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
     val environment = deliveryConfigRepository.environmentFor(resource.id)
     val account = defaultImageAccount
@@ -95,13 +95,13 @@ class ImageResolver(
       regions = regions
     ) ?: throw NoImageFoundForRegions(artifactVersion, regions)
 
-    return VersionedNameImage(image, artifact, artifactVersion)
+    return VersionedNamedImage(image, artifact, artifactVersion)
   }
 
   private suspend fun resolveFromJenkinsJob(
     resource: Resource<ClusterSpec>,
     imageProvider: JenkinsImageProvider
-  ): VersionedNameImage {
+  ): VersionedNamedImage {
     val image = imageService.getNamedImageFromJenkinsInfo(
       imageProvider.packageName,
       dynamicConfigService.getConfig("images.default-account", "test"),
@@ -111,10 +111,10 @@ class ImageResolver(
     ) ?: throw NoImageFound(imageProvider.packageName)
 
     log.info("Image found for {}: {}", imageProvider.packageName, image)
-    return VersionedNameImage(image, null, null)
+    return VersionedNamedImage(image, null, null)
   }
 
-  private fun Resource<ClusterSpec>.withVirtualMachineImages(image: VersionedNameImage): Resource<ClusterSpec> {
+  private fun Resource<ClusterSpec>.withVirtualMachineImages(image: VersionedNamedImage): Resource<ClusterSpec> {
     val imageIdByRegion = image
       .namedImage
       .amis

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -42,7 +42,7 @@ class ImageResolver(
   override val supportedKind: String = "cluster"
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
-  data class VersionedNameImage(
+  data class VersionedNamedImage(
     val namedImage: NamedImage,
     val artifact: DeliveryArtifact?,
     val version: String?

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -4,6 +4,7 @@ import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.deb
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.LaunchConfigurationSpec
@@ -41,6 +42,12 @@ class ImageResolver(
   override val supportedKind: String = "cluster"
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
+  data class VersionedNameImage(
+    val namedImage: NamedImage,
+    val artifact: DeliveryArtifact?,
+    val version: String?
+  )
+
   override fun invoke(resource: Resource<ClusterSpec>): Resource<ClusterSpec> {
     val imageProvider = resource.spec.imageProvider ?: return resource
     val image = runBlocking {
@@ -60,7 +67,7 @@ class ImageResolver(
   private suspend fun resolveFromReference(
     resource: Resource<ClusterSpec>,
     imageProvider: ReferenceArtifactImageProvider
-  ): NamedImage {
+  ): VersionedNameImage {
     val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
     val artifact = deliveryConfig.artifacts.find { it.reference == imageProvider.reference && it.type == deb }
       ?: throw NoMatchingArtifactException(deliveryConfig.name, deb, imageProvider.reference)
@@ -71,7 +78,7 @@ class ImageResolver(
   private suspend fun resolveFromArtifact(
     resource: Resource<ClusterSpec>,
     artifact: DebianArtifact
-  ): NamedImage {
+  ): VersionedNameImage {
     val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
     val environment = deliveryConfigRepository.environmentFor(resource.id)
     val account = defaultImageAccount
@@ -82,17 +89,19 @@ class ImageResolver(
       artifact,
       environment.name
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
-    return imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+    val image = imageService.getLatestNamedImageWithAllRegionsForAppVersion(
       appVersion = AppVersion.parseName(artifactVersion),
       account = account,
       regions = regions
     ) ?: throw NoImageFoundForRegions(artifactVersion, regions)
+
+    return VersionedNameImage(image, artifact, artifactVersion)
   }
 
   private suspend fun resolveFromJenkinsJob(
     resource: Resource<ClusterSpec>,
     imageProvider: JenkinsImageProvider
-  ): NamedImage {
+  ): VersionedNameImage {
     val image = imageService.getNamedImageFromJenkinsInfo(
       imageProvider.packageName,
       dynamicConfigService.getConfig("images.default-account", "test"),
@@ -102,18 +111,19 @@ class ImageResolver(
     ) ?: throw NoImageFound(imageProvider.packageName)
 
     log.info("Image found for {}: {}", imageProvider.packageName, image)
-    return image
+    return VersionedNameImage(image, null, null)
   }
 
-  private fun Resource<ClusterSpec>.withVirtualMachineImages(image: NamedImage): Resource<ClusterSpec> {
+  private fun Resource<ClusterSpec>.withVirtualMachineImages(image: VersionedNameImage): Resource<ClusterSpec> {
     val imageIdByRegion = image
+      .namedImage
       .amis
       .filterNotNullValues()
       .filterValues { it.isNotEmpty() }
       .mapValues { it.value.first() }
     val missingRegions = spec.locations.regions.map { it.name } - imageIdByRegion.keys
     if (missingRegions.isNotEmpty()) {
-      throw NoImageFoundForRegions(image.imageName, missingRegions)
+      throw NoImageFoundForRegions(image.namedImage.imageName, missingRegions)
     }
 
     val overrides = mutableMapOf<String, ServerGroupSpec>()
@@ -123,13 +133,16 @@ class ImageResolver(
         .withVirtualMachineImage(
           VirtualMachineImage(
             imageIdByRegion.getValue(region),
-            image.appVersion,
-            image.baseImageVersion
+            image.namedImage.appVersion,
+            image.namedImage.baseImageVersion
           )
         )
     }
 
-    return copy(spec = spec.copy(overrides = overrides))
+    return copy(spec = spec.copy(
+      overrides = overrides,
+      deliveryArtifact = image.artifact,
+      artifactVersion = image.version))
   }
 
   private fun ServerGroupSpec?.withVirtualMachineImage(image: VirtualMachineImage) =

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -46,7 +46,7 @@ internal class ImageResolverTests : JUnit5Minutests {
     val imageRegion: String = "ap-south-1",
     val resourceRegion: String = imageRegion
   ) {
-    val artifact = DebianArtifact(name = "fnord", deliveryConfigName = "my-manifest", statuses = listOf(RELEASE))
+    val artifact = DebianArtifact(name = "fnord", deliveryConfigName = "my-manifest", statuses = setOf(RELEASE))
     private val account = "test"
     val version1 = "1.0.0-123456"
     val version2 = "1.1.0-123456"
@@ -162,7 +162,7 @@ internal class ImageResolverTests : JUnit5Minutests {
     }
 
     derivedContext<Fixture<ArtifactImageProvider>>("an image derived from an artifact") {
-      val artifact = DebianArtifact(name = "fnord", deliveryConfigName = "my-manifest", statuses = listOf(RELEASE))
+      val artifact = DebianArtifact(name = "fnord", deliveryConfigName = "my-manifest", statuses = setOf(RELEASE))
       fixture {
         Fixture(
           ArtifactImageProvider(artifact, listOf(RELEASE))

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
@@ -47,13 +47,13 @@ fun mapToArtifact(
     val details = objectMapper.readValue<Map<String, Any>>(json)
     return when (type) {
       deb -> {
-        val statuses: List<ArtifactStatus> = details["statuses"]?.let { it ->
+        val statuses: Set<ArtifactStatus> = details["statuses"]?.let { it ->
           try {
-            objectMapper.convertValue<List<ArtifactStatus>>(it)
+            objectMapper.convertValue<Set<ArtifactStatus>>(it)
           } catch (e: java.lang.IllegalArgumentException) {
             null
           }
-        } ?: emptyList()
+        } ?: emptySet()
         DebianArtifact(
           name = name,
           statuses = statuses,

--- a/keel-sql/src/main/resources/db/changelog/20200211-environment-artifact-veto.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200211-environment-artifact-veto.yml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-environment_artifact_versions-promotion-reference
+      author: asher
+      changes:
+        - addColumn:
+            tableName: environment_artifact_versions
+            columns:
+              - column:
+                  name: promotion_reference
+                  type: varchar(255)
+                  afterColumn: promotion_status
+  - changeSet:
+      id: create-environment_artifact_versions-status-idx
+      author: asher
+      changes:
+        - createIndex:
+            indexName: eav_status_idx
+            tableName: environment_artifact_versions
+            columns:
+              - column:
+                  name: promotion_status

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -86,7 +86,6 @@ databaseChangeLog:
   - include:
      file: changelog/20200122-delivery-config-api-version.yml
      relativeToChangelogFile: true
-
   - include:
       file: changelog/20200109-create-task-tracking-table.yml
       relativeToChangelogFile: true
@@ -95,4 +94,7 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: changelog/20200127-environment-artifact-pin-table.yml
+      relativeToChangelogFile: true
+  - include:
+      file: changelog/20200211-environment-artifact-veto.yml
       relativeToChangelogFile: true

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -1,15 +1,20 @@
 package com.netflix.spinnaker.keel.test
 
 import com.netflix.spinnaker.keel.SPINNAKER_API_V1
+import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.plugins.SimpleResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
+import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
+import de.danielbechler.diff.introspection.ObjectDiffProperty
 import java.util.UUID
 
 const val TEST_API = "test.$SPINNAKER_API_V1"
@@ -21,6 +26,23 @@ fun resource(
   application: String = "fnord"
 ): Resource<DummyResourceSpec> =
   DummyResourceSpec(id = id, application = application)
+    .let { spec ->
+      resource(
+        apiVersion = apiVersion,
+        kind = kind,
+        spec = spec,
+        id = spec.id,
+        application = application
+      )
+    }
+
+fun artifactVersionedResource(
+  apiVersion: String = TEST_API,
+  kind: String = "whatever",
+  id: String = randomString(),
+  application: String = "fnord"
+): Resource<DummyArtifactVersionedResourceSpec> =
+  DummyArtifactVersionedResourceSpec(id = id, application = application)
     .let { spec ->
       resource(
         apiVersion = apiVersion,
@@ -128,11 +150,27 @@ data class DummyLocatableResourceSpec(
   )
 ) : ResourceSpec, Locatable<SimpleLocations>
 
+data class DummyArtifactVersionedResourceSpec(
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  override val id: String = randomString(),
+  val data: String = randomString(),
+  override val application: String = "fnord",
+  override val artifactVersion: String? = "fnord-42.0",
+  override val deliveryArtifact: DeliveryArtifact? = DebianArtifact(name = "fnord")
+) : ResourceSpec, ArtifactVersioned
+
 data class DummyResource(
   val id: String = randomString(),
   val data: String = randomString()
 ) {
   constructor(spec: DummyResourceSpec) : this(spec.id, spec.data)
+}
+
+data class DummyArtifactVersionedResource(
+  val id: String = randomString(),
+  val data: String = randomString()
+) {
+  constructor(spec: DummyArtifactVersionedResourceSpec) : this(spec.id, spec.data)
 }
 
 fun randomString(length: Int = 8) =

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -1,13 +1,13 @@
 package com.netflix.spinnaker.keel.test
 
 import com.netflix.spinnaker.keel.SPINNAKER_API_V1
-import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.VersionedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.plugins.SimpleResourceHandler
@@ -157,7 +157,7 @@ data class DummyArtifactVersionedResourceSpec(
   override val application: String = "fnord",
   override val artifactVersion: String? = "fnord-42.0",
   override val deliveryArtifact: DeliveryArtifact? = DebianArtifact(name = "fnord")
-) : ResourceSpec, ArtifactVersioned
+) : ResourceSpec, VersionedArtifact
 
 data class DummyResource(
   val id: String = randomString(),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -19,11 +19,15 @@ package com.netflix.spinnaker.keel.api.titus.cluster
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.titus.exceptions.ErrorResolvingContainerException
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
@@ -34,6 +38,7 @@ import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.core.api.RedBlack
 import com.netflix.spinnaker.keel.docker.ContainerProvider
 import com.netflix.spinnaker.keel.docker.DigestProvider
+import java.time.Duration
 
 /**
  * "Simplified" representation of
@@ -44,8 +49,18 @@ data class TitusClusterSpec(
   val deployWith: ClusterDeployStrategy = RedBlack(),
   override val locations: SimpleLocations,
   private val _defaults: TitusServerGroupSpec,
-  val overrides: Map<String, TitusServerGroupSpec> = emptyMap()
-) : Monikered, Locatable<SimpleLocations> {
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  val overrides: Map<String, TitusServerGroupSpec> = emptyMap(),
+  @JsonIgnore
+  override val deliveryArtifact: DeliveryArtifact? = null,
+  @JsonIgnore
+  override val artifactVersion: String? = null,
+  @JsonIgnore
+  override val maxDiffCount: Int? = 2,
+  @JsonIgnore
+  // Once clusters go unhappy, only retry when the diff changes, or if manually unvetoed
+  override val unhappyWaitTime: Duration? = Duration.ZERO
+) : Monikered, Locatable<SimpleLocations>, ArtifactVersioned, UnhappyControl {
 
   @JsonIgnore
   override val id = "${locations.account}:$moniker"
@@ -197,7 +212,9 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       iamProfile = resolveIamProfile(it.name),
       migrationPolicy = resolveMigrationPolicy(it.name),
       resources = resolveResources(it.name),
-      tags = defaults.tags + overrides[it.name]?.tags
+      tags = defaults.tags + overrides[it.name]?.tags,
+      deliveryArtifact = deliveryArtifact,
+      artifactVersion = artifactVersion
     )
   }
     .toSet()

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -21,12 +21,12 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonUnwrapped
-import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.VersionedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.titus.exceptions.ErrorResolvingContainerException
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
@@ -60,7 +60,7 @@ data class TitusClusterSpec(
   @JsonIgnore
   // Once clusters go unhappy, only retry when the diff changes, or if manually unvetoed
   override val unhappyWaitTime: Duration? = Duration.ZERO
-) : Monikered, Locatable<SimpleLocations>, ArtifactVersioned, UnhappyControl {
+) : Monikered, Locatable<SimpleLocations>, VersionedArtifact, UnhappyControl {
 
   @JsonIgnore
   override val id = "${locations.account}:$moniker"

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.keel.api.titus.cluster
 
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.api.titus.SPINNAKER_TITUS_API_V1
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -53,8 +54,16 @@ class TitusImageResolver(
   override fun getAccountFromSpec(resource: Resource<TitusClusterSpec>) =
     resource.spec.deriveRegistry()
 
-  override fun updateContainerInSpec(resource: Resource<TitusClusterSpec>, container: ContainerProvider) =
-    resource.copy(spec = resource.spec.copy(_defaults = resource.spec.defaults.copy(container = container)))
+  override fun updateContainerInSpec(
+    resource: Resource<TitusClusterSpec>,
+    container: ContainerProvider,
+    artifact: DockerArtifact,
+    tag: String
+  ) =
+    resource.copy(spec = resource.spec.copy(
+      _defaults = resource.spec.defaults.copy(container = container),
+      deliveryArtifact = artifact,
+      artifactVersion = tag))
 
   override fun getTags(account: String, organization: String, image: String) =
     runBlocking {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -18,9 +18,9 @@
 package com.netflix.spinnaker.keel.api.titus.cluster
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.VersionedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
@@ -70,7 +70,7 @@ data class TitusServerGroup(
   override val maxDiffCount: Int? = null,
   @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
   override val unhappyWaitTime: Duration? = null
-) : ArtifactVersioned, UnhappyControl
+) : VersionedArtifact, UnhappyControl
 
 val TitusServerGroup.moniker: Moniker
   get() = parseMoniker(name)

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -17,7 +17,11 @@
  */
 package com.netflix.spinnaker.keel.api.titus.cluster
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.ArtifactVersioned
 import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
@@ -27,6 +31,7 @@ import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.docker.DigestProvider
 import de.danielbechler.diff.inclusion.Inclusion
 import de.danielbechler.diff.introspection.ObjectDiffProperty
+import java.time.Duration
 
 data class TitusServerGroup(
   /**
@@ -54,8 +59,18 @@ data class TitusServerGroup(
   val dependencies: ClusterDependencies = ClusterDependencies(),
   val deferredInitialization: Boolean = true,
   val delayBeforeDisableSec: Int = 0,
-  val delayBeforeScaleDownSec: Int = 0
-)
+  val delayBeforeScaleDownSec: Int = 0,
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  override val deliveryArtifact: DeliveryArtifact? = null,
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  override val artifactVersion: String? = null,
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  override val maxDiffCount: Int? = null,
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  override val unhappyWaitTime: Duration? = null
+) : ArtifactVersioned, UnhappyControl
 
 val TitusServerGroup.moniker: Moniker
   get() = parseMoniker(name)


### PR DESCRIPTION
Given a scenario where an approved artifact version only comes up healthy in one region of a multi-region cluster, we want to ensure the cluster and its containing environment are automatically restored to a good and consistent state. Prior to this PR, the cluster would enter an unhappy state after 5 deploy attempts with the cluster left running inconsistent versions across regions. Other clusters in the environment with the same artifact reference continue to resolve desired state to the problematic artifact version.

With this PR, after 2 failed attempts deploying a cluster, the artifact version is vetoed from the environment. All clusters in the environment referencing the artifact should then resolve to the previous version. In the scenario where a multi-region cluster successfully deployed in only one region, that region is rolled back in the next actuation loop.