### PR TITLE
fix(coverage): Move codecov metric publishing to master build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,3 +28,6 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: ./gradlew -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace
+      - name: Codecov
+        uses: codecov/codecov-action@v1.0.6
+        if: github.ref == 'refs/heads/master'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,5 +58,3 @@ jobs:
             ${{ steps.release_info.outputs.CHANGELOG }}
            draft: false
            prerelease: ${{ steps.release_info.outputs.IS_CANDIDATE }}
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.6


### PR DESCRIPTION
Another follow-up to #946.