### PR TITLE
feat(api): Add stateless constraint information to artifact summary

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -75,8 +75,6 @@ data class StatefulConstraintSummary(
 data class StatelessConstraintSummary(
   val type: String,
   val currentlyPassing: Boolean,
-  val status: ConstraintStatus? = null,
-  val comment: String? = null,
   val attributes: ConstraintMetadata? = null
 )
 
@@ -88,5 +86,5 @@ data class DependOnConstraintMetadata(
 
 data class AllowedTimesConstraintMetadata(
   val windows: List<TimeWindow>,
-  val tz: String? = null
+  val timezone: String? = null
 ) : ConstraintMetadata()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -56,7 +56,8 @@ data class ArtifactSummaryInEnvironment(
   val deployedAt: Instant? = null,
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
-  val statefulConstraints: List<StatefulConstraintSummary> = emptyList()
+  val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
+  val statelessConstraints: List<StatelessConstraintSummary?> = emptyList()
 )
 
 @JsonInclude(Include.NON_NULL)
@@ -69,3 +70,23 @@ data class StatefulConstraintSummary(
   val comment: String? = null,
   val attributes: ConstraintStateAttributes? = null
 )
+
+@JsonInclude(Include.NON_NULL)
+data class StatelessConstraintSummary(
+  val type: String,
+  val currentlyPassing: Boolean,
+  val status: ConstraintStatus? = null,
+  val comment: String? = null,
+  val attributes: ConstraintMetadata? = null
+)
+
+abstract class ConstraintMetadata(val type: String)
+
+data class DependOnConstraintMetadata(
+  val environment: String
+) : ConstraintMetadata("depends-on")
+
+data class AllowedTimesConstraintMetadata(
+  val windows: List<TimeWindow>,
+  val tz: String? = null
+) : ConstraintMetadata("allowed-times")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -80,13 +80,13 @@ data class StatelessConstraintSummary(
   val attributes: ConstraintMetadata? = null
 )
 
-abstract class ConstraintMetadata(val type: String)
+abstract class ConstraintMetadata()
 
 data class DependOnConstraintMetadata(
   val environment: String
-) : ConstraintMetadata("depends-on")
+) : ConstraintMetadata()
 
 data class AllowedTimesConstraintMetadata(
   val windows: List<TimeWindow>,
   val tz: String? = null
-) : ConstraintMetadata("allowed-times")
+) : ConstraintMetadata()

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -38,14 +38,14 @@ import org.springframework.stereotype.Component
 @Component
 class ApplicationService(
   private val repository: KeelRepository,
-  private val constraints: List<ConstraintEvaluator<*>>
+  private val constraintEvaluators: List<ConstraintEvaluator<*>>
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
-  private val explicitConstraints: List<ConstraintEvaluator<*>> = constraints.filter { !it.isImplicit() }
-  private val statefulEvaluators: List<ConstraintEvaluator<*>> = explicitConstraints
+  private val explicitConstraintEvaluators: List<ConstraintEvaluator<*>> = constraintEvaluators.filter { !it.isImplicit() }
+  private val statefulEvaluators: List<ConstraintEvaluator<*>> = explicitConstraintEvaluators
     .filterIsInstance<StatefulConstraintEvaluator<*>>()
 
-  private val statelessEvaluators = explicitConstraints - statefulEvaluators
+  private val statelessEvaluators = explicitConstraintEvaluators - statefulEvaluators
 
   fun hasManagedResources(application: String) = repository.hasManagedResources(application)
 
@@ -177,8 +177,8 @@ class ApplicationService(
           type = constraint.type,
           currentlyPassing = it.canPromote(artifact, version = version, deliveryConfig = deliveryConfig, targetEnvironment = environment),
           attributes = when (constraint) {
-              is DependsOnConstraint -> DependOnConstraintMetadata(constraint.environment)
-              is TimeWindowConstraint -> AllowedTimesConstraintMetadata(constraint.windows, constraint.tz)
+            is DependsOnConstraint -> DependOnConstraintMetadata(constraint.environment)
+            is TimeWindowConstraint -> AllowedTimesConstraintMetadata(constraint.windows, constraint.tz)
             else -> null
           }
         )

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -12,17 +12,21 @@ import com.netflix.spinnaker.keel.constraints.ConstraintEvaluator
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.constraints.StatefulConstraintEvaluator
+import com.netflix.spinnaker.keel.core.api.AllowedTimesConstraintMetadata
 import com.netflix.spinnaker.keel.core.api.ArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.BuildMetadata
+import com.netflix.spinnaker.keel.core.api.DependOnConstraintMetadata
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.GitMetadata
 import com.netflix.spinnaker.keel.core.api.PromotionStatus
 import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
 import com.netflix.spinnaker.keel.core.api.StatelessConstraintSummary
+import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import org.slf4j.LoggerFactory
@@ -171,7 +175,12 @@ class ApplicationService(
       }?.let {
         StatelessConstraintSummary(
           type = constraint.type,
-          currentlyPassing = it.canPromote(artifact, version = version, deliveryConfig = deliveryConfig, targetEnvironment = environment)
+          currentlyPassing = it.canPromote(artifact, version = version, deliveryConfig = deliveryConfig, targetEnvironment = environment),
+          attributes = when (constraint) {
+              is DependsOnConstraint -> DependOnConstraintMetadata(constraint.environment)
+              is TimeWindowConstraint -> AllowedTimesConstraintMetadata(constraint.windows, constraint.tz)
+            else -> null
+          }
         )
       }
     }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -519,6 +519,11 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                     status: "NOT_EVALUATED"
                   - type: "pipeline"
                     status: "NOT_EVALUATED"
+                  statelessConstraints:
+                  - type: "depends-on"
+                    currentlyPassing: false
+                  - attributes:
+                      environment: "staging"
                 build:
                   id: 3
                 git:
@@ -538,6 +543,11 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                     status: "NOT_EVALUATED"
                   - type: "pipeline"
                     status: "NOT_EVALUATED"
+                  statelessConstraints:
+                  - type: "depends-on"
+                    currentlyPassing: false
+                  - attributes:
+                    environment: "staging"
                 build:
                   id: 2
                 git:
@@ -560,6 +570,11 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                     status: "NOT_EVALUATED"
                   - type: "pipeline"
                     status: "NOT_EVALUATED"
+                  statelessConstraints:
+                  - type: "depends-on"
+                    currentlyPassing: false
+                  - attributes:
+                    environment: "staging"
                 build:
                   id: 1
                 git:
@@ -589,6 +604,11 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                     comment: "Aye!"
                   - type: "pipeline"
                     status: "NOT_EVALUATED"
+                  statelessConstraints:
+                  - type: "depends-on"
+                    currentlyPassing: true
+                  - attributes:
+                    environment: "staging"
                 build:
                   id: 0
                 git:

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -522,7 +522,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                   statelessConstraints:
                   - type: "depends-on"
                     currentlyPassing: false
-                  - attributes:
+                    attributes:
                       environment: "staging"
                 build:
                   id: 3
@@ -546,8 +546,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                   statelessConstraints:
                   - type: "depends-on"
                     currentlyPassing: false
-                  - attributes:
-                    environment: "staging"
+                    attributes:
+                      environment: "staging"
                 build:
                   id: 2
                 git:
@@ -572,9 +572,9 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                     status: "NOT_EVALUATED"
                   statelessConstraints:
                   - type: "depends-on"
-                    currentlyPassing: false
-                  - attributes:
-                    environment: "staging"
+                    currentlyPassing: true
+                    attributes:
+                      environment: "staging"
                 build:
                   id: 1
                 git:
@@ -607,8 +607,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
                   statelessConstraints:
                   - type: "depends-on"
                     currentlyPassing: true
-                  - attributes:
-                    environment: "staging"
+                    attributes:
+                      environment: "staging"
                 build:
                   id: 0
                 git:


### PR DESCRIPTION
Closes #889 
Adding stateless constraints info the artifact summary API.
an example of the output would be:
```json
              "statelessConstraints": [
                {
                  "type": "depends-on",
                  "currentlyPassing": true,
                  "attributes": {
                    "environment": "testing"
                  }
                },
                {
                  "type": "allowed-times",
                  "currentlyPassing": false,
                  "attributes": {
                    "windows": [
                      {
                        "days": "Wed",
                        "hours": "12-14"
                      }
                    ],
                    "tz": "America/Los_Angeles"
                  }
                }
              ]
```
