### PR TITLE
fix(events): Fix issue with synthetic resource paused events in API

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
@@ -24,12 +24,14 @@ import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
+import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.persistence.PausedRepository
 import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope
 import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope.RESOURCE
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -38,7 +40,8 @@ import org.springframework.stereotype.Component
 class ActuationPauser(
   val resourceRepository: ResourceRepository,
   val pausedRepository: PausedRepository,
-  val publisher: ApplicationEventPublisher
+  val publisher: ApplicationEventPublisher,
+  val clock: Clock
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -66,44 +69,64 @@ class ActuationPauser(
   fun pauseApplication(application: String) {
     log.info("Pausing application $application")
     pausedRepository.pauseApplication(application)
-    publisher.publishEvent(ApplicationActuationPaused(application))
+    publisher.publishEvent(ApplicationActuationPaused(application, "Application $application paused", clock))
   }
 
   fun resumeApplication(application: String) {
     log.info("Resuming application $application")
     pausedRepository.resumeApplication(application)
-    publisher.publishEvent(ApplicationActuationResumed(application))
+    publisher.publishEvent(ApplicationActuationResumed(application, "Application $application resumed", clock))
     resourceRepository.getResourcesByApplication(application)
       .forEach {
         // helps a user not be confused by an out of date status from before a pause
-        publisher.publishEvent(ResourceActuationResumed(it))
+        publisher.publishEvent(ResourceActuationResumed(it, clock))
       }
   }
 
   fun pauseResource(id: String) {
     log.info("Pausing resource $id")
     pausedRepository.pauseResource(id)
-    publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id)))
+    publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id), null, clock.instant()))
   }
 
   fun resumeResource(id: String) {
     log.info("Resuming resource $id")
     pausedRepository.resumeResource(id)
     // helps a user not be confused by an out of date status from before a pause
-    publisher.publishEvent(ResourceActuationResumed(resourceRepository.get(id)))
+    publisher.publishEvent(ResourceActuationResumed(resourceRepository.get(id), clock))
   }
 
   fun pausedApplications(): List<String> =
     pausedRepository.getPausedApplications()
 
+  /**
+   * Adds a pause event to the resource history for every pause event from the parent application.
+   * We do this dynamically so that it applies to all resources in the app, even those added _after_ the
+   * application was paused.
+  */
   fun addSyntheticPausedEvents(originalEvents: List<ResourceEvent>, resource: Resource<*>) =
-    originalEvents.toMutableList().also { events ->
-      // For user clarity we add a pause event to the resource history for every pause event from the parent app.
-      // We do this dynamically here so that it applies to all resources in the app, even those added _after_ the
-      // application was paused.
-      val appPausedEvents = resourceRepository
-        .applicationEventHistory(resource.application, events.last().timestamp)
-        .filterIsInstance<ApplicationActuationPaused>()
+    originalEvents.toMutableList().let { events ->
+      val oldestResourceEvent = events.last()
+      val relevantAppEvents = resourceRepository
+        .applicationEventHistory(resource.application, oldestResourceEvent.timestamp)
+      val appPausedEvents = relevantAppEvents.filterIsInstance<ApplicationActuationPaused>()
+      val oldestAppPausedEvent = appPausedEvents.lastOrNull()
+      val oldestAppResumedEvent = relevantAppEvents.lastOrNull { it is ApplicationActuationResumed }
+
+      // Handles the case when a resource was added to the application *after* the application was paused, as follows:
+      // If the oldest resource event in history is ResourceCreated (i.e. the very first event for the resource)...
+      if (oldestResourceEvent is ResourceCreated &&
+        // ...and the oldest ApplicationActuationResumed in the life of the resource happened after the resource was created
+        oldestAppResumedEvent != null && oldestAppResumedEvent.timestamp.isAfter(oldestResourceEvent.timestamp) &&
+        // ...and either there's no ApplicationActuationPaused event or the oldest one is later the oldest resume (i.e. a different pause)
+        (oldestAppPausedEvent == null || oldestAppResumedEvent.timestamp.isBefore(oldestAppPausedEvent.timestamp))) {
+        // ...then add a synthetic ResouceActuationPaused event with the timestamp of resource creation
+        events.add(
+          events.indexOf(oldestResourceEvent),
+          ResourceActuationPaused(resource, "Resource actuation paused at the application level",
+            oldestResourceEvent.timestamp)
+        )
+      }
 
       appPausedEvents.forEach { appPaused ->
         val lastBeforeAppPaused = events.firstOrNull { event ->
@@ -120,5 +143,7 @@ class ActuationPauser(
           )
         }
       }
+
+      events
     }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
@@ -31,6 +31,7 @@ import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Clock
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expect
 import strikt.assertions.isFalse
@@ -49,7 +50,7 @@ class ActuationPauserTests : JUnit5Minutests {
     }
     val pausedRepository = InMemoryPausedRepository()
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
-    val subject = ActuationPauser(resourceRepository, pausedRepository, publisher)
+    val subject = ActuationPauser(resourceRepository, pausedRepository, publisher, Clock.systemDefaultZone())
   }
 
   fun tests() = rootContext<Fixture> {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -32,7 +32,6 @@ class EventController(
     log.debug("Getting state history for: $id")
     val resource = repository.getResource(id)
     val events = repository.resourceEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
-
     return actuationPauser.addSyntheticPausedEvents(events, resource)
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -71,8 +71,7 @@ internal class ApplicationControllerTests {
         """
           |{
           |"hasManagedResources":true,
-          |"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}],
-          |"currentEnvironmentConstraints":[]
+          |"resources":[{"id":"${res.id}","kind":"${res.kind}","status":"CREATED"}]
           |}
         """.trimMargin()
       ))


### PR DESCRIPTION
Fixes a left-over issue from #842 whereby a resource created after the parent application was paused would not have a corresponding `ResourceActuationPaused` event in the beginning of its event history.