### PR TITLE
feat(api): API  improvements for environments/artifacts UI

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -103,7 +103,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     artifact: DeliveryArtifact = artifact1
   ): ArtifactVersionStatus {
     return subject
-      .versionsByEnvironment(manifest)
+      .getEnvironmentSummaries(manifest)
       .first { it.name == environment.name }
       .artifacts
       .first {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -44,7 +44,7 @@ import strikt.assertions.isTrue
 import strikt.assertions.succeeded
 
 /**
- * Tests that involve creating, updateting, or deleting things from two or more of the three repositories present.
+ * Tests that involve creating, updating, or deleting things from two or more of the three repositories present.
  *
  * Tests that only apply to one repository should live in the repository-specific test classes.
  */

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -1,0 +1,31 @@
+package com.netflix.spinnaker.keel.core.api
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import java.time.Instant
+
+/**
+ * Summarized data about a specific artifact, mostly for use by the UI.
+ */
+data class ArtifactSummary(
+  val name: String,
+  val type: ArtifactType,
+  val versions: Set<ArtifactVersionSummary>?
+)
+
+data class ArtifactVersionSummary(
+  val version: String,
+  val environments: Set<ArtifactSummaryInEnvironment>
+)
+
+data class ArtifactSummaryInEnvironment(
+  @JsonProperty("name")
+  val environment: String,
+  @JsonIgnore
+  val version: String,
+  val state: String,
+  val deployedAt: Instant? = null,
+  val replacedAt: Instant? = null,
+  val replacedBy: String? = null
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -11,7 +11,7 @@ import java.time.Instant
 data class ArtifactSummary(
   val name: String,
   val type: ArtifactType,
-  val versions: Set<ArtifactVersionSummary>?
+  val versions: Set<ArtifactVersionSummary> = emptySet()
 )
 
 data class ArtifactVersionSummary(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -1,12 +1,21 @@
 package com.netflix.spinnaker.keel.core.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.api.id
 
-data class EnvironmentArtifactsSummary(
-  val name: String,
-  val artifacts: Collection<ArtifactVersions>
-)
+data class EnvironmentSummary(
+  @JsonIgnore val environment: Environment,
+  val artifacts: Set<ArtifactVersions>
+) {
+  val name: String
+    get() = environment.name
+
+  val resources: Set<String>
+    get() = environment.resources.map { it.id }.toSet()
+}
 
 data class ArtifactVersions(
   val name: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -6,6 +6,9 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.id
 
+/**
+ * Summarized data about a specific environment, mostly for use by the UI.
+ */
 data class EnvironmentSummary(
   @JsonIgnore val environment: Environment,
   val artifacts: Set<ArtifactVersions>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -188,6 +188,7 @@ interface ArtifactRepository {
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType)
 
   fun getArtifactSummaryInEnvironment(
+    deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactName: String,
     artifactType: ArtifactType,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -187,10 +187,11 @@ interface ArtifactRepository {
    */
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType)
 
-  fun getCurrentVersionDeployedIn(
+  fun getArtifactSummaryInEnvironment(
     environmentName: String,
     artifactName: String,
-    artifactType: ArtifactType
+    artifactType: ArtifactType,
+    version: String
   ): ArtifactSummaryInEnvironment?
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 
 interface ArtifactRepository {
@@ -163,7 +163,7 @@ interface ArtifactRepository {
   /**
    * Fetches the status of artifact versions in the environments of [deliveryConfig].
    */
-  fun versionsByEnvironment(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactsSummary>
+  fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary>
 
   /**
    * Pin an environment to only deploy a specific DeliveryArtifact version

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
@@ -185,6 +186,12 @@ interface ArtifactRepository {
    * Removes a specific pin from [targetEnvironment], by [reference] and [type].
    */
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType)
+
+  fun getCurrentVersionDeployedIn(
+    environmentName: String,
+    artifactName: String,
+    artifactType: ArtifactType
+  ): ArtifactSummaryInEnvironment?
 }
 
 class NoSuchArtifactException(name: String, type: ArtifactType) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.UID
@@ -368,8 +368,8 @@ class CombinedRepository(
   override fun markAsSuccessfullyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String) =
     artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, version, targetEnvironment)
 
-  override fun versionsByEnvironment(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactsSummary> =
-    artifactRepository.versionsByEnvironment(deliveryConfig)
+  override fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary> =
+    artifactRepository.getEnvironmentSummaries(deliveryConfig)
 
   override fun pinEnvironment(deliveryConfig: DeliveryConfig, environmentArtifactPin: EnvironmentArtifactPin) =
     artifactRepository.pinEnvironment(deliveryConfig, environmentArtifactPin)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -11,7 +11,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.UID
@@ -173,7 +173,7 @@ interface KeelRepository {
 
   fun markAsSuccessfullyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String)
 
-  fun versionsByEnvironment(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactsSummary>
+  fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary>
 
   fun pinEnvironment(deliveryConfig: DeliveryConfig, environmentArtifactPin: EnvironmentArtifactPin)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -5,11 +5,12 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.comparator
 import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
@@ -340,7 +341,7 @@ class InMemoryArtifactRepository : ArtifactRepository {
     statuses[version] = DEPLOYING
   }
 
-  override fun versionsByEnvironment(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactsSummary> =
+  override fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary> =
     deliveryConfig
       .environments
       .map { environment ->
@@ -375,7 +376,8 @@ class InMemoryArtifactRepository : ArtifactRepository {
               )
             )
           }
-        EnvironmentArtifactsSummary(environment.name, artifactVersions)
+          .toSet()
+        EnvironmentSummary(environment, artifactVersions)
       }
 
   override fun pinEnvironment(deliveryConfig: DeliveryConfig, environmentArtifactPin: EnvironmentArtifactPin) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -428,7 +428,12 @@ class InMemoryArtifactRepository : ArtifactRepository {
       .forEach { pinnedVersions.remove(it.key) }
   }
 
-  override fun getCurrentVersionDeployedIn(environmentName: String, artifactName: String, artifactType: ArtifactType): ArtifactSummaryInEnvironment? {
+  override fun getArtifactSummaryInEnvironment(
+    environmentName: String,
+    artifactName: String,
+    artifactType: ArtifactType,
+    version: String
+  ): ArtifactSummaryInEnvironment? {
     TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -446,7 +446,7 @@ class InMemoryArtifactRepository : ArtifactRepository {
     return ArtifactSummaryInEnvironment(
       environment = environmentName,
       version = version,
-      state = statuses.filterKeys { it == version }.values.first().toString(),
+      state = statuses.filterKeys { it == version }.values.first().toString().toLowerCase(),
       deployedAt = null, // TODO
       replacedAt = null, // TODO
       replacedBy = null // TODO

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -457,6 +457,7 @@ class InMemoryArtifactRepository : ArtifactRepository {
     artifacts.clear()
     approvedVersions.clear()
     deployedVersions.clear()
+    versions.clear()
   }
 
   private data class ArtifactVersionAndStatus(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -429,12 +429,28 @@ class InMemoryArtifactRepository : ArtifactRepository {
   }
 
   override fun getArtifactSummaryInEnvironment(
+    deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactName: String,
     artifactType: ArtifactType,
     version: String
   ): ArtifactSummaryInEnvironment? {
-    TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    val artifact = deliveryConfig.artifacts.find { it ->
+      it.deliveryConfigName == deliveryConfig.name && it.name == artifactName && it.type == artifactType
+    } ?: throw ArtifactNotFoundException(artifactName, artifactType, "", deliveryConfig.name)
+
+    val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
+    val key = EnvironmentVersionsKey(artifactId, deliveryConfig, environmentName)
+    val statuses = statusByEnvironment.getOrDefault(key, emptyMap<String, String>())
+
+    return ArtifactSummaryInEnvironment(
+      environment = environmentName,
+      version = version,
+      state = statuses.filterKeys { it == version }.values.first().toString(),
+      deployedAt = null, // TODO
+      replacedAt = null, // TODO
+      replacedBy = null // TODO
+    )
   }
 
   fun dropAll() {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
@@ -425,6 +426,10 @@ class InMemoryArtifactRepository : ArtifactRepository {
         v.type == type.name
     }
       .forEach { pinnedVersions.remove(it.key) }
+  }
+
+  override fun getCurrentVersionDeployedIn(environmentName: String, artifactName: String, artifactType: ArtifactType): ArtifactSummaryInEnvironment? {
+    TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
   }
 
   fun dropAll() {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -831,7 +831,7 @@ class SqlArtifactRepository(
           ArtifactSummaryInEnvironment(
             environment = environmentName,
             version = version,
-            state = promotionStatus,
+            state = promotionStatus.toLowerCase(),
             deployedAt = deployedAt.toInstant(ZoneOffset.UTC),
             replacedAt = replacedAt,
             replacedBy = replacedBy

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -776,6 +776,7 @@ class SqlArtifactRepository(
   }
 
   override fun getArtifactSummaryInEnvironment(
+    deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactName: String,
     artifactType: ArtifactType,
@@ -791,7 +792,10 @@ class SqlArtifactRepository(
           ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS
         )
         .from(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(
+        .innerJoin(ENVIRONMENT)
+        .on(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
+        .where(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(deliveryConfig.uid))
+        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(
           select(ENVIRONMENT.UID).from(ENVIRONMENT).where(ENVIRONMENT.NAME.eq(environmentName)))
         )
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -12,7 +12,7 @@ import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.core.comparator
@@ -578,7 +578,7 @@ class SqlArtifactRepository(
     }
   }
 
-  override fun versionsByEnvironment(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactsSummary> {
+  override fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary> {
     return deliveryConfig.environments.map { environment ->
       val artifactVersions = deliveryConfig.artifacts.map { artifact ->
         val versionsInEnvironment = jooq
@@ -672,8 +672,8 @@ class SqlArtifactRepository(
             vetoed = versions[VETOED] ?: emptyList()
           )
         )
-      }
-      EnvironmentArtifactsSummary(environment.name, artifactVersions)
+      }.toSet()
+      EnvironmentSummary(environment, artifactVersions)
     }
   }
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -44,21 +44,18 @@ class ApplicationController(
   )
   fun get(
     @PathVariable("application") application: String,
-    @RequestParam("includeDetails", required = false, defaultValue = "false") includeDetails: Boolean,
-    @RequestParam("entities", required = false, defaultValue = "resources") entities: List<String>
+    @RequestParam("entities", required = false, defaultValue = "") entities: List<String>
   ): Map<String, Any> {
     return mutableMapOf<String, Any>(
       "applicationPaused" to actuationPauser.applicationIsPaused(application),
       "hasManagedResources" to applicationService.hasManagedResources(application)
     ).also { results ->
-      if (includeDetails) {
-        entities.forEach { entity ->
-          results[entity] = when (entity) {
-            "resources" -> applicationService.getResourceSummariesFor(application)
-            "environments" -> applicationService.getEnvironmentSummariesFor(application)
-            "artifacts" -> applicationService.getArtifactSummariesFor(application)
-            else -> throw InvalidRequestException("Unknown entity type: $entity")
-          }
+      entities.forEach { entity ->
+        results[entity] = when (entity) {
+          "resources" -> applicationService.getResourceSummariesFor(application)
+          "environments" -> applicationService.getEnvironmentSummariesFor(application)
+          "artifacts" -> applicationService.getArtifactSummariesFor(application)
+          else -> throw InvalidRequestException("Unknown entity type: $entity")
         }
       }
     }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -51,11 +51,14 @@ class ApplicationController(
       "applicationPaused" to actuationPauser.applicationIsPaused(application),
       "hasManagedResources" to applicationService.hasManagedResources(application)
     ).also { results ->
-      entities.forEach { entity ->
-        results[entity] = when (entity) {
-          "resources" -> applicationService.getResourceSummariesFor(application)
-          "environments" -> applicationService.getEnvironmentSummariesFor(application)
-          else -> throw InvalidRequestException("Unknown entity type: $entity")
+      if (includeDetails) {
+        entities.forEach { entity ->
+          results[entity] = when (entity) {
+            "resources" -> applicationService.getResourceSummariesFor(application)
+            "environments" -> applicationService.getEnvironmentSummariesFor(application)
+            "artifacts" -> applicationService.getArtifactSummariesFor(application)
+            else -> throw InvalidRequestException("Unknown entity type: $entity")
+          }
         }
       }
     }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -18,8 +18,8 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.pause.ActuationPauser
-import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
+import com.netflix.spinnaker.keel.services.ApplicationService
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -33,8 +33,8 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/application"])
 class ApplicationController(
-  private val repository: KeelRepository,
-  private val actuationPauser: ActuationPauser
+  private val actuationPauser: ActuationPauser,
+  private val applicationService: ApplicationService
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -44,32 +44,20 @@ class ApplicationController(
   )
   fun get(
     @PathVariable("application") application: String,
-    @RequestParam("includeDetails", required = false, defaultValue = "false") includeDetails: Boolean
+    @RequestParam("includeDetails", required = false, defaultValue = "false") includeDetails: Boolean,
+    @RequestParam("entities", required = false, defaultValue = "resources") entities: List<String>
   ): Map<String, Any> {
-    if (includeDetails) {
-      var resources = repository.getSummaryByApplication(application)
-      resources = resources.map { summary ->
-        if (actuationPauser.resourceIsPaused(summary.id)) {
-          // we only update the status if the individual resource is paused,
-          // because the application pause is reflected in the response as a top level key.
-          summary.copy(status = PAUSED)
-        } else {
-          summary
+    return mutableMapOf<String, Any>(
+      "applicationPaused" to actuationPauser.applicationIsPaused(application),
+      "hasManagedResources" to applicationService.hasManagedResources(application)
+    ).also { results ->
+      entities.forEach { entity ->
+        results[entity] = when (entity) {
+          "resources" -> applicationService.getResourceSummariesFor(application)
+          else -> throw InvalidRequestException("Unknown entity type: $entity")
         }
       }
-      val constraintStates = repository.constraintStateFor(application)
-
-      return mapOf(
-        "applicationPaused" to actuationPauser.applicationIsPaused(application),
-        "hasManagedResources" to resources.isNotEmpty(),
-        "resources" to resources,
-        "currentEnvironmentConstraints" to constraintStates
-      )
     }
-    return mapOf(
-      "applicationPaused" to actuationPauser.applicationIsPaused(application),
-      "hasManagedResources" to repository.hasManagedResources(application)
-    )
   }
 
   @PostMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -54,6 +54,7 @@ class ApplicationController(
       entities.forEach { entity ->
         results[entity] = when (entity) {
           "resources" -> applicationService.getResourceSummariesFor(application)
+          "environments" -> applicationService.getEnvironmentSummariesFor(application)
           else -> throw InvalidRequestException("Unknown entity type: $entity")
         }
       }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.rest
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactsSummary
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.diff.AdHocDiffer
 import com.netflix.spinnaker.keel.diff.EnvironmentDiff
@@ -84,17 +83,6 @@ class DeliveryConfigController(
   // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
     //  in [ExceptionHandler])
     mapOf("status" to "valid")
-
-  @GetMapping(
-    path = ["/{name}/artifacts"],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  fun getArtifacts(
-    @PathVariable("name") name: String
-  ): List<EnvironmentArtifactsSummary> =
-    repository.getDeliveryConfig(name).let {
-      repository.versionsByEnvironment(it)
-    }
 
   @GetMapping(
     path = ["/{name}/environment/{environment}/constraints"],

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -1,11 +1,17 @@
 package com.netflix.spinnaker.keel.services
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.core.api.ArtifactSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.keel.persistence.ResourceSummary
+import java.lang.IllegalArgumentException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -15,7 +21,8 @@ import org.springframework.stereotype.Component
 @Component
 class ApplicationService(
   private val pauser: ActuationPauser,
-  private val repository: KeelRepository
+  private val repository: KeelRepository,
+  private val artifactRepository: ArtifactRepository
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -38,19 +45,139 @@ class ApplicationService(
   }
 
   fun getEnvironmentSummariesFor(application: String): List<EnvironmentSummary> =
-      getFirstDeliveryConfigFor(application)
-        ?.let { deliveryConfig ->
-          repository.getEnvironmentSummaries(deliveryConfig)
-        }
-        ?: emptyList()
+    getFirstDeliveryConfigFor(application)
+      ?.let { deliveryConfig ->
+        artifactRepository.getEnvironmentSummaries(deliveryConfig)
+      }
+      ?: emptyList()
 
-  private fun getFirstDeliveryConfigFor(application: String): DeliveryConfig? {
-    return repository.getDeliveryConfigsByApplication(application).also {
+  /**
+   * Returns a list of [ArtifactSummary] by traversing the list of [EnvironmentSummary] for the same application
+   * and reindexing the data so that it matches the right format. This is essentially a data transformation for
+   * the benefit of the UI.
+   */
+  fun getArtifactSummariesFor(application: String): List<ArtifactSummary> {
+    val environmentSummaries = getEnvironmentSummariesFor(application)
+
+    // map of artifacts to the environments where they appear
+    val artifactsToEnvironments = environmentSummaries.flatMap { environmentSummary ->
+      environmentSummary.artifacts.map { artifact ->
+        artifact.key to environmentSummary.name
+      }
+    }.toMap()
+
+    // map of environments to the set of artifact summaries by state
+    val artifactSummariesByEnvironmentAndState = environmentSummaries.associate { environmentSummary ->
+      environmentSummary.name to mapOf(
+        "current" to mutableSetOf<ArtifactSummaryInEnvironment>(),
+        "deploying" to mutableSetOf<ArtifactSummaryInEnvironment>(),
+        "pending" to mutableSetOf<ArtifactSummaryInEnvironment>(),
+        "approved" to mutableSetOf<ArtifactSummaryInEnvironment>(),
+        "previous" to mutableSetOf<ArtifactSummaryInEnvironment>(),
+        "vetoed" to mutableSetOf<ArtifactSummaryInEnvironment>()
+      )
+    }
+
+    // map of version summaries by artifact
+    val versionSummariesByArtifact = environmentSummaries.flatMap { environmentSummary ->
+      environmentSummary.artifacts.map { artifact ->
+        artifact.key to mutableSetOf<ArtifactVersionSummary>()
+      }
+    }.toMap()
+
+    // for each environment...
+    val artifactSummaries = environmentSummaries.flatMap { environmentSummary ->
+
+      // for each artifact in the environment...
+      environmentSummary.artifacts.map { artifact ->
+        val versionsByState = mapOf(
+          "current" to artifact.versions.current,
+          "deploying" to artifact.versions.deploying,
+          "pending" to artifact.versions.pending,
+          "approved" to artifact.versions.approved,
+          "previous" to artifact.versions.previous,
+          "vetoed" to artifact.versions.vetoed
+        )
+
+        // ...get the currently deployed version in the environment...
+        val currentVersion = artifactRepository.getCurrentVersionDeployedIn(
+          environmentSummary.name,
+          artifact.name,
+          artifact.type
+        )
+
+        // ...get the artifact versions by state...
+        versionsByState.entries.map {
+          val state = it.key
+          val versions = it.value
+
+          // ...generate a artifact summary as it pertains to the environment...
+          val summaryInEnvironment = ArtifactSummaryInEnvironment(
+            environment = artifactsToEnvironments[artifact.key]!!, // safe because we build the map off known versions
+            state = state,
+            version = versions.toString(),
+            deployedAt = if (state == "current") {
+              currentVersion?.deployedAt
+            } else {
+              null
+            },
+            replacedAt = null, // TODO
+            replacedBy = null // TODO
+          )
+
+          // ...then record the artifact version summary for each version for that state...
+          if (versions != null) {
+            versionSummariesByArtifact[artifact.key]!!.addAll(
+              when (versions) {
+                is String -> setOf(
+                  ArtifactVersionSummary(
+                    version = versions,
+                    environments = artifactSummariesByEnvironmentAndState
+                      .get(environmentSummary.name)!! // safe because we create the maps with these keys above
+                      .get(state)!! // safe because we create the maps with these keys above
+                      .also { artifactSummariesInEnvironment ->
+                        artifactSummariesInEnvironment.add(summaryInEnvironment)
+                      }
+                  )
+                )
+                is Iterable<*> -> {
+                  versions.map { version ->
+                    ArtifactVersionSummary(
+                      version = version.toString(),
+                      environments = artifactSummariesByEnvironmentAndState
+                        .get(environmentSummary.name)!! // safe because we create the maps with these keys above
+                        .get(state)!! // safe because we create the maps with these keys above
+                        .also { artifactSummariesInEnvironment ->
+                          artifactSummariesInEnvironment.add(summaryInEnvironment)
+                        }
+                    )
+                  }
+                }
+                else -> throw IllegalArgumentException("Invalid type of versions field: ${versions?.javaClass}")
+              }
+            )
+          }
+        }
+        // finally, create the artifact summary by looking up the version summaries that were built above
+        ArtifactSummary(
+          name = artifact.name,
+          type = artifact.type,
+          versions = versionSummariesByArtifact[artifact.key]
+        )
+      }
+    }
+
+    return artifactSummaries
+  }
+
+  private fun getFirstDeliveryConfigFor(application: String): DeliveryConfig? =
+    repository.getDeliveryConfigsByApplication(application).also {
       if (it.size > 1) {
         log.warn("Application $application has ${it.size} delivery configs. " +
           "Returning the first one: ${it.first().name}.")
       }
-    }
-      .firstOrNull()
-  }
+    }.firstOrNull()
+
+  private val ArtifactVersions.key: String
+    get() = "${type.name}:$name"
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.persistence.ResourceStatus
+import com.netflix.spinnaker.keel.persistence.ResourceSummary
+import org.springframework.stereotype.Component
+
+/**
+ * Service object that offers high-level APIs for application-related operations.
+ */
+@Component
+class ApplicationService(
+  private val pauser: ActuationPauser,
+  private val repository: KeelRepository
+) {
+
+  fun hasManagedResources(application: String) = repository.hasManagedResources(application)
+
+  fun getResourceSummariesFor(application: String): List<ResourceSummary> {
+    var resources = repository.getSummaryByApplication(application)
+    resources = resources.map { summary ->
+      if (pauser.resourceIsPaused(summary.id)) {
+        // we only update the status if the individual resource is paused,
+        // because the application pause is reflected in the response as a top level key.
+        summary.copy(status = ResourceStatus.PAUSED)
+      } else {
+        summary
+      }
+    }
+    // val constraintStates = repository.constraintStateFor(application)
+
+    return resources
+  }
+}

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -73,11 +73,10 @@ class ApplicationService(
    * |    For each artifact in the environment:
    * |    |    Build a map of artifact versions by state (e.g. pending, current, previous, etc.).
    * |    |    For each pair of (state, versions):
-   * |    |    |    Record the artifact version summary.
    * |    |    |    For each version in this state:
-   * |    |    |    |    Get and cache an artifact summary for this version in this environment.
-   * |    |    |    |     Create the artifact version summary for this version and cache it.
-   * |    |    Finally, create the artifact summary by looking up the version summaries that were built above.
+   * |    |    |    |    Get and cache an [ArtifactSummaryInEnvironment] for this version in this environment.
+   * |    |    |    |    Create and cache the [ArtifactVersionSummary] for this version.
+   * |    |    Finally, create the [ArtifactSummary] by looking up the "inner" summaries that were built above.
    * Return a flat list of all the artifact summaries for all environments in the delivery config.
    */
   fun getArtifactSummariesFor(application: String): List<ArtifactSummary> {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -1,9 +1,12 @@
 package com.netflix.spinnaker.keel.services
 
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.keel.persistence.ResourceSummary
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 /**
@@ -14,6 +17,7 @@ class ApplicationService(
   private val pauser: ActuationPauser,
   private val repository: KeelRepository
 ) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   fun hasManagedResources(application: String) = repository.hasManagedResources(application)
 
@@ -31,5 +35,22 @@ class ApplicationService(
     // val constraintStates = repository.constraintStateFor(application)
 
     return resources
+  }
+
+  fun getEnvironmentSummariesFor(application: String): List<EnvironmentSummary> =
+      getFirstDeliveryConfigFor(application)
+        ?.let { deliveryConfig ->
+          repository.getEnvironmentSummaries(deliveryConfig)
+        }
+        ?: emptyList()
+
+  private fun getFirstDeliveryConfigFor(application: String): DeliveryConfig? {
+    return repository.getDeliveryConfigsByApplication(application).also {
+      if (it.size > 1) {
+        log.warn("Application $application has ${it.size} delivery configs. " +
+          "Returning the first one: ${it.first().name}.")
+      }
+    }
+      .firstOrNull()
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -110,7 +110,6 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       deliveryConfigRepository.dropAll()
       resourceRepository.dropAll()
       artifactRepository.dropAll()
-      actuationPauser.resumeApplication(application)
       clearAllMocks()
     }
 
@@ -145,6 +144,10 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       context("with paused application") {
         before {
           actuationPauser.pauseApplication(application)
+        }
+
+        after {
+          actuationPauser.resumeApplication(application)
         }
 
         test("reflects application paused status in basic summary") {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -121,8 +121,10 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         artifactRepository.register(artifact)
         artifactRepository.store(artifact, "1.0.0", ArtifactStatus.RELEASE)
         artifactRepository.store(artifact, "1.0.1", ArtifactStatus.RELEASE)
+        artifactRepository.store(artifact, "1.0.2", ArtifactStatus.RELEASE)
         artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.0", "test")
-        artifactRepository.approveVersionFor(deliveryConfig, artifact, "1.0.1", "test")
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.1", "test")
+        artifactRepository.approveVersionFor(deliveryConfig, artifact, "1.0.2", "test")
       }
 
       test("can get basic summary by application") {
@@ -203,12 +205,14 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                       "type":"deb",
                       "statuses":[],
                       "versions":{
-                        "current":"1.0.0",
+                        "current":"1.0.1",
                         "pending":[],
                         "approved":[
-                          "1.0.1"
+                          "1.0.2"
                         ],
-                        "previous":[],
+                        "previous":[
+                          "1.0.0"
+                        ],
                         "vetoed":[]
                       }
                     }
@@ -246,12 +250,21 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                       "environments":[
                         {
                           "name":"test",
-                          "state":"current"
+                          "state":"previous"
                         }
                       ]
                     },
                     {
                       "version":"1.0.1",
+                      "environments":[
+                        {
+                          "name":"test",
+                          "state":"current"
+                        }
+                      ]
+                    },
+                    {
+                      "version":"1.0.2",
                       "environments":[
                         {
                           "name":"test",
@@ -273,6 +286,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         val result = mvc
           .perform(request)
           .andExpect(status().isOk)
+          .andDo { print(it.response.contentAsString) }
           .andReturn()
         val response = configuredObjectMapper().readValue<Map<String, Any>>(result.response.contentAsString)
         expectThat(response.keys)

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -243,7 +243,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                       "environments":[
                         {
                           "name":"test",
-                          "state":"CURRENT"
+                          "state":"current"
                         }
                       ]
                     },
@@ -252,7 +252,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                       "environments":[
                         {
                           "name":"test",
-                          "state":"APPROVED"
+                          "state":"approved"
                         }
                       ]
                     }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -298,6 +298,32 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             "artifacts"
           )
       }
+
+      test("can get multiple types of summaries by application with comma-separate list of entities") {
+        val request = get("/application/$application?includeDetails=true&entities=resources,environments,artifacts")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        val result = mvc
+          .perform(request)
+          .andExpect(status().isOk)
+          .andDo { print(it.response.contentAsString) }
+          .andReturn()
+        val response = configuredObjectMapper().readValue<Map<String, Any>>(result.response.contentAsString)
+        expectThat(response.keys)
+          .containsExactly(
+            "applicationPaused",
+            "hasManagedResources",
+            "resources",
+            "environments",
+            "artifacts"
+          )
+      }
+
+      test("returns bad request for unknown entities") {
+        val request = get("/application/$application?includeDetails=true&entities=bananas")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        mvc.perform(request)
+          .andExpect(status().isBadRequest)
+      }
     }
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -1,15 +1,29 @@
 package com.netflix.spinnaker.keel.rest
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.KeelApplication
-import com.netflix.spinnaker.keel.api.application
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
+import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.resource
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Test
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.clearAllMocks
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -21,6 +35,8 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
@@ -28,53 +44,243 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
-internal class ApplicationControllerTests {
+internal class ApplicationControllerTests : JUnit5Minutests {
   @Autowired
   lateinit var mvc: MockMvc
+
+  @Autowired
+  lateinit var deliveryConfigRepository: InMemoryDeliveryConfigRepository
 
   @Autowired
   lateinit var resourceRepository: InMemoryResourceRepository
 
   @Autowired
+  lateinit var artifactRepository: InMemoryArtifactRepository
+
+  @Autowired
   lateinit var actuationPauser: ActuationPauser
 
-  @AfterEach
-  fun clearRepository() {
-    resourceRepository.dropAll()
+  object Fixture {
+    const val application = "fnord"
+
+    val artifact = DebianArtifact(name = application, deliveryConfigName = "manifest")
+
+    val cluster = resource(
+      kind = SPINNAKER_EC2_API_V1.qualify("cluster"),
+      spec = ClusterSpec(
+        moniker = Moniker(application, "api"),
+        imageProvider = ArtifactImageProvider(deliveryArtifact = artifact),
+        locations = SubnetAwareLocations(
+          account = "test",
+          vpc = "vpc0",
+          subnet = "internal (vpc0)",
+          regions = setOf(
+            SubnetAwareRegionSpec(
+              name = "us-west-2",
+              availabilityZones = setOf("us-west-2a", "us-west-2b", "us-west-2c")
+            )
+          )
+        ),
+        _defaults = ClusterSpec.ServerGroupSpec(
+          launchConfiguration = ClusterSpec.LaunchConfigurationSpec(
+            instanceType = "m4.2xlarge",
+            ebsOptimized = true,
+            iamRole = "fnordInstanceProfile",
+            keyPair = "fnordKeyPair"
+          )
+        )
+      )
+    )
+
+    private val testEnv = Environment(name = "test", resources = setOf(cluster))
+
+    val deliveryConfig = DeliveryConfig(
+      name = "manifest",
+      application = application,
+      serviceAccount = "keel@spinnaker",
+      artifacts = setOf(artifact),
+      environments = setOf(testEnv)
+    )
   }
 
-  @Test
-  fun `can get resource summaries by application`() {
-    val res = resource()
-    resourceRepository.store(res)
-    resourceRepository.appendHistory(ResourceCreated(res))
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture }
 
-    var request = get("/application/${res.application}")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andExpect(content().json(
-        """
-          {
-            "hasManagedResources":true
-          }
-        """.trimIndent()
-      ))
+    after {
+      deliveryConfigRepository.dropAll()
+      resourceRepository.dropAll()
+      artifactRepository.dropAll()
+      actuationPauser.resumeApplication(application)
+      clearAllMocks()
+    }
 
-    request = get("/application/${res.application}?includeDetails=true")
-      .accept(MediaType.APPLICATION_JSON_VALUE)
-    mvc
-      .perform(request)
-      .andExpect(status().isOk)
-      .andExpect(content().json(
-        """
-          |{
-          |"hasManagedResources":true,
-          |"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}],
-          |"currentEnvironmentConstraints":[]
-          |}
-        """.trimMargin()
-      ))
+    context("application with delivery config exists") {
+      before {
+        deliveryConfigRepository.store(deliveryConfig)
+        resourceRepository.store(cluster)
+        resourceRepository.appendHistory(ResourceCreated(cluster))
+        artifactRepository.register(artifact)
+        artifactRepository.store(artifact, "1.0.0", ArtifactStatus.RELEASE)
+        artifactRepository.store(artifact, "1.0.1", ArtifactStatus.RELEASE)
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.0", "test")
+        artifactRepository.approveVersionFor(deliveryConfig, artifact, "1.0.1", "test")
+      }
+
+      test("can get basic summary by application") {
+        val request = get("/application/$application")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        mvc
+          .perform(request)
+          .andExpect(status().isOk)
+          .andExpect(content().json(
+            """
+              {
+                "applicationPaused":false,
+                "hasManagedResources":true
+              }
+            """.trimIndent()
+          ))
+      }
+
+      context("with paused application") {
+        before {
+          actuationPauser.pauseApplication(application)
+        }
+
+        test("reflects application paused status in basic summary") {
+          val request = get("/application/$application")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+          mvc
+            .perform(request)
+            .andExpect(status().isOk)
+            .andExpect(content().json(
+              """
+              {
+                "applicationPaused":true,
+                "hasManagedResources":true
+              }
+            """.trimIndent()
+            ))
+        }
+      }
+
+      test("can get resource summaries by application") {
+        val request = get("/application/$application?includeDetails=true")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        mvc
+          .perform(request)
+          .andExpect(status().isOk)
+          .andExpect(content().json(
+            """
+              |{
+              |"hasManagedResources":true,
+              |"resources":[{"id":"${cluster.id}","kind":"${cluster.kind}","status":"CREATED"}]
+              |}
+            """.trimMargin()
+          ))
+      }
+
+      test("can get environment summaries by application") {
+        val request = get("/application/$application?includeDetails=true&entities=environments")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        mvc
+          .perform(request)
+          .andExpect(status().isOk)
+          .andDo { print(it.response.contentAsString) }
+          .andExpect(content().json(
+            """
+            {
+              "applicationPaused":false,
+              "hasManagedResources":true,
+              "environments":[
+                {
+                  "artifacts":[
+                    {
+                      "name":"fnord",
+                      "type":"deb",
+                      "statuses":[],
+                      "versions":{
+                        "current":"1.0.0",
+                        "pending":[],
+                        "approved":[
+                          "1.0.1"
+                        ],
+                        "previous":[],
+                        "vetoed":[]
+                      }
+                    }
+                  ],
+                  "name":"test",
+                  "resources":[
+                    "ec2:cluster:test:fnord-api"
+                  ]
+                }
+              ]
+            }
+            """.trimMargin()
+          ))
+      }
+
+      test("can get artifact summaries by application") {
+        val request = get("/application/$application?includeDetails=true&entities=artifacts")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        mvc
+          .perform(request)
+          .andExpect(status().isOk)
+          .andDo { print(it.response.contentAsString) }
+          .andExpect(content().json(
+            """
+            {
+              "applicationPaused":false,
+              "hasManagedResources":true,
+              "artifacts":[
+                {
+                  "name":"fnord",
+                  "type":"deb",
+                  "versions":[
+                    {
+                      "version":"1.0.0",
+                      "environments":[
+                        {
+                          "name":"test",
+                          "state":"CURRENT"
+                        }
+                      ]
+                    },
+                    {
+                      "version":"1.0.1",
+                      "environments":[
+                        {
+                          "name":"test",
+                          "state":"APPROVED"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+            """.trimIndent()
+          ))
+      }
+
+      test("can get multiple types of summaries by application") {
+        val request = get("/application/$application?includeDetails=true&entities=resources&entities=environments&entities=artifacts")
+          .accept(MediaType.APPLICATION_JSON_VALUE)
+        val result = mvc
+          .perform(request)
+          .andExpect(status().isOk)
+          .andReturn()
+        val response = configuredObjectMapper().readValue<Map<String, Any>>(result.response.contentAsString)
+        expectThat(response.keys)
+          .containsExactly(
+            "applicationPaused",
+            "hasManagedResources",
+            "resources",
+            "environments",
+            "artifacts"
+          )
+      }
+    }
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -170,7 +170,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       }
 
       test("can get resource summaries by application") {
-        val request = get("/application/$application?includeDetails=true")
+        val request = get("/application/$application?entities=resources")
           .accept(MediaType.APPLICATION_JSON_VALUE)
         mvc
           .perform(request)
@@ -186,7 +186,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       }
 
       test("can get environment summaries by application") {
-        val request = get("/application/$application?includeDetails=true&entities=environments")
+        val request = get("/application/$application?entities=environments")
           .accept(MediaType.APPLICATION_JSON_VALUE)
         mvc
           .perform(request)
@@ -229,7 +229,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       }
 
       test("can get artifact summaries by application") {
-        val request = get("/application/$application?includeDetails=true&entities=artifacts")
+        val request = get("/application/$application?entities=artifacts")
           .accept(MediaType.APPLICATION_JSON_VALUE)
         mvc
           .perform(request)
@@ -281,7 +281,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       }
 
       test("can get multiple types of summaries by application") {
-        val request = get("/application/$application?includeDetails=true&entities=resources&entities=environments&entities=artifacts")
+        val request = get("/application/$application?entities=resources&entities=environments&entities=artifacts")
           .accept(MediaType.APPLICATION_JSON_VALUE)
         val result = mvc
           .perform(request)
@@ -300,7 +300,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       }
 
       test("can get multiple types of summaries by application with comma-separate list of entities") {
-        val request = get("/application/$application?includeDetails=true&entities=resources,environments,artifacts")
+        val request = get("/application/$application?entities=resources,environments,artifacts")
           .accept(MediaType.APPLICATION_JSON_VALUE)
         val result = mvc
           .perform(request)
@@ -319,7 +319,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
       }
 
       test("returns bad request for unknown entities") {
-        val request = get("/application/$application?includeDetails=true&entities=bananas")
+        val request = get("/application/$application?entities=bananas")
           .accept(MediaType.APPLICATION_JSON_VALUE)
         mvc.perform(request)
           .andExpect(status().isBadRequest)


### PR DESCRIPTION
This PR addresses additions and changes to the `/application` API required by `deck` in the new Environments UI, including:
- Refactoring the `/application` endpoint to support returning multiple views into the environment, resource and artifact data
- Moving the existing "environments summary" API previously under `/delivery-configs` over to the `/application` endpoint
- Adding support for an artifact-centric view into the data

Sample response:
```yaml
---
applicationPaused: false
hasManagedResources: true
resources:
- id: titus:cluster:titustestvpc:serverlablpollo
  kind: titus/cluster@v1
  status: ACTUATING
  moniker:
    app: serverlablpollo
  locations:
    account: titustestvpc
    vpc: vpc0
    regions:
    - name: eu-west-1
    - name: us-east-1
    - name: us-west-2
environments:
- artifacts:
  - name: spkr/mddemo-titus
    type: docker
    statuses: []
    versions:
      current: latest
      pending: []
      approved: []
      previous:
      - oldest
      vetoed: []
  name: test
  resources:
  - titus:cluster:titustestvpc:serverlablpollo
artifacts:
- name: spkr/mddemo-titus
  type: docker
  versions:
  - version: latest
    environments:
    - name: test
      state: current
      deployedAt: '2020-03-04T13:20:03Z'
  - version: oldest
    environments:
    - name: test
      state: previous
      deployedAt: '2020-03-03T13:20:03Z'
      replacedAt: '2020-03-04T13:20:03Z'
      replacedBy: latest
```

More comments on the implementation inline.

Closes #643 