### PR TITLE
feat(api): limit 1 delivery config per app

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -379,6 +379,39 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
           expectThat(subject.allResourceNames().size).isEqualTo(0)
         }
       }
+
+      context("a second delivery config for an app fails to persist") {
+        val submittedConfig1 = SubmittedDeliveryConfig(
+          name = configName,
+          application = "keel",
+          serviceAccount = "keel@spinnaker",
+          artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+          environments = setOf(
+            SubmittedEnvironment(
+              name = "test",
+              resources = setOf(
+                SubmittedResource(
+                  metadata = mapOf("serviceAccount" to "keel@spinnaker"),
+                  kind = TEST_API_V1.qualify("whatever"),
+                  spec = DummyResourceSpec(data = "o hai")
+                )
+              ),
+              constraints = emptySet()
+            )
+          )
+        )
+
+        val submittedConfig2 = submittedConfig1.copy(name = "double-trouble")
+        test("an error is thrown and config is deleted") {
+          subject.upsertDeliveryConfig(submittedConfig1)
+          expectCatching {
+            subject.upsertDeliveryConfig(submittedConfig2)
+          }.failed()
+            .isA<TooManyDeliveryConfigsException>()
+
+          expectThat(subject.getDeliveryConfigsByApplication("keel").size).isEqualTo(1)
+        }
+      }
     }
   }
 }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -402,7 +402,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
         )
 
         val submittedConfig2 = submittedConfig1.copy(name = "double-trouble")
-        test("an error is thrown and config is deleted") {
+        test("an error is thrown and config is not persisted") {
           subject.upsertDeliveryConfig(submittedConfig1)
           expectCatching {
             subject.upsertDeliveryConfig(submittedConfig2)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryPeriodicallyCheckedTests.kt
@@ -13,7 +13,7 @@ abstract class DeliveryConfigRepositoryPeriodicallyCheckedTests<S : DeliveryConf
       .map { i ->
         DeliveryConfig(
           name = "delivery-config-$i",
-          application = "fnord",
+          application = "fnord-$i",
           serviceAccount = "keel@spinnaker"
         )
           .also(subject::store)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -88,6 +88,14 @@ class CombinedRepository(
       null
     }
 
+    val existingConfigs = getDeliveryConfigsByApplication(deliveryConfig.application)
+
+    if (old == null && existingConfigs.isNotEmpty()) {
+      // we only allow one delivery config, so throw an error if someone is trying to submit a new config
+      // instead of updating the existing config
+      throw TooManyDeliveryConfigsException(deliveryConfig.application, existingConfigs.map { it.name })
+    }
+
     deliveryConfig.resources.forEach { resource ->
       upsert(resource)
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -150,4 +150,7 @@ class NoSuchDeliveryConfigName(name: String) : NoSuchDeliveryConfigException("No
 class NoMatchingArtifactException(deliveryConfigName: String, type: ArtifactType, reference: String) :
   RuntimeException("No artifact with reference $reference and type $type found in delivery config $deliveryConfigName")
 
+class TooManyDeliveryConfigsException(application: String, existing: List<String>) :
+  UserException("A delivery config already exists for application $application, and we only allow one per application - please delete existing configs $existing before submitting a new config")
+
 class OrphanedResourceException(id: String) : SystemException("Resource $id exists without being a part of a delivery config")

--- a/keel-sql/src/main/resources/db/changelog/20200330-delivery-config-unique-per-application.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200330-delivery-config-unique-per-application.yml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: delivery-config-unique-per-application
+      author: emjburns
+      changes:
+        - createIndex:
+            indexName: delivery_config_application_idx
+            tableName: delivery_config
+            unique: true
+            columns:
+              - column:
+                  name: application
+      rollback:
+        - dropIndex:
+            indexName: delivery_config_application_idx
+            tableName: delivery_config

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -84,8 +84,8 @@ databaseChangeLog:
       file: changelog/20200122-service-account-on-delivery-config.yml
       relativeToChangelogFile: true
   - include:
-     file: changelog/20200122-delivery-config-api-version.yml
-     relativeToChangelogFile: true
+      file: changelog/20200122-delivery-config-api-version.yml
+      relativeToChangelogFile: true
   - include:
       file: changelog/20200109-create-task-tracking-table.yml
       relativeToChangelogFile: true
@@ -112,4 +112,7 @@ databaseChangeLog:
       relativeToChangelogFile: true
   - include:
       file: changelog/20200313-json-columns.yml
+      relativeToChangelogFile: true
+  - include:
+      file: changelog/20200330-delivery-config-unique-per-application.yml
       relativeToChangelogFile: true


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/676.

A first pass at limiting delivery configs to one per app.

Right now, we're making the choice to limit delivery configs to one per app so that it's easy to work with from the UI. This assumption might change as we get more adoption. I've put this one easy limit together now, which will prevent you from saving a new delivery config if one exists for your app. 

Do you think we need more precautions than this?