### PR TITLE
fix(errors): Improve error message for NoImageSatisfiesConstraints

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
@@ -26,4 +26,4 @@ class NoImageFoundForRegions(artifactName: String, regions: Collection<String>) 
   ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in regions ${regions.joinToString()}")
 
 class NoImageSatisfiesConstraints(artifactName: String, environment: String) :
-  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName in environment $environment")
+  ResourceCurrentlyUnresolvable("No image found for artifact $artifactName that satisfies constraints in environment $environment")


### PR DESCRIPTION
Improve the wording on this exception so that it's not ambiguous/misleading in the UI:
![image](https://user-images.githubusercontent.com/1323478/78206832-bde1fb00-7454-11ea-9ad9-61be8cc785d1.png)

The real error here is that there's no image that _currently passes the constraints in the environment_. The current message seems to imply there's something missing in the environment, which is not the case.