### PR TITLE
feat(repository): disallow duplicate artifact refs

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateArtifactReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateArtifactReferenceException.kt
@@ -3,6 +3,6 @@ package com.netflix.spinnaker.keel.exceptions
 class DuplicateArtifactReferenceException(
   private val artifactNameToRef: Map<String, String>
 ) : ValidationException(
-  "Multiple artifacts are using the same string as a reference: $artifactNameToRef. " +
+  "Multiple artifacts are using the same reference: $artifactNameToRef. " +
     "Please ensure each artifact has a unique reference."
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateArtifactReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateArtifactReferenceException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.exceptions
+
+class DuplicateArtifactReferenceException(
+  private val artifactNameToRef: Map<String, String>
+) : ValidationException(
+  "Multiple artifacts are using the same string as a reference: $artifactNameToRef. " +
+    "Please ensure each artifact has a unique reference."
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateResourceIdException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateResourceIdException.kt
@@ -1,9 +1,5 @@
 package com.netflix.spinnaker.keel.exceptions
 
-open class ValidationException(
-  val msg: String
-) : RuntimeException(msg)
-
 class DuplicateResourceIdException(
   val ids: List<String>,
   val envsToResources: Map<String, List<String>>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/ValidationException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/ValidationException.kt
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.keel.exceptions
+
+open class ValidationException(
+  val msg: String
+) : RuntimeException(msg)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.keel.core.api.normalize
 import com.netflix.spinnaker.keel.core.api.resources
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import java.time.Clock
 import java.time.Duration
@@ -156,25 +157,53 @@ class CombinedRepository(
   }
 
   /**
-   * Validates that resources have unique ids, throws an exception if invalid
+   * Run validation checks against delivery config to ensure:
+   *
+   * - resources have unique ids
+   * - artifacts have unique references
+   *
+   * Throws an exception if config fails any checks
    */
   private fun validate(config: DeliveryConfig) {
-    val resources = config.environments.map { it.resources }.flatten().map { it.id }
-    val distinct = resources.distinct()
 
-    if (resources.size != distinct.size) {
-      val duplicates = resources.groupingBy { it }.eachCount().filter { it.value > 1 }.keys.toList()
+    // helper function to get duplicates in a list
+    val duplicates: (List<String>) -> List<String> =
+      { ls -> ls.groupingBy { it }.eachCount().filter { it.value > 1 }.keys.toList() }
+
+    /**
+     * check: resources have unique ids
+     */
+
+    val resources = config.environments.map { it.resources }.flatten().map { it.id }
+    val duplicateResources = duplicates(resources)
+
+    if (duplicateResources.isNotEmpty()) {
       val envToResources: Map<String, MutableList<String>> = config.environments
         .map { env -> env.name to env.resources.map { it.id }.toMutableList() }.toMap()
       val envsAndDuplicateResources = envToResources
         .filterValues { rs: MutableList<String> ->
           // remove all the resources we don't care about from this mapping
-          rs.removeIf { it !in duplicates }
+          rs.removeIf { it !in duplicateResources }
           // if there are resources left that we care about, leave it in the map
           rs.isNotEmpty()
         }
-      log.error("Validation failed for ${config.name}, duplicates found: $envsAndDuplicateResources")
-      throw DuplicateResourceIdException(duplicates, envsAndDuplicateResources)
+      log.error("Validation failed for ${config.name}, duplicates resource ids found: $envsAndDuplicateResources")
+      throw DuplicateResourceIdException(duplicateResources, envsAndDuplicateResources)
+    }
+
+    /**
+     * check: artifacts have unique references
+     */
+    val refs = config.artifacts.map { it.reference }
+    val duplicateRefs = duplicates(refs)
+
+    if (duplicateRefs.isNotEmpty()) {
+      val duplicatesArtifactNameToRef: Map<String, String> = config.artifacts
+        .filter { duplicateRefs.contains(it.reference) }
+        .map { art -> art.name to art.reference }.toMap()
+
+      log.error("Validation failed for ${config.name}, duplicate artifact references found: $duplicatesArtifactNameToRef")
+      throw DuplicateArtifactReferenceException(duplicatesArtifactNameToRef)
     }
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -167,13 +167,16 @@ class CombinedRepository(
   private fun validate(config: DeliveryConfig) {
 
     // helper function to get duplicates in a list
-    val duplicates: (List<String>) -> List<String> =
-      { ls -> ls.groupingBy { it }.eachCount().filter { it.value > 1 }.keys.toList() }
+    fun duplicates(ids: List<String>): List<String> =
+      ids.groupingBy { it }
+        .eachCount()
+        .filter { it.value > 1 }
+        .keys
+        .toList()
 
     /**
      * check: resources have unique ids
      */
-
     val resources = config.environments.map { it.resources }.flatten().map { it.id }
     val duplicateResources = duplicates(resources)
 
@@ -200,7 +203,7 @@ class CombinedRepository(
     if (duplicateRefs.isNotEmpty()) {
       val duplicatesArtifactNameToRef: Map<String, String> = config.artifacts
         .filter { duplicateRefs.contains(it.reference) }
-        .map { art -> art.name to art.reference }.toMap()
+        .associate { art -> art.name to art.reference }
 
       log.error("Validation failed for ${config.name}, duplicate artifact references found: $duplicatesArtifactNameToRef")
       throw DuplicateArtifactReferenceException(duplicatesArtifactNameToRef)

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -11,9 +11,9 @@ import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
-import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
 import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
+import com.netflix.spinnaker.keel.exceptions.ValidationException
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
@@ -70,9 +70,9 @@ class ExceptionHandler(
     return ApiError(e)
   }
 
-  @ExceptionHandler(DuplicateResourceIdException::class)
+  @ExceptionHandler(ValidationException::class)
   @ResponseStatus(BAD_REQUEST)
-  fun onDuplicateResourceIds(e: DuplicateResourceIdException): ApiError {
+  fun onDuplicateResourceIds(e: ValidationException): ApiError {
     log.error(e.message)
     return ApiError(e)
   }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -72,7 +72,7 @@ class ExceptionHandler(
 
   @ExceptionHandler(ValidationException::class)
   @ResponseStatus(BAD_REQUEST)
-  fun onDuplicateResourceIds(e: ValidationException): ApiError {
+  fun onInvalidDeliveryConfig(e: ValidationException): ApiError {
     log.error(e.message)
     return ApiError(e)
   }


### PR DESCRIPTION
Enforce that all artifacts in a delivery configuration have a unique reference.

Fixes #761.

If a user attempts to submit a delivery configuration that violates this, the response payload looks like this:

```
---
message: "Multiple artifacts are using the same reference: {lhochstein/lorintesttitus=my-artifact,\
  \ emburns/spin-titus-demo=my-artifact}. Please ensure each artifact has a unique\
  \ reference."
```

~(As an aside, I don't think keel should return a 500 error on input that fails validation, but that's the current behavior).~ (*My mistake: returning 500 was not the previous behavior on a validation error*)

It will also log a similar error message at the ERROR level:

```
Multiple artifacts are using the same reference: {lhochstein/lorintesttitus=my-artifact, emburns/spin-titus-demo=my-artifact}. Please ensure each artifact has a unique reference.
```
