### PR TITLE
feat(summary): giving artifact versions a display name and metadata

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -1,5 +1,10 @@
 package com.netflix.spinnaker.keel.api.artifacts
 
+import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
+import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_JOB
+import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_SEMVER
+import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
+
 enum class ArtifactType {
   deb, docker
 }
@@ -31,9 +36,17 @@ data class DockerArtifact(
   override val name: String,
   override val deliveryConfigName: String? = null,
   override val reference: String = name,
-  val tagVersionStrategy: TagVersionStrategy = TagVersionStrategy.SEMVER_TAG,
+  val tagVersionStrategy: TagVersionStrategy = SEMVER_TAG,
   val captureGroupRegex: String? = null,
   override val versioningStrategy: VersioningStrategy = DockerVersioningStrategy(tagVersionStrategy, captureGroupRegex)
 ) : DeliveryArtifact() {
   override val type = ArtifactType.docker
+
+  fun hasBuild(): Boolean {
+    return tagVersionStrategy in listOf(BRANCH_JOB_COMMIT_BY_JOB, SEMVER_JOB_COMMIT_BY_JOB, SEMVER_JOB_COMMIT_BY_SEMVER)
+  }
+
+  fun hasCommit(): Boolean {
+    return tagVersionStrategy in listOf(BRANCH_JOB_COMMIT_BY_JOB, SEMVER_JOB_COMMIT_BY_JOB, SEMVER_JOB_COMMIT_BY_SEMVER)
+  }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.keel.core.api
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import java.time.Instant
@@ -14,9 +16,29 @@ data class ArtifactSummary(
   val versions: Set<ArtifactVersionSummary> = emptySet()
 )
 
+@JsonInclude(Include.NON_NULL)
 data class ArtifactVersionSummary(
   val version: String,
-  val environments: Set<ArtifactSummaryInEnvironment>
+  val displayName: String,
+  val environments: Set<ArtifactSummaryInEnvironment>,
+  val build: BuildMetadata? = null,
+  val git: GitMetadata? = null
+)
+
+/**
+ * todo eb: other information should go here, like a link to the jenkins build. But that needs to be done
+ * in a scalable way. For now, this is just a minimal container for information we can parse from the version.
+ */
+data class BuildMetadata(
+  val id: Int
+)
+
+/**
+ * todo eb: other information should go here, like a link to the commit. But that needs to be done
+ * in a scalable way. For now, this is just a minimal container for information we can parse from the version.
+ */
+data class GitMetadata(
+  val commit: String
 )
 
 data class ArtifactSummaryInEnvironment(

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -171,17 +171,17 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         deliveryConfig.environments.flatMap { it.resources }.forEach { resource ->
           resourceRepository.appendHistory(ResourceValid(resource))
         }
-        artifactRepository.store(artifact, "1.0.0", ArtifactStatus.RELEASE)
-        artifactRepository.store(artifact, "1.0.1", ArtifactStatus.RELEASE)
-        artifactRepository.store(artifact, "1.0.2", ArtifactStatus.RELEASE)
-        artifactRepository.store(artifact, "1.0.3", ArtifactStatus.RELEASE)
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.0", "test")
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.0", "staging")
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.0", "production")
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.1", "test")
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.1", "staging")
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "1.0.2", "test")
-        artifactRepository.approveVersionFor(deliveryConfig, artifact, "1.0.3", "test")
+        artifactRepository.store(artifact, "fnord-1.0.0-h0.2add2c9", ArtifactStatus.RELEASE)
+        artifactRepository.store(artifact, "fnord-1.0.1-h1.2add2c9", ArtifactStatus.RELEASE)
+        artifactRepository.store(artifact, "fnord-1.0.2-h2.2add2c9", ArtifactStatus.RELEASE)
+        artifactRepository.store(artifact, "fnord-1.0.3-h3.2add2c9", ArtifactStatus.RELEASE)
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.2add2c9", "test")
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.2add2c9", "staging")
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.2add2c9", "production")
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.1-h1.2add2c9", "test")
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.1-h1.2add2c9", "staging")
+        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.2-h2.2add2c9", "test")
+        artifactRepository.approveVersionFor(deliveryConfig, artifact, "fnord-1.0.3-h3.2add2c9", "test")
       }
 
       test("can get basic summary by application") {
@@ -348,13 +348,13 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                 statuses:
                 - "RELEASE"
                 versions:
-                  current: "1.0.2"
+                  current: "fnord-1.0.2-h2.2add2c9"
                   pending: []
                   approved:
-                  - "1.0.3"
+                  - "fnord-1.0.3-h3.2add2c9"
                   previous:
-                  - "1.0.0"
-                  - "1.0.1"
+                  - "fnord-1.0.0-h0.2add2c9"
+                  - "fnord-1.0.1-h1.2add2c9"
                   vetoed: []
               name: "test"
               resources:
@@ -366,13 +366,13 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                 statuses:
                 - "RELEASE"
                 versions:
-                  current: "1.0.1"
+                  current: "fnord-1.0.1-h1.2add2c9"
                   pending:
-                  - "1.0.2"
-                  - "1.0.3"
+                  - "fnord-1.0.2-h2.2add2c9"
+                  - "fnord-1.0.3-h3.2add2c9"
                   approved: []
                   previous:
-                  - "1.0.0"
+                  - "fnord-1.0.0-h0.2add2c9"
                   vetoed: []
               name: "staging"
               resources:
@@ -384,11 +384,11 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                 statuses:
                 - "RELEASE"
                 versions:
-                  current: "1.0.0"
+                  current: "fnord-1.0.0-h0.2add2c9"
                   pending:
-                  - "1.0.1"
-                  - "1.0.2"
-                  - "1.0.3"
+                  - "fnord-1.0.1-h1.2add2c9"
+                  - "fnord-1.0.2-h2.2add2c9"
+                  - "fnord-1.0.3-h3.2add2c9"
                   approved: []
                   previous: []
                   vetoed: []
@@ -416,31 +416,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             - name: "fnord"
               type: "deb"
               versions:
-              - version: "1.0.0"
-                environments:
-                - name: "test"
-                  state: "previous"
-                - name: "staging"
-                  state: "previous"
-                - name: "production"
-                  state: "current"
-              - version: "1.0.1"
-                environments:
-                - name: "test"
-                  state: "previous"
-                - name: "staging"
-                  state: "current"
-                - name: "production"
-                  state: "pending"
-              - version: "1.0.2"
-                environments:
-                - name: "test"
-                  state: "current"
-                - name: "staging"
-                  state: "pending"
-                - name: "production"
-                  state: "pending"
-              - version: "1.0.3"
+              - version: "fnord-1.0.3-h3.2add2c9"
+                displayName: "1.0.3"
                 environments:
                 - name: "test"
                   state: "approved"
@@ -448,6 +425,49 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                   state: "pending"
                 - name: "production"
                   state: "pending"
+                build:
+                  id: 3
+                git:
+                  commit: "2add2c9"
+              - version: "fnord-1.0.2-h2.2add2c9"
+                displayName: "1.0.2"
+                environments:
+                - name: "test"
+                  state: "current"
+                - name: "staging"
+                  state: "pending"
+                - name: "production"
+                  state: "pending"
+                build:
+                  id: 2
+                git:
+                  commit: "2add2c9"
+              - version: "fnord-1.0.1-h1.2add2c9"
+                displayName: "1.0.1"
+                environments:
+                - name: "test"
+                  state: "previous"
+                - name: "staging"
+                  state: "current"
+                - name: "production"
+                  state: "pending"
+                build:
+                  id: 1
+                git:
+                  commit: "2add2c9"
+              - version: "fnord-1.0.0-h0.2add2c9"
+                displayName: "1.0.0"
+                environments:
+                - name: "test"
+                  state: "previous"
+                - name: "staging"
+                  state: "previous"
+                - name: "production"
+                  state: "current"
+                build:
+                  id: 0
+                git:
+                  commit: "2add2c9"
             """.trimIndent()
           ))
       }


### PR DESCRIPTION
closes https://github.com/spinnaker/keel/issues/887.

Adding some info to artifact versions so the UI has great data to display. Fallback is to not display any metadata if it doesn't exist.

Right now I'm parsing things from the version string which is brittle but okay for Netflix and this stage. In the future we will want a sustainable strategy for pulling info from stash/jenkins/git/etc and maybe storing it somewhere. We will need a refactor for that. 

Refactored the tests to have an actual app version so that we test the debian parsing with frigga.

In a future PR I'll look at also adding some docker tests.

Looks like: (leaving the list of environments empty here to make the example smaller)

```yaml
---
artifacts:
- name: emburns/spin-titus-demo
  type: docker
  versions:
  - version: master-h7.d6760b2
    displayName: master-h7.d6760b2
    environments: []
    build:
      id: 7
    git:
      commit: d6760b2
- name: deb-sample-app-server
  type: deb
  versions:
  - version: deb-sample-app-server-0.115.0-h345.2add2c9
    displayName: 0.115.0
    environments: []
    build:
      id: 345
    git:
      commit: 2add2c9
```