### PR TITLE
feat(api): Add stateful constraint information to artifact summaries

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
@@ -8,7 +8,8 @@ import java.time.temporal.TemporalAmount
 
 class MutableClock(
   private var instant: Instant = Instant.now(),
-  private val zone: ZoneId = ZoneId.of("UTC")
+  private val zone: ZoneId = ZoneId.of("UTC"),
+  private val start: Instant = instant
 ) : Clock() {
 
   override fun withZone(zone: ZoneId): MutableClock {
@@ -35,5 +36,9 @@ class MutableClock(
 
   fun instant(newInstant: Instant) {
     instant = newInstant
+  }
+
+  fun reset() {
+    instant = start
   }
 }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
@@ -9,7 +9,7 @@ import java.time.temporal.TemporalAmount
 class MutableClock(
   private var instant: Instant = Instant.now(),
   private val zone: ZoneId = ZoneId.of("UTC"),
-  private val start: Instant = instant
+  val start: Instant = instant
 ) : Clock() {
 
   override fun withZone(zone: ZoneId): MutableClock {
@@ -28,11 +28,11 @@ class MutableClock(
     instant = instant.plus(amount)
   }
 
-  fun tickSeconds(seconds: Long) = incrementBy(Duration.ofSeconds(seconds))
+  fun tickSeconds(seconds: Long) = incrementBy(Duration.ofSeconds(seconds)).let { instant }
 
-  fun tickMinutes(minutes: Long) = incrementBy(Duration.ofMinutes(minutes))
+  fun tickMinutes(minutes: Long) = incrementBy(Duration.ofMinutes(minutes)).let { instant }
 
-  fun tickHours(hours: Long) = incrementBy(Duration.ofHours(hours))
+  fun tickHours(hours: Long) = incrementBy(Duration.ofHours(hours)).let { instant }
 
   fun instant(newInstant: Instant) {
     instant = newInstant

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.constraints.ConstraintStateAttributes
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus
 import java.time.Instant
 
 /**
@@ -44,6 +46,7 @@ data class GitMetadata(
   val commit: String
 )
 
+@JsonInclude(Include.NON_EMPTY)
 data class ArtifactSummaryInEnvironment(
   @JsonProperty("name")
   val environment: String,
@@ -52,5 +55,17 @@ data class ArtifactSummaryInEnvironment(
   val state: String,
   val deployedAt: Instant? = null,
   val replacedAt: Instant? = null,
-  val replacedBy: String? = null
+  val replacedBy: String? = null,
+  val constraints: List<EnvironmentConstraintSummary> = emptyList()
+)
+
+@JsonInclude(Include.NON_NULL)
+data class EnvironmentConstraintSummary(
+  val type: String,
+  val status: ConstraintStatus,
+  val createdAt: Instant,
+  val judgedBy: String? = null,
+  val judgedAt: Instant? = null,
+  val comment: String? = null,
+  val attributes: ConstraintStateAttributes? = null
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -4,12 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import java.time.Instant
 
 /**
  * Summarized data about a specific artifact, mostly for use by the UI.
  */
+@JsonPropertyOrder(value = ["name", "type", "versions"])
 data class ArtifactSummary(
   val name: String,
   val type: ArtifactType,
@@ -17,6 +19,7 @@ data class ArtifactSummary(
 )
 
 @JsonInclude(Include.NON_NULL)
+@JsonPropertyOrder(value = ["name", "version", "state"])
 data class ArtifactVersionSummary(
   val version: String,
   val displayName: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.core.api
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
@@ -10,6 +11,7 @@ import com.netflix.spinnaker.keel.api.id
 /**
  * Summarized data about a specific environment, mostly for use by the UI.
  */
+@JsonPropertyOrder(value = ["name"])
 data class EnvironmentSummary(
   @JsonIgnore val environment: Environment,
   val artifacts: Set<ArtifactVersions>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -187,6 +187,10 @@ interface ArtifactRepository {
    */
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType)
 
+  /**
+   * Given information about a delivery config, environment, artifact and version, returns a summary that can be
+   * used by the UI.
+   */
   fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,
     environmentName: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -414,5 +414,16 @@ class CombinedRepository(
 
   override fun deleteVeto(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String) =
     artifactRepository.deleteVeto(deliveryConfig, artifact, version, targetEnvironment)
+
+  override fun getArtifactSummaryInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String,
+    artifactName: String,
+    artifactType: ArtifactType,
+    version: String
+  ) = artifactRepository.getArtifactSummaryInEnvironment(
+    deliveryConfig, environmentName, artifactName, artifactType, version
+  )
+
   // END ArtifactRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
@@ -205,5 +206,18 @@ interface KeelRepository {
   ): Boolean
 
   fun deleteVeto(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String)
+
+  /**
+   * Given information about a delivery config, environment, artifact and version, returns a summary that can be
+   * used by the UI, or null if the artifact version is not applicable to the environment.
+   */
+  fun getArtifactSummaryInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String,
+    artifactName: String,
+    artifactType: ArtifactType,
+    version: String
+  ): ArtifactSummaryInEnvironment?
+
   // END ArtifactRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -458,10 +458,10 @@ class InMemoryArtifactRepository(
     val key = EnvironmentVersionsKey(artifactId, deliveryConfig, environmentName)
     val statuses = statusByEnvironment.getOrDefault(key, emptyMap<String, String>())
     val artifactDeployedVersions = deployedVersions[key]
-      ?.sortedBy { (_, deployedAt) -> deployedAt }
+      ?.sortedBy { (_, deployedAt) -> deployedAt } // ascending because we want to get the replacement deployment using `firstOrNull` below
     val deployedAt = artifactDeployedVersions?.find { (ver, _) -> ver == version }?.second
     val (replacedBy, replacedAt) = artifactDeployedVersions?.firstOrNull { (ver, at) ->
-      ver != version && deployedAt != null && at.isBefore(deployedAt) }
+      ver != version && deployedAt != null && at.isAfter(deployedAt) }
       ?: Pair(null, null)
 
     return ArtifactSummaryInEnvironment(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.keel.persistence.ArtifactReferenceNotFoundException
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
 import java.time.Clock
+import java.time.Instant
 import java.util.UUID
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
@@ -38,7 +39,7 @@ class InMemoryArtifactRepository(
   private val artifacts = mutableMapOf<UUID, DeliveryArtifact>()
 
   private val approvedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
-  private val deployedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
+  private val deployedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<Pair<String, Instant>>>()
   private val vetoedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
   private val pinnedVersions = mutableMapOf<EnvironmentVersionsKey, EnvironmentArtifactPin>()
   private val statusByEnvironment = mutableMapOf<EnvironmentVersionsKey, MutableMap<String, PromotionStatus>>()
@@ -222,7 +223,7 @@ class InMemoryArtifactRepository(
   ): Boolean {
     val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
     val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
-    return deployedVersions[key]?.contains(version) ?: false
+    return deployedVersions[key]?.any { (v, _) -> v == version } ?: false
   }
 
   override fun markAsSuccessfullyDeployedTo(
@@ -233,11 +234,12 @@ class InMemoryArtifactRepository(
   ) {
     val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
     val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
+    val deployedVersion = Pair(version, clock.instant())
     val list = deployedVersions[key]
     if (list == null) {
-      deployedVersions[key] = mutableListOf(version)
+      deployedVersions[key] = mutableListOf(deployedVersion)
     } else {
-      list.add(version)
+      list.add(deployedVersion)
     }
 
     val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
@@ -320,7 +322,7 @@ class InMemoryArtifactRepository(
     }
 
     approvedVersions.getOrPut(key, ::mutableListOf).remove(version)
-    deployedVersions.getOrPut(key, ::mutableListOf).remove(version)
+    deployedVersions.getOrPut(key, ::mutableListOf).removeIf { (v, _) -> v == version }
     vetoedVersions.getOrPut(key, ::mutableListOf).add(version)
 
     val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
@@ -455,6 +457,12 @@ class InMemoryArtifactRepository(
     val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
     val key = EnvironmentVersionsKey(artifactId, deliveryConfig, environmentName)
     val statuses = statusByEnvironment.getOrDefault(key, emptyMap<String, String>())
+    val artifactDeployedVersions = deployedVersions[key]
+      ?.sortedBy { (_, deployedAt) -> deployedAt }
+    val deployedAt = artifactDeployedVersions?.find { (ver, _) -> ver == version }?.second
+    val (replacedBy, replacedAt) = artifactDeployedVersions?.firstOrNull { (ver, at) ->
+      ver != version && deployedAt != null && at.isBefore(deployedAt) }
+      ?: Pair(null, null)
 
     return ArtifactSummaryInEnvironment(
       environment = environmentName,
@@ -462,9 +470,9 @@ class InMemoryArtifactRepository(
       state = statuses.filterKeys { it == version }.values.firstOrNull()
         ?.toString()?.toLowerCase()
         ?: PromotionStatus.PENDING.name.toLowerCase(),
-      deployedAt = null, // TODO
-      replacedAt = null, // TODO
-      replacedBy = null // TODO
+      deployedAt = deployedAt,
+      replacedAt = replacedAt,
+      replacedBy = replacedBy
     )
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -56,8 +56,5 @@ private fun ObjectMapper.configureSaneDateTimeRepresentation(): ObjectMapper =
     .enable(WRITE_DATES_WITH_ZONE_ID)
     .enable(WRITE_DATE_KEYS_AS_TIMESTAMPS)
     .disable(WRITE_DURATIONS_AS_TIMESTAMPS)
-    .apply {
-      dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").apply {
-        timeZone = TimeZone.getTimeZone("UTC")
-      }
-    }
+    .setTimeZone(TimeZone.getTimeZone("UTC"))
+    .setDateFormat(SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"))

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -837,7 +837,6 @@ class SqlArtifactRepository(
             }
             else -> Pair(null, null)
           }
-
           ArtifactSummaryInEnvironment(
             environment = environmentName,
             version = version,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import de.huxhorn.sulky.ulid.ULID
 import java.time.Clock
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.beans.factory.getBeansOfType
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -34,6 +35,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Primary
 import org.springframework.core.Ordered.HIGHEST_PRECEDENCE
 import org.springframework.scheduling.TaskScheduler
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
@@ -49,9 +51,11 @@ class DefaultConfiguration {
   fun idGenerator(): ULID = ULID()
 
   @Bean
+  @Primary
   fun objectMapper(): ObjectMapper = configuredObjectMapper()
 
   @Bean
+  @Qualifier("yamlMapper")
   fun yamlMapper(): YAMLMapper = configuredYamlMapper()
 
   @Bean

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -60,13 +60,13 @@ import strikt.assertions.containsExactly
 
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [KeelApplication::class, MockEurekaConfiguration::class, ApplicationControllerTests.ClockConfiguration::class],
+  classes = [KeelApplication::class, MockEurekaConfiguration::class, ApplicationControllerTests.TestConfiguration::class],
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 internal class ApplicationControllerTests : JUnit5Minutests {
   @Configuration
-  class ClockConfiguration {
+  class TestConfiguration {
     @Bean
     fun clock(): Clock = MutableClock(
       Instant.parse("2020-03-25T00:00:00.00Z"),


### PR DESCRIPTION
Adds information about stateful constraints applicable to an artifact version within an environment, in support of the UI.

Closes #888.