### PR TITLE
chore(mergify): if an autobump fails, request a review

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
 pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
+      - base=master
       - status-success=build
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
@@ -10,8 +11,47 @@ pull_request_rules:
         strict: smart
       label:
         add: ["auto merged"]
-  - name: Automatically merge kork autobump PRs on CI success
+  - name: Automatically merge release branch changes on CI success and release manager review
     conditions:
+      - base~=^release-
+      - status-success=build
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
+  # This rule exists to handle release branches that are still building using Travis CI instead of
+  # using Github actions. It can be deleted once all active release branches are running Github actions.
+  - name: Automatically merge release branch changes on Travis CI success and release manager review
+    conditions:
+      - base~=^release-
+      - status-success=continuous-integration/travis-ci/pr
+      - "label=ready to merge"
+      - "approved-reviews-by=@release-managers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
+  - name: Automatically merge PRs from maintainers on CI success and review
+    conditions:
+      - base=master
+      - status-success=build
+      - "label=ready to merge"
+      - "author=@oss-approvers"
+    actions:
+      merge:
+        method: squash
+        strict: smart
+      label:
+        add: ["auto merged"]
+  - name: Automatically merge autobump PRs on CI success
+    conditions:
+      - base=master
       - status-success=build
       - "label~=autobump-*"
       - "author:spinnakerbot"
@@ -21,3 +61,12 @@ pull_request_rules:
         strict: smart
       label:
         add: ["auto merged"]
+  - name: Request reviews for autobump PRs on CI failure
+    conditions:
+      - base=master
+      - status-failure=build
+      - "label~=autobump-*"
+      - base=master
+    actions:
+      request_reviews:
+        teams: ["oss-reviewers"]


### PR DESCRIPTION
Also adds the release-branch rules which don't really apply to keel since we aren't making open source releases of it, but it still seems easier to just keep all these files in sync...