### PR TITLE
fix(export): Fix export API to handle new kind format

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
@@ -16,12 +16,11 @@ data class ResourceKind(
   }
 
   companion object {
-    const val DEFAULT_API_VERSION = "v1"
-    val RESOURCE_KIND_FORMAT = Regex("""([\w.-]+)/([\w.-]+)@v(.+)""")
+    private val resourceKindFormat = Regex("""([\w.-]+)/([\w.-]+)@v(.+)""")
 
     @JvmStatic
     fun parseKind(value: String): ResourceKind =
-      RESOURCE_KIND_FORMAT
+      resourceKindFormat
         .matchEntire(value)
         ?.destructured
         ?.let { (group, kind, version) -> ResourceKind(group, kind, version) }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceKind.kt
@@ -16,11 +16,12 @@ data class ResourceKind(
   }
 
   companion object {
-    private val resourceKindFormat = Regex("""([\w.-]+)/([\w.-]+)@v(.+)""")
+    const val DEFAULT_API_VERSION = "v1"
+    val RESOURCE_KIND_FORMAT = Regex("""([\w.-]+)/([\w.-]+)@v(.+)""")
 
     @JvmStatic
     fun parseKind(value: String): ResourceKind =
-      resourceKindFormat
+      RESOURCE_KIND_FORMAT
         .matchEntire(value)
         ?.destructured
         ?.let { (group, kind, version) -> ResourceKind(group, kind, version) }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -150,7 +150,7 @@ data class SupportedKind<SPEC : ResourceSpec>(
 )
 
 /**
- * Searches a list of `ResourceHandler`s and returns the first that supports [kind].
+ * Searches a list of []ResourceHandler]s and returns the first that supports [kind].
  *
  * @throws UnsupportedKind if no appropriate handlers are found in the list.
  */
@@ -159,10 +159,27 @@ fun Collection<ResourceHandler<*, *>>.supporting(
 ): ResourceHandler<*, *> =
   find { it.supportedKind.kind == kind } ?: throw UnsupportedKind(kind)
 
+/**
+ * Searches a list of [ResourceHandler]s and returns the ones that support the specified [group] and [unqualifiedKind].
+ *
+ * @throws UnsupportedKind if no appropriate handlers are found in the list.
+ */
+fun Collection<ResourceHandler<*, *>>.supporting(
+  group: String,
+  unqualifiedKind: String
+): List<ResourceHandler<*, *>> =
+  filter { it.supportedKind.kind.group == group && it.supportedKind.kind.kind == unqualifiedKind }
+    ?: throw UnsupportedKind("$group/$unqualifiedKind")
+
+/**
+ * Searches a list of [ResourceHandler] and returns the ones that support the specified [specClass].
+ */
 fun <T : ResourceSpec> Collection<ResourceHandler<*, *>>.supporting(
   specClass: Class<T>
 ): ResourceHandler<*, *>? =
   find { it.supportedKind.specClass == specClass }
 
-class UnsupportedKind(kind: ResourceKind) :
-  IllegalStateException("No resource handler supporting \"$kind\" is available")
+class UnsupportedKind(kind: String) :
+  IllegalStateException("No resource handler supporting \"$kind\" is available") {
+  constructor(kind: ResourceKind) : this(kind.toString())
+}

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -150,7 +150,7 @@ data class SupportedKind<SPEC : ResourceSpec>(
 )
 
 /**
- * Searches a list of []ResourceHandler]s and returns the first that supports [kind].
+ * Searches a list of [ResourceHandler]s and returns the first that supports [kind].
  *
  * @throws UnsupportedKind if no appropriate handlers are found in the list.
  */

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
-import com.netflix.spinnaker.keel.test.TEST_API
+import com.netflix.spinnaker.keel.test.TEST_API_V1
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -224,7 +224,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
       context("resource lifecycle") {
         val resource = SubmittedResource(
           metadata = mapOf("serviceAccount" to "keel@spinnaker"),
-          kind = TEST_API.qualify("whatever"),
+          kind = TEST_API_V1.qualify("whatever"),
           spec = DummyResourceSpec(data = "o hai")
         ).normalize()
 
@@ -317,7 +317,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
               name = "test",
               resources = setOf(
                 SubmittedResource(
-                  kind = TEST_API.qualify("whatever"),
+                  kind = TEST_API_V1.qualify("whatever"),
                   spec = DummyResourceSpec("test", "im a twin", "keel")
                 )
               ),
@@ -327,7 +327,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
               name = "prod",
               resources = setOf(
                 SubmittedResource(
-                  kind = TEST_API.qualify("whatever"),
+                  kind = TEST_API_V1.qualify("whatever"),
                   spec = DummyResourceSpec("test", "im a twin", "keel")
                 )
               ),
@@ -363,7 +363,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
               resources = setOf(
                 SubmittedResource(
                   metadata = mapOf("serviceAccount" to "keel@spinnaker"),
-                  kind = TEST_API.qualify("whatever"),
+                  kind = TEST_API_V1.qualify("whatever"),
                   spec = DummyResourceSpec(data = "o hai")
                 )
               ),

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/DummyResourceTypeIdentifier.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/DummyResourceTypeIdentifier.kt
@@ -5,12 +5,12 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.test.DummyLocatableResourceSpec
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
-import com.netflix.spinnaker.keel.test.TEST_API
+import com.netflix.spinnaker.keel.test.TEST_API_V1
 
 internal object DummyResourceTypeIdentifier : ResourceTypeIdentifier {
   override fun identify(kind: ResourceKind): Class<out ResourceSpec> {
     return when (kind) {
-      TEST_API.qualify("locatable") -> DummyLocatableResourceSpec::class.java
+      TEST_API_V1.qualify("locatable") -> DummyLocatableResourceSpec::class.java
       else -> DummyResourceSpec::class.java
     }
   }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
-import com.netflix.spinnaker.keel.test.DummyResourceHandler
+import com.netflix.spinnaker.keel.test.DummyResourceHandlerV1
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import com.ninjasquad.springmockk.SpykBean
@@ -183,5 +183,5 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
 @Configuration
 internal class TestConfiguration {
   @Bean
-  fun dummyResourceHandler() = DummyResourceHandler
+  fun dummyResourceHandler() = DummyResourceHandlerV1
 }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -20,10 +20,11 @@ import de.danielbechler.diff.introspection.ObjectDiffProperty
 import java.time.Duration
 import java.util.UUID
 
-val TEST_API = ApiVersion("test")
+val TEST_API_V1 = ApiVersion("test", "1")
+val TEST_API_V2 = ApiVersion("test", "2")
 
 fun resource(
-  kind: ResourceKind = TEST_API.qualify("whatever"),
+  kind: ResourceKind = TEST_API_V1.qualify("whatever"),
   id: String = randomString(),
   application: String = "fnord"
 ): Resource<DummyResourceSpec> =
@@ -38,7 +39,7 @@ fun resource(
     }
 
 fun artifactVersionedResource(
-  kind: ResourceKind = TEST_API.qualify("whatever"),
+  kind: ResourceKind = TEST_API_V1.qualify("whatever"),
   id: String = randomString(),
   application: String = "fnord"
 ): Resource<DummyArtifactVersionedResourceSpec> =
@@ -53,7 +54,7 @@ fun artifactVersionedResource(
     }
 
 fun submittedResource(
-  kind: ResourceKind = TEST_API.qualify("whatever"),
+  kind: ResourceKind = TEST_API_V1.qualify("whatever"),
   application: String = "fnord"
 ): SubmittedResource<DummyResourceSpec> =
   DummyResourceSpec(application = application)
@@ -65,7 +66,7 @@ fun submittedResource(
     }
 
 fun locatableResource(
-  kind: ResourceKind = TEST_API.qualify("locatable"),
+  kind: ResourceKind = TEST_API_V1.qualify("locatable"),
   id: String = randomString(),
   application: String = "fnord",
   locations: SimpleLocations = SimpleLocations(
@@ -85,7 +86,7 @@ fun locatableResource(
     }
 
 fun <T : Monikered> resource(
-  kind: ResourceKind = TEST_API.qualify("whatever"),
+  kind: ResourceKind = TEST_API_V1.qualify("whatever"),
   spec: T
 ): Resource<T> = resource(
   kind = kind,
@@ -95,7 +96,7 @@ fun <T : Monikered> resource(
 )
 
 fun <T : ResourceSpec> resource(
-  kind: ResourceKind = TEST_API.qualify("whatever"),
+  kind: ResourceKind = TEST_API_V1.qualify("whatever"),
   spec: T,
   id: String = spec.id,
   application: String = "fnord"
@@ -111,7 +112,7 @@ fun <T : ResourceSpec> resource(
   )
 
 fun <T : ResourceSpec> submittedResource(
-  kind: ResourceKind = TEST_API.qualify("whatever"),
+  kind: ResourceKind = TEST_API_V1.qualify("whatever"),
   spec: T
 ): SubmittedResource<T> =
   SubmittedResource(
@@ -176,9 +177,18 @@ fun randomString(length: Int = 8) =
     .joinToString("")
     .substring(0 until length)
 
-object DummyResourceHandler : SimpleResourceHandler<DummyResourceSpec>(emptyList()) {
+object DummyResourceHandlerV1 : SimpleResourceHandler<DummyResourceSpec>(emptyList()) {
   override val supportedKind =
-    SupportedKind(TEST_API.qualify("whatever"), DummyResourceSpec::class.java)
+    SupportedKind(TEST_API_V1.qualify("whatever"), DummyResourceSpec::class.java)
+
+  override suspend fun current(resource: Resource<DummyResourceSpec>): DummyResourceSpec? {
+    TODO("not implemented")
+  }
+}
+
+object DummyResourceHandlerV2 : SimpleResourceHandler<DummyResourceSpec>(emptyList()) {
+  override val supportedKind =
+    SupportedKind(TEST_API_V2.qualify("whatever"), DummyResourceSpec::class.java)
 
   override suspend fun current(resource: Resource<DummyResourceSpec>): DummyResourceSpec? {
     TODO("not implemented")

--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
   implementation("net.logstash.logback:logstash-logback-encoder")
   implementation("org.springdoc:springdoc-openapi-webmvc-core:1.2.32")
   implementation("org.springdoc:springdoc-openapi-kotlin:1.2.32")
+  implementation("org.apache.maven:maven-artifact:3.6.3")
 
   testImplementation("io.strikt:strikt-jackson")
   testImplementation(project(":keel-test"))

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.Exportable
+import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.supporting
@@ -10,8 +11,10 @@ import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
+import org.springframework.util.comparator.NullSafeComparator
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
@@ -66,11 +69,27 @@ class ExportController(
     @PathVariable("name") name: String,
     @RequestHeader("X-SPINNAKER-USER") user: String
   ): SubmittedResource<*> {
-    val provider = cloudProviderOverrides[cloudProvider] ?: cloudProvider
-    val kind = typeToKind.getOrDefault(type.toLowerCase(), type.toLowerCase()).let(::parseKind)
+    val group = cloudProviderOverrides[cloudProvider] ?: cloudProvider
+
+    val kind = type.toLowerCase().let { t ->
+      // Detect whether the type provided is fully-qualified
+      if (ResourceKind.RESOURCE_KIND_FORMAT.matches(t)) {
+        t
+      } else {
+        // If not, look up the latest supported version based on the group and kind, or use the default if none found
+        val normalizedType = typeToKind.getOrDefault(t, t)
+        val latestVersion = handlers
+          .supporting(group, normalizedType)
+          .map { h -> h.supportedKind.kind.version }
+          .sortedWith(versionComparator)
+          .last()
+        "$group/$normalizedType@v$latestVersion"
+      }
+    }.let(::parseKind)
+
     val handler = handlers.supporting(kind)
     val exportable = Exportable(
-      cloudProvider = provider,
+      cloudProvider = group,
       account = account,
       user = user,
       moniker = parseMoniker(name),
@@ -93,5 +112,17 @@ class ExportController(
         )
       }
     }
+  }
+
+  companion object {
+    private val versionPrefix = """^v""".toRegex()
+    val versionComparator: Comparator<String> = NullSafeComparator<String>(
+      Comparator<String> { s1, s2 ->
+        DefaultArtifactVersion(s1?.replace(versionPrefix, "")).compareTo(
+          DefaultArtifactVersion(s2?.replace(versionPrefix, ""))
+        )
+      },
+      true // null is considered lower
+    )
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -18,7 +18,7 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
-import com.netflix.spinnaker.keel.test.TEST_API
+import com.netflix.spinnaker.keel.test.TEST_API_V1
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -88,14 +88,14 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
               SubmittedEnvironment(
                 name = "test",
                 resources = setOf(SubmittedResource(
-                  kind = TEST_API.qualify("whatever"),
+                  kind = TEST_API_V1.qualify("whatever"),
                   spec = DummyResourceSpec(data = "resource in test")
                 ))
               ),
               SubmittedEnvironment(
                 name = "prod",
                 resources = setOf(SubmittedResource(
-                  kind = TEST_API.qualify("whatever"),
+                  kind = TEST_API_V1.qualify("whatever"),
                   spec = DummyResourceSpec(data = "resource in prod")
                 )),
                 constraints = setOf(DependsOnConstraint("test"))

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DummyResourceConfiguration.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DummyResourceConfiguration.kt
@@ -1,9 +1,9 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.netflix.spinnaker.keel.test.DummyResourceHandler
+import com.netflix.spinnaker.keel.test.DummyResourceHandlerV1
 import org.springframework.context.annotation.Bean
 
 internal class DummyResourceConfiguration {
   @Bean
-  fun dummyResourceHandler() = DummyResourceHandler
+  fun dummyResourceHandler() = DummyResourceHandlerV1
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandlerTests.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.jsontype.NamedType
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
-import com.netflix.spinnaker.keel.test.DummyResourceHandler
+import com.netflix.spinnaker.keel.test.DummyResourceHandlerV1
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
-import com.netflix.spinnaker.keel.test.TEST_API
+import com.netflix.spinnaker.keel.test.TEST_API_V1
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expect
@@ -18,10 +18,10 @@ class ExceptionHandlerTests : JUnit5Minutests {
   class Fixture(
     brokenYaml: String
   ) {
-    val subject = ExceptionHandler(listOf(DummyResourceHandler))
+    val subject = ExceptionHandler(listOf(DummyResourceHandlerV1))
     val mapper = configuredYamlMapper()
     val parseException = try {
-        mapper.registerSubtypes(NamedType(DummyResourceSpec::class.java, TEST_API.qualify("whatever").toString()))
+        mapper.registerSubtypes(NamedType(DummyResourceSpec::class.java, TEST_API_V1.qualify("whatever").toString()))
         mapper.readValue(brokenYaml, SubmittedDeliveryConfig::class.java)
         throw IllegalArgumentException("test is broken")
       } catch (e: JsonMappingException) {
@@ -46,7 +46,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               constraints: []
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec: {}
           """.trimIndent()
         )
@@ -79,7 +79,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               constraints: []
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec: {}
           """.trimIndent()
         )
@@ -111,7 +111,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
             - constraints: []
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec: {}
           """.trimIndent()
         )
@@ -144,7 +144,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               constraints: true # wrong
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec: {}
           """.trimIndent()
         )
@@ -178,7 +178,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               notifications: []
               resources:
               - spec: {}
-                # kind: "${TEST_API.qualify("whatever")}"
+                # kind: "${TEST_API_V1.qualify("whatever")}"
           """.trimIndent()
         )
       }
@@ -210,7 +210,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               constraints: []
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec:
                   intData: "wrong"
           """.trimIndent()
@@ -244,7 +244,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               constraints: []
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec:
                   timeData: "wrong"
           """.trimIndent()
@@ -278,7 +278,7 @@ class ExceptionHandlerTests : JUnit5Minutests {
               constraints: []
               notifications: []
               resources:
-              - kind: "${TEST_API.qualify("whatever")}"
+              - kind: "${TEST_API_V1.qualify("whatever")}"
                 spec:
                   enumData: "wrong"
           """.trimIndent()

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExportControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ExportControllerTests.kt
@@ -1,0 +1,37 @@
+package com.netflix.spinnaker.keel.rest
+
+import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.test.DummyResourceHandlerV1
+import com.netflix.spinnaker.keel.test.DummyResourceHandlerV2
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+internal class ExportControllerTests : JUnit5Minutests {
+  class Fixture {
+    val subject = ExportController(
+      handlers = listOf(DummyResourceHandlerV1, DummyResourceHandlerV2),
+      cloudDriverCache = mockk(relaxed = true)
+    )
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("parsing a resource kind from the cloud provider (group) and type (unqualified kind)") {
+      test("returns the kind of the latest supported version") {
+        expectThat(subject.parseKind("test", "whatever"))
+          .isEqualTo(ResourceKind("test", "whatever", "2"))
+      }
+    }
+
+    context("parsing a resource from the type with a version included") {
+      test("returns the kind with the specified version") {
+        expectThat(subject.parseKind("test", "whatever@v1"))
+          .isEqualTo(ResourceKind("test", "whatever", "1"))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes the export API in a backwards-compatible manner with the old resource kind format. Introduces new behavior in terms of looking up the correct handler by defaulting to the one that supports the latest version for the specified group and kind.