### PR TITLE
fix(titus): throw correct exception if no digest is found

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusImageResolver.kt
@@ -75,7 +75,7 @@ class TitusImageResolver(
     runBlocking {
       val repository = "$organization/$image"
       val images = cloudDriverService.findDockerImages(account, repository, tag)
-      images.first().digest
+      images.firstOrNull()?.digest
         ?: throw NoDigestFound(repository, tag) // sha should be the same in all accounts for titus
     }
 


### PR DESCRIPTION
For titus clusters seeing this error:

```
com.netflix.spinnaker.keel.plugin.CannotResolveDesiredState: Unable to resolve desired state of titus:cluster:titustestvpc:emburnstest-mmmwaffles-testing due to: List is empty
...
Caused by: java.util.NoSuchElementException: List is empty.
```

This is caused when we try to access the first item of an empty list. Fixing the handling here so that the `NoDigestFound` exception actually gets thrown.