### PR TITLE
feat(api): Validation API and better parsing errors

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -166,5 +166,12 @@ fun Collection<ResourceHandler<*, *>>.supporting(
   }
     ?: throw UnsupportedKind(apiVersion, kind)
 
+fun <T : ResourceSpec> Collection<ResourceHandler<*, *>>.supporting(
+  specClass: Class<T>
+): ResourceHandler<*, *>? =
+  find {
+    it.supportedKind.specClass == specClass
+  }
+
 class UnsupportedKind(apiVersion: String, kind: String) :
   IllegalStateException("No resource handler supporting \"$kind\" in \"$apiVersion\" is available")

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -15,6 +15,7 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
 import de.danielbechler.diff.introspection.ObjectDiffProperty
+import java.time.Duration
 import java.util.UUID
 
 const val TEST_API = "test.$SPINNAKER_API_V1"
@@ -137,7 +138,11 @@ data class DummyResourceSpec(
   override val id: String = randomString(),
   val data: String = randomString(),
   override val application: String = "fnord"
-) : ResourceSpec
+) : ResourceSpec {
+  val intData: Int = 1234
+  val boolData: Boolean = true
+  val timeData: Duration = Duration.ofMinutes(5)
+}
 
 data class DummyLocatableResourceSpec(
   override val id: String = randomString(),

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -134,6 +134,8 @@ fun <T : ResourceSpec> submittedResource(
     spec = spec
   )
 
+enum class DummyEnum { VALUE }
+
 data class DummyResourceSpec(
   override val id: String = randomString(),
   val data: String = randomString(),
@@ -142,6 +144,7 @@ data class DummyResourceSpec(
   val intData: Int = 1234
   val boolData: Boolean = true
   val timeData: Duration = Duration.ofMinutes(5)
+  val enumData: DummyEnum = DummyEnum.VALUE
 }
 
 data class DummyLocatableResourceSpec(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -73,6 +73,16 @@ class DeliveryConfigController(
   fun diff(@RequestBody deliveryConfig: SubmittedDeliveryConfig): List<EnvironmentDiff> =
     adHocDiffer.calculate(deliveryConfig)
 
+  @PostMapping(
+    path = ["/validate"],
+    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  fun validate(@RequestBody deliveryConfig: SubmittedDeliveryConfig) =
+    // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
+    //  in [ExceptionHandler])
+    mapOf("status" to "valid")
+
   @GetMapping(
     path = ["/{name}/artifacts"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -87,8 +87,8 @@ class ExceptionHandler(
         else -> when (rootCause) {
           null -> ParsingError.OTHER
           is MissingKotlinParameterException -> ParsingError.MISSING_PROPERTY
-          is IllegalStateException -> ParsingError.ILLEGAL_VALUE
-          is IllegalArgumentException -> ParsingError.ILLEGAL_VALUE
+          is IllegalStateException -> ParsingError.INVALID_VALUE
+          is IllegalArgumentException -> ParsingError.INVALID_VALUE
           is MismatchedInputException -> ParsingError.INVALID_TYPE
           is InvalidTypeIdException -> ParsingError.INVALID_TYPE
           is InvalidFormatException -> ParsingError.INVALID_FORMAT
@@ -162,9 +162,9 @@ data class ApiError(
 
 enum class ParsingError {
   MISSING_PROPERTY,
-  ILLEGAL_VALUE,
   INVALID_TYPE,
   INVALID_FORMAT,
+  INVALID_VALUE, // used when we can't determine if the problem is type or format
   OTHER;
 
   @JsonValue

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -88,10 +88,10 @@ class ExceptionHandler(
           null -> ParsingError.OTHER
           is MissingKotlinParameterException -> ParsingError.MISSING_PROPERTY
           is IllegalStateException -> ParsingError.ILLEGAL_VALUE
-          is InvalidFormatException -> ParsingError.ILLEGAL_VALUE
           is IllegalArgumentException -> ParsingError.ILLEGAL_VALUE
           is MismatchedInputException -> ParsingError.INVALID_TYPE
           is InvalidTypeIdException -> ParsingError.INVALID_TYPE
+          is InvalidFormatException -> ParsingError.INVALID_FORMAT
           is DateTimeParseException -> ParsingError.INVALID_FORMAT
           else -> ParsingError.OTHER
         }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -1,6 +1,15 @@
 package com.netflix.spinnaker.keel.rest
 
+import com.fasterxml.jackson.annotation.JsonValue
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import com.fasterxml.jackson.databind.exc.InvalidTypeIdException
+import com.fasterxml.jackson.databind.exc.MismatchedInputException
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
+import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
@@ -9,6 +18,8 @@ import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceException
+import java.lang.IllegalArgumentException
+import java.time.format.DateTimeParseException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.http.HttpStatus.CONFLICT
@@ -21,13 +32,21 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
 @RestControllerAdvice
-class ExceptionHandler {
+class ExceptionHandler(
+  private val resourceHandlers: List<ResourceHandler<*, *>>
+) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   @ExceptionHandler(HttpMessageConversionException::class, HttpMessageNotReadableException::class)
   @ResponseStatus(BAD_REQUEST)
   fun onParseFailure(e: Exception): ApiError {
     log.error(e.message)
-    return ApiError(e)
+    return when (e.cause) {
+      null -> ApiError(e)
+      is JsonMappingException ->
+        ApiError(e, (e.cause as JsonMappingException).toDetails())
+      else -> ApiError(e)
+    }
   }
 
   @ExceptionHandler(FailedNormalizationException::class, UnsupportedKind::class)
@@ -58,12 +77,121 @@ class ExceptionHandler {
     return ApiError(e)
   }
 
-  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+  private fun JsonMappingException.toDetails(): ParsingErrorDetails {
+    val (rootCause, problemPath) = findRootCause()
+
+    return ParsingErrorDetails(
+      error = when (this) {
+        // caters to missing properties at the root-level (e.g. serviceAccount)
+        is MissingKotlinParameterException -> ParsingError.MISSING_PROPERTY
+        else -> when (rootCause) {
+          null -> ParsingError.OTHER
+          is MissingKotlinParameterException -> ParsingError.MISSING_PROPERTY
+          is IllegalStateException -> ParsingError.ILLEGAL_VALUE
+          is InvalidFormatException -> ParsingError.ILLEGAL_VALUE
+          is IllegalArgumentException -> ParsingError.ILLEGAL_VALUE
+          is MismatchedInputException -> ParsingError.INVALID_TYPE
+          is InvalidTypeIdException -> ParsingError.INVALID_TYPE
+          is DateTimeParseException -> ParsingError.INVALID_FORMAT
+          else -> ParsingError.OTHER
+        }
+      },
+      message = rootCause.message,
+      location = mapOf(
+        "line" to (location?.lineNr ?: -1),
+        "column" to (location?.columnNr ?: -1)
+      ),
+      path = problemPath.map { ref ->
+        val type = if (ref.from is Class<*>) {
+          ref.from as Class<*>
+        } else {
+          ref.from.javaClass
+        }
+        mapOf(
+          "type" to if (Set::class.java.isAssignableFrom(type)) {
+            // for some reason, Jackson says the type of arrays in the JSON is a java.util.HashSet
+            "array"
+          } else if (ResourceSpec::class.java.isAssignableFrom(type)) {
+            // for ResourceSpec sub-types, use the API version/kind instead of the class name
+            val handler = resourceHandlers.supporting(type as Class<ResourceSpec>)
+            if (handler != null) {
+              "${handler.supportedKind.apiVersion}/${handler.supportedKind.kind}"
+            } else {
+              type.name
+            }
+          } else {
+            type.name
+          },
+          "field" to ref.fieldName,
+          "index" to if (ref.index == -1) {
+            null
+          } else {
+            ref.index
+          }
+        )
+      }
+    )
+  }
+
+  private fun JsonMappingException.findRootCause(): Pair<Throwable, List<JsonMappingException.Reference>> {
+    if (this.cause == null) {
+      return Pair(this, this.path)
+    }
+    var exception: Throwable = this
+    var paths: MutableList<JsonMappingException.Reference> = this.path.toMutableList()
+    while (exception.cause != null && exception.cause != exception) {
+      exception = exception.cause!!
+      if (exception is JsonMappingException) {
+        paths.addAll(exception.path)
+      }
+    }
+    return Pair(exception, paths)
+  }
 }
 
 /**
  * Error details returned as JSON/YAML.
  */
-data class ApiError(val message: String?) {
-  constructor(ex: Throwable) : this(ex.cause?.message ?: ex.message)
+data class ApiError(
+  val message: String?,
+  val details: ApiErrorDetails?
+) {
+  constructor(ex: Throwable, details: ApiErrorDetails? = null) :
+    this(ex.cause?.message ?: ex.message, details)
+}
+
+enum class ParsingError {
+  MISSING_PROPERTY,
+  ILLEGAL_VALUE,
+  INVALID_TYPE,
+  INVALID_FORMAT,
+  OTHER;
+
+  @JsonValue
+  fun toLowerCase() = name.toLowerCase()
+}
+
+interface ApiErrorDetails
+
+data class ParsingErrorDetails(
+  val error: ParsingError,
+  val message: String?,
+  val location: Map<String, Int>,
+  val path: List<Map<String, Any?>>
+) : ApiErrorDetails {
+  val pathExpression: String
+  init {
+    // Makes a JSONPath expression for the problem path
+    pathExpression = "".let { str ->
+      var sum = str
+      path.forEach {
+        sum += when {
+          it["field"] != null -> "." + it["field"]
+          it["type"] == "array" -> "[" + it["index"].toString() + "]"
+          else -> ""
+        }
+      }
+      sum
+    }
+  }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
@@ -1,0 +1,275 @@
+package com.netflix.spinnaker.keel.rest
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import com.netflix.spinnaker.keel.test.DummyResourceHandler
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.TEST_API
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expect
+import strikt.assertions.getValue
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.size
+
+class ExceptionHandlerTests : JUnit5Minutests {
+  class Fixture(
+    brokenYaml: String
+  ) {
+    val subject = ExceptionHandler(listOf(DummyResourceHandler))
+    val mapper = configuredYamlMapper()
+    val parseException = try {
+        mapper.registerSubtypes(NamedType(DummyResourceSpec::class.java, "$TEST_API/whatever"))
+        mapper.readValue(brokenYaml, SubmittedDeliveryConfig::class.java)
+        throw IllegalArgumentException("test is broken")
+      } catch (e: JsonMappingException) {
+        // we wrap it to emulate the HttpMessageConversionException passed to ExceptionHandler
+        Exception(e)
+      }
+    val apiError = subject.onParseFailure(parseException)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    context("delivery config missing required top-level field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            # serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - name: test
+              constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec: {}
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.MISSING_PROPERTY)
+              get { path }.size.isEqualTo(1)
+              get { pathExpression }.isEqualTo(".serviceAccount")
+            }
+          }
+        }
+      }
+    }
+
+    context("delivery config with invalid top-level field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: true # wrong
+            environments:
+            - name: test
+              constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec: {}
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.INVALID_TYPE)
+              get { path }.size.isEqualTo(1)
+              get { pathExpression }.isEqualTo(".artifacts")
+            }
+          }
+        }
+      }
+    }
+
+    context("environment with missing required field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec: {}
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.ILLEGAL_VALUE)
+              get { path }.size.isEqualTo(2)
+              get { pathExpression }.isEqualTo(".environments[0]")
+            }
+          }
+        }
+      }
+    }
+
+    context("environment with invalid type for field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - name: test
+              constraints: true # wrong
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec: {}
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.INVALID_TYPE)
+              get { path }.size.isEqualTo(3)
+              get { pathExpression }.isEqualTo(".environments[0].constraints")
+            }
+          }
+        }
+      }
+    }
+
+    context("resource missing field checked by validation") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - name: test
+              constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                # kind: "whatever"
+                spec: {}
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.ILLEGAL_VALUE)
+              get { path }.size.isEqualTo(4)
+              get { pathExpression }.isEqualTo(".environments[0].resources[0]")
+            }
+          }
+        }
+      }
+    }
+
+    context("resource with invalid type for field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - name: test
+              constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec:
+                  intData: "wrong"
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.ILLEGAL_VALUE)
+              get { path }.size.isEqualTo(5)
+              get { pathExpression }.isEqualTo(".environments[0].resources[0].intData")
+            }
+          }
+        }
+      }
+    }
+
+    context("resource with invalid format for field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - name: test
+              constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec:
+                  timeData: "wrong"
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.INVALID_FORMAT)
+              get { path }.size.isEqualTo(5)
+              get { pathExpression }.isEqualTo(".environments[0].resources[0].timeData")
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
@@ -228,7 +228,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
         expect {
           that(apiError.details) {
             isA<ParsingErrorDetails>().and {
-              get { error }.isEqualTo(ParsingError.ILLEGAL_VALUE)
+              get { error }.isEqualTo(ParsingError.INVALID_TYPE)
               get { path }.size.isEqualTo(5)
               get { pathExpression }.isEqualTo(".environments[0].resources[0].intData")
             }
@@ -266,6 +266,41 @@ class ExceptionHandlerTests : JUnit5Minutests {
               get { error }.isEqualTo(ParsingError.INVALID_FORMAT)
               get { path }.size.isEqualTo(5)
               get { pathExpression }.isEqualTo(".environments[0].resources[0].timeData")
+            }
+          }
+        }
+      }
+    }
+
+    context("resource with invalid value for enum field") {
+      fixture {
+        Fixture(
+          """
+            ---
+            name: fnord
+            application: fnord
+            serviceAccount: keel@netlix.com
+            artifacts: []
+            environments:
+            - name: test
+              constraints: []
+              notifications: []
+              resources:
+              - apiVersion: $TEST_API
+                kind: "whatever"
+                spec:
+                  enumData: "wrong"
+          """.trimIndent()
+        )
+      }
+
+      test("should cause an ApiError with the expected details") {
+        expect {
+          that(apiError.details) {
+            isA<ParsingErrorDetails>().and {
+              get { error }.isEqualTo(ParsingError.INVALID_TYPE)
+              get { path }.size.isEqualTo(5)
+              get { pathExpression }.isEqualTo(".environments[0].resources[0].enumData")
             }
           }
         }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
@@ -10,7 +10,6 @@ import com.netflix.spinnaker.keel.test.TEST_API
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expect
-import strikt.assertions.getValue
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.size
@@ -125,7 +124,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
         expect {
           that(apiError.details) {
             isA<ParsingErrorDetails>().and {
-              get { error }.isEqualTo(ParsingError.ILLEGAL_VALUE)
+              get { error }.isEqualTo(ParsingError.INVALID_VALUE)
               get { path }.size.isEqualTo(2)
               get { pathExpression }.isEqualTo(".environments[0]")
             }
@@ -193,7 +192,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
         expect {
           that(apiError.details) {
             isA<ParsingErrorDetails>().and {
-              get { error }.isEqualTo(ParsingError.ILLEGAL_VALUE)
+              get { error }.isEqualTo(ParsingError.INVALID_VALUE)
               get { path }.size.isEqualTo(4)
               get { pathExpression }.isEqualTo(".environments[0].resources[0]")
             }


### PR DESCRIPTION
Introduces the following:
1. Additional logic in `ExceptionHandler` when dealing with YAML/JSON parsing errors by leveraging details exposed by Jackson and translating them into a well-defined format that should be easy to parse in the UI/CLI.
2. A `/delivery-configs/validate` API that is basically a no-op but which, by delegating to Jackson to parse the request body as a `SubmittedDeliveryConfig`, takes advantage of the functionality in (1) to implement a very simple validation API.

Example response:
```yaml
message: "Cannot construct instance of `com.netflix.spinnaker.keel.core.api.SubmittedResource`,\
  \ problem: Cannot deserialize value of type `com.netflix.spinnaker.keel.test.DummyEnum`\
  \ from String \"wrong\": not one of the values accepted for Enum class: [VALUE]\n\
  \ at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.keel.test.DummyResourceSpec[\"\
  enumData\"])\n at [Source: UNKNOWN; line: -1, column: -1] (through reference chain:\
  \ java.util.HashSet[0]) (through reference chain: com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig[\"\
  environments\"]->java.util.HashSet[0]->com.fasterxml.jackson.databind.node.ObjectNode[\"\
  resources\"])"
details:
  error: "invalid_type"
  message: "Cannot deserialize value of type `com.netflix.spinnaker.keel.test.DummyEnum`\
    \ from String \"wrong\": not one of the values accepted for Enum class: [VALUE]\n\
    \ at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.keel.test.DummyResourceSpec[\"\
    enumData\"])"
  location:
    line: -1
    column: -1
  path:
  - type: "com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig"
    field: "environments"
  - type: "array"
    index: 0
  - type: "com.fasterxml.jackson.databind.node.ObjectNode"
    field: "resources"
  - type: "array"
    index: 0
  - type: "test.spinnaker.netflix.com/v1/whatever"
    field: "enumData"
  pathExpression: ".environments[0].resources[0].enumData"
```

Closes #367 
Enablement for #818