### PR TITLE
chore(api): endpoint to judge constraints by application

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ConstraintState.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ConstraintState.kt
@@ -49,7 +49,7 @@ data class UpdatedConstraintStatus(
   val type: String,
   val artifactVersion: String,
   val status: ConstraintStatus,
-  val comment: String?
+  val comment: String? = null
 )
 
 @JsonTypeInfo(

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
@@ -44,7 +44,11 @@ class SampleDockerImageResolverTests : JUnit5Minutests {
   val configRepo: InMemoryDeliveryConfigRepository = InMemoryDeliveryConfigRepository()
   val artifactRepo: InMemoryArtifactRepository = InMemoryArtifactRepository()
   val resourceRepo: InMemoryResourceRepository = InMemoryResourceRepository()
-  val repository: KeelRepository = combinedInMemoryRepository(configRepo, artifactRepo, resourceRepo)
+  val repository: KeelRepository = combinedInMemoryRepository(
+    deliveryConfigRepository = configRepo,
+    artifactRepository = artifactRepo,
+    resourceRepository = resourceRepo
+  )
 
   private val artifact = DockerArtifact(name = "spkr/keeldemo", reference = "spkr/keeldemo", tagVersionStrategy = SEMVER_TAG, deliveryConfigName = "mydeliveryconfig")
 

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
@@ -14,15 +14,17 @@ import java.time.Clock
  * A util for generating a combined repository with in memory implementations for tests
  */
 fun combinedInMemoryRepository(
-  deliveryConfigRepository: DeliveryConfigRepository = InMemoryDeliveryConfigRepository(),
-  artifactRepository: ArtifactRepository = InMemoryArtifactRepository(),
-  resourceRepository: ResourceRepository = InMemoryResourceRepository()
+  clock: Clock = Clock.systemUTC(),
+  deliveryConfigRepository: DeliveryConfigRepository = InMemoryDeliveryConfigRepository(clock),
+  artifactRepository: ArtifactRepository = InMemoryArtifactRepository(clock),
+  resourceRepository: ResourceRepository = InMemoryResourceRepository(clock)
 ): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, Clock.systemUTC(), mockk(relaxed = true))
+  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, mockk(relaxed = true))
 
 fun combinedMockRepository(
   deliveryConfigRepository: DeliveryConfigRepository = mockk(relaxed = true),
   artifactRepository: ArtifactRepository = mockk(relaxed = true),
-  resourceRepository: ResourceRepository = mockk(relaxed = true)
+  resourceRepository: ResourceRepository = mockk(relaxed = true),
+  clock: Clock = Clock.systemUTC()
 ): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, Clock.systemUTC(), mockk(relaxed = true))
+  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, mockk(relaxed = true))

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -50,7 +50,7 @@ class AuthorizationSupport(
   }
 
   fun userCanModifyApplication(application: String): Boolean = try {
-    val deliveryConfig = repository.getDeliveryConfigsByApplication(application).first()
+    val deliveryConfig = repository.getDeliveryConfigForApplication(application)
     userCanModifyDeliveryConfig(deliveryConfig.serviceAccount, application, deliveryConfig.name)
   } catch (e: NoSuchElementException) {
     // If there are no delivery configs for that application return true so this is handled correctly in the controller.

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -46,13 +46,26 @@ class AuthorizationSupport(
 
   fun userCanModifySpec(serviceAccount: String, specOrName: Any): Boolean {
     val auth = SecurityContextHolder.getContext().authentication
-    return userCanAccessServiceAccount(auth, serviceAccount, specOrName)
+    return userCanAccessServiceAccount(auth, serviceAccount, "Resource: $specOrName")
+  }
+
+  fun userCanModifyApplication(application: String): Boolean = try {
+    val deliveryConfig = repository.getDeliveryConfigsByApplication(application).first()
+    userCanModifyDeliveryConfig(deliveryConfig.serviceAccount, application, deliveryConfig.name)
+  } catch (e: NoSuchElementException) {
+    // If there are no delivery configs for that application return true so this is handled correctly in the controller.
+    true
+  }
+
+  fun userCanModifyDeliveryConfig(serviceAccount: String, application: String, manifestName: String): Boolean {
+    val auth = SecurityContextHolder.getContext().authentication
+    return userCanAccessServiceAccount(auth, serviceAccount, "Delivery config for application $application: $manifestName")
   }
 
   fun userCanAccessServiceAccount(auth: Authentication, serviceAccount: String, specOrName: Any): Boolean {
     val hasPermission = permissionEvaluator.hasPermission(auth, serviceAccount, "SERVICE_ACCOUNT", "ignored-svcAcct-auth")
     log.debug(
-      "[AUTH] {} is trying to access service account {}. They{} have permission. Resource: {}",
+      "[AUTH] {} is trying to access service account {}. They{} have permission. {}",
       auth.principal,
       serviceAccount,
       if (hasPermission) "" else " DO NOT",

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -1,18 +1,13 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.constraints.ConstraintState
-import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.diff.AdHocDiffer
 import com.netflix.spinnaker.keel.diff.EnvironmentDiff
-import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
 import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
-import java.time.Instant
 import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -20,9 +15,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -83,47 +76,6 @@ class DeliveryConfigController(
   // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
     //  in [ExceptionHandler])
     mapOf("status" to "valid")
-
-  @GetMapping(
-    path = ["/{name}/environment/{environment}/constraints"],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  fun getConstraintState(
-    @PathVariable("name") name: String,
-    @PathVariable("environment") environment: String,
-    @RequestParam("limit") limit: Int?
-  ): List<ConstraintState> =
-    repository.constraintStateFor(name, environment, limit ?: DEFAULT_MAX_EVENTS)
-
-  @Deprecated(
-    "Deprecated in favor of referring to the manifest by application for ease of ui interaction",
-    replaceWith = ReplaceWith("/applications/{application}/environment/{environment}/constraint")
-  )
-  @PostMapping(
-    path = ["/{name}/environment/{environment}/constraint"],
-    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
-    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
-  )
-  fun updateConstraintStatus(
-    @RequestHeader("X-SPINNAKER-USER") user: String,
-    @PathVariable("name") name: String,
-    @PathVariable("environment") environment: String,
-    @RequestBody status: UpdatedConstraintStatus
-  ) {
-    val currentState = repository.getConstraintState(
-      name,
-      environment,
-      status.artifactVersion,
-      status.type) ?: throw InvalidConstraintException(
-      "$name/$environment/${status.type}/${status.artifactVersion}", "constraint not found")
-
-    repository.storeConstraintState(
-      currentState.copy(
-        status = status.status,
-        comment = status.comment ?: currentState.comment,
-        judgedAt = Instant.now(),
-        judgedBy = user))
-  }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -95,13 +95,15 @@ class DeliveryConfigController(
   ): List<ConstraintState> =
     repository.constraintStateFor(name, environment, limit ?: DEFAULT_MAX_EVENTS)
 
+  @Deprecated(
+    "Deprecated in favor of referring to the manifest by application for ease of ui interaction",
+    replaceWith = ReplaceWith("/applications/{application}/environment/{environment}/constraint")
+  )
   @PostMapping(
     path = ["/{name}/environment/{environment}/constraint"],
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  // TODO: This should be validated against write access to a service account. Service accounts should
-  //  become a top-level property of either delivery configs or environments.
   fun updateConstraintStatus(
     @RequestHeader("X-SPINNAKER-USER") user: String,
     @PathVariable("name") name: String,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -12,8 +12,8 @@ import com.netflix.spinnaker.keel.constraints.ConstraintEvaluator
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.constraints.StatefulConstraintEvaluator
-import com.netflix.spinnaker.keel.core.api.AllowedTimesConstraintMetadata
 import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
+import com.netflix.spinnaker.keel.core.api.AllowedTimesConstraintMetadata
 import com.netflix.spinnaker.keel.core.api.ArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.constraints.StatefulConstraintEvaluator
 import com.netflix.spinnaker.keel.core.api.AllowedTimesConstraintMetadata
+import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
@@ -27,8 +28,10 @@ import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
 import com.netflix.spinnaker.keel.core.api.StatelessConstraintSummary
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
+import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
+import java.time.Instant
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -50,6 +53,28 @@ class ApplicationService(
   fun hasManagedResources(application: String) = repository.hasManagedResources(application)
 
   fun getConstraintStatesFor(application: String) = repository.constraintStateFor(application)
+
+  fun getConstraintStatesFor(application: String, environment: String, limit: Int): List<ConstraintState> {
+    val config = repository.getDeliveryConfigForApplication(application)
+    return repository.constraintStateFor(config.name, environment, limit)
+  }
+
+  fun updateConstraintStatus(user: String, application: String, environment: String, status: UpdatedConstraintStatus) {
+    val config = repository.getDeliveryConfigForApplication(application)
+    val currentState = repository.getConstraintState(
+      config.name,
+      environment,
+      status.artifactVersion,
+      status.type) ?: throw InvalidConstraintException(
+      "${config.name}/$environment/${status.type}/${status.artifactVersion}", "constraint not found")
+
+    repository.storeConstraintState(
+      currentState.copy(
+        status = status.status,
+        comment = status.comment ?: currentState.comment,
+        judgedAt = Instant.now(),
+        judgedBy = user))
+  }
 
   /**
    * Returns a list of [ResourceSummary] for the specified application.

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -1,0 +1,379 @@
+package com.netflix.spinnaker.keel
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
+import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
+import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus.NOT_EVALUATED
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus.OVERRIDE_PASS
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactVersions
+import com.netflix.spinnaker.keel.core.api.BuildMetadata
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
+import com.netflix.spinnaker.keel.core.api.GitMetadata
+import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.keel.core.api.PipelineConstraint
+import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
+import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
+import com.netflix.spinnaker.keel.events.ResourceValid
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.services.ApplicationService
+import com.netflix.spinnaker.keel.test.combinedInMemoryRepository
+import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.clearAllMocks
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
+import strikt.assertions.isNotNull
+
+class ApplicationServiceTests : JUnit5Minutests {
+  class Fixture {
+    val clock: MutableClock = MutableClock(
+      Instant.parse("2020-03-25T00:00:00.00Z"),
+      ZoneId.of("UTC")
+    )
+    val deliveryConfigRepository = InMemoryDeliveryConfigRepository(clock)
+    val artifactRepository = InMemoryArtifactRepository(clock)
+    val resourceRepository = InMemoryResourceRepository(clock)
+    val repository: KeelRepository = combinedInMemoryRepository(
+      deliveryConfigRepository = deliveryConfigRepository,
+      artifactRepository = artifactRepository,
+      resourceRepository = resourceRepository,
+      clock = clock
+    )
+    val applicationService = ApplicationService(repository)
+
+    val application = "fnord"
+
+    val artifact = DebianArtifact(
+      name = application,
+      deliveryConfigName = "manifest",
+      reference = "fnord",
+      statuses = setOf(ArtifactStatus.RELEASE)
+    )
+
+    val clusterDefaults = ClusterSpec.ServerGroupSpec(
+      launchConfiguration = ClusterSpec.LaunchConfigurationSpec(
+        instanceType = "m4.2xlarge",
+        ebsOptimized = true,
+        iamRole = "fnordInstanceProfile",
+        keyPair = "fnordKeyPair"
+      )
+    )
+
+    val environments = listOf("test", "staging", "production").associateWith { name ->
+      Environment(
+        name = name,
+        constraints = if (name == "production") {
+          setOf(
+            DependsOnConstraint("staging"),
+            ManualJudgementConstraint(),
+            PipelineConstraint(pipelineId = "fakePipeline")
+          )
+        } else {
+          emptySet()
+        },
+        resources = setOf(
+          // cluster with new-style artifact reference
+          resource(
+            kind = SPINNAKER_EC2_API_V1.qualify("cluster"),
+            spec = ClusterSpec(
+              moniker = Moniker(application, "$name"),
+              imageProvider = ReferenceArtifactImageProvider(reference = "fnord"),
+              locations = SubnetAwareLocations(
+                account = "test",
+                vpc = "vpc0",
+                subnet = "internal (vpc0)",
+                regions = setOf(
+                  SubnetAwareRegionSpec(
+                    name = "us-west-2",
+                    availabilityZones = setOf("us-west-2a", "us-west-2b", "us-west-2c")
+                  )
+                )
+              ),
+              _defaults = clusterDefaults
+            )
+          ),
+          // cluster with old-style image provider
+          resource(
+            kind = SPINNAKER_EC2_API_V1.qualify("cluster"),
+            spec = ClusterSpec(
+              moniker = Moniker(application, "$name-east"),
+              imageProvider = ArtifactImageProvider(deliveryArtifact = artifact),
+              locations = SubnetAwareLocations(
+                account = "test",
+                vpc = "vpc0",
+                subnet = "internal (vpc0)",
+                regions = setOf(
+                  SubnetAwareRegionSpec(
+                    name = "us-east-1",
+                    availabilityZones = setOf("us-east-1a", "us-east-1b", "us-east-1c")
+                  )
+                )
+              ),
+              _defaults = clusterDefaults
+            )
+          )
+        )
+      )
+    }
+
+    val deliveryConfig = DeliveryConfig(
+      name = "manifest",
+      application = application,
+      serviceAccount = "keel@spinnaker",
+      artifacts = setOf(artifact),
+      environments = environments.values.toSet()
+    )
+  }
+
+  fun applicationServiceTests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    before {
+      clock.reset()
+    }
+
+    after {
+      deliveryConfigRepository.dropAll()
+      artifactRepository.dropAll()
+      resourceRepository.dropAll()
+      clearAllMocks()
+    }
+
+    context("delivery config exists and there has been activity") {
+      before {
+        repository.upsertDeliveryConfig(deliveryConfig)
+        // these events are required because Resource.toResourceSummary() relies on events to determine resource status
+        deliveryConfig.environments.flatMap { it.resources }.forEach { resource ->
+          repository.resourceAppendHistory(ResourceValid(resource))
+        }
+        repository.storeArtifact(artifact, "fnord-1.0.0-h0.a0a0a0a", ArtifactStatus.RELEASE)
+        repository.storeArtifact(artifact, "fnord-1.0.1-h1.b1b1b1b", ArtifactStatus.RELEASE)
+        repository.storeArtifact(artifact, "fnord-1.0.2-h2.c2c2c2c", ArtifactStatus.RELEASE)
+        repository.storeArtifact(artifact, "fnord-1.0.3-h3.d3d3d3d", ArtifactStatus.RELEASE)
+
+        // with our fake clock moving forward, simulate artifact approvals and deployments
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.a0a0a0a", "test")
+        clock.tickHours(1) // 2020-03-25T01:00:00.00Z
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.a0a0a0a", "staging")
+        val productionDeployed = clock.tickHours(1) // 2020-03-25T02:00:00.00Z
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.a0a0a0a", "production")
+        clock.tickHours(1) // 2020-03-25T03:00:00.00Z
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.1-h1.b1b1b1b", "test")
+        clock.tickHours(1) // 2020-03-25T04:00:00.00Z
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.1-h1.b1b1b1b", "staging")
+        clock.tickHours(1) // 2020-03-25T05:00:00.00Z
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.2-h2.c2c2c2c", "test")
+        repository.approveVersionFor(deliveryConfig, artifact, "fnord-1.0.3-h3.d3d3d3d", "test")
+        repository.storeConstraintState(
+          ConstraintState(
+            deliveryConfigName = deliveryConfig.name,
+            environmentName = "production",
+            artifactVersion = "fnord-1.0.0-h0.a0a0a0a",
+            type = "manual-judgement",
+            status = ConstraintStatus.OVERRIDE_PASS,
+            createdAt = clock.start,
+            judgedAt = productionDeployed.minus(Duration.ofMinutes(30)),
+            judgedBy = "lpollo@acme.com",
+            comment = "Aye!"
+          )
+        )
+      }
+
+      test("can get resource summary by application") {
+        val summaries = applicationService.getResourceSummariesFor(application)
+
+        expect {
+          that(summaries.size).isEqualTo(6)
+          that(summaries.map { it.status }.filter { it == HAPPY }.size).isEqualTo(6)
+          that(summaries.map { it.moniker?.stack }).containsExactlyInAnyOrder("test", "staging", "production", "test-east", "staging-east", "production-east")
+        }
+      }
+
+      test("can get environment summaries by application") {
+        val summaries = applicationService.getEnvironmentSummariesFor(application)
+
+        val production = summaries.find { it.name == "production" }
+        val staging = summaries.find { it.name == "staging" }
+        val test = summaries.find { it.name == "test" }
+
+        val expectedProd = EnvironmentSummary(
+          deliveryConfig.environments.find { it.name == "production" }!!,
+          setOf(ArtifactVersions(
+            artifact.name,
+            artifact.type,
+            artifact.statuses,
+            ArtifactVersionStatus(
+              current = "fnord-1.0.0-h0.a0a0a0a",
+              pending = listOf("fnord-1.0.1-h1.b1b1b1b", "fnord-1.0.2-h2.c2c2c2c", "fnord-1.0.3-h3.d3d3d3d"),
+              approved = listOf(),
+              previous = listOf(),
+              vetoed = listOf(),
+              deploying = null
+            )
+          ))
+        )
+        val expectedStage = EnvironmentSummary(
+          deliveryConfig.environments.find { it.name == "staging" }!!,
+          setOf(ArtifactVersions(
+            artifact.name,
+            artifact.type,
+            artifact.statuses,
+            ArtifactVersionStatus(
+              current = "fnord-1.0.1-h1.b1b1b1b",
+              pending = listOf("fnord-1.0.2-h2.c2c2c2c", "fnord-1.0.3-h3.d3d3d3d"),
+              approved = listOf(),
+              previous = listOf("fnord-1.0.0-h0.a0a0a0a"),
+              vetoed = listOf(),
+              deploying = null
+            )
+          ))
+        )
+        val expectedTest = EnvironmentSummary(
+          deliveryConfig.environments.find { it.name == "test" }!!,
+          setOf(ArtifactVersions(
+            artifact.name,
+            artifact.type,
+            artifact.statuses,
+            ArtifactVersionStatus(
+              current = "fnord-1.0.2-h2.c2c2c2c",
+              pending = listOf(),
+              approved = listOf("fnord-1.0.3-h3.d3d3d3d"),
+              previous = listOf("fnord-1.0.0-h0.a0a0a0a", "fnord-1.0.1-h1.b1b1b1b"),
+              vetoed = listOf(),
+              deploying = null
+            )
+          ))
+        )
+        expect {
+          that(summaries.size).isEqualTo(3)
+          that(production).isNotNull()
+          that(production).isEqualTo(expectedProd)
+          that(staging).isNotNull()
+          that(staging).isEqualTo(expectedStage)
+          that(test).isNotNull()
+          that(test).isEqualTo(expectedTest)
+        }
+      }
+
+      test("can get artifact summaries by application") {
+        val summaries = applicationService.getArtifactSummariesFor(application)
+        val v3 = ArtifactVersionSummary(
+          version = "fnord-1.0.3-h3.d3d3d3d",
+          displayName = "1.0.3",
+          environments = setOf(
+            ArtifactSummaryInEnvironment(environment = "test", version = "fnord-1.0.3-h3.d3d3d3d", state = "approved"),
+            ArtifactSummaryInEnvironment(environment = "staging", version = "fnord-1.0.3-h3.d3d3d3d", state = "pending"),
+            ArtifactSummaryInEnvironment(environment = "production", version = "fnord-1.0.3-h3.d3d3d3d", state = "pending", statefulConstraints = listOf(StatefulConstraintSummary("manual-judgement", NOT_EVALUATED), StatefulConstraintSummary("pipeline", NOT_EVALUATED)))
+          ),
+          build = BuildMetadata(3),
+          git = GitMetadata("d3d3d3d")
+        )
+        val v2 = ArtifactVersionSummary(
+          version = "fnord-1.0.2-h2.c2c2c2c",
+          displayName = "1.0.2",
+          environments = setOf( // todo eb: this is changing every time (deployed at time...
+            ArtifactSummaryInEnvironment(environment = "test", version = "fnord-1.0.2-h2.c2c2c2c", state = "current", deployedAt = Instant.parse("2020-03-25T05:00:00Z")),
+            ArtifactSummaryInEnvironment(environment = "staging", version = "fnord-1.0.2-h2.c2c2c2c", state = "pending"),
+            ArtifactSummaryInEnvironment(environment = "production", version = "fnord-1.0.2-h2.c2c2c2c", state = "pending", statefulConstraints = listOf(StatefulConstraintSummary("manual-judgement", NOT_EVALUATED), StatefulConstraintSummary("pipeline", NOT_EVALUATED)))
+          ),
+          build = BuildMetadata(2),
+          git = GitMetadata("c2c2c2c")
+        )
+        val v1 = ArtifactVersionSummary(
+          version = "fnord-1.0.1-h1.b1b1b1b",
+          displayName = "1.0.1",
+          environments = setOf(
+            ArtifactSummaryInEnvironment(environment = "test", version = "fnord-1.0.1-h1.b1b1b1b", state = "previous", deployedAt = Instant.parse("2020-03-25T03:00:00Z"), replacedAt = Instant.parse("2020-03-25T05:00:00Z"), replacedBy = "fnord-1.0.2-h2.c2c2c2c"),
+            ArtifactSummaryInEnvironment(environment = "staging", version = "fnord-1.0.1-h1.b1b1b1b", state = "current", deployedAt = Instant.parse("2020-03-25T04:00:00Z")),
+            ArtifactSummaryInEnvironment(environment = "production", version = "fnord-1.0.1-h1.b1b1b1b", state = "pending", statefulConstraints = listOf(StatefulConstraintSummary("manual-judgement", NOT_EVALUATED), StatefulConstraintSummary("pipeline", NOT_EVALUATED)))
+          ),
+          build = BuildMetadata(1),
+          git = GitMetadata("b1b1b1b")
+        )
+        val v0 = ArtifactVersionSummary(
+          version = "fnord-1.0.0-h0.a0a0a0a",
+          displayName = "1.0.0",
+          environments = setOf(
+            ArtifactSummaryInEnvironment(environment = "test", version = "fnord-1.0.0-h0.a0a0a0a", state = "previous", deployedAt = Instant.parse("2020-03-25T00:00:00Z"), replacedAt = Instant.parse("2020-03-25T03:00:00Z"), replacedBy = "fnord-1.0.1-h1.b1b1b1b"),
+            ArtifactSummaryInEnvironment(environment = "staging", version = "fnord-1.0.0-h0.a0a0a0a", state = "previous", deployedAt = Instant.parse("2020-03-25T01:00:00Z"), replacedAt = Instant.parse("2020-03-25T04:00:00Z"), replacedBy = "fnord-1.0.1-h1.b1b1b1b"),
+            ArtifactSummaryInEnvironment(environment = "production", version = "fnord-1.0.0-h0.a0a0a0a", state = "current", deployedAt = Instant.parse("2020-03-25T02:00:00Z"), statefulConstraints = listOf(StatefulConstraintSummary("manual-judgement", OVERRIDE_PASS, startedAt = Instant.parse("2020-03-25T00:00:00Z"), judgedBy = "lpollo@acme.com", judgedAt = Instant.parse("2020-03-25T01:30:00Z"), comment = "Aye!"), StatefulConstraintSummary("pipeline", NOT_EVALUATED)))
+          ),
+          build = BuildMetadata(0),
+          git = GitMetadata("a0a0a0a")
+        )
+
+        expect {
+          that(summaries.size).isEqualTo(1)
+          that(summaries.first().versions.find { it.version == "fnord-1.0.3-h3.d3d3d3d" }).isEqualTo(v3)
+          that(summaries.first().versions.find { it.version == "fnord-1.0.2-h2.c2c2c2c" }).isEqualTo(v2)
+          that(summaries.first().versions.find { it.version == "fnord-1.0.1-h1.b1b1b1b" }).isEqualTo(v1)
+          that(summaries.first().versions.find { it.version == "fnord-1.0.0-h0.a0a0a0a" }).isEqualTo(v0)
+        }
+      }
+
+      test("no constraints have been evaluated") {
+        val states = applicationService.getConstraintStatesFor(application, "prod", 10)
+        expectThat(states).isEmpty()
+      }
+
+      test("pending manual judgement") {
+        val judgement = ConstraintState(deliveryConfig.name, "production", "fnord-1.0.2-h2.c2c2c2c", "manual-judgement", PENDING)
+        repository.storeConstraintState(judgement)
+
+        val states = applicationService.getConstraintStatesFor(application, "production", 10)
+        expect {
+          that(states).isNotEmpty()
+          that(states.size).isEqualTo(2)
+          that(states.first().status).isEqualTo(PENDING)
+          that(states.first().type).isEqualTo("manual-judgement")
+        }
+      }
+
+      test("approve manual judgement") {
+        val judgement = ConstraintState(deliveryConfig.name, "production", "fnord-1.0.2-h2.c2c2c2c", "manual-judgement", PENDING)
+        repository.storeConstraintState(judgement)
+
+        val updatedState = UpdatedConstraintStatus("manual-judgement", "fnord-1.0.2-h2.c2c2c2c", OVERRIDE_PASS)
+        applicationService.updateConstraintStatus("keel", application, "production", updatedState)
+
+        val states = applicationService.getConstraintStatesFor(application, "production", 10)
+        expect {
+          that(states).isNotEmpty()
+          that(states.size).isEqualTo(2)
+          that(states.first().status).isEqualTo(OVERRIDE_PASS)
+          that(states.first().type).isEqualTo("manual-judgement")
+        }
+      }
+    }
+  }
+}

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -9,11 +9,9 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus.OVERRIDE_PASS

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -16,12 +16,11 @@ import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.ec2.ArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
-import com.netflix.spinnaker.keel.constraints.ConstraintState
-import com.netflix.spinnaker.keel.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus.OVERRIDE_PASS
+import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
 import com.netflix.spinnaker.keel.core.api.PipelineConstraint
-import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
@@ -31,15 +30,14 @@ import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepos
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.resource
-import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import com.netflix.spinnaker.time.MutableClock
+import com.ninjasquad.springmockk.MockkBean
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.clearAllMocks
+import io.mockk.every
 import io.mockk.mockk
-import java.nio.charset.StandardCharsets
 import java.time.Clock
-import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import org.junit.jupiter.api.extension.ExtendWith
@@ -54,10 +52,8 @@ import org.springframework.context.annotation.Primary
 import org.springframework.http.MediaType
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.MvcResult
-import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.ContentResultMatchers
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import strikt.api.expectThat
@@ -82,6 +78,9 @@ internal class ApplicationControllerTests : JUnit5Minutests {
     @Primary
     fun publisher(): ApplicationEventPublisher = mockk(relaxed = true)
   }
+
+  @MockkBean
+  lateinit var authorizationSupport: AuthorizationSupport
 
   @Autowired
   lateinit var mvc: MockMvc
@@ -162,26 +161,6 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               ),
               _defaults = clusterDefaults
             )
-          ),
-          // cluster with old-style image provider
-          resource(
-            kind = SPINNAKER_EC2_API_V1.qualify("cluster"),
-            spec = ClusterSpec(
-              moniker = Moniker(application, "$name-east"),
-              imageProvider = ArtifactImageProvider(deliveryArtifact = artifact),
-              locations = SubnetAwareLocations(
-                account = "test",
-                vpc = "vpc0",
-                subnet = "internal (vpc0)",
-                regions = setOf(
-                  SubnetAwareRegionSpec(
-                    name = "us-east-1",
-                    availabilityZones = setOf("us-east-1a", "us-east-1b", "us-east-1c")
-                  )
-                )
-              ),
-              _defaults = clusterDefaults
-            )
           )
         )
       )
@@ -201,6 +180,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
 
     before {
       clock.reset()
+      every { authorizationSupport.userCanModifyApplication(application) } returns true
     }
 
     after {
@@ -217,38 +197,6 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         deliveryConfig.environments.flatMap { it.resources }.forEach { resource ->
           resourceRepository.appendHistory(ResourceValid(resource))
         }
-        artifactRepository.store(artifact, "fnord-1.0.0-h0.a0a0a0a", ArtifactStatus.RELEASE)
-        artifactRepository.store(artifact, "fnord-1.0.1-h1.b1b1b1b", ArtifactStatus.RELEASE)
-        artifactRepository.store(artifact, "fnord-1.0.2-h2.c2c2c2c", ArtifactStatus.RELEASE)
-        artifactRepository.store(artifact, "fnord-1.0.3-h3.d3d3d3d", ArtifactStatus.RELEASE)
-
-        // with our fake clock moving forward, simulate artifact approvals and deployments
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.a0a0a0a", "test")
-        clock.tickHours(1) // 2020-03-25T01:00:00.00Z
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.a0a0a0a", "staging")
-        val productionDeployed = clock.tickHours(1) // 2020-03-25T02:00:00.00Z
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.0-h0.a0a0a0a", "production")
-        clock.tickHours(1) // 2020-03-25T03:00:00.00Z
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.1-h1.b1b1b1b", "test")
-        clock.tickHours(1) // 2020-03-25T04:00:00.00Z
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.1-h1.b1b1b1b", "staging")
-        clock.tickHours(1) // 2020-03-25T05:00:00.00Z
-        artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, "fnord-1.0.2-h2.c2c2c2c", "test")
-        artifactRepository.approveVersionFor(deliveryConfig, artifact, "fnord-1.0.3-h3.d3d3d3d", "test")
-
-        deliveryConfigRepository.storeConstraintState(
-          ConstraintState(
-            deliveryConfigName = deliveryConfig.name,
-            environmentName = "production",
-            artifactVersion = "fnord-1.0.0-h0.a0a0a0a",
-            type = "manual-judgement",
-            status = ConstraintStatus.OVERRIDE_PASS,
-            createdAt = clock.start,
-            judgedAt = productionDeployed.minus(Duration.ofMinutes(30)),
-            judgedBy = "lpollo@acme.com",
-            comment = "Aye!"
-          )
-        )
       }
 
       test("can get basic summary by application") {
@@ -293,333 +241,6 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         }
       }
 
-      test("can get resource summaries by application") {
-        val request = get("/application/$application?entities=resources")
-          .accept(APPLICATION_YAML_VALUE)
-        mvc
-          .perform(request)
-          .andExpect(status().isOk)
-          .andDo { println(it.response.contentAsString) }
-          .andExpect(content().yaml(
-            """
-            applicationPaused: false
-            hasManagedResources: true
-            currentEnvironmentConstraints:
-            - deliveryConfigName: "manifest"
-              environmentName: "production"
-              artifactVersion: "fnord-1.0.0-h0.a0a0a0a"
-              type: "manual-judgement"
-              status: "OVERRIDE_PASS"
-              createdAt: "2020-03-25T00:00:00Z"
-              judgedBy: "lpollo@acme.com"
-              judgedAt: "2020-03-25T01:30:00Z"
-              comment: "Aye!"
-            resources:
-            - id: "ec2:cluster:test:fnord-test-west"
-              kind: "ec2/cluster@v1"
-              status: "HAPPY"
-              moniker:
-                app: "fnord"
-                stack: "test-west"
-              locations:
-                account: "test"
-                vpc: "vpc0"
-                regions:
-                - name: "us-west-2"
-              artifact:
-                name: "fnord"
-                type: "deb"
-            - id: "ec2:cluster:test:fnord-test-east"
-              kind: "ec2/cluster@v1"
-              status: "HAPPY"
-              moniker:
-                app: "fnord"
-                stack: "test-east"
-              locations:
-                account: "test"
-                vpc: "vpc0"
-                regions:
-                - name: "us-east-1"
-              artifact:
-                name: "fnord"
-                type: "deb"
-            - id: "ec2:cluster:test:fnord-staging-west"
-              kind: "ec2/cluster@v1"
-              status: "HAPPY"
-              moniker:
-                app: "fnord"
-                stack: "staging-west"
-              locations:
-                account: "test"
-                vpc: "vpc0"
-                regions:
-                - name: "us-west-2"
-              artifact:
-                name: "fnord"
-                type: "deb"
-            - id: "ec2:cluster:test:fnord-staging-east"
-              kind: "ec2/cluster@v1"
-              status: "HAPPY"
-              moniker:
-                app: "fnord"
-                stack: "staging-east"
-              locations:
-                account: "test"
-                vpc: "vpc0"
-                regions:
-                - name: "us-east-1"
-              artifact:
-                name: "fnord"
-                type: "deb"
-            - id: "ec2:cluster:test:fnord-production-west"
-              kind: "ec2/cluster@v1"
-              status: "HAPPY"
-              moniker:
-                app: "fnord"
-                stack: "production-west"
-              locations:
-                account: "test"
-                vpc: "vpc0"
-                regions:
-                - name: "us-west-2"
-              artifact:
-                name: "fnord"
-                type: "deb"
-            - id: "ec2:cluster:test:fnord-production-east"
-              kind: "ec2/cluster@v1"
-              status: "HAPPY"
-              moniker:
-                app: "fnord"
-                stack: "production-east"
-              locations:
-                account: "test"
-                vpc: "vpc0"
-                regions:
-                - name: "us-east-1"
-              artifact:
-                name: "fnord"
-                type: "deb"
-            """.trimIndent()
-          ))
-      }
-
-      test("can get environment summaries by application") {
-        val request = get("/application/$application?entities=environments")
-          .accept(APPLICATION_YAML_VALUE)
-        mvc
-          .perform(request)
-          .andExpect(status().isOk)
-          .andDo { println(it.response.contentAsString) }
-          .andExpect(content().yaml(
-            """
-            applicationPaused: false
-            hasManagedResources: true
-            currentEnvironmentConstraints:
-            - deliveryConfigName: "manifest"
-              environmentName: "production"
-              artifactVersion: "fnord-1.0.0-h0.a0a0a0a"
-              type: "manual-judgement"
-              status: "OVERRIDE_PASS"
-              createdAt: "2020-03-25T00:00:00Z"
-              judgedBy: "lpollo@acme.com"
-              judgedAt: "2020-03-25T01:30:00Z"
-              comment: "Aye!"
-            environments:
-            - name: "test"
-              artifacts:
-              - name: "fnord"
-                type: "deb"
-                statuses:
-                - "RELEASE"
-                versions:
-                  current: "fnord-1.0.2-h2.c2c2c2c"
-                  pending: []
-                  approved:
-                  - "fnord-1.0.3-h3.d3d3d3d"
-                  previous:
-                  - "fnord-1.0.0-h0.a0a0a0a"
-                  - "fnord-1.0.1-h1.b1b1b1b"
-                  vetoed: []
-              resources:
-              - "ec2:cluster:test:fnord-test-west"
-              - "ec2:cluster:test:fnord-test-east"
-            - name: "staging"
-              artifacts:
-              - name: "fnord"
-                type: "deb"
-                statuses:
-                - "RELEASE"
-                versions:
-                  current: "fnord-1.0.1-h1.b1b1b1b"
-                  pending:
-                  - "fnord-1.0.2-h2.c2c2c2c"
-                  - "fnord-1.0.3-h3.d3d3d3d"
-                  approved: []
-                  previous:
-                  - "fnord-1.0.0-h0.a0a0a0a"
-                  vetoed: []
-              resources:
-              - "ec2:cluster:test:fnord-staging-west"
-              - "ec2:cluster:test:fnord-staging-east"
-            - name: "production"
-              artifacts:
-              - name: "fnord"
-                type: "deb"
-                statuses:
-                - "RELEASE"
-                versions:
-                  current: "fnord-1.0.0-h0.a0a0a0a"
-                  pending:
-                  - "fnord-1.0.1-h1.b1b1b1b"
-                  - "fnord-1.0.2-h2.c2c2c2c"
-                  - "fnord-1.0.3-h3.d3d3d3d"
-                  approved: []
-                  previous: []
-                  vetoed: []
-              resources:
-              - "ec2:cluster:test:fnord-production-west"
-              - "ec2:cluster:test:fnord-production-east"
-            """.trimIndent()
-          ))
-      }
-
-      test("can get artifact summaries by application") {
-        val request = get("/application/$application?entities=artifacts")
-          .accept(APPLICATION_YAML_VALUE)
-        mvc
-          .perform(request)
-          .andExpect(status().isOk)
-          .andDo { println(it.response.contentAsString) }
-          .andExpect(content().yaml(
-            """
-            applicationPaused: false
-            hasManagedResources: true
-            currentEnvironmentConstraints:
-            - deliveryConfigName: "manifest"
-              environmentName: "production"
-              artifactVersion: "fnord-1.0.0-h0.a0a0a0a"
-              type: "manual-judgement"
-              status: "OVERRIDE_PASS"
-              createdAt: "2020-03-25T00:00:00Z"
-              judgedBy: "lpollo@acme.com"
-              judgedAt: "2020-03-25T01:30:00Z"
-              comment: "Aye!"
-            artifacts:
-            - name: "fnord"
-              type: "deb"
-              versions:
-              - version: "fnord-1.0.3-h3.d3d3d3d"
-                displayName: "1.0.3"
-                environments:
-                - name: "test"
-                  state: "approved"
-                - name: "staging"
-                  state: "pending"
-                - name: "production"
-                  state: "pending"
-                  statefulConstraints:
-                  - type: "manual-judgement"
-                    status: "NOT_EVALUATED"
-                  - type: "pipeline"
-                    status: "NOT_EVALUATED"
-                  statelessConstraints:
-                  - type: "depends-on"
-                    currentlyPassing: false
-                    attributes:
-                      environment: "staging"
-                build:
-                  id: 3
-                git:
-                  commit: "d3d3d3d"
-              - version: "fnord-1.0.2-h2.c2c2c2c"
-                displayName: "1.0.2"
-                environments:
-                - name: "test"
-                  state: "current"
-                  deployedAt: "2020-03-25T05:00:00Z"
-                - name: "staging"
-                  state: "pending"
-                - name: "production"
-                  state: "pending"
-                  statefulConstraints:
-                  - type: "manual-judgement"
-                    status: "NOT_EVALUATED"
-                  - type: "pipeline"
-                    status: "NOT_EVALUATED"
-                  statelessConstraints:
-                  - type: "depends-on"
-                    currentlyPassing: false
-                    attributes:
-                      environment: "staging"
-                build:
-                  id: 2
-                git:
-                  commit: "c2c2c2c"
-              - version: "fnord-1.0.1-h1.b1b1b1b"
-                displayName: "1.0.1"
-                environments:
-                - name: "test"
-                  state: "previous"
-                  deployedAt: "2020-03-25T03:00:00Z"
-                  replacedAt: "2020-03-25T05:00:00Z"
-                  replacedBy: "fnord-1.0.2-h2.c2c2c2c"
-                - name: "staging"
-                  state: "current"
-                  deployedAt: "2020-03-25T04:00:00Z"
-                - name: "production"
-                  state: "pending"
-                  statefulConstraints:
-                  - type: "manual-judgement"
-                    status: "NOT_EVALUATED"
-                  - type: "pipeline"
-                    status: "NOT_EVALUATED"
-                  statelessConstraints:
-                  - type: "depends-on"
-                    currentlyPassing: true
-                    attributes:
-                      environment: "staging"
-                build:
-                  id: 1
-                git:
-                  commit: "b1b1b1b"
-              - version: "fnord-1.0.0-h0.a0a0a0a"
-                displayName: "1.0.0"
-                environments:
-                - name: "test"
-                  state: "previous"
-                  deployedAt: "2020-03-25T00:00:00Z"
-                  replacedAt: "2020-03-25T03:00:00Z"
-                  replacedBy: "fnord-1.0.1-h1.b1b1b1b"
-                - name: "staging"
-                  state: "previous"
-                  deployedAt: "2020-03-25T01:00:00Z"
-                  replacedAt: "2020-03-25T04:00:00Z"
-                  replacedBy: "fnord-1.0.1-h1.b1b1b1b"
-                - name: "production"
-                  state: "current"
-                  deployedAt: "2020-03-25T02:00:00Z"
-                  statefulConstraints:
-                  - type: "manual-judgement"
-                    status: "OVERRIDE_PASS"
-                    startedAt: "2020-03-25T00:00:00Z"
-                    judgedBy: "lpollo@acme.com"
-                    judgedAt: "2020-03-25T01:30:00Z"
-                    comment: "Aye!"
-                  - type: "pipeline"
-                    status: "NOT_EVALUATED"
-                  statelessConstraints:
-                  - type: "depends-on"
-                    currentlyPassing: true
-                    attributes:
-                      environment: "staging"
-                build:
-                  id: 0
-                git:
-                  commit: "a0a0a0a"
-            """.trimIndent()
-          ))
-      }
-
       test("can get multiple types of summaries by application") {
         val request = get("/application/$application?entities=resources&entities=environments&entities=artifacts")
           .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -659,61 +280,60 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             "artifacts"
           )
       }
-
-      test("returns bad request for unknown entities") {
-        val request = get("/application/$application?entities=bananas")
-          .accept(MediaType.APPLICATION_JSON_VALUE)
-        mvc.perform(request)
-          .andExpect(status().isBadRequest)
-      }
-
-      test("is backwards-compatible with older version of the API") {
-        var request = get("/application/$application?includeDetails=false")
-          .accept(MediaType.APPLICATION_JSON_VALUE)
-        var result = mvc
-          .perform(request)
-          .andExpect(status().isOk)
-          .andDo { print(it.response.contentAsString) }
-          .andReturn()
-        var response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
-        expectThat(response.keys)
-          .containsExactly(
-            "applicationPaused",
-            "hasManagedResources",
-            "currentEnvironmentConstraints"
-          )
-
-        request = get("/application/$application?includeDetails=true")
-          .accept(MediaType.APPLICATION_JSON_VALUE)
-        result = mvc
-          .perform(request)
-          .andExpect(status().isOk)
-          .andDo { print(it.response.contentAsString) }
-          .andReturn()
-        response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
-        expectThat(response.keys)
-          .containsExactly(
-            "applicationPaused",
-            "hasManagedResources",
-            "currentEnvironmentConstraints",
-            "resources"
-          )
-      }
     }
-  }
 
-  private fun ContentResultMatchers.yaml(expectedYaml: String): ResultMatcher {
-    return ResultMatcher { result: MvcResult ->
-      val content = result.response.getContentAsString(StandardCharsets.UTF_8)
-      val actual = yamlMapper.readValue<Map<String, Any?>>(content)
-      val expected = yamlMapper.readValue<Map<String, Any?>>(expectedYaml)
-      val diff = DefaultResourceDiff(actual, expected)
+    test("returns bad request for unknown entities") {
+      val request = get("/application/$application?entities=bananas")
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+      mvc.perform(request)
+        .andExpect(status().isBadRequest)
+    }
 
-      if (!diff.hasChanges()) {
-        true
-      } else {
-        throw AssertionError("Actual and expected YAML differ: \n${diff.toDeltaJson()}")
+    test("is backwards-compatible with older version of the API") {
+      var request = get("/application/$application?includeDetails=false")
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+      var result = mvc
+        .perform(request)
+        .andExpect(status().isOk)
+        .andDo { print(it.response.contentAsString) }
+        .andReturn()
+      var response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
+      expectThat(response.keys)
+        .containsExactly(
+          "applicationPaused",
+          "hasManagedResources",
+          "currentEnvironmentConstraints"
+        )
+
+      request = get("/application/$application?includeDetails=true")
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+      result = mvc
+        .perform(request)
+        .andExpect(status().isOk)
+        .andDo { print(it.response.contentAsString) }
+        .andReturn()
+      response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
+      expectThat(response.keys)
+        .containsExactly(
+          "applicationPaused",
+          "hasManagedResources",
+          "currentEnvironmentConstraints",
+          "resources"
+        )
+    }
+
+    test("rejects an unauthorized user from judging constraints") {
+      before {
+        every { authorizationSupport.userCanModifyApplication(application) } returns false
       }
+      val request = post(
+        "/application/$application/environment/prod/constraint",
+        UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
+      )
+        .accept(MediaType.APPLICATION_JSON_VALUE)
+      mvc
+        .perform(request)
+        .andExpect(status().is4xxClientError)
     }
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -23,14 +23,11 @@ import com.netflix.spinnaker.keel.test.TEST_API_V1
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import org.hamcrest.CoreMatchers.containsString
-import org.hamcrest.CoreMatchers.not
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
-import org.springframework.http.MediaType
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import org.springframework.test.web.servlet.MockMvc
@@ -41,8 +38,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import strikt.api.expectCatching
 import strikt.api.expectThat
-import strikt.assertions.hasSize
-import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.succeeded
@@ -269,84 +264,6 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
                 ?.constraints
             ).isNotNull()
           }
-
-          context("no environments with stateful constraints have been evaluated") {
-            test("no constraint state") {
-              getProdConstraintResponse(contentType)
-                // Response assertions that aren't dependent on contentType or deserialization
-                .andExpect(status().isOk)
-                .andExpect(content().string(not(containsString("status"))))
-
-              val states = getProdConstraintStates(contentType)
-              expectThat(states).isEmpty()
-            }
-          }
-
-          derivedContext<ResultActions>("interacting with manual judgement") {
-            val constraintStateYaml =
-              """---
-                |type: manual-judgement
-                |artifactVersion: keel-1.0.2
-                |status: OVERRIDE_PASS
-              """.trimMargin()
-
-            val constraintStateJson =
-              """{
-                |  "type": "manual-judgement",
-                |  "artifactVersion": "keel-1.0.2",
-                |  "status": "OVERRIDE_PASS"
-                |}
-              """.trimMargin()
-
-            fixture {
-              val judgement = ConstraintState("keel-manifest", "prod", "keel-1.0.2", "manual-judgement", PENDING)
-              deliveryConfigRepository.storeConstraintState(judgement)
-
-              getProdConstraintResponse(contentType)
-            }
-
-            test("pending manual judgement") {
-              andExpect(status().isOk)
-              andExpect(content().string(containsString("manual-judgement")))
-              andExpect(content().string(containsString("PENDING")))
-            }
-
-            derivedContext<ResultActions>("approving manual judgement") {
-              fixture {
-                val request = post(
-                  "/delivery-configs/keel-manifest/environment/prod/constraint")
-                  .accept(contentType)
-                  .contentType(contentType)
-                  .content(when (contentType) {
-                    APPLICATION_YAML -> constraintStateYaml
-                    else -> constraintStateJson
-                  })
-                  .header("X-SPINNAKER-USER", "keel")
-
-                mvc.perform(request)
-              }
-
-              test("judgement is persisted") {
-                andExpect(status().isOk)
-
-                val judgement = deliveryConfigRepository
-                  .getConstraintState("keel-manifest", "prod", "keel-1.0.2", "manual-judgement")
-
-                expectThat(judgement).isNotNull()
-                expectThat(judgement!!.status).isEqualTo(OVERRIDE_PASS)
-                expectThat(judgement.judgedBy).isEqualTo("keel")
-              }
-
-              test("persisted judgement is in rest response") {
-                val states = getProdConstraintStates(contentType)
-                expectThat(states).hasSize(1)
-                with(states.first()) {
-                  expectThat(status).isEqualTo(OVERRIDE_PASS)
-                  expectThat(judgedBy).isEqualTo("keel")
-                }
-              }
-            }
-          }
         }
 
         derivedContext<ResultActions>("the submitted manifest is missing a required field") {
@@ -397,24 +314,4 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
       }
     }
   }
-
-  private fun getProdConstraintResponse(contentType: MediaType) =
-    mvc.perform(
-      get("/delivery-configs/keel-manifest/environment/prod/constraints")
-        .accept(contentType)
-        .contentType(contentType)
-    )
-
-  private fun getProdConstraintStates(contentType: MediaType): List<ConstraintState> =
-    getProdConstraintResponse(contentType)
-      .andReturn()
-      .response
-      .contentAsString
-      .let {
-        if (contentType == APPLICATION_YAML) {
-          configuredYamlMapper().readValue(it)
-        } else {
-          configuredObjectMapper().readValue(it)
-        }
-      }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -4,9 +4,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.constraints.ConstraintState
-import com.netflix.spinnaker.keel.constraints.ConstraintStatus.OVERRIDE_PASS
-import com.netflix.spinnaker.keel.constraints.ConstraintStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.SubmittedEnvironment


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/940.

The UI needs to be able to judge constraints by using the application name instead of the delivery config name. This PR adds a new endpoint that is the same as the delivery config endpoint (see linked issue). This new endpoint has auth protections as well.

I removed the old endpoint, and also updated the tests for this functionality. I moved all tests for constraints and generating the views to the `ApplicationServiceTests` class. I kept actual controller tests (like auth rejection) in the controller tests.