### PR TITLE
Make BaseImageCache map to base_ami_version rather than just imageName

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
@@ -6,8 +6,9 @@ interface BaseImageCache {
   /**
    * @param os the desired base image operating system.
    * @param label the desired base image label.
-   * @return the id of the requested base image, if it exists.
+   * @return the base AMI version (i.e. the "appversion" of the base AMI) of the requested base
+   * image, if it exists.
    * @throws UnknownBaseImage if there is no known base image for [os] and [label].
    */
-  fun getBaseImage(os: String, label: BaseLabel): String
+  fun getBaseAmiVersion(os: String, label: BaseLabel): String
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
@@ -3,10 +3,21 @@ package com.netflix.spinnaker.keel.bakery
 import com.netflix.spinnaker.keel.api.artifacts.BaseLabel
 import org.springframework.boot.context.properties.ConfigurationProperties
 
+/**
+ * @param baseImages a map of OS to label -> base AMI version. For example
+ * ```
+ * xenial:
+ *   CANDIDATE: nflx-base-5.530.0-h1663.61bf5c1
+ *   RELEASE: nflx-base-5.523.0-h1645.61bf5c1
+ * bionic:
+ *   CANDIDATE: nflx-base-5.530.0-h1663.61bf5c1
+ *   RELEASE: nflx-base-5.523.0-h1645.61bf5c1
+ * ```
+ */
 class DefaultBaseImageCache(
   private val baseImages: Map<String, Map<String, String>>
 ) : BaseImageCache {
-  override fun getBaseImage(os: String, label: BaseLabel) =
+  override fun getBaseAmiVersion(os: String, label: BaseLabel) =
     baseImages[os]?.get(label.name.toLowerCase()) ?: throw UnknownBaseImage(os, label)
 }
 

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -36,9 +36,9 @@ class ImageHandler(
           ArtifactCheckSkipped(artifact.type, artifact.name, "ActuationInProgress")
         )
       } else {
-        val latestVersion = artifact.findLatestVersion()
-        val latestBaseImageVersion = artifact.getLatestBaseImageVersion()
-        val image = imageService.getLatestImage(artifact.name, "test")
+        val latestVersion = artifact.findLatestArtifactVersion()
+        val latestBaseImageVersion = artifact.findLatestBaseAmiVersion()
+        val image = artifact.findLatestAmi()
 
         if (image == null) {
           log.debug("No image found for {}", artifact.name)
@@ -65,15 +65,16 @@ class ImageHandler(
     }
   }
 
-  private suspend fun DebianArtifact.getLatestBaseImageVersion(): String {
-    val version = baseImageCache.getBaseImage(vmOptions.baseOs, vmOptions.baseLabel)
-    return imageService.findBaseAmi(version)
-  }
+  private suspend fun DeliveryArtifact.findLatestAmi() =
+    imageService.getLatestImage(name, "test")
+
+  private fun DebianArtifact.findLatestBaseAmiVersion() =
+    baseImageCache.getBaseAmiVersion(vmOptions.baseOs, vmOptions.baseLabel)
 
   /**
    * First checks our repo, and if a version isn't found checks igor.
    */
-  private suspend fun DebianArtifact.findLatestVersion(): String {
+  private suspend fun DebianArtifact.findLatestArtifactVersion(): String {
     try {
       val knownVersion = repository
         .artifactVersions(this)

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCacheTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCacheTests.kt
@@ -15,14 +15,14 @@ internal class DefaultBaseImageCacheTests : JUnit5Minutests {
   object Fixture {
     val config = """
       |bionic:
-      |  candidate: bionicbase-x86_64-201904232145-ebs
-      |  unstable: bionicbase-unstable-x86_64-201904252133-ebs
-      |  release: bionicbase-x86_64-201904041959-ebs
+      |  candidate: nflx-base-5.375.0-h1224.8808866
+      |  unstable: nflx-base-5.375.1-h1225.8808866~unstable
+      |  release: nflx-base-5.365.0-h1191.6a005e3
       |xenial:
-      |  candidate: xenialbase-x86_64-201904232145-ebs
-      |  unstable: xenialbase-unstable-x86_64-201904252133-ebs
-      |  release: xenialbase-x86_64-201904041959-ebs
-      |  previous: xenialbase-x86_64-201902202219-ebs
+      |  candidate: nflx-base-5.375.0-h1224.8808866
+      |  unstable: nflx-base-5.375.1-h1225.8808866~unstable
+      |  release: nflx-base-5.365.0-h1191.6a005e3
+      |  previous: nflx-base-5.344.0-h1137.cc92ef3
       |""".trimMargin()
     val baseImageCache = DefaultBaseImageCache(YAMLMapper().readValue(config))
   }
@@ -30,20 +30,20 @@ internal class DefaultBaseImageCacheTests : JUnit5Minutests {
   fun tests() = rootContext<Fixture> {
     fixture { Fixture }
 
-    test("returns the AMI id for a valid os/label") {
-      expectThat(baseImageCache.getBaseImage("bionic", RELEASE))
-        .isEqualTo("bionicbase-x86_64-201904041959-ebs")
+    test("returns the base AMI version for a valid os/label") {
+      expectThat(baseImageCache.getBaseAmiVersion("bionic", RELEASE))
+        .isEqualTo("nflx-base-5.365.0-h1191.6a005e3")
     }
 
     test("throw an exception for an invalid label") {
       expectThrows<UnknownBaseImage> {
-        baseImageCache.getBaseImage("bionic", PREVIOUS)
+        baseImageCache.getBaseAmiVersion("bionic", PREVIOUS)
       }
     }
 
     test("throw an exception for an invalid os") {
       expectThrows<UnknownBaseImage> {
-        baseImageCache.getBaseImage("windows", RELEASE)
+        baseImageCache.getBaseAmiVersion("windows", RELEASE)
       }
     }
   }

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -74,16 +74,13 @@ internal class ImageHandlerTests : JUnit5Minutests {
       )
     )
 
-    val baseImageVersion = "nflx-base-5.378.0-h1230.8808866"
+    val baseAmiVersion = "nflx-base-5.378.0-h1230.8808866"
 
     val image = Image(
-      baseAmiVersion = baseImageVersion,
+      baseAmiVersion = baseAmiVersion,
       appVersion = "${artifact.name}-0.161.0-h63.24d0843",
       regions = artifact.vmOptions.regions
     )
-
-    val baseImageName = "xenialbase-x86_64-201904291721-ebs"
-    val baseAmi = baseImage(baseImageVersion, baseImageName)
 
     val deliveryConfig = deliveryConfig(
       configName = artifact.deliveryConfigName!!,
@@ -220,11 +217,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
         context("the base image is up-to-date") {
           before {
             every {
-              baseImageCache.getBaseImage(artifact.vmOptions.baseOs, artifact.vmOptions.baseLabel)
-            } returns baseAmi.imageName
-            every {
-              imageService.findBaseAmi(any())
-            } returns baseImageVersion
+              baseImageCache.getBaseAmiVersion(artifact.vmOptions.baseOs, artifact.vmOptions.baseLabel)
+            } returns baseAmiVersion
           }
 
           context("the desired version is known") {
@@ -373,14 +367,10 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
         context("a newer base image exists") {
           before {
-            val newerBaseAmi = "xenialbase-x86_64-202004081724-ebs"
-            val newerBaseImageVersion = "nflx-base-5.380.0-h1234.8808866"
+            val newerBaseAmiVersion = "nflx-base-5.380.0-h1234.8808866"
             every {
-              baseImageCache.getBaseImage(artifact.vmOptions.baseOs, artifact.vmOptions.baseLabel)
-            } returns newerBaseAmi
-            every {
-              imageService.findBaseAmi(any())
-            } returns newerBaseImageVersion
+              baseImageCache.getBaseAmiVersion(artifact.vmOptions.baseOs, artifact.vmOptions.baseLabel)
+            } returns newerBaseAmiVersion
 
             repository.storeArtifact(artifact.name, artifact.type, image.appVersion, FINAL)
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -179,20 +179,17 @@ class ImageService(
         amiMatches(allTags, buildHost, buildName, buildNumber)
       }
 
-  suspend fun findBaseAmi(baseImage: String): String {
-    return cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, baseImage, "test")
+  suspend fun findBaseAmiVersion(baseImageName: String): String {
+    return cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, baseImageName, "test")
       .lastOrNull()
       ?.let { namedImage ->
-        val tags = namedImage
+        namedImage
           .tagsByImageId
           .values
-          .first { it?.containsKey("base_ami_version") ?: false }
-        if (tags != null) {
-          tags.getValue("base_ami_version")!!
-        } else {
-          null
-        }
-      } ?: throw BaseAmiNotFound(baseImage)
+          .filterNotNull()
+          .find { it.containsKey("base_ami_version") }
+          ?.getValue("base_ami_version")
+      } ?: throw BaseAmiNotFound(baseImageName)
   }
 
   private fun getAllTags(image: NamedImage): Map<String, String> {


### PR DESCRIPTION
Obviously, this will require equivalent change in `keel-nflx` where we'll use `ImageService.findBaseAmiVersion` to go from the image name we get from the Bakery's fast property to the actual `base_ami_version` tag on that image.