### PR TITLE
Convert all clocks to UTC

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -88,7 +88,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
     val resourceRepositoryProvider: () -> R,
     val artifactRepositoryProvider: () -> A
   ) {
-    private val clock: Clock = Clock.systemDefaultZone()
+    private val clock: Clock = Clock.systemUTC()
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
 
     val resourceTypeIdentifier: ResourceTypeIdentifier =

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
@@ -1,13 +1,14 @@
 package com.netflix.spinnaker.time
 
 import java.time.Clock
+import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.TemporalAmount
 
 class MutableClock(
   private var instant: Instant = Instant.now(),
-  private val zone: ZoneId = ZoneId.systemDefault()
+  private val zone: ZoneId = ZoneId.of("UTC")
 ) : Clock() {
 
   override fun withZone(zone: ZoneId): MutableClock {
@@ -25,6 +26,12 @@ class MutableClock(
   fun incrementBy(amount: TemporalAmount) {
     instant = instant.plus(amount)
   }
+
+  fun tickSeconds(seconds: Long) = incrementBy(Duration.ofSeconds(seconds))
+
+  fun tickMinutes(minutes: Long) = incrementBy(Duration.ofMinutes(minutes))
+
+  fun tickHours(hours: Long) = incrementBy(Duration.ofHours(hours))
 
   fun instant(newInstant: Instant) {
     instant = newInstant

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
@@ -25,7 +25,7 @@ abstract class PersistentEvent {
   open val ignoreRepeatedInHistory: Boolean = false
 
   companion object {
-    val clock: Clock = Clock.systemDefaultZone()
+    val clock: Clock = Clock.systemUTC()
   }
 
   enum class Scope {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -23,11 +23,14 @@ import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
 import com.netflix.spinnaker.keel.persistence.ArtifactReferenceNotFoundException
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
+import java.time.Clock
 import java.util.UUID
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
-class InMemoryArtifactRepository : ArtifactRepository {
+class InMemoryArtifactRepository(
+  private val clock: Clock = Clock.systemUTC()
+) : ArtifactRepository {
   // we want to store versions by name and type, not each artifact, so that we only store them once
   private val versions = mutableMapOf<VersionsKey, MutableList<ArtifactVersionAndStatus>>()
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
@@ -14,7 +14,7 @@ import java.time.Instant
 import java.time.Instant.EPOCH
 
 class InMemoryDeliveryConfigRepository(
-  private val clock: Clock = Clock.systemDefaultZone()
+  private val clock: Clock = Clock.systemUTC()
 ) : DeliveryConfigRepository {
 
   private val configs = mutableMapOf<String, DeliveryConfig>()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepository.kt
@@ -23,7 +23,7 @@ import java.time.Clock
 import java.time.Instant
 
 class InMemoryDiffFingerprintRepository(
-  private val clock: Clock = Clock.systemDefaultZone()
+  private val clock: Clock = Clock.systemUTC()
 ) : DiffFingerprintRepository {
   private val hashes: MutableMap<String, Record> = mutableMapOf()
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
@@ -34,7 +34,7 @@ import java.time.Instant
 import java.time.Instant.EPOCH
 
 class InMemoryResourceRepository(
-  private val clock: Clock = Clock.systemDefaultZone()
+  private val clock: Clock = Clock.systemUTC()
 ) : ResourceRepository {
 
   private val resources = mutableMapOf<String, Resource<*>>()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryTaskTrackingRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryTaskTrackingRepository.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.persistence.TaskTrackingRepository
 import java.time.Clock
 
 class InMemoryTaskTrackingRepository(
-  private val clock: Clock = Clock.systemDefaultZone()
+  private val clock: Clock = Clock.systemUTC()
 ) : TaskTrackingRepository {
 
   private val tasks: MutableSet<TaskRecord> = mutableSetOf()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -58,6 +58,6 @@ private fun ObjectMapper.configureSaneDateTimeRepresentation(): ObjectMapper =
     .disable(WRITE_DURATIONS_AS_TIMESTAMPS)
     .apply {
       dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").apply {
-        timeZone = TimeZone.getDefault()
+        timeZone = TimeZone.getTimeZone("UTC")
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -76,7 +76,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       actuationPauser,
       vetoEnforcer,
       publisher,
-      Clock.systemDefaultZone())
+      Clock.systemUTC())
   }
 
   fun tests() = rootContext<Fixture> {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -23,7 +23,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
   data class Fixture(
     val mapper: ObjectMapper = configuredObjectMapper(),
     val resource: Resource<*>,
-    val clock: Clock = Clock.fixed(Instant.now(), ZoneId.systemDefault())
+    val clock: Clock = Clock.fixed(Instant.now(), ZoneId.of("UTC"))
   )
 
   val Fixture.createdEvent: ResourceCreated

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
@@ -50,7 +50,7 @@ class ActuationPauserTests : JUnit5Minutests {
     }
     val pausedRepository = InMemoryPausedRepository()
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
-    val subject = ActuationPauser(resourceRepository, pausedRepository, publisher, Clock.systemDefaultZone())
+    val subject = ActuationPauser(resourceRepository, pausedRepository, publisher, Clock.systemUTC())
   }
 
   fun tests() = rootContext<Fixture> {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepositoryTests.kt
@@ -12,7 +12,7 @@ class InMemoryArtifactRepositoryTests : ArtifactRepositoryTests<InMemoryArtifact
   }
 
   private val deliveryConfigRepository = InMemoryDeliveryConfigRepository(
-    Clock.systemDefaultZone())
+    Clock.systemUTC())
 
   override fun persist(manifest: DeliveryConfig) {
     deliveryConfigRepository.store(manifest)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
@@ -34,7 +34,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
 
   fun tests() = rootContext<TelemetryListener> {
     fixture {
-      TelemetryListener(registry, Clock.systemDefaultZone())
+      TelemetryListener(registry, Clock.systemUTC())
     }
 
     before {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -891,7 +891,7 @@ class ClusterHandler(
       .toSet()
 
   private fun Instant.iso() =
-    atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_DATE_TIME)
+    atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_DATE_TIME)
 
   /**
    * Translates a ServerGroup object to a ClusterSpec.ServerGroupSpec with default values omitted for export.

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -63,7 +63,7 @@ internal class ClusterExportTests : JUnit5Minutests {
   val cloudDriverCache = mockk<CloudDriverCache>()
   val orcaService = mockk<OrcaService>()
   val normalizers = emptyList<Resolver<ClusterSpec>>()
-  val clock = Clock.systemDefaultZone()
+  val clock = Clock.systemUTC()
   val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk()
   val combinedRepository = combinedMockRepository(deliveryConfigRepository = deliveryConfigRepository)

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -83,7 +83,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val orcaService = mockk<OrcaService>()
   val objectMapper = ObjectMapper().registerKotlinModule()
   val normalizers = emptyList<Resolver<ClusterSpec>>()
-  val clock = Clock.systemDefaultZone()
+  val clock = Clock.systemUTC()
   val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
   val deliveryConfigRepository: InMemoryDeliveryConfigRepository = mockk()
   val combinedRepository = combinedMockRepository(deliveryConfigRepository = deliveryConfigRepository)

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/OrcaTaskLauncherTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/OrcaTaskLauncherTests.kt
@@ -49,7 +49,7 @@ import strikt.assertions.isNotEmpty
 
 class OrcaTaskLauncherTests : JUnit5Minutests {
   class Fixture {
-    val clock = Clock.systemDefaultZone()
+    val clock = Clock.systemUTC()
     val orcaService: OrcaService = mockk()
     val deliveryConfigRepository = InMemoryDeliveryConfigRepository(clock)
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
@@ -17,7 +17,7 @@ class SqlArtifactRepositoryTests : ArtifactRepositoryTests<SqlArtifactRepository
 
   private val deliveryConfigRepository = SqlDeliveryConfigRepository(
     jooq,
-    Clock.systemDefaultZone(),
+    Clock.systemUTC(),
     DummyResourceTypeIdentifier,
     objectMapper,
     sqlRetry

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
@@ -17,13 +17,13 @@ internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDelivery
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun createDeliveryConfigRepository(resourceTypeIdentifier: ResourceTypeIdentifier): SqlDeliveryConfigRepository =
-    SqlDeliveryConfigRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
+    SqlDeliveryConfigRepository(jooq, Clock.systemUTC(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
 
   override fun createResourceRepository(): SqlResourceRepository =
-    SqlResourceRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
+    SqlResourceRepository(jooq, Clock.systemUTC(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
 
   override fun createArtifactRepository(): SqlArtifactRepository =
-    SqlArtifactRepository(jooq, Clock.systemDefaultZone(), objectMapper, sqlRetry)
+    SqlArtifactRepository(jooq, Clock.systemUTC(), objectMapper, sqlRetry)
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
@@ -21,13 +21,13 @@ internal object SqlDeliveryConfigRepositoryTests : DeliveryConfigRepositoryTests
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun createDeliveryConfigRepository(resourceTypeIdentifier: ResourceTypeIdentifier): SqlDeliveryConfigRepository =
-    SqlDeliveryConfigRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
+    SqlDeliveryConfigRepository(jooq, Clock.systemUTC(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
 
   override fun createResourceRepository(): SqlResourceRepository =
-    SqlResourceRepository(jooq, Clock.systemDefaultZone(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
+    SqlResourceRepository(jooq, Clock.systemUTC(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
 
   override fun createArtifactRepository(): SqlArtifactRepository =
-    SqlArtifactRepository(jooq, Clock.systemDefaultZone(), objectMapper, sqlRetry)
+    SqlArtifactRepository(jooq, Clock.systemUTC(), objectMapper, sqlRetry)
 
   override fun flush() {
     cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepositoryTests.kt
@@ -17,7 +17,7 @@ internal object SqlTaskTrackingRepositoryTests : TaskTrackingRepositoryTests<Sql
   override fun factory(clock: Clock): SqlTaskTrackingRepository {
     return SqlTaskTrackingRepository(
       jooq,
-      Clock.systemDefaultZone(),
+      Clock.systemUTC(),
       sqlRetry
     )
   }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
@@ -18,11 +18,11 @@ fun combinedInMemoryRepository(
   artifactRepository: ArtifactRepository = InMemoryArtifactRepository(),
   resourceRepository: ResourceRepository = InMemoryResourceRepository()
 ): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, Clock.systemDefaultZone(), mockk(relaxed = true))
+  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, Clock.systemUTC(), mockk(relaxed = true))
 
 fun combinedMockRepository(
   deliveryConfigRepository: DeliveryConfigRepository = mockk(relaxed = true),
   artifactRepository: ArtifactRepository = mockk(relaxed = true),
   resourceRepository: ResourceRepository = mockk(relaxed = true)
 ): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, Clock.systemDefaultZone(), mockk(relaxed = true))
+  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, Clock.systemUTC(), mockk(relaxed = true))

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -422,7 +422,7 @@ class TitusClusterHandler(
       .toSet()
 
   private fun Instant.iso() =
-    atZone(ZoneId.systemDefault()).format(DateTimeFormatter.ISO_DATE_TIME)
+    atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ISO_DATE_TIME)
 
   private fun TitusServerGroup.exportSpec(application: String): TitusServerGroupSpec {
     val defaults = TitusServerGroupSpec(

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -58,7 +58,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
     combinedRepository,
     publisher
   )
-  val clock = Clock.systemDefaultZone()
+  val clock = Clock.systemUTC()
 
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -100,7 +100,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
     combinedRepository,
     publisher
   )
-  val clock = Clock.systemDefaultZone()
+  val clock = Clock.systemUTC()
 
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -43,7 +43,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
 class DefaultConfiguration {
   @Bean
   @ConditionalOnMissingBean
-  fun clock(): Clock = Clock.systemDefaultZone()
+  fun clock(): Clock = Clock.systemUTC()
 
   @Bean
   fun idGenerator(): ULID = ULID()
@@ -60,7 +60,7 @@ class DefaultConfiguration {
 
   @Bean
   @ConditionalOnMissingBean
-  fun artifactRepository(): ArtifactRepository = InMemoryArtifactRepository()
+  fun artifactRepository(clock: Clock): ArtifactRepository = InMemoryArtifactRepository(clock)
 
   @Bean
   @ConditionalOnMissingBean


### PR DESCRIPTION
We had previously discussed the need to standardize on a timezone or UTC. Recently, when writing new tests for the API where I tried to use a UTC clock, I realized it wouldn’t work because not all components rely on the Spring configuration, and even if I tweaked the tests to pass today by converting timestamps to PDT, they would break whenever we exit daylight savings. This PR settles on using UTC across the board.

Closes #862 