### PR TITLE
fix(events): Revisit reflecting application paused/resumed events on resources

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -35,9 +35,9 @@ data class ApplicationActuationPaused(
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(application: String, reason: String? = null, clock: Clock = Companion.clock) : this(
+  constructor(application: String, clock: Clock = Companion.clock) : this(
     application,
-    reason,
+    "Application $application paused",
     clock.instant()
   )
 }
@@ -52,9 +52,9 @@ data class ApplicationActuationResumed(
 ) : ApplicationEvent() {
   @JsonIgnore override val ignoreRepeatedInHistory = true
 
-  constructor(application: String, reason: String? = null, clock: Clock = Companion.clock) : this(
+  constructor(application: String, clock: Clock = Companion.clock) : this(
     application,
-    reason,
+    "Application $application resumed",
     clock.instant()
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -15,8 +15,7 @@ import java.time.Instant
   JsonSubTypes.Type(value = ApplicationActuationPaused::class, name = "ApplicationActuationPaused"),
   JsonSubTypes.Type(value = ApplicationActuationResumed::class, name = "ApplicationActuationResumed")
 )
-sealed class ApplicationEvent : PersistentEvent() {
-  @JsonIgnore
+abstract class ApplicationEvent : PersistentEvent() {
   override val scope = Scope.APPLICATION
 
   override val uid: String

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -29,7 +29,6 @@ abstract class ApplicationEvent : PersistentEvent() {
  */
 data class ApplicationActuationPaused(
   override val application: String,
-  val reason: String?,
   override val timestamp: Instant
 ) : ApplicationEvent() {
   @JsonIgnore
@@ -37,7 +36,6 @@ data class ApplicationActuationPaused(
 
   constructor(application: String, clock: Clock = Companion.clock) : this(
     application,
-    "Application $application paused",
     clock.instant()
   )
 }
@@ -47,14 +45,12 @@ data class ApplicationActuationPaused(
  */
 data class ApplicationActuationResumed(
   override val application: String,
-  val reason: String?,
   override val timestamp: Instant
 ) : ApplicationEvent() {
   @JsonIgnore override val ignoreRepeatedInHistory = true
 
   constructor(application: String, clock: Clock = Companion.clock) : this(
     application,
-    "Application $application resumed",
     clock.instant()
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
@@ -1,8 +1,20 @@
 package com.netflix.spinnaker.keel.events
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Clock
 import java.time.Instant
 
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  property = "type",
+  include = JsonTypeInfo.As.PROPERTY
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = ApplicationEvent::class, name = "application"),
+  JsonSubTypes.Type(value = ResourceEvent::class, name = "resource")
+)
 abstract class PersistentEvent {
   abstract val scope: Scope
   abstract val application: String
@@ -15,7 +27,7 @@ abstract class PersistentEvent {
   }
 
   enum class Scope {
-    RESOURCE,
-    APPLICATION
+    @JsonProperty("resource") RESOURCE,
+    @JsonProperty("application") APPLICATION
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.events
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
@@ -20,6 +21,7 @@ abstract class PersistentEvent {
   abstract val application: String
   abstract val uid: String // The unique ID of the thing associated with the scope. Defined in sub-classes.
   abstract val timestamp: Instant
+  @JsonIgnore
   open val ignoreRepeatedInHistory: Boolean = false
 
   companion object {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -201,18 +201,16 @@ data class ResourceActuationPaused(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
-  val reason: String?,
   override val timestamp: Instant
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, reason: String? = null, timestamp: Instant = clock.instant()) : this(
+  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
     resource.kind,
     resource.id,
     resource.application,
-    reason,
-    timestamp
+    clock.instant()
   )
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -55,8 +55,8 @@ import java.time.Instant
   Type(value = ResourceTaskFailed::class, name = "ResourceTaskFailed"),
   Type(value = ResourceTaskSucceeded::class, name = "ResourceTaskSucceeded")
 )
-sealed class ResourceEvent : PersistentEvent() {
-  @JsonIgnore override val scope = Scope.RESOURCE
+abstract class ResourceEvent : PersistentEvent() {
+  override val scope = Scope.RESOURCE
   abstract val kind: ResourceKind
   abstract val id: String
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
+import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceEvent
@@ -30,6 +31,7 @@ import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope
 import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope.RESOURCE
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import java.time.Clock
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -38,7 +40,8 @@ import org.springframework.stereotype.Component
 class ActuationPauser(
   val resourceRepository: ResourceRepository,
   val pausedRepository: PausedRepository,
-  val publisher: ApplicationEventPublisher
+  val publisher: ApplicationEventPublisher,
+  val clock: Clock
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -66,59 +69,55 @@ class ActuationPauser(
   fun pauseApplication(application: String) {
     log.info("Pausing application $application")
     pausedRepository.pauseApplication(application)
-    publisher.publishEvent(ApplicationActuationPaused(application))
+    publisher.publishEvent(ApplicationActuationPaused(application, "Application $application paused", clock))
   }
 
   fun resumeApplication(application: String) {
     log.info("Resuming application $application")
     pausedRepository.resumeApplication(application)
-    publisher.publishEvent(ApplicationActuationResumed(application))
-    resourceRepository.getResourcesByApplication(application)
-      .forEach {
-        // helps a user not be confused by an out of date status from before a pause
-        publisher.publishEvent(ResourceActuationResumed(it))
-      }
+    publisher.publishEvent(ApplicationActuationResumed(application, "Application $application resumed", clock))
   }
 
   fun pauseResource(id: String) {
     log.info("Pausing resource $id")
     pausedRepository.pauseResource(id)
-    publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id)))
+    publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id), null, clock.instant()))
   }
 
   fun resumeResource(id: String) {
     log.info("Resuming resource $id")
     pausedRepository.resumeResource(id)
     // helps a user not be confused by an out of date status from before a pause
-    publisher.publishEvent(ResourceActuationResumed(resourceRepository.get(id)))
+    publisher.publishEvent(ResourceActuationResumed(resourceRepository.get(id), clock))
   }
 
   fun pausedApplications(): List<String> =
     pausedRepository.getPausedApplications()
 
-  fun addSyntheticPausedEvents(originalEvents: List<ResourceEvent>, resource: Resource<*>) =
-    originalEvents.toMutableList().also { events ->
-      // For user clarity we add a pause event to the resource history for every pause event from the parent app.
-      // We do this dynamically here so that it applies to all resources in the app, even those added _after_ the
-      // application was paused.
-      val appPausedEvents = resourceRepository
-        .applicationEventHistory(resource.application, events.last().timestamp)
-        .filterIsInstance<ApplicationActuationPaused>()
+  /**
+   * Adds [ApplicationActuationPaused] and [ApplicationActuationResumed] events to the resource event history so that
+   * it reflects actuation pauses/resumes at the application level.
+   */
+  fun addApplicationActuationEvents(originalEvents: List<ResourceEvent>, resource: Resource<*>) =
+    mutableListOf<PersistentEvent>()
+      .also { events ->
+        events.addAll(originalEvents)
+        val oldestResourceEvent = events.last()
+        val relevantAppEvents = resourceRepository
+          .applicationEventHistory(resource.application, oldestResourceEvent.timestamp)
+          .filter { it is ApplicationActuationPaused || it is ApplicationActuationResumed }
 
-      appPausedEvents.forEach { appPaused ->
-        val lastBeforeAppPaused = events.firstOrNull { event ->
-          event.timestamp.isBefore(appPaused.timestamp)
-        }
+        relevantAppEvents.forEach { appEvent ->
+          val lastBeforeAppEvent = events.firstOrNull { event ->
+            event.timestamp.isBefore(appEvent.timestamp)
+          }
 
-        if (lastBeforeAppPaused == null) {
-          log.warn("Unable to find a resource event just before application paused event at ${appPaused.timestamp}")
-        } else {
-          events.add(
-            events.indexOf(lastBeforeAppPaused),
-            ResourceActuationPaused(resource, "Resource actuation paused at the application level",
-              appPaused.timestamp)
-          )
+          if (lastBeforeAppEvent == null) {
+            log.warn("Unable to find a resource event just before application event at ${appEvent.timestamp}")
+          } else {
+            events.add(events.indexOf(lastBeforeAppEvent), appEvent)
+          }
         }
+        events
       }
-    }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -111,7 +111,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
         context("management is paused for that resource") {
           before {
-            resourceRepository.appendHistory(ResourceActuationPaused(resource, "ActuationPaused"))
+            resourceRepository.appendHistory(ResourceActuationPaused(resource))
             every { actuationPauser.isPaused(resource) } returns true
             runBlocking {
               subject.checkResource(resource)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -47,7 +47,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val deltaResolvedEvent = ResourceDeltaResolved(resource)
     val dependencyMissingEvent = ResourceCheckUnresolvable(resource, object : ResourceCurrentlyUnresolvable("I guess I can't find the AMI or something") {})
     val errorEvent = ResourceCheckError(resource, InvalidResourceFormatException("bad resource", "who knows"))
-    val actuationPausedEvent = ResourceActuationPaused(resource, "whatever")
+    val actuationPausedEvent = ResourceActuationPaused(resource)
     val actuationResumedEvent = ResourceActuationResumed(resource)
     val resourceValidEvent = ResourceValid(resource)
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
@@ -31,6 +31,7 @@ import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import java.time.Clock
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expect
 import strikt.assertions.isFalse
@@ -49,7 +50,7 @@ class ActuationPauserTests : JUnit5Minutests {
     }
     val pausedRepository = InMemoryPausedRepository()
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
-    val subject = ActuationPauser(resourceRepository, pausedRepository, publisher)
+    val subject = ActuationPauser(resourceRepository, pausedRepository, publisher, Clock.systemDefaultZone())
   }
 
   fun tests() = rootContext<Fixture> {
@@ -82,7 +83,6 @@ class ActuationPauserTests : JUnit5Minutests {
           that(subject.isPaused(resource1)).isFalse()
           that(subject.isPaused(resource2)).isFalse()
         }
-        verify(exactly = 2) { publisher.publishEvent(ofType<ResourceActuationResumed>()) }
       }
 
       test("resume event is generated") {
@@ -90,7 +90,7 @@ class ActuationPauserTests : JUnit5Minutests {
         verify(exactly = 1) {
           publisher.publishEvent(ofType<ApplicationActuationResumed>())
         }
-        verify(exactly = 2) {
+        verify(exactly = 0) {
           publisher.publishEvent(ofType<ResourceActuationResumed>())
         }
       }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -840,7 +840,7 @@ class SqlArtifactRepository(
             environment = environmentName,
             version = version,
             state = promotionStatus.toLowerCase(),
-            deployedAt = deployedAt.toInstant(ZoneOffset.UTC),
+            deployedAt = deployedAt?.toInstant(ZoneOffset.UTC),
             replacedAt = replacedAt,
             replacedBy = replacedBy
           )

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
@@ -28,11 +28,10 @@ class EventController(
   fun eventHistory(
     @PathVariable("id") id: String,
     @RequestParam("limit") limit: Int?
-  ): List<ResourceEvent> {
+  ): List<PersistentEvent> {
     log.debug("Getting state history for: $id")
     val resource = repository.getResource(id)
     val events = repository.resourceEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
-
-    return actuationPauser.addSyntheticPausedEvents(events, resource)
+    return actuationPauser.addApplicationActuationEvents(events, resource)
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -213,11 +213,11 @@ class ApiDocTests : JUnit5Minutests {
           )
       }
 
-      test("does not include interim sealed classes in oneOf") {
-        at("/components/schemas/ResourceEvent/oneOf")
+      SKIP - test("does not include interim sealed classes in oneOf") {
+        at("/components/schemas/ResourceCheckResult/oneOf")
           .isArray()
           .findValuesAsText("\$ref")
-          .doesNotContain(constructRef("ResourceCheckResult"))
+          .doesNotContain(constructRef("ResourceCheckError"))
       }
 
       test("does not create schemas for interim sealed classes") {
@@ -263,7 +263,7 @@ class ApiDocTests : JUnit5Minutests {
       }
 
       test("instant properties are date-time format strings") {
-        at("/components/schemas/ResourceCreated/properties/timestamp")
+        at("/components/schemas/PersistentEvent/properties/timestamp")
           .and {
             path("type").textValue().isEqualTo("string")
             path("format").textValue().isEqualTo("date-time")

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -10,15 +10,14 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
+import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
-import com.netflix.spinnaker.keel.events.ResourceActuationPaused
-import com.netflix.spinnaker.keel.events.ResourceActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
-import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceUpdated
 import com.netflix.spinnaker.keel.events.ResourceValid
+import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
@@ -62,10 +61,13 @@ internal class EventControllerTests : JUnit5Minutests {
   lateinit var mvc: MockMvc
 
   @Autowired
+  lateinit var clock: MutableClock
+
+  @Autowired
   lateinit var resourceRepository: InMemoryResourceRepository
 
   @Autowired
-  lateinit var clock: MutableClock
+  lateinit var actuationPauser: ActuationPauser
 
   object Fixture {
     val resource: Resource<*> = resource()
@@ -129,7 +131,7 @@ internal class EventControllerTests : JUnit5Minutests {
               .andExpect(status().isOk)
               .andExpect(content().contentTypeCompatibleWith(accept))
               .andReturn()
-            expectThat(result.response.contentAs<List<ResourceEvent>>())
+            expectThat(result.response.contentAs<List<PersistentEvent>>())
               .hasSize(10)
               .map { it.javaClass }
               .containsExactly(
@@ -161,44 +163,96 @@ internal class EventControllerTests : JUnit5Minutests {
           .isArray()
           .hasSize(limit)
       }
+    }
 
-      context("with application paused at various times") {
-        before {
-          with(resourceRepository) {
-            dropAll()
-            store(resource)
-            appendHistory(ResourceCreated(resource, clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ResourceValid(resource, clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ApplicationActuationPaused(resource.application, "Application paused", clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ApplicationActuationResumed(resource.application, "Application resumed", clock))
-            // ActuationPauser.resumeApplication generates ResourceActuationResumed events for all child resources
-            appendHistory(ResourceActuationResumed(resource, clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ResourceValid(resource, clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ApplicationActuationPaused(resource.application, "Application paused", clock))
-          }
+    context("with application paused at various times") {
+      before {
+        with(resourceRepository) {
+          dropAll()
+          store(resource)
+          appendHistory(ResourceCreated(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          appendHistory(ResourceValid(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.pauseApplication(resource.application)
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.resumeApplication(resource.application)
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.pauseApplication(resource.application)
         }
+      }
 
-        test("has matching resource paused event injected in the right position") {
-          val request = get(eventsUri).accept(APPLICATION_YAML)
-          val result = mvc
-            .perform(request)
-            .andReturn()
-          expectThat(result.response.contentAs<List<ResourceEvent>>())
-            .map { it.javaClass }
-            .containsExactly(
-              ResourceActuationPaused::class.java,
-              ResourceValid::class.java,
-              ResourceActuationResumed::class.java,
-              ResourceActuationPaused::class.java,
-              ResourceValid::class.java,
-              ResourceCreated::class.java
-            )
+      test("has application paused and resumed events injected in the right positions") {
+        val request = get(eventsUri).accept(APPLICATION_YAML)
+        val result = mvc
+          .perform(request)
+          .andReturn()
+        expectThat(result.response.contentAs<List<PersistentEvent>>())
+          .map { it.javaClass }
+          .containsExactly(
+            ApplicationActuationPaused::class.java,
+            ApplicationActuationResumed::class.java,
+            ApplicationActuationPaused::class.java,
+            ResourceValid::class.java,
+            ResourceCreated::class.java
+          )
+      }
+    }
+
+    context("with a new resource created AFTER the application is paused") {
+      before {
+        with(resourceRepository) {
+          dropAll()
+          actuationPauser.pauseApplication(resource.application)
+          clock.incrementBy(TEN_MINUTES)
+          store(resource)
+          appendHistory(ResourceCreated(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.resumeApplication(resource.application)
         }
+      }
+
+      test("has application resumed event injected in the right position") {
+        val request = get(eventsUri).accept(APPLICATION_YAML)
+        val result = mvc
+          .perform(request)
+          .andReturn()
+        expectThat(result.response.contentAs<List<PersistentEvent>>())
+          .map { it.javaClass }
+          .containsExactly(
+            ApplicationActuationResumed::class.java,
+            ResourceCreated::class.java
+          )
+      }
+    }
+
+    context("with application pauses BEFORE and AFTER a new resource is created") {
+      before {
+        with(resourceRepository) {
+          dropAll()
+          actuationPauser.pauseApplication(resource.application)
+          clock.incrementBy(TEN_MINUTES)
+          store(resource)
+          appendHistory(ResourceCreated(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.resumeApplication(resource.application)
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.pauseApplication(resource.application)
+        }
+      }
+
+      test("has matching resource paused events injected in the right positions") {
+        val request = get(eventsUri).accept(APPLICATION_YAML)
+        val result = mvc
+          .perform(request)
+          .andReturn()
+        expectThat(result.response.contentAs<List<PersistentEvent>>())
+          .map { it.javaClass }
+          .containsExactly(
+            ApplicationActuationPaused::class.java,
+            ApplicationActuationResumed::class.java,
+            ResourceCreated::class.java
+          )
       }
     }
   }


### PR DESCRIPTION
This is an alternative take on #842 and #853. Instead of injecting synthetic resource events in the history, we inject the original application-level paused/resumed events as appropriate.

Sample API response:
```yaml
- type: "ApplicationActuationPaused"
  application: "fnord"
  reason: "Application fnord paused"
  timestamp: "2020-03-11T06:27:03.453Z"
  scope: "application"
  uid: "fnord"
- type: "ApplicationActuationResumed"
  application: "fnord"
  reason: "Application fnord resumed"
  timestamp: "2020-03-11T06:17:03.453Z"
  scope: "application"
  uid: "fnord"
- type: "ApplicationActuationPaused"
  application: "fnord"
  reason: "Application fnord paused"
  timestamp: "2020-03-11T06:07:03.453Z"
  scope: "application"
  uid: "fnord"
- type: "ResourceValid"
  kind: "test/whatever@v1"
  id: "test:whatever:33323037"
  application: "fnord"
  timestamp: "2020-03-11T05:57:03.453Z"
  scope: "resource"
  uid: "test:whatever:33323037"
- type: "ResourceCreated"
  kind: "test/whatever@v1"
  id: "test:whatever:33323037"
  application: "fnord"
  timestamp: "2020-03-11T05:47:03.453Z"
  ignoreRepeatedInHistory: false
  scope: "resource"
  uid: "test:whatever:33323037"
```