### PR TITLE
feat(api): Add synthetic NOT_EVALUATED status for stateful constraints

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ConstraintState.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ConstraintState.kt
@@ -34,6 +34,7 @@ val List<ConstraintState>.allPass: Boolean
   get() = all { it.status.passes() }
 
 enum class ConstraintStatus(private val passed: Boolean, private val failed: Boolean) {
+  NOT_EVALUATED(false, false),
   PENDING(false, false),
   PASS(true, false),
   FAIL(false, true),

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -56,14 +56,14 @@ data class ArtifactSummaryInEnvironment(
   val deployedAt: Instant? = null,
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
-  val constraints: List<EnvironmentConstraintSummary> = emptyList()
+  val statefulConstraints: List<StatefulConstraintSummary> = emptyList()
 )
 
 @JsonInclude(Include.NON_NULL)
-data class EnvironmentConstraintSummary(
+data class StatefulConstraintSummary(
   val type: String,
   val status: ConstraintStatus,
-  val createdAt: Instant,
+  val startedAt: Instant? = null,
   val judgedBy: String? = null,
   val judgedAt: Instant? = null,
   val comment: String? = null,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/UID.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/UID.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.core.api
 
 import de.huxhorn.sulky.ulid.ULID
+import java.time.Instant
 
 typealias UID = ULID.Value
 
@@ -9,3 +10,5 @@ private val idGenerator by lazy { ULID() }
 fun randomUID(): UID = idGenerator.nextValue()
 
 fun parseUID(ulid: String): UID = ULID.parseULID(ulid)
+
+fun UID.timestampAsInstant() = Instant.ofEpochMilli(timestamp())


### PR DESCRIPTION
This is just a left-over from #926, where I forgot to add the synthetic `NOT_EVALUATED` constraint status for those constraints which have not yet been evaluated (i.e. a state even before `PENDING`).