### PR TITLE
chore(pin): move pinning to the application controller

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -85,7 +85,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     val version6 = "master-h12.4ea8a9d"
 
     val pin1 = EnvironmentArtifactPin(
-      deliveryConfigName = manifest.name,
       targetEnvironment = environment2.name, // staging
       reference = artifact2.reference,
       type = artifact2.type.name,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.core.api
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 
 data class EnvironmentArtifactPin(
-  val deliveryConfigName: String,
   val targetEnvironment: String,
   val reference: String,
   val type: String,

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -750,7 +750,7 @@ class SqlArtifactRepository(
   override fun pinEnvironment(deliveryConfig: DeliveryConfig, environmentArtifactPin: EnvironmentArtifactPin) {
     with(environmentArtifactPin) {
       val environment = deliveryConfig.environmentNamed(targetEnvironment)
-      val artifact = get(deliveryConfigName, reference, ArtifactType.valueOf(type.toLowerCase()))
+      val artifact = get(deliveryConfig.name, reference, ArtifactType.valueOf(type.toLowerCase()))
 
       sqlRetry.withRetry(WRITE) {
         jooq.insertInto(ENVIRONMENT_ARTIFACT_PIN)

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -5,7 +5,6 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.deb
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.docker
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.valueOf
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
@@ -69,52 +68,6 @@ class ArtifactController(
   @ResponseStatus(ACCEPTED)
   fun sync() {
     publisher.publishEvent(ArtifactSyncEvent(true))
-  }
-
-  @PostMapping(
-    path = ["/pin"]
-  )
-  @ResponseStatus(ACCEPTED)
-  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #pin.deliveryConfigName)
-    and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #pin.deliveryConfigName)"""
-  )
-  fun pin(
-    @RequestHeader("X-SPINNAKER-USER") user: String,
-    @RequestBody pin: EnvironmentArtifactPin
-  ) {
-    checkNotNull(pin.version) {
-      "A version to pin is required."
-    }
-
-    val deliveryConfig = repository.getDeliveryConfig(pin.deliveryConfigName)
-    repository.pinEnvironment(deliveryConfig, pin.copy(pinnedBy = user))
-  }
-
-  @DeleteMapping(
-    path = ["/pin"]
-  )
-  @ResponseStatus(ACCEPTED)
-  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #pin.deliveryConfigName)
-    and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #pin.deliveryConfigName)"""
-  )
-  fun deletePin(@RequestBody pin: EnvironmentArtifactPin) {
-    val deliveryConfig = repository.getDeliveryConfig(pin.deliveryConfigName)
-    repository.deletePin(deliveryConfig, pin.targetEnvironment, pin.reference, valueOf(pin.type.toUpperCase()))
-  }
-
-  @DeleteMapping(
-    path = ["/pin/{deliveryConfig}/{targetEnvironment}"]
-  )
-  @ResponseStatus(ACCEPTED)
-  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #deliveryConfigName)
-    and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #deliveryConfigName)"""
-  )
-  fun deletePin(
-    @PathVariable("deliveryConfig") deliveryConfigName: String,
-    @PathVariable("targetEnvironment") targetEnvironment: String
-  ) {
-    val deliveryConfig = repository.getDeliveryConfig(deliveryConfigName)
-    repository.deletePin(deliveryConfig, targetEnvironment)
   }
 
   @PostMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -4,6 +4,7 @@ import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.StatefulConstraint
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.deb
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.docker
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
@@ -21,6 +22,7 @@ import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.BuildMetadata
 import com.netflix.spinnaker.keel.core.api.DependOnConstraintMetadata
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.GitMetadata
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
@@ -72,6 +74,21 @@ class ApplicationService(
         comment = status.comment ?: currentState.comment,
         judgedAt = Instant.now(),
         judgedBy = user))
+  }
+
+  fun pin(application: String, pin: EnvironmentArtifactPin, user: String) {
+    val config = repository.getDeliveryConfigForApplication(application)
+    repository.pinEnvironment(config, pin.copy(pinnedBy = user))
+  }
+
+  fun deletePin(application: String, pin: EnvironmentArtifactPin) {
+    val config = repository.getDeliveryConfigForApplication(application)
+    repository.deletePin(config, pin.targetEnvironment, pin.reference, ArtifactType.valueOf(pin.type))
+  }
+
+  fun deletePin(application: String, targetEnvironment: String) {
+    val config = repository.getDeliveryConfigForApplication(application)
+    repository.deletePin(config, targetEnvironment)
   }
 
   /**

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus.OVERRIDE_PASS
 import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
 import com.netflix.spinnaker.keel.core.api.PipelineConstraint
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
@@ -452,6 +453,67 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = delete("/application/fnord/pause")
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+              .header("X-SPINNAKER-USER", "keel@keel.io")
+
+            mvc.perform(request).andExpect(status().isForbidden)
+          }
+        }
+      }
+
+      context("POST /application/fnord/pin") {
+        context("with no WRITE access to application") {
+          before {
+            authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
+            authorizationSupport.allowServiceAccountAccess(APPLICATION)
+          }
+          test("request is forbidden") {
+            val request = post("/application/fnord/pin").addData(jsonMapper,
+              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null, null)
+            )
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+              .header("X-SPINNAKER-USER", "keel@keel.io")
+
+            mvc.perform(request).andExpect(status().isForbidden)
+          }
+        }
+        context("with no access to service account") {
+          before {
+            authorizationSupport.denyServiceAccountAccess(APPLICATION)
+            authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
+          }
+          test("request is forbidden") {
+            val request = post("/application/fnord/pin").addData(jsonMapper,
+              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null, null)
+            )
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+              .header("X-SPINNAKER-USER", "keel@keel.io")
+
+            mvc.perform(request).andExpect(status().isForbidden)
+          }
+        }
+      }
+      context("DELETE /application/fnord/pin/test") {
+        context("with no WRITE access to application") {
+          before {
+            authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
+            authorizationSupport.allowServiceAccountAccess(APPLICATION)
+          }
+          test("request is forbidden") {
+            val request = delete("/application/fnord/pin/test")
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+              .header("X-SPINNAKER-USER", "keel@keel.io")
+
+            mvc.perform(request).andExpect(status().isForbidden)
+          }
+        }
+        context("with no access to service account") {
+          before {
+            authorizationSupport.denyServiceAccountAccess(APPLICATION)
+            authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
+          }
+          test("request is forbidden") {
+            val request = delete("/application/fnord/pin/test")
               .accept(MediaType.APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", "keel@keel.io")
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -5,7 +5,6 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.FINAL
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
@@ -97,66 +96,6 @@ internal class ArtifactControllerTests : JUnit5Minutests {
     }
 
     context("API permission checks") {
-      context("POST /artifacts/pin") {
-        context("with no WRITE access to application") {
-          before {
-            authorizationSupport.denyApplicationAccess(WRITE, DELIVERY_CONFIG)
-            authorizationSupport.allowServiceAccountAccess(DELIVERY_CONFIG)
-          }
-          test("request is forbidden") {
-            val request = post("/artifacts/pin").addData(jsonMapper,
-              EnvironmentArtifactPin("myconfig", "test", "ref", "deb", "0.0.1", null, null)
-            )
-              .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
-
-            mvc.perform(request).andExpect(status().isForbidden)
-          }
-        }
-        context("with no access to service account") {
-          before {
-            authorizationSupport.denyServiceAccountAccess(DELIVERY_CONFIG)
-            authorizationSupport.allowApplicationAccess(WRITE, DELIVERY_CONFIG)
-          }
-          test("request is forbidden") {
-            val request = post("/artifacts/pin").addData(jsonMapper,
-              EnvironmentArtifactPin("myconfig", "test", "ref", "deb", "0.0.1", null, null)
-            )
-              .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
-
-            mvc.perform(request).andExpect(status().isForbidden)
-          }
-        }
-      }
-      context("DELETE /artifacts/pin/myconfig/test") {
-        context("with no WRITE access to application") {
-          before {
-            authorizationSupport.denyApplicationAccess(WRITE, DELIVERY_CONFIG)
-            authorizationSupport.allowServiceAccountAccess(DELIVERY_CONFIG)
-          }
-          test("request is forbidden") {
-            val request = delete("/artifacts/pin/myconfig/test")
-              .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
-
-            mvc.perform(request).andExpect(status().isForbidden)
-          }
-        }
-        context("with no access to service account") {
-          before {
-            authorizationSupport.denyServiceAccountAccess(DELIVERY_CONFIG)
-            authorizationSupport.allowApplicationAccess(WRITE, DELIVERY_CONFIG)
-          }
-          test("request is forbidden") {
-            val request = delete("/artifacts/pin/myconfig/test")
-              .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
-
-            mvc.perform(request).andExpect(status().isForbidden)
-          }
-        }
-      }
       context("POST /artifacts/veto") {
         context("with no WRITE access to application") {
           before {


### PR DESCRIPTION
Move pin operations to the application controller so that they're consistent with the other things the UI is going to call. 

Will add auth once the big PR by @luispollo (#955) has been merged in.

I did not add tests because all these methods are just passthrough, and testing should be done on the artifact repository.

Part of https://github.com/spinnaker/keel/issues/979