### PR TITLE
chore(tests): trying to stop flakey delivery config test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-_**IMPORTANT:** This service is currently under development and is not ready for production._
+_**IMPORTANT:** This service is currently under development and is not ready for production use._
+
 
 ---
 # High Level Project Overview

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -62,10 +62,12 @@ class ArtifactListener(
       }
   }
 
+  /**
+   * Fetch latest version of an artifact after it is registered.
+   */
   @EventListener(ArtifactRegisteredEvent::class)
   fun onArtifactRegisteredEvent(event: ArtifactRegisteredEvent) {
     val artifact = event.artifact
-    artifactRepository.register(artifact)
 
     if (artifactRepository.versions(artifact).isEmpty()) {
       when (artifact) {

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/resource/ImageHandler.kt
@@ -80,6 +80,7 @@ class ImageHandler(
       log.debug("Latest known version of $name = null")
       if (!artifactRepository.isRegistered(name, type)) {
         // we clearly care about this artifact, let's register it.
+        artifactRepository.register(this)
         publisher.publishEvent(ArtifactRegisteredEvent(this))
       }
     }
@@ -117,37 +118,37 @@ class ImageHandler(
       "reference" to artifactRef,
       "metadata" to emptyMap<String, Any>(),
       "provenance" to "n/a"
-      )
+    )
 
     log.info("baking new image for {}", resource.spec.artifactName)
     val description = "Bake ${resourceDiff.desired.appVersion}"
 
     try {
       val taskRef = taskLauncher.submitJob(
-      user = resource.serviceAccount,
-      application = resource.application,
-      notifications = emptySet(),
-      subject = description,
-      description = description,
-      correlationId = resource.id,
-      stages = listOf(
-        Job(
-          "bake",
-          mapOf(
-            "amiSuffix" to "",
-            "baseOs" to resource.spec.baseOs,
-            "baseLabel" to resource.spec.baseLabel.name.toLowerCase(),
-            "cloudProviderType" to "aws",
-            "package" to artifactRef.substringAfterLast("/"),
-            "regions" to resource.spec.regions,
-            "storeType" to resource.spec.storeType.name.toLowerCase(),
-            "user" to "keel",
-            "vmType" to "hvm"
+        user = resource.serviceAccount,
+        application = resource.application,
+        notifications = emptySet(),
+        subject = description,
+        description = description,
+        correlationId = resource.id,
+        stages = listOf(
+          Job(
+            "bake",
+            mapOf(
+              "amiSuffix" to "",
+              "baseOs" to resource.spec.baseOs,
+              "baseLabel" to resource.spec.baseLabel.name.toLowerCase(),
+              "cloudProviderType" to "aws",
+              "package" to artifactRef.substringAfterLast("/"),
+              "regions" to resource.spec.regions,
+              "storeType" to resource.spec.storeType.name.toLowerCase(),
+              "user" to "keel",
+              "vmType" to "hvm"
+            )
           )
-        )
-      ),
-      artifacts = listOf(artifact)
-    )
+        ),
+        artifacts = listOf(artifact)
+      )
       return listOf(Task(id = taskRef.id, name = description))
     } catch (e: Exception) {
       log.error("Error launching orca bake for: ${description.toLowerCase()}")

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -58,6 +58,7 @@ class ArtifactController(
   )
   @ResponseStatus(ACCEPTED)
   fun register(@RequestBody artifact: DeliveryArtifact) {
+    repository.register(artifact)
     publisher.publishEvent(ArtifactRegisteredEvent(artifact))
   }
 


### PR DESCRIPTION
I made a small change so that the artifact registration event doesn't cause a double artifact registration. I think that was the problem with the flakey delivery config transactionality test - sometimes, the artifact would get registered, then rolled back, then registered again. 

Since i haven't seen the test failure after I made that change I'm going to hope that was the problem, merge this in, and keep monitoring it.