### PR TITLE
fix(veto): fix Value annotation syntax

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -45,8 +45,8 @@ class UnhappyVeto(
   private val unhappyVetoRepository: UnhappyVetoRepository,
   private val dynamicConfigService: DynamicConfigService,
 
-  @Value("\${veto.unhappy.waiting-time:PT10M}") // tests fail if default not specified here
-  private val configuredWaitingTime: String = "PT10M"
+  @Value("\${veto.unhappy.waiting-time:PT10M}")
+  private val configuredWaitingTime: String
 ) : Veto {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -44,7 +44,6 @@ class UnhappyVeto(
   private val diffFingerprintRepository: DiffFingerprintRepository,
   private val unhappyVetoRepository: UnhappyVetoRepository,
   private val dynamicConfigService: DynamicConfigService,
-
   @Value("\${veto.unhappy.waiting-time:PT10M}")
   private val configuredWaitingTime: String
 ) : Veto {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -44,7 +44,8 @@ class UnhappyVeto(
   private val diffFingerprintRepository: DiffFingerprintRepository,
   private val unhappyVetoRepository: UnhappyVetoRepository,
   private val dynamicConfigService: DynamicConfigService,
-  @Value("veto.unhappy.waiting-time")
+
+  @Value("\${veto.unhappy.waiting-time:PT10M}") // tests fail if default not specified here
   private val configuredWaitingTime: String = "PT10M"
 ) : Veto {
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/veto/UnhappyVetoTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/veto/UnhappyVetoTests.kt
@@ -54,7 +54,7 @@ class UnhappyVetoTests : JUnit5Minutests {
         getConfig(String::class.java, "veto.unhappy.waiting-time", any())
       } returns "PT10M"
     }
-    val subject = UnhappyVeto(resourceRepository, diffFingerprintRepository, unhappyRepository, dynamicConfigService)
+    val subject = UnhappyVeto(resourceRepository, diffFingerprintRepository, unhappyRepository, dynamicConfigService, "PT10M")
   }
 
   fun tests() = rootContext<Fixture> {


### PR DESCRIPTION
Add missing syntax for variable substitution

Fixes an issue in #866. This is work to address #894