### PR TITLE
fix(api): Fix authorization for POST /delivery-configs

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -32,8 +32,8 @@ class DeliveryConfigController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #name)
-    and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #name)"""
+  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #deliveryConfig.application)
+    and @authorizationSupport.hasServiceAccountAccess(#deliveryConfig.serviceAccount)"""
   )
   fun upsert(
     @RequestBody
@@ -85,7 +85,7 @@ class DeliveryConfigController(
   )
   @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.name)")
   fun validate(@RequestBody deliveryConfig: SubmittedDeliveryConfig) =
-    // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
+  // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
     //  in [ExceptionHandler])
     mapOf("status" to "valid")
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -390,7 +390,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
-            authorizationSupport.allowServiceAccountAccess(APPLICATION)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = post("/application/fnord/environment/prod/constraint").addData(jsonMapper,
@@ -404,7 +404,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(APPLICATION)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
           }
           test("request is forbidden") {
@@ -436,7 +436,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
-            authorizationSupport.allowServiceAccountAccess(APPLICATION)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = delete("/application/fnord/pause")
@@ -448,7 +448,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(APPLICATION)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
           }
           test("request is forbidden") {
@@ -465,7 +465,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
-            authorizationSupport.allowServiceAccountAccess(APPLICATION)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = post("/application/fnord/pin").addData(jsonMapper,
@@ -479,7 +479,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(APPLICATION)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
           }
           test("request is forbidden") {
@@ -497,7 +497,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
-            authorizationSupport.allowServiceAccountAccess(APPLICATION)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = delete("/application/fnord/pin/test")
@@ -509,7 +509,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(APPLICATION)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
           }
           test("request is forbidden") {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -100,7 +100,7 @@ internal class ArtifactControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, DELIVERY_CONFIG)
-            authorizationSupport.allowServiceAccountAccess(DELIVERY_CONFIG)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = post("/artifacts/veto").addData(jsonMapper,
@@ -114,7 +114,7 @@ internal class ArtifactControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(DELIVERY_CONFIG)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, DELIVERY_CONFIG)
           }
           test("request is forbidden") {
@@ -132,7 +132,7 @@ internal class ArtifactControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, DELIVERY_CONFIG)
-            authorizationSupport.allowServiceAccountAccess(DELIVERY_CONFIG)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = delete("/artifacts/veto/myconfig/test/deb/ref/0.0.1")
@@ -144,7 +144,7 @@ internal class ArtifactControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(DELIVERY_CONFIG)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, DELIVERY_CONFIG)
           }
           test("request is forbidden") {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationTestSupport.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationTestSupport.kt
@@ -24,6 +24,9 @@ fun AuthorizationSupport.allowAll() {
     hasServiceAccountAccess(any<String>(), any())
   } returns true
   every {
+    hasServiceAccountAccess(any())
+  } returns true
+  every {
     checkServiceAccountAccess(any<TargetEntity>(), any())
   } just Runs
   every {
@@ -85,24 +88,27 @@ fun AuthorizationSupport.denyCloudAccountAccess(action: Action, target: TargetEn
 /**
  * Mocks authorization to pass for [AuthorizationSupport.hasServiceAccountAccess].
  */
-fun AuthorizationSupport.allowServiceAccountAccess(target: TargetEntity) {
+fun AuthorizationSupport.allowServiceAccountAccess() {
   every {
-    hasServiceAccountAccess(target.name, any())
+    hasServiceAccountAccess(any(), any())
   } returns true
   every {
-    checkServiceAccountAccess(target, any())
+    checkServiceAccountAccess(any(), any())
   } just Runs
 }
 
 /**
  * Mocks authorization to fail for [AuthorizationSupport.hasServiceAccountAccess].
  */
-fun AuthorizationSupport.denyServiceAccountAccess(target: TargetEntity) {
+fun AuthorizationSupport.denyServiceAccountAccess() {
   every {
-    hasServiceAccountAccess(target.name, any())
+    hasServiceAccountAccess(any(), any())
   } returns false
   every {
-    checkServiceAccountAccess(target, any())
+    hasServiceAccountAccess(any())
+  } returns false
+  every {
+    checkServiceAccountAccess(any(), any())
   } throws AccessDeniedException("Nuh-uh!")
 }
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -15,6 +15,7 @@ import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepos
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
+import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.APPLICATION
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
@@ -359,8 +360,8 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
       context("POST /delivery-configs") {
         context("with no WRITE access to application") {
           before {
-            authorizationSupport.denyApplicationAccess(WRITE, DELIVERY_CONFIG)
-            authorizationSupport.allowServiceAccountAccess(DELIVERY_CONFIG)
+            authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = post("/delivery-configs").addData(jsonMapper, deliveryConfig)
@@ -372,8 +373,8 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.allowApplicationAccess(WRITE, DELIVERY_CONFIG)
-            authorizationSupport.denyServiceAccountAccess(DELIVERY_CONFIG)
+            authorizationSupport.allowApplicationAccess(WRITE, APPLICATION)
+            authorizationSupport.denyServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = post("/delivery-configs").addData(jsonMapper, deliveryConfig)

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -184,7 +184,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
         context("with no WRITE access to application") {
           before {
             authorizationSupport.denyApplicationAccess(WRITE, RESOURCE)
-            authorizationSupport.allowServiceAccountAccess(RESOURCE)
+            authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
             val request = delete("/resources/test:${resource.id}/pause")
@@ -196,7 +196,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
         }
         context("with no access to service account") {
           before {
-            authorizationSupport.denyServiceAccountAccess(RESOURCE)
+            authorizationSupport.denyServiceAccountAccess()
             authorizationSupport.allowApplicationAccess(WRITE, RESOURCE)
           }
           test("request is forbidden") {


### PR DESCRIPTION
I had a bad reference in the SPeL expression, and forgot that the submitted delivery config is not in the database yet. 😝 