### PR TITLE
fix(summary): add artifact reference

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -13,10 +13,11 @@ import java.time.Instant
 /**
  * Summarized data about a specific artifact, mostly for use by the UI.
  */
-@JsonPropertyOrder(value = ["name", "type", "versions"])
+@JsonPropertyOrder(value = ["name", "type", "reference", "versions"])
 data class ArtifactSummary(
   val name: String,
   val type: ArtifactType,
+  val reference: String,
   val versions: Set<ArtifactVersionSummary> = emptySet()
 )
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -49,6 +49,7 @@ data class EnvironmentSummary(
 data class ArtifactVersions(
   val name: String,
   val type: ArtifactType,
+  val reference: String,
   val statuses: Set<ArtifactStatus>,
   val versions: ArtifactVersionStatus
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ResourceSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ResourceSummary.kt
@@ -49,5 +49,6 @@ data class ResourceSummary(
 @JsonInclude(JsonInclude.Include.NON_NULL)
 data class ResourceArtifactSummary(
   val name: String?,
-  val type: ArtifactType?
+  val type: ArtifactType?,
+  val reference: String?
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -246,7 +246,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
       }
     )
 
-  private fun DeliveryArtifact.toResourceArtifactSummary() = ResourceArtifactSummary(name, type)
+  private fun DeliveryArtifact.toResourceArtifactSummary() = ResourceArtifactSummary(name, type, reference)
 
   companion object {
     const val DEFAULT_MAX_EVENTS: Int = 10

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -405,6 +405,7 @@ class InMemoryArtifactRepository(
             ArtifactVersions(
               name = artifact.name,
               type = artifact.type,
+              reference = artifact.reference,
               statuses = when (artifact) {
                 is DebianArtifact -> artifact.statuses
                 else -> emptySet()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -729,6 +729,7 @@ class SqlArtifactRepository(
         ArtifactVersions(
           name = artifact.name,
           type = artifact.type,
+          reference = artifact.reference,
           statuses = releaseStatuses,
           versions = ArtifactVersionStatus(
             current = currentVersion,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -168,6 +168,7 @@ class ApplicationService(
       return@map ArtifactSummary(
         name = artifact.name,
         type = artifact.type,
+        reference = artifact.reference,
         versions = artifactVersionSummaries.toSet()
       )
     }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -254,6 +254,7 @@ class ApplicationServiceTests : JUnit5Minutests {
           setOf(ArtifactVersions(
             artifact.name,
             artifact.type,
+            artifact.reference,
             artifact.statuses,
             ArtifactVersionStatus(
               current = version0,
@@ -271,6 +272,7 @@ class ApplicationServiceTests : JUnit5Minutests {
           setOf(ArtifactVersions(
             artifact.name,
             artifact.type,
+            artifact.reference,
             artifact.statuses,
             ArtifactVersionStatus(
               current = version2,
@@ -288,6 +290,7 @@ class ApplicationServiceTests : JUnit5Minutests {
           setOf(ArtifactVersions(
             artifact.name,
             artifact.type,
+            artifact.reference,
             artifact.statuses,
             ArtifactVersionStatus(
               current = version3,


### PR DESCRIPTION
Artifacts are guaranteed to be unique by reference in a delivery config. They are not guaranteed to be unique by name + type. Adding reference here for artifact, resource, and environment summaries. @erikmunson you are able to use `reference` instead of name and type.

Fixes https://github.com/spinnaker/keel/issues/980