### PR TITLE
fix(configs): get by app returns one delivery config

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -409,7 +409,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
           }.failed()
             .isA<TooManyDeliveryConfigsException>()
 
-          expectThat(subject.getDeliveryConfigsByApplication("keel").size).isEqualTo(1)
+          expectThat(subject.getDeliveryConfigForApplication("keel").name).isEqualTo(configName)
         }
       }
     }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -21,10 +21,8 @@ import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.failed
-import strikt.assertions.first
 import strikt.assertions.hasSize
 import strikt.assertions.isA
-import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.succeeded
 
@@ -141,8 +139,8 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
 
       test("retrieving config by application returns an empty list") {
         getByApplication()
-          .succeeded()
-          .isEmpty()
+          .failed()
+          .isA<NoSuchDeliveryConfigException>()
       }
     }
 
@@ -163,8 +161,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
       test("the config can be retrieved by application") {
         getByApplication()
           .succeeded()
-          .hasSize(1)
-          .first()
           .get(DeliveryConfig::name)
           .isEqualTo(deliveryConfig.name)
       }
@@ -229,7 +225,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         test("artifacts are attached when retrieved by application") {
           getByApplication()
             .succeeded()
-            .first()
             .get { artifacts }.isEqualTo(deliveryConfig.artifacts)
         }
 
@@ -243,7 +238,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         test("environments are attached when retrieved by application") {
           getByApplication()
             .succeeded()
-            .first()
             .get { environments }
             .isEqualTo(deliveryConfig.environments)
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -88,12 +88,16 @@ class CombinedRepository(
       null
     }
 
-    val existingConfigs = getDeliveryConfigsByApplication(deliveryConfig.application)
+    val existingConfig = try {
+      getDeliveryConfigForApplication(deliveryConfig.application)
+    } catch (e: NoSuchDeliveryConfigException) {
+      null
+    }
 
-    if (old == null && existingConfigs.isNotEmpty()) {
+    if (old == null && existingConfig != null) {
       // we only allow one delivery config, so throw an error if someone is trying to submit a new config
       // instead of updating the existing config
-      throw TooManyDeliveryConfigsException(deliveryConfig.application, existingConfigs.map { it.name })
+      throw TooManyDeliveryConfigsException(deliveryConfig.application, existingConfig.name)
     }
 
     deliveryConfig.resources.forEach { resource ->
@@ -243,7 +247,7 @@ class CombinedRepository(
   override fun deliveryConfigFor(resourceId: String): DeliveryConfig =
     deliveryConfigRepository.deliveryConfigFor(resourceId)
 
-  override fun getDeliveryConfigsByApplication(application: String): Collection<DeliveryConfig> =
+  override fun getDeliveryConfigForApplication(application: String): DeliveryConfig =
     deliveryConfigRepository.getByApplication(application)
 
   override fun deleteDeliveryConfigByApplication(application: String): Int =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -34,10 +34,9 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun deliveryConfigFor(resourceId: String): DeliveryConfig
 
   /**
-   * @return All [DeliveryConfig] instances associated with [application], or an empty collection if
-   * there are none.
+   * @return the [DeliveryConfig] associated with [application], throws [NoDeliveryConfigForApplication] if none
    */
-  fun getByApplication(application: String): Collection<DeliveryConfig>
+  fun getByApplication(application: String): DeliveryConfig
 
   /**
    * Delete the [DeliveryConfig] persisted for an application. This does not delete the underlying
@@ -146,11 +145,12 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
 
 sealed class NoSuchDeliveryConfigException(message: String) : UserException(message)
 class NoSuchDeliveryConfigName(name: String) : NoSuchDeliveryConfigException("No delivery config named $name exists in the repository")
+class NoDeliveryConfigForApplication(application: String) : NoSuchDeliveryConfigException("No delivery config for application $application exists in the repository")
 
 class NoMatchingArtifactException(deliveryConfigName: String, type: ArtifactType, reference: String) :
   RuntimeException("No artifact with reference $reference and type $type found in delivery config $deliveryConfigName")
 
-class TooManyDeliveryConfigsException(application: String, existing: List<String>) :
-  UserException("A delivery config already exists for application $application, and we only allow one per application - please delete existing configs $existing before submitting a new config")
+class TooManyDeliveryConfigsException(application: String, existing: String) :
+  UserException("A delivery config already exists for application $application, and we only allow one per application - please delete existing config $existing before submitting a new config")
 
 class OrphanedResourceException(id: String) : SystemException("Resource $id exists without being a part of a delivery config")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -85,7 +85,7 @@ interface KeelRepository {
 
   fun deliveryConfigFor(resourceId: String): DeliveryConfig
 
-  fun getDeliveryConfigsByApplication(application: String): Collection<DeliveryConfig>
+  fun getDeliveryConfigForApplication(application: String): DeliveryConfig
 
   fun deleteDeliveryConfigByApplication(application: String): Int
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.OrphanedResourceException
 import java.time.Clock
@@ -30,8 +31,8 @@ class InMemoryDeliveryConfigRepository(
     lastCheckTimes.clear()
   }
 
-  override fun getByApplication(application: String) =
-    configs.values.filter { it.application == application }
+  override fun getByApplication(application: String): DeliveryConfig =
+    configs.values.firstOrNull() { it.application == application } ?: throw NoDeliveryConfigForApplication(application)
 
   override fun deleteByApplication(application: String): Int {
     val size = configs.count { it.value.application == application }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -27,9 +27,8 @@ class AdminController(
     @PathVariable("application") application: String
   ) {
     log.debug("Deleting all data for application: $application")
-    repository.getDeliveryConfigsByApplication(application).forEach { config ->
-      repository.deleteDeliveryConfig(config.name)
-    }
+    val config = repository.getDeliveryConfigForApplication(application)
+    repository.deleteDeliveryConfig(config.name)
   }
 
   @GetMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EnvironmentController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EnvironmentController.kt
@@ -19,7 +19,7 @@ class EnvironmentController(
   )
   fun list(@PathVariable("application") application: String) =
     repository
-      .getDeliveryConfigsByApplication(application)
-      .flatMap { it.environments }
+      .getDeliveryConfigForApplication(application)
+      .environments
       .map { it.name }
 }


### PR DESCRIPTION
Delivery config changes to follow enforcing one config per app (https://github.com/spinnaker/keel/pull/944). This will make it easier to work with delivery configs.