### PR TITLE
fix(artifacts): don't keep marking as deployed over and over

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactDeployedListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactDeployedListener.kt
@@ -32,13 +32,21 @@ class ArtifactDeployedListener(
       )
 
       if (approvedForEnv) {
-        log.info("Marking {} as deployed in {} for config {} because it is already deployed", event.artifactVersion, env.name, deliveryConfig.name)
-        repository.markAsSuccessfullyDeployedTo(
+        val markedCurrentlyDeployed = repository.isCurrentlyDeployedTo(
           deliveryConfig = deliveryConfig,
           artifact = artifact,
           version = event.artifactVersion,
           targetEnvironment = env.name
         )
+        if (!markedCurrentlyDeployed) {
+          log.info("Marking {} as deployed in {} for config {} because it is already deployed", event.artifactVersion, env.name, deliveryConfig.name)
+          repository.markAsSuccessfullyDeployedTo(
+            deliveryConfig = deliveryConfig,
+            artifact = artifact,
+            version = event.artifactVersion,
+            targetEnvironment = env.name
+          )
+        }
       }
     }
 }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -348,6 +348,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
               .isTrue()
           }
 
+          test("the version is marked as currently deployed") {
+            expectThat(subject.isCurrentlyDeployedTo(manifest, artifact1, version1, environment1.name))
+              .isTrue()
+            expectThat(subject.isCurrentlyDeployedTo(manifest, artifact3, version6, environment2.name))
+              .isTrue()
+          }
+
           test("the version is current in the environment") {
             expectThat(versionsIn(environment1)) {
               get(ArtifactVersionStatus::pending).containsExactlyInAnyOrder(version2, version3)
@@ -391,6 +398,11 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
               test("the old version is still considered successfully deployed") {
                 expectThat(subject.wasSuccessfullyDeployedTo(manifest, artifact1, version1, environment1.name))
                   .isTrue()
+              }
+
+              test("the old version is not considered currently deployed") {
+                expectThat(subject.isCurrentlyDeployedTo(manifest, artifact1, version1, environment1.name))
+                  .isFalse()
               }
 
               test("the new version is also considered successfully deployed") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -118,6 +118,16 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   ): Boolean
 
   /**
+   * @return `true` if [version] is currently deployed successfully to [targetEnvironment].
+   */
+  fun isCurrentlyDeployedTo(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String
+  ): Boolean
+
+  /**
    * Marks [version] as successfully deployed to [targetEnvironment] (i.e. future calls to
    * [wasSuccessfullyDeployedTo] will return `true` for that version.
    */

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -397,6 +397,9 @@ class CombinedRepository(
   override fun wasSuccessfullyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String): Boolean =
     artifactRepository.wasSuccessfullyDeployedTo(deliveryConfig, artifact, version, targetEnvironment)
 
+  override fun isCurrentlyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String): Boolean =
+    artifactRepository.isCurrentlyDeployedTo(deliveryConfig, artifact, version, targetEnvironment)
+
   override fun markAsSuccessfullyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String) =
     artifactRepository.markAsSuccessfullyDeployedTo(deliveryConfig, artifact, version, targetEnvironment)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -185,6 +185,8 @@ interface KeelRepository {
 
   fun wasSuccessfullyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String): Boolean
 
+  fun isCurrentlyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String): Boolean
+
   fun markAsSuccessfullyDeployedTo(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String)
 
   fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -233,6 +233,19 @@ class InMemoryArtifactRepository(
     return deployedVersions[key]?.any { (v, _) -> v == version } ?: false
   }
 
+  override fun isCurrentlyDeployedTo(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String
+  ): Boolean {
+    val artifactId = getId(artifact) ?: throw NoSuchArtifactException(artifact)
+    val key = EnvironmentVersionsKey(artifactId, deliveryConfig, targetEnvironment)
+
+    val statuses = statusByEnvironment.getOrPut(key, ::mutableMapOf)
+    return statuses.filterKeys { it == version }.filterValues { it == CURRENT }.isNotEmpty()
+  }
+
   override fun markAsSuccessfullyDeployedTo(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,


### PR DESCRIPTION
I discovered that as long as an artifact is deployed, we will keep marking it as successfully deployed/current to an environment over and over again. This means that the deployed time will keep updating. This is confusing and incorrect. This PR fixes the behavior so we only mark a version as current in an environment if the version is not current.

Pretty sure this bug has been around for months but I didn't notice it until the awesome environments view kept telling me my artifact was deployed "less than a minute ago"