### PR TITLE
feat(artifact): introduce SKIPPED status, more data for previous

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
@@ -1,0 +1,112 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
+import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import java.time.Clock
+import strikt.api.expect
+import strikt.assertions.containsExactlyInAnyOrder
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+
+/**
+ * In the artifact repository we have several methods that generate summary views of data
+ * that are returned in the /application/{application} endpoint.
+ * This class tests some of that data generation.
+ */
+abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit5Minutests {
+
+  abstract fun factory(clock: Clock): T
+
+  val clock = MutableClock()
+
+  open fun T.flush() {}
+
+  data class Fixture<T : ArtifactRepository>(
+    val subject: T
+  ) {
+    // the artifact built off a feature branch
+    val artifact = DebianArtifact(
+      name = "keeldemo",
+      deliveryConfigName = "my-manifest",
+      reference = "my-artifact",
+      vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
+      statuses = setOf(RELEASE)
+    )
+
+    val environment1 = Environment("aa")
+    val environment2 = Environment(
+      name = "bb",
+      constraints = setOf(DependsOnConstraint("test"), ManualJudgementConstraint())
+    )
+    val manifest = DeliveryConfig(
+      name = "my-manifest",
+      application = "fnord",
+      serviceAccount = "keel@spinnaker",
+      artifacts = setOf(artifact),
+      environments = setOf(environment1, environment2)
+    )
+    val version1 = "keeldemo-1.0.1-h11.1a1a1a1" // release
+    val version2 = "keeldemo-1.0.2-h12.2b2b2b2" // release
+//    val version3 = "keeldemo-1.0.3-h13.3c3c3c3" // release
+  }
+
+  open fun Fixture<T>.persist() {
+    with(subject) {
+      register(artifact)
+      setOf(version1, version2).forEach {
+        store(artifact, it, RELEASE)
+      }
+    }
+    persist(manifest)
+  }
+
+  abstract fun persist(manifest: DeliveryConfig)
+
+  fun tests() = rootContext<Fixture<T>> {
+    fixture { Fixture(factory(clock)) }
+
+    before {
+      persist()
+    }
+
+    after {
+      subject.flush()
+    }
+
+    context("artifact 1 skipped in env 1, mj before env 2") {
+      before {
+        // version 1 and 2 are approved in env 1 approved in env 1
+        subject.approveVersionFor(manifest, artifact, version1, environment1.name)
+        subject.approveVersionFor(manifest, artifact, version2, environment1.name)
+        // only version 2 is approved in env 2
+        subject.approveVersionFor(manifest, artifact, version2, environment2.name)
+        // version 1 has been skipped in env 1 by version 2
+        subject.markAsSkipped(manifest, artifact, version1, environment1.name, version2)
+        // version 2 was successfully deployed to both envs
+        subject.markAsSuccessfullyDeployedTo(manifest, artifact, version2, environment1.name)
+        subject.markAsSuccessfullyDeployedTo(manifest, artifact, version2, environment2.name)
+      }
+
+      test("skipped versions don't get a pending status in the next env") {
+        val summaries = subject.getEnvironmentSummaries(manifest).sortedBy { it.name }
+        expect {
+          that(summaries.size).isEqualTo(2)
+          that(summaries[0].artifacts.first().versions.current).isEqualTo(version2)
+          that(summaries[0].artifacts.first().versions.pending).isEmpty()
+          that(summaries[0].artifacts.first().versions.skipped).containsExactlyInAnyOrder(version1)
+          that(summaries[1].artifacts.first().versions.current).isEqualTo(version2)
+          that(summaries[1].artifacts.first().versions.pending).isEmpty()
+          that(summaries[1].artifacts.first().versions.skipped).containsExactlyInAnyOrder(version1)
+        }
+      }
+    }
+  }
+}

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
@@ -80,30 +80,30 @@ abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit
       subject.flush()
     }
 
-    context("artifact 1 superseded in envA, manual judgement before envB") {
+    context("artifact 1 skipped in envA, manual judgement before envB") {
       before {
         // version 1 and 2 are approved in env A
         subject.approveVersionFor(manifest, artifact, version1, environmentA.name)
         subject.approveVersionFor(manifest, artifact, version2, environmentA.name)
         // only version 2 is approved in env B
         subject.approveVersionFor(manifest, artifact, version2, environmentB.name)
-        // version 1 has been superseded in env A by version 2
-        subject.markAsSuperseded(manifest, artifact, version1, environmentA.name, version2)
+        // version 1 has been skipped in env A by version 2
+        subject.markAsSkipped(manifest, artifact, version1, environmentA.name, version2)
         // version 2 was successfully deployed to both envs
         subject.markAsSuccessfullyDeployedTo(manifest, artifact, version2, environmentA.name)
         subject.markAsSuccessfullyDeployedTo(manifest, artifact, version2, environmentB.name)
       }
 
-      test("superseded versions don't get a pending status in the next env") {
+      test("skipped versions don't get a pending status in the next env") {
         val summaries = subject.getEnvironmentSummaries(manifest).sortedBy { it.name }
         expect {
           that(summaries.size).isEqualTo(2)
           that(summaries[0].artifacts.first().versions.current).isEqualTo(version2)
           that(summaries[0].artifacts.first().versions.pending).isEmpty()
-          that(summaries[0].artifacts.first().versions.superseded).containsExactlyInAnyOrder(version1)
+          that(summaries[0].artifacts.first().versions.skipped).containsExactlyInAnyOrder(version1)
           that(summaries[1].artifacts.first().versions.current).isEqualTo(version2)
           that(summaries[1].artifacts.first().versions.pending).isEmpty()
-          that(summaries[1].artifacts.first().versions.superseded).containsExactlyInAnyOrder(version1)
+          that(summaries[1].artifacts.first().versions.skipped).containsExactlyInAnyOrder(version1)
         }
       }
     }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -54,6 +54,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
       statuses = setOf(SNAPSHOT)
     )
+
     // the artifact built off of master
     val artifact2 = DebianArtifact(
       name = "keeldemo",
@@ -417,14 +418,14 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
               subject.markAsSuccessfullyDeployedTo(manifest, artifact1, version3, environment1.name)
             }
 
-            test("the lower version was marked as skipped") {
+            test("the lower version was marked as superseded") {
               val result = versionsIn(environment1)
               expectThat(result) {
                 get(ArtifactVersionStatus::pending).isEmpty()
                 get(ArtifactVersionStatus::current).isEqualTo(version3)
                 get(ArtifactVersionStatus::deploying).isNull()
                 get(ArtifactVersionStatus::previous).containsExactly(version1)
-                get(ArtifactVersionStatus::skipped).containsExactly(version2)
+                get(ArtifactVersionStatus::superseded).containsExactly(version2)
               }
             }
           }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -418,14 +418,14 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
               subject.markAsSuccessfullyDeployedTo(manifest, artifact1, version3, environment1.name)
             }
 
-            test("the lower version was marked as superseded") {
+            test("the lower version was marked as skipped") {
               val result = versionsIn(environment1)
               expectThat(result) {
                 get(ArtifactVersionStatus::pending).isEmpty()
                 get(ArtifactVersionStatus::current).isEqualTo(version3)
                 get(ArtifactVersionStatus::deploying).isNull()
                 get(ArtifactVersionStatus::previous).containsExactly(version1)
-                get(ArtifactVersionStatus::superseded).containsExactly(version2)
+                get(ArtifactVersionStatus::skipped).containsExactly(version2)
               }
             }
           }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -10,6 +10,10 @@ import com.netflix.spinnaker.keel.telemetry.ArtifactCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.EnvironmentsCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceLoadFailed
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
@@ -23,10 +27,6 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import java.time.Duration
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.coroutines.CoroutineContext
-import kotlin.math.max
 
 @Component
 class CheckScheduler(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -7,6 +7,13 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.APPROVED
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 
 /**
  * Summarized data about a specific environment, mostly for use by the UI.
@@ -26,12 +33,13 @@ data class EnvironmentSummary(
     artifacts.find { it.name == artifact.name && it.type == artifact.type }
       ?.let {
         when (version) {
-          it.versions.current -> PromotionStatus.CURRENT
-          it.versions.deploying -> PromotionStatus.DEPLOYING
-          in it.versions.previous -> PromotionStatus.PREVIOUS
-          in it.versions.approved -> PromotionStatus.APPROVED
-          in it.versions.pending -> PromotionStatus.PENDING
-          in it.versions.vetoed -> PromotionStatus.VETOED
+          it.versions.current -> CURRENT
+          it.versions.deploying -> DEPLOYING
+          in it.versions.previous -> PREVIOUS
+          in it.versions.approved -> APPROVED
+          in it.versions.pending -> PENDING
+          in it.versions.vetoed -> VETOED
+          in it.versions.skipped -> SKIPPED
           else -> throw IllegalStateException("Unknown promotion status for artifact ${it.type}:${it.name}@$version in environment ${this.name}"
           )
         }
@@ -51,5 +59,6 @@ data class ArtifactVersionStatus(
   val pending: List<String>,
   val approved: List<String>,
   val previous: List<String>,
-  val vetoed: List<String>
+  val vetoed: List<String>,
+  val skipped: List<String>
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -12,7 +12,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
-import com.netflix.spinnaker.keel.core.api.PromotionStatus.SUPERSEDED
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 
 /**
@@ -39,7 +39,7 @@ data class EnvironmentSummary(
           in it.versions.approved -> APPROVED
           in it.versions.pending -> PENDING
           in it.versions.vetoed -> VETOED
-          in it.versions.superseded -> SUPERSEDED
+          in it.versions.skipped -> SKIPPED
           else -> throw IllegalStateException("Unknown promotion status for artifact ${it.type}:${it.name}@$version in environment ${this.name}"
           )
         }
@@ -60,5 +60,5 @@ data class ArtifactVersionStatus(
   val approved: List<String>,
   val previous: List<String>,
   val vetoed: List<String>,
-  val superseded: List<String>
+  val skipped: List<String>
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -12,7 +12,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
-import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.SUPERSEDED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 
 /**
@@ -39,7 +39,7 @@ data class EnvironmentSummary(
           in it.versions.approved -> APPROVED
           in it.versions.pending -> PENDING
           in it.versions.vetoed -> VETOED
-          in it.versions.skipped -> SKIPPED
+          in it.versions.superseded -> SUPERSEDED
           else -> throw IllegalStateException("Unknown promotion status for artifact ${it.type}:${it.name}@$version in environment ${this.name}"
           )
         }
@@ -60,5 +60,5 @@ data class ArtifactVersionStatus(
   val approved: List<String>,
   val previous: List<String>,
   val vetoed: List<String>,
-  val skipped: List<String>
+  val superseded: List<String>
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
@@ -1,5 +1,32 @@
 package com.netflix.spinnaker.keel.core.api
 
 enum class PromotionStatus {
-  PENDING, APPROVED, DEPLOYING, CURRENT, PREVIOUS, VETOED
+  /**
+   * Waiting on constraint evaluation before being approved
+   */
+  PENDING,
+  /**
+   * Has passed constraints successfully, and wil be deployed imminently
+   */
+  APPROVED,
+  /**
+   * Deploying in the environment
+   */
+  DEPLOYING,
+  /**
+   * Currently deployed in the environment
+   */
+  CURRENT,
+  /**
+   * Was deployed in the environment, but was replaced by a new version
+   */
+  PREVIOUS,
+  /**
+   * Never allowed to be in the environment again
+   */
+  VETOED,
+  /**
+   * Was approved for the environment, but a newer version was deployed instead
+   */
+  SKIPPED
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
@@ -5,28 +5,34 @@ enum class PromotionStatus {
    * Waiting on constraint evaluation before being approved
    */
   PENDING,
+
   /**
    * Has passed constraints successfully, and wil be deployed imminently
    */
   APPROVED,
+
   /**
    * Deploying in the environment
    */
   DEPLOYING,
+
   /**
    * Currently deployed in the environment
    */
   CURRENT,
+
   /**
    * Was deployed in the environment, but was replaced by a new version
    */
   PREVIOUS,
+
   /**
    * Never allowed to be in the environment again
    */
   VETOED,
+
   /**
    * Was approved for the environment, but a newer version was deployed instead
    */
-  SKIPPED
+  SUPERSEDED
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
@@ -7,7 +7,7 @@ enum class PromotionStatus {
   PENDING,
 
   /**
-   * Has passed constraints successfully, and wil be deployed imminently
+   * Has passed constraints successfully, and will be deployed imminently
    */
   APPROVED,
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PromotionStatus.kt
@@ -32,7 +32,7 @@ enum class PromotionStatus {
   VETOED,
 
   /**
-   * Was approved for the environment, but a newer version was deployed instead
+   * Was approved for the environment, but a newer version was deployed or evaluated instead
    */
-  SUPERSEDED
+  SKIPPED
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -164,9 +164,9 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   )
 
   /**
-   * Marks a version of an artifact as superseded for an environment, with information on what version superseded it.
+   * Marks a version of an artifact as skipped for an environment, with information on what version superseded it.
    */
-  fun markAsSuperseded(
+  fun markAsSkipped(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
     version: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.APPROVED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
-import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.SUPERSEDED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 import com.netflix.spinnaker.keel.core.comparator
 import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
@@ -45,7 +45,7 @@ class InMemoryArtifactRepository(
   private val deployedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<Pair<String, Instant>>>()
   private val vetoedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<String>>()
   private val pinnedVersions = mutableMapOf<EnvironmentVersionsKey, EnvironmentArtifactPin>()
-  private val skippedVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<Skipped>>()
+  private val supersededVersions = mutableMapOf<EnvironmentVersionsKey, MutableList<Superseded>>()
   private val statusByEnvironment = mutableMapOf<EnvironmentVersionsKey, MutableMap<String, PromotionStatus>>()
   private val vetoReference = mutableMapOf<EnvironmentVersionsKey, MutableMap<String, String>>()
   private val lastCheckTimes = mutableMapOf<DeliveryArtifact, Instant>()
@@ -252,12 +252,12 @@ class InMemoryArtifactRepository(
     val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
     // update all previous "current" versions to "previous"
     statuses.filterValues { it == CURRENT }.forEach { statuses[it.key] = PREVIOUS }
-    // update all previous "approved" versions with a lower version number to "skipped"
+    // update all previous "approved" versions with a lower version number to "superseded"
     statuses
       .filterValues { it == APPROVED }
       .filterKeys { artifact.versioningStrategy.comparator.compare(it, version) > 0 }
       .forEach {
-        statuses[it.key] = SKIPPED
+        statuses[it.key] = SUPERSEDED
       }
     statuses[version] = CURRENT
   }
@@ -372,12 +372,12 @@ class InMemoryArtifactRepository(
     statuses[version] = DEPLOYING
   }
 
-  override fun markAsSkipped(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String, skippedByVersion: String) {
+  override fun markAsSuperseded(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String, supersededByVersion: String) {
     val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
     val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
     val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
-    statuses[version] = SKIPPED
-    skippedVersions.getOrPut(key, ::mutableListOf).add(Skipped(version, skippedByVersion, clock.instant()))
+    statuses[version] = SUPERSEDED
+    supersededVersions.getOrPut(key, ::mutableListOf).add(Superseded(version, supersededByVersion, clock.instant()))
   }
 
   override fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary> =
@@ -412,11 +412,11 @@ class InMemoryArtifactRepository(
               versions = ArtifactVersionStatus(
                 current = currentVersion,
                 deploying = statuses.filterValues { it == DEPLOYING }.keys.firstOrNull(),
-                pending = removeLowerIfCurrentExists(artifact, currentVersion, pending),
+                pending = removeOlderIfCurrentExists(artifact, currentVersion, pending),
                 approved = statuses.filterValues { it == APPROVED }.keys.toList(),
                 previous = statuses.filterValues { it == PREVIOUS }.keys.toList(),
                 vetoed = statuses.filterValues { it == VETOED }.keys.toList(),
-                skipped = lowerThanCurrent(artifact, currentVersion, pending).plus(statuses.filterValues { it == SKIPPED }.keys.toList())
+                superseded = removeNewerIfCurrentExists(artifact, currentVersion, pending).plus(statuses.filterValues { it == SUPERSEDED }.keys.toList())
               )
             )
           }
@@ -519,10 +519,10 @@ class InMemoryArtifactRepository(
       .toList()
   }
 
-  private data class Skipped(
+  private data class Superseded(
     val version: String,
-    val skippedByVersion: String,
-    val skippedAt: Instant
+    val supersededByVersion: String,
+    val supersededAt: Instant
   )
 
   private data class ArtifactVersionAndStatus(

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryApplicationSummaryGenerationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryApplicationSummaryGenerationTests.kt
@@ -1,0 +1,20 @@
+package com.netflix.spinnaker.keel.persistence.memory
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.persistence.ApplicationSummaryGenerationTests
+import java.time.Clock
+
+class InMemoryApplicationSummaryGenerationTests : ApplicationSummaryGenerationTests<InMemoryArtifactRepository>() {
+  override fun factory(clock: Clock) = InMemoryArtifactRepository(clock)
+
+  override fun InMemoryArtifactRepository.flush() {
+    dropAll()
+  }
+
+  private val deliveryConfigRepository = InMemoryDeliveryConfigRepository(
+    Clock.systemUTC())
+
+  override fun persist(manifest: DeliveryConfig) {
+    deliveryConfigRepository.store(manifest)
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
-import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.SUPERSEDED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.core.comparator
@@ -396,7 +396,7 @@ class SqlArtifactRepository(
           .set(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT, currentTimestamp())
           .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, CURRENT.name)
           .execute()
-        // update old "CURRENT" to "PREVIOUS, set promotionReference for use in summary data
+        // update old "CURRENT" to "PREVIOUS
         txn
           .update(ENVIRONMENT_ARTIFACT_VERSIONS)
           .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, PREVIOUS.name)
@@ -407,17 +407,17 @@ class SqlArtifactRepository(
           .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(CURRENT.name))
           .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.ne(version))
           .execute()
-        // update any past artifacts that were "APPROVED" to be "SKIPPED
-        //        // because the new version takes precedence
+        // update any past artifacts that were "APPROVED" to be "SUPERSEDED"
+        // because the new version takes precedence
         val approvedButOld = txn.select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
           .from(ENVIRONMENT_ARTIFACT_VERSIONS)
           .where(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(APPROVED.name))
           .fetch(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
-          .filter { isLower(artifact, it, version) }
+          .filter { isOlder(artifact, it, version) }
 
         txn
           .update(ENVIRONMENT_ARTIFACT_VERSIONS)
-          .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SUPERSEDED.name)
           .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, version)
           .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
           .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
@@ -617,12 +617,12 @@ class SqlArtifactRepository(
     }
   }
 
-  override fun markAsSkipped(
+  override fun markAsSuperseded(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
     version: String,
     targetEnvironment: String,
-    skippedByVersion: String
+    supersededByVersion: String
   ) {
     val environment = deliveryConfig.environmentNamed(targetEnvironment)
     val environmentUid = deliveryConfig.getUidFor(environment)
@@ -632,12 +632,12 @@ class SqlArtifactRepository(
         .set(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID, environmentUid)
         .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID, artifact.uid)
         .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION, version)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, skippedByVersion)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SUPERSEDED.name)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, supersededByVersion)
         .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
         .onDuplicateKeyUpdate()
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, skippedByVersion)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SUPERSEDED.name)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, supersededByVersion)
         .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
         .execute()
     }
@@ -734,11 +734,11 @@ class SqlArtifactRepository(
             current = currentVersion,
             deploying = versions[DEPLOYING]?.firstOrNull(),
             // take out stateful constraint values that will never happen
-            pending = removeLowerIfCurrentExists(artifact, currentVersion, versions[PENDING]),
+            pending = removeOlderIfCurrentExists(artifact, currentVersion, versions[PENDING]),
             approved = versions[APPROVED] ?: emptyList(),
             previous = versions[PREVIOUS] ?: emptyList(),
             vetoed = versions[VETOED] ?: emptyList(),
-            skipped = lowerThanCurrent(artifact, currentVersion, versions[PENDING]).plus(versions[SKIPPED]
+            superseded = removeNewerIfCurrentExists(artifact, currentVersion, versions[PENDING]).plus(versions[SUPERSEDED]
               ?: emptyList())
           )
         )

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -383,48 +383,49 @@ class SqlArtifactRepository(
     val environment = deliveryConfig.environmentNamed(targetEnvironment)
     val environmentUid = deliveryConfig.getUidFor(environment)
     sqlRetry.withRetry(WRITE) {
-      jooq
-        .insertInto(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID, environmentUid)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID, artifact.uid)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION, version)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT, currentTimestamp())
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, CURRENT.name)
-        .onDuplicateKeyUpdate()
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT, currentTimestamp())
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, CURRENT.name)
-        .execute()
-    }
-    sqlRetry.withRetry(WRITE) {
-      // update old "CURRENT" to "PREVIOUS, set promotionReference for use in summary data
-      jooq
-        .update(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, PREVIOUS.name)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, version)
-        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(CURRENT.name))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.ne(version))
-        .execute()
-    }
-    sqlRetry.withRetry(WRITE) {
-      // update any past artifacts that were "APPROVED" to be "SKIPPED
-      // because the new version takes precedence
-      val approvedButOld = jooq.select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
-        .from(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .where(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(APPROVED.name))
-        .fetch(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
-        .filter { artifact.versioningStrategy.comparator.compare(it, version) > 0 } // get the lower versions
+      jooq.transaction { config ->
+        val txn = DSL.using(config)
+        txn
+          .insertInto(ENVIRONMENT_ARTIFACT_VERSIONS)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID, environmentUid)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID, artifact.uid)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION, version)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT, currentTimestamp())
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, CURRENT.name)
+          .onDuplicateKeyUpdate()
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT, currentTimestamp())
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, CURRENT.name)
+          .execute()
+        // update old "CURRENT" to "PREVIOUS, set promotionReference for use in summary data
+        txn
+          .update(ENVIRONMENT_ARTIFACT_VERSIONS)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, PREVIOUS.name)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, version)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
+          .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(CURRENT.name))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.ne(version))
+          .execute()
+        // update any past artifacts that were "APPROVED" to be "SKIPPED
+        //        // because the new version takes precedence
+        val approvedButOld = txn.select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
+          .from(ENVIRONMENT_ARTIFACT_VERSIONS)
+          .where(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(APPROVED.name))
+          .fetch(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
+          .filter { isLower(artifact, it, version) }
 
-      jooq
-        .update(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
-        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, version)
-        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(APPROVED.name))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.`in`(*approvedButOld.toTypedArray()))
-        .execute()
+        txn
+          .update(ENVIRONMENT_ARTIFACT_VERSIONS)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, version)
+          .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
+          .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(APPROVED.name))
+          .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.`in`(*approvedButOld.toTypedArray()))
+          .execute()
+      }
     }
   }
 
@@ -616,6 +617,32 @@ class SqlArtifactRepository(
     }
   }
 
+  override fun markAsSkipped(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String,
+    skippedByVersion: String
+  ) {
+    val environment = deliveryConfig.environmentNamed(targetEnvironment)
+    val environmentUid = deliveryConfig.getUidFor(environment)
+    sqlRetry.withRetry(WRITE) {
+      jooq
+        .insertInto(ENVIRONMENT_ARTIFACT_VERSIONS)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID, environmentUid)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID, artifact.uid)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION, version)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, skippedByVersion)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
+        .onDuplicateKeyUpdate()
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY, skippedByVersion)
+        .set(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT, currentTimestamp())
+        .execute()
+    }
+  }
+
   override fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary> {
     return deliveryConfig.environments.map { environment ->
       val artifactVersions = deliveryConfig.artifacts.map { artifact ->
@@ -697,18 +724,22 @@ class SqlArtifactRepository(
           }, { (version, _, _) ->
             version
           })
+
+        val currentVersion = versions[CURRENT]?.firstOrNull()
         ArtifactVersions(
           name = artifact.name,
           type = artifact.type,
           statuses = releaseStatuses,
           versions = ArtifactVersionStatus(
-            current = versions[CURRENT]?.firstOrNull(),
+            current = currentVersion,
             deploying = versions[DEPLOYING]?.firstOrNull(),
-            pending = versions[PENDING] ?: emptyList(),
+            // take out stateful constraint values that will never happen
+            pending = removeLowerIfCurrentExists(artifact, currentVersion, versions[PENDING]),
             approved = versions[APPROVED] ?: emptyList(),
             previous = versions[PREVIOUS] ?: emptyList(),
             vetoed = versions[VETOED] ?: emptyList(),
-            skipped = versions[SKIPPED] ?: emptyList()
+            skipped = lowerThanCurrent(artifact, currentVersion, versions[PENDING]).plus(versions[SKIPPED]
+              ?: emptyList())
           )
         )
       }.toSet()
@@ -827,7 +858,6 @@ class SqlArtifactRepository(
         .where(DELIVERY_ARTIFACT.NAME.eq(artifactName))
         .and(DELIVERY_ARTIFACT.TYPE.eq(artifactType.name))
         .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
-        .limit(1)
         .fetchOne(DELIVERY_ARTIFACT.UID)
         ?: error("Artifact not found: name=$artifactName, type=$artifactType, deliveryConfig=${deliveryConfig.name}")
 
@@ -836,7 +866,6 @@ class SqlArtifactRepository(
         .from(ENVIRONMENT)
         .where(ENVIRONMENT.NAME.eq(environmentName))
         .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(deliveryConfig.uid))
-        .limit(1)
         .fetchOne(ENVIRONMENT.UID)
         ?: error("Environment '$environmentName not found")
 
@@ -844,35 +873,16 @@ class SqlArtifactRepository(
         .select(
           ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION,
           ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT,
-          ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS
+          ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS,
+          ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY,
+          ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT
         )
         .from(ENVIRONMENT_ARTIFACT_VERSIONS)
         .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifactUid))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
         .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.desc())
-        .limit(1)
-        .fetchOne { (version, deployedAt, promotionStatus) ->
-          // todo eb: use PROMOTION_REFERENCE and add a new column, REPLACED_TIME to avoid this nested query
-          val (replacedBy, replacedAt) = when (promotionStatus) {
-            CURRENT.name, PREVIOUS.name -> {
-              jooq
-                .select(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION, ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT)
-                .from(ENVIRONMENT_ARTIFACT_VERSIONS)
-                .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
-                .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifactUid))
-                .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.ne(version))
-                .and(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.isNotNull)
-                .and(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.greaterThan(deployedAt))
-                .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.ne(VETOED.name))
-                .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.asc())
-                .limit(1)
-                .fetchOne { (replacedBy, replacedAt) ->
-                  Pair(replacedBy, replacedAt)
-                } ?: Pair(null, null)
-            }
-            else -> Pair(null, null)
-          }
+        .fetchOne { (version, deployedAt, promotionStatus, replacedBy, replacedAt) ->
           ArtifactSummaryInEnvironment(
             environment = environmentName,
             version = version,

--- a/keel-sql/src/main/resources/db/changelog/20200402-more-artifact-info.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200402-more-artifact-info.yml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: more-artifact-info
+      author: emjburns
+      changes:
+        - addColumn:
+            tableName: environment_artifact_versions
+            columns:
+              - column:
+                  name: replaced_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: replaced_at
+                  type: timestamp(3)
+                  constraints:
+                    nullable: true
+      rollback:
+        - dropColumn:
+            tableName: environment_artifact_versions
+            columnName: replaced_by
+        - dropColumn:
+            tableName: environment_artifact_versions
+            columnName: replaced_at

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -122,3 +122,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200401-resource-check-veto.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200402-more-artifact-info.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApplicationSummaryGenerationTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApplicationSummaryGenerationTests.kt
@@ -1,0 +1,36 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.persistence.ApplicationSummaryGenerationTests
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import java.time.Clock
+
+class SqlApplicationSummaryGenerationTests : ApplicationSummaryGenerationTests<SqlArtifactRepository>() {
+  private val testDatabase = initTestDatabase()
+  private val jooq = testDatabase.context
+  private val objectMapper = configuredObjectMapper()
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+
+  private val deliveryConfigRepository = SqlDeliveryConfigRepository(
+    jooq,
+    Clock.systemUTC(),
+    DummyResourceTypeIdentifier,
+    objectMapper,
+    sqlRetry
+  )
+
+  override fun factory(clock: Clock): SqlArtifactRepository =
+    SqlArtifactRepository(jooq, clock, objectMapper, sqlRetry)
+
+  override fun SqlArtifactRepository.flush() {
+    SqlTestUtil.cleanupDb(jooq)
+  }
+
+  override fun persist(manifest: DeliveryConfig) {
+    deliveryConfigRepository.store(manifest)
+  }
+}

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -259,7 +259,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               previous = listOf(),
               vetoed = listOf(),
               deploying = null,
-              skipped = listOf()
+              superseded = listOf()
             )
           ))
         )
@@ -276,7 +276,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               previous = listOf("fnord-1.0.0-h0.a0a0a0a"),
               vetoed = listOf(),
               deploying = null,
-              skipped = listOf()
+              superseded = listOf()
             )
           ))
         )
@@ -293,7 +293,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               previous = listOf("fnord-1.0.0-h0.a0a0a0a", "fnord-1.0.1-h1.b1b1b1b"),
               vetoed = listOf(),
               deploying = null,
-              skipped = listOf()
+              superseded = listOf()
             )
           ))
         )

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -259,7 +259,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               previous = listOf(),
               vetoed = listOf(),
               deploying = null,
-              superseded = listOf()
+              skipped = listOf()
             )
           ))
         )
@@ -276,7 +276,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               previous = listOf("fnord-1.0.0-h0.a0a0a0a"),
               vetoed = listOf(),
               deploying = null,
-              superseded = listOf()
+              skipped = listOf()
             )
           ))
         )
@@ -293,7 +293,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               previous = listOf("fnord-1.0.0-h0.a0a0a0a", "fnord-1.0.1-h1.b1b1b1b"),
               vetoed = listOf(),
               deploying = null,
-              superseded = listOf()
+              skipped = listOf()
             )
           ))
         )

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -258,7 +258,8 @@ class ApplicationServiceTests : JUnit5Minutests {
               approved = listOf(),
               previous = listOf(),
               vetoed = listOf(),
-              deploying = null
+              deploying = null,
+              skipped = listOf()
             )
           ))
         )
@@ -274,7 +275,8 @@ class ApplicationServiceTests : JUnit5Minutests {
               approved = listOf(),
               previous = listOf("fnord-1.0.0-h0.a0a0a0a"),
               vetoed = listOf(),
-              deploying = null
+              deploying = null,
+              skipped = listOf()
             )
           ))
         )
@@ -290,7 +292,8 @@ class ApplicationServiceTests : JUnit5Minutests {
               approved = listOf("fnord-1.0.3-h3.d3d3d3d"),
               previous = listOf("fnord-1.0.0-h0.a0a0a0a", "fnord-1.0.1-h1.b1b1b1b"),
               vetoed = listOf(),
-              deploying = null
+              deploying = null,
+              skipped = listOf()
             )
           ))
         )


### PR DESCRIPTION
Recently we were talking about artifact statuses. We have an `APPROVED` status which means "this artifact is ready to be deployed". But, we sometimes have the situation where an artifact is approved for an environment but never deployed to that environment. This is probably because the artifact was superseded by another version of an artifact (both were ready to deploy, but we deployed the latest one). 

We also have a `PENDING` status for artifacts to represent that something might be going on in the future, but we have no idea what. That is calculated like this: we look at all versions we know about, and versions that we have data for in an environment (like `APPROVED`/`CURRENT` etc). The versions that we know about but are not in the environment are marked `PENDING`. This is weird, because some versions are never going to happen (for example: two artifacts are waiting on manual judgment. You approve the latest one. We ignore that other version for ever and ever).

This PR introduces a `SKIPPED` status which will get set when an artifact is marked as `CURRENT` in an environment. When an artifact is marked as deployed, we
- set the existing `CURRENT` artifact to `PREVIOUS` (this pr also updates the `promotion_reference` column to contain what artifact replaced it)
- set any versions that are lower than the existing version and have a status of `APPROVED` to `SKIPPED` (for example: 1.1.1, 1.2.1, and 1.3.1 are all approved. 1.2.1 is marked as `CURRENT`. 1.1.1 would be marked as `SKIPPED`. 1.3.1 would be untouched)

This will make our existing data a bit wonkey (i.e. every place we now have `APPROVED` but that's out of date and confusing). It should be straightforward going forward.

This `SKIPPED` status is also used for pending judgments. That works like this:
- we calculate `PENDING` in the same way as described above
- we mark any versions that are < the current version in the environment as `SKIPPED`

After this PR is merged, we should have a better view of artifacts that will never be deployed.