### PR TITLE
fix(TaskEvents): Adding task id and name to resource events

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -297,17 +297,17 @@ data class ResourceTaskFailed(
   override val id: String,
   override val application: String,
   val reason: String?,
-  val task: Task,
+  val tasks: List<Task>,
   override val timestamp: Instant
 ) : ResourceEvent() {
 
-  constructor(resource: Resource<*>, reason: String?, task: Task, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, reason: String?, tasks: List<Task>, clock: Clock = Companion.clock) : this(
     resource.apiVersion,
     resource.kind,
     resource.id,
     resource.application,
     reason,
-    task,
+    tasks,
     clock.instant()
   )
 }
@@ -320,16 +320,16 @@ data class ResourceTaskSucceeded(
   override val kind: String,
   override val id: String,
   override val application: String,
-  val task: Task,
+  val tasks: List<Task>,
   override val timestamp: Instant
 ) : ResourceEvent() {
 
-  constructor(resource: Resource<*>, task: Task, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, tasks: List<Task>, clock: Clock = Companion.clock) : this(
     resource.apiVersion,
     resource.kind,
     resource.id,
     resource.application,
-    task,
+    tasks,
     clock.instant()
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -297,15 +297,17 @@ data class ResourceTaskFailed(
   override val id: String,
   override val application: String,
   val reason: String?,
+  val task: Task,
   override val timestamp: Instant
 ) : ResourceEvent() {
 
-  constructor(resource: Resource<*>, reason: String?, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, reason: String?, task: Task, clock: Clock = Companion.clock) : this(
     resource.apiVersion,
     resource.kind,
     resource.id,
     resource.application,
     reason,
+    task,
     clock.instant()
   )
 }
@@ -318,14 +320,16 @@ data class ResourceTaskSucceeded(
   override val kind: String,
   override val id: String,
   override val application: String,
+  val task: Task,
   override val timestamp: Instant
 ) : ResourceEvent() {
 
-  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, task: Task, clock: Clock = Companion.clock) : this(
     resource.apiVersion,
     resource.kind,
     resource.id,
     resource.application,
+    task,
     clock.instant()
   )
 }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
@@ -62,10 +62,10 @@ class OrcaTaskMonitorAgent(
               when (taskDetails.status.isSuccess()) {
                 true -> publisher.publishEvent(
                   ResourceTaskSucceeded(
-                    resourceRepository.get(id), Task(taskDetails.id, taskDetails.name), clock))
+                    resourceRepository.get(id), listOf(Task(taskDetails.id, taskDetails.name)), clock))
                 false -> publisher.publishEvent(
                   ResourceTaskFailed(
-                    resourceRepository.get(id), taskDetails.execution.stages.getFailureMessage() ?: "", Task(taskDetails.id, taskDetails.name), clock))
+                    resourceRepository.get(id), taskDetails.execution.stages.getFailureMessage() ?: "", listOf(Task(taskDetails.id, taskDetails.name)), clock))
               }
             } catch (e: NoSuchResourceId) {
               log.warn("No resource found for id $resourceId")

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.orca
 
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.keel.api.actuation.SubjectType.RESOURCE
+import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.events.ResourceTaskFailed
 import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
 import com.netflix.spinnaker.keel.events.TaskCreatedEvent
@@ -61,10 +62,10 @@ class OrcaTaskMonitorAgent(
               when (taskDetails.status.isSuccess()) {
                 true -> publisher.publishEvent(
                   ResourceTaskSucceeded(
-                    resourceRepository.get(id), clock))
+                    resourceRepository.get(id), Task(taskDetails.id, taskDetails.name), clock))
                 false -> publisher.publishEvent(
                   ResourceTaskFailed(
-                    resourceRepository.get(id), taskDetails.execution.stages.getFailureMessage() ?: "", clock))
+                    resourceRepository.get(id), taskDetails.execution.stages.getFailureMessage() ?: "", Task(taskDetails.id, taskDetails.name), clock))
               }
             } catch (e: NoSuchResourceId) {
               log.warn("No resource found for id $resourceId")

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
@@ -135,7 +135,7 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
         }
 
         verify(exactly = 1) { publisher.publishEvent(ofType<ResourceTaskFailed>()) }
-        resourceRepository.appendHistory(ResourceTaskFailed(resource, orcaExceptions().details.errors.joinToString(","), task, clock))
+        resourceRepository.appendHistory(ResourceTaskFailed(resource, orcaExceptions().details.errors.joinToString(","), listOf(task), clock))
 
         expectThat(resourceRepository.eventHistory(resource.id))
           .first()
@@ -164,7 +164,7 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
 
         verify(exactly = 1) { publisher.publishEvent(ofType<ResourceTaskFailed>()) }
         resourceRepository.appendHistory(ResourceTaskFailed(resource,
-          "The following security groups do not exist: 'keeldemo-main-elb' in 'test' vpc-46f5a223", task, clock))
+          "The following security groups do not exist: 'keeldemo-main-elb' in 'test' vpc-46f5a223", listOf(task), clock))
 
         expectThat(resourceRepository.eventHistory(resource.id))
           .first()

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.actuation.SubjectType
+import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceTaskFailed
@@ -49,6 +50,11 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
       id = "123",
       subject = "${SubjectType.CONSTRAINT}:${resource.id}",
       name = "canary constraint")
+
+    val task = Task(
+      id = "123",
+      name = "upsert server group"
+    )
   }
 
   data class OrcaTaskMonitorAgentFixture(
@@ -129,7 +135,7 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
         }
 
         verify(exactly = 1) { publisher.publishEvent(ofType<ResourceTaskFailed>()) }
-        resourceRepository.appendHistory(ResourceTaskFailed(resource, orcaExceptions().details.errors.joinToString(","), clock))
+        resourceRepository.appendHistory(ResourceTaskFailed(resource, orcaExceptions().details.errors.joinToString(","), task, clock))
 
         expectThat(resourceRepository.eventHistory(resource.id))
           .first()
@@ -157,7 +163,8 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
         }
 
         verify(exactly = 1) { publisher.publishEvent(ofType<ResourceTaskFailed>()) }
-        resourceRepository.appendHistory(ResourceTaskFailed(resource, "The following security groups do not exist: 'keeldemo-main-elb' in 'test' vpc-46f5a223", clock))
+        resourceRepository.appendHistory(ResourceTaskFailed(resource,
+          "The following security groups do not exist: 'keeldemo-main-elb' in 'test' vpc-46f5a223", task, clock))
 
         expectThat(resourceRepository.eventHistory(resource.id))
           .first()


### PR DESCRIPTION
- issue https://github.com/spinnaker/keel/issues/829
- added orca task data (id + name) for `ResourceTaskFailed` and `ResourceTaskSucceeded`, in order for deck to be able to parse this data and show it in the history view.
- since only a single task can be associated with these events, only a single task gets saved (and not a list).
