### PR TITLE
fix(artifacts): mark as deploying, version in task description

### DIFF
--- a/keel-artifact/keel-artifact.gradle.kts
+++ b/keel-artifact/keel-artifact.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
+  testImplementation(project(":keel-test"))
 }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactDeployingListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactDeployingListener.kt
@@ -1,0 +1,52 @@
+package com.netflix.spinnaker.keel.artifact
+
+import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class ArtifactDeployingListener(
+  private val repository: KeelRepository
+) {
+
+  private val log = LoggerFactory.getLogger(javaClass)
+
+  @EventListener(ArtifactVersionDeploying::class)
+  fun onArtifactVersionDeploying(event: ArtifactVersionDeploying) =
+    runBlocking {
+      val resourceId = event.resourceId
+      val resource = repository.getResource(resourceId)
+      val deliveryConfig = repository.deliveryConfigFor(resourceId)
+      val env = repository.environmentFor(resourceId)
+
+      // if there's no artifact associated with this resource, we do nothing.
+      val artifact = resource.findAssociatedArtifact(deliveryConfig) ?: return@runBlocking
+
+      val approvedForEnv = repository.isApprovedFor(
+        deliveryConfig = deliveryConfig,
+        artifact = artifact,
+        version = event.artifactVersion,
+        targetEnvironment = env.name
+      )
+
+      if (approvedForEnv) {
+        log.info("Marking {} as deploying in {} for config {}", event.artifactVersion, env.name, deliveryConfig.name)
+        repository.markAsDeployingTo(
+          deliveryConfig = deliveryConfig,
+          artifact = artifact,
+          version = event.artifactVersion,
+          targetEnvironment = env.name
+        )
+      } else {
+        log.warn(
+          "Somehow {} is deploying in {} for config {} without being approved for that environment",
+          event.artifactVersion,
+          env.name,
+          deliveryConfig.name
+        )
+      }
+    }
+}

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactDeployingListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactDeployingListenerTests.kt
@@ -1,0 +1,74 @@
+package com.netflix.spinnaker.keel.artifact
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.combinedMockRepository
+import com.netflix.spinnaker.keel.test.deliveryConfig
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+
+internal class ArtifactDeployingListenerTests : JUnit5Minutests {
+  class Fixture {
+    val r: Resource<DummyResourceSpec> = spyk(resource())
+    val config = deliveryConfig(resource = r)
+    val artifact = config.artifacts.first()
+    val repository = combinedMockRepository()
+
+    val event = ArtifactVersionDeploying(
+      resourceId = r.id,
+      artifactVersion = "1.1.1"
+    )
+
+    val subject = ArtifactDeployingListener(repository)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    before {
+      every { repository.getResource(r.id) } returns r
+      every { repository.deliveryConfigFor(r.id) } returns config
+      every { repository.environmentFor(r.id) } returns config.environments.first()
+    }
+
+    context("no artifact associated with the resource") {
+      test("nothing is marked deploying") {
+        subject.onArtifactVersionDeploying(event)
+        verify(exactly = 0) { repository.isApprovedFor(config, any(), event.artifactVersion, any()) }
+        verify(exactly = 0) { repository.markAsDeployingTo(config, any(), event.artifactVersion, any()) }
+      }
+    }
+
+    context("an artifact is associated with a resource") {
+      before {
+        every { r.findAssociatedArtifact(config) } returns artifact
+      }
+      context("artifact is approved for env") {
+        before {
+          every { repository.isApprovedFor(any(), any(), event.artifactVersion, any()) } returns true
+        }
+
+        test("version is marked deploying") {
+          subject.onArtifactVersionDeploying(event)
+          verify(exactly = 1) { repository.markAsDeployingTo(any(), any(), event.artifactVersion, any()) }
+        }
+      }
+
+      context("artifact is not approved for env") {
+        before {
+          every { repository.isApprovedFor(any(), any(), event.artifactVersion, any()) } returns false
+        }
+        test("nothing is marked as deploying") {
+          subject.onArtifactVersionDeploying(event)
+          verify(exactly = 0) { repository.markAsDeployingTo(config, any(), event.artifactVersion, any()) }
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ArtifactVersionDeploying.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ArtifactVersionDeploying.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.events
+
+/**
+ * An event fired when we launch a task to deploy a new version to a cluster
+ */
+data class ArtifactVersionDeploying(
+  val resourceId: String,
+  val artifactVersion: String
+)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/MissingAppVersionException.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/MissingAppVersionException.kt
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.keel.ec2
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+
+class MissingAppVersionException(
+  val resourceId: String
+) : IntegrationException("Resource $resourceId is missing version information. Is the appVersion tag missing from the AMI?")


### PR DESCRIPTION
Fixes https://github.com/spinnaker/keel/issues/915:
(1) Adds "DEPLOYING" when we launch tasks to deploy new versions to clusters. Note: for Titus that means we have to translate the digest to the desired app version. 

(2) Since we're already calculating the version to send in an event right after the task launches, also include the version in the task description so it shows up in the UI (like `Upsert server group emburnstest-md-test2 to deb-sample-app-server-0.117.0-h347.3cc480c in account/region`