### PR TITLE
fix(metrics): record drift from last resource check

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -8,7 +8,6 @@ import com.netflix.spinnaker.keel.persistence.AgentLockRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.EnvironmentsCheckTimedOut
-import com.netflix.spinnaker.keel.telemetry.ResourceCheckCompleted
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceLoadFailed
 import java.time.Duration
@@ -61,7 +60,6 @@ class CheckScheduler(
   fun checkResources() {
     if (enabled.get()) {
       log.debug("Starting scheduled resource validation…")
-      publisher.publishEvent(ScheduledResourceCheckStarting)
 
       val job = launch {
         supervisorScope {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.persistence.AgentLockRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.EnvironmentsCheckTimedOut
+import com.netflix.spinnaker.keel.telemetry.ResourceCheckCompleted
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceLoadFailed
 import java.time.Duration
@@ -79,7 +80,10 @@ class CheckScheduler(
                    * to prevent the cancellation of all coroutines under [job]
                    */
                   withTimeout(checkTimeout.toMillis()) {
-                    launch { resourceActuator.checkResource(it) }
+                    launch {
+                      resourceActuator.checkResource(it)
+                      publisher.publishEvent(ResourceCheckCompleted)
+                    }
                   }
                 } catch (e: TimeoutCancellationException) {
                   log.error("Timed out checking resource ${it.id}", e)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ScheduledResourceCheckStarting.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ScheduledResourceCheckStarting.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.actuation
 
-object ScheduledResourceCheckStarting
+object ResourceCheckCompleted
 
 object ScheduledEnvironmentCheckStarting
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -11,6 +11,8 @@ data class ResourceCheckSkipped(
   val skipper: String = "unknown"
 ) : TelemetryEvent()
 
+object ResourceCheckCompleted : TelemetryEvent()
+
 data class ResourceCheckTimedOut(
   val kind: ResourceKind,
   val id: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -11,8 +11,6 @@ data class ResourceCheckSkipped(
   val skipper: String = "unknown"
 ) : TelemetryEvent()
 
-object ResourceCheckCompleted : TelemetryEvent()
-
 data class ResourceCheckTimedOut(
   val kind: ResourceKind,
   val id: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -6,7 +6,6 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.patterns.PolledMeter
 import com.netflix.spinnaker.keel.actuation.ScheduledArtifactCheckStarting
 import com.netflix.spinnaker.keel.actuation.ScheduledEnvironmentCheckStarting
-import com.netflix.spinnaker.keel.actuation.ScheduledResourceCheckStarting
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCheckResult
 import java.time.Clock
@@ -115,8 +114,8 @@ class TelemetryListener(
     ).safeIncrement()
   }
 
-  @EventListener(ScheduledResourceCheckStarting::class)
-  fun onScheduledCheckStarting(event: ScheduledResourceCheckStarting) {
+  @EventListener(ResourceCheckCompleted::class)
+  fun onResourceCheckCompleted(event: ResourceCheckCompleted) {
     lastResourceCheck.set(clock.instant())
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -4,6 +4,7 @@ import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Counter
 import com.netflix.spectator.api.Registry
 import com.netflix.spectator.api.patterns.PolledMeter
+import com.netflix.spinnaker.keel.actuation.ResourceCheckCompleted
 import com.netflix.spinnaker.keel.actuation.ScheduledArtifactCheckStarting
 import com.netflix.spinnaker.keel.actuation.ScheduledEnvironmentCheckStarting
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched


### PR DESCRIPTION
Calculate the resource check drift metric (keel.resource.check.drift)
by using the last time resource check succeeded as the start time.

Previously, it was calculating based on the beginning of the actuation
loop, which would drop to zero when the loop restarted due to timeout.

Fixes #950
