### PR TITLE
fix(events): Tolerate missing tasks in resource events

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
@@ -16,7 +16,7 @@ data class ResourceKind(
   }
 
   companion object {
-    private val resourceKindFormat = Regex("""([\w.-]+)/([\w.-]+)@v(.+)""")
+    private val resourceKindFormat = Regex("""([\w.-]+)/([\w.-]+)\@v(.+)""")
 
     @JvmStatic
     fun parseKind(value: String): ResourceKind =

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
@@ -16,7 +16,7 @@ data class ResourceKind(
   }
 
   companion object {
-    private val resourceKindFormat = Regex("""([\w.-]+)/([\w.-]+)\@v(.+)""")
+    private val resourceKindFormat = Regex("""([\w.-]+)/([\w.-]+)@v(.+)""")
 
     @JvmStatic
     fun parseKind(value: String): ResourceKind =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -270,7 +270,7 @@ data class ResourceTaskFailed(
   override val id: String,
   override val application: String,
   val reason: String?,
-  val tasks: List<Task>,
+  val tasks: List<Task> = emptyList(),
   override val timestamp: Instant
 ) : ResourceEvent() {
 
@@ -291,7 +291,7 @@ data class ResourceTaskSucceeded(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
-  val tasks: List<Task>,
+  val tasks: List<Task> = emptyList(),
   override val timestamp: Instant
 ) : ResourceEvent() {
 


### PR DESCRIPTION
Fixes an issue with the `ResourceTaskSucceeded` and `ResourceTaskFailed` event classes which were causing deserialization to fail for existing records without task references.