### PR TITLE
If we can't parse a resource in the database, stop checking

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -17,6 +17,10 @@ data class ResourceCheckTimedOut(
   val application: String
 ) : TelemetryEvent()
 
+data class ResourceLoadFailed(
+  val ex: Throwable
+) : TelemetryEvent()
+
 data class ArtifactVersionUpdated(
   val name: String,
   val type: ArtifactType

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepositoryTests.kt
@@ -10,7 +10,7 @@ internal class InMemoryDeliveryConfigRepositoryTests : DeliveryConfigRepositoryT
   override fun createDeliveryConfigRepository(resourceTypeIdentifier: ResourceTypeIdentifier): InMemoryDeliveryConfigRepository =
     InMemoryDeliveryConfigRepository()
 
-  override fun createResourceRepository(): InMemoryResourceRepository =
+  override fun createResourceRepository(resourceTypeIdentifier: ResourceTypeIdentifier): InMemoryResourceRepository =
     InMemoryResourceRepository()
 
   override fun createArtifactRepository(): InMemoryArtifactRepository =

--- a/keel-sql/src/main/resources/db/changelog/20200401-resource-check-veto.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200401-resource-check-veto.yml
@@ -1,0 +1,18 @@
+databaseChangeLog:
+  - changeSet:
+      id: resource-check-ignore
+      author: fletch
+      changes:
+      - addColumn:
+          tableName: resource_last_checked
+          columns:
+          - column:
+              name: ignore
+              type: boolean
+              defaultValue: false
+              constraints:
+                nullable: false
+      rollback:
+      - dropColumn:
+          tableName: resource
+          columnName: ignore

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -119,3 +119,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200325-create-artifact-last-checked-table.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200401-resource-check-veto.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/DummyResourceTypeIdentifier.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/DummyResourceTypeIdentifier.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.sql
 
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
 import com.netflix.spinnaker.keel.resources.ResourceTypeIdentifier
 import com.netflix.spinnaker.keel.test.DummyLocatableResourceSpec
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
@@ -11,7 +12,8 @@ internal object DummyResourceTypeIdentifier : ResourceTypeIdentifier {
   override fun identify(kind: ResourceKind): Class<out ResourceSpec> {
     return when (kind) {
       TEST_API_V1.qualify("locatable") -> DummyLocatableResourceSpec::class.java
-      else -> DummyResourceSpec::class.java
+      TEST_API_V1.qualify("whatever") -> DummyResourceSpec::class.java
+      else -> throw UnsupportedKind(kind)
     }
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
@@ -21,10 +21,10 @@ internal object SqlDeliveryConfigRepositoryTests : DeliveryConfigRepositoryTests
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun createDeliveryConfigRepository(resourceTypeIdentifier: ResourceTypeIdentifier): SqlDeliveryConfigRepository =
-    SqlDeliveryConfigRepository(jooq, Clock.systemUTC(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
+    SqlDeliveryConfigRepository(jooq, Clock.systemUTC(), resourceTypeIdentifier, objectMapper, sqlRetry)
 
-  override fun createResourceRepository(): SqlResourceRepository =
-    SqlResourceRepository(jooq, Clock.systemUTC(), DummyResourceTypeIdentifier, objectMapper, sqlRetry)
+  override fun createResourceRepository(resourceTypeIdentifier: ResourceTypeIdentifier): SqlResourceRepository =
+    SqlResourceRepository(jooq, Clock.systemUTC(), resourceTypeIdentifier, objectMapper, sqlRetry)
 
   override fun createArtifactRepository(): SqlArtifactRepository =
     SqlArtifactRepository(jooq, Clock.systemUTC(), objectMapper, sqlRetry)


### PR DESCRIPTION
After I promoted the change where we no longer check image resources, but instead check artifacts, we discovered that resource checking halted because Keel was no longer able to parse resources with `ImageSpec` payloads.

This change makes it so that if we hit that condition, we'll flag the resource as unreadable and stop checking it. That way resources we _can_ handle will continue being processed.