### PR TITLE
chore(bake): add a metric to alert on for when we bake too much

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -154,6 +154,7 @@ class ImageHandler(
         ),
         artifacts = listOf(artifactPayload)
       )
+      publisher.publishEvent(BakeLaunched(appVersion.toString()))
       return listOf(Task(id = taskRef.id, name = description))
     } catch (e: Exception) {
       log.error("Error launching bake for: ${description.toLowerCase()}")
@@ -180,3 +181,4 @@ data class BakeCredentials(
 )
 
 data class ImageRegionMismatchDetected(val image: Image, val regions: Set<String>)
+data class BakeLaunched(val appVersion: String)

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.bakery.telemetry
 
 import com.netflix.spectator.api.BasicTag
 import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.keel.bakery.artifact.BakeLaunched
 import com.netflix.spinnaker.keel.bakery.artifact.ImageRegionMismatchDetected
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
@@ -27,9 +28,24 @@ class BakeryTelemetryListener(private val spectator: Registry) {
       }
   }
 
+  @EventListener(BakeLaunched::class)
+  fun onBakeLaunched(event: BakeLaunched) {
+    spectator.counter(
+      BAKE_LAUNCHED_ID,
+      listOf(
+        BasicTag("appVersion", event.appVersion)
+      )
+    )
+      .runCatching { increment() }
+      .onFailure {
+        log.error("Exception incrementing {} counter: {}", BAKE_LAUNCHED_ID, it.message)
+      }
+  }
+
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   companion object {
     private const val IMAGE_REGION_MISMATCH_DETECTED_ID = "keel.bakery.image.region.mismatch"
+    private const val BAKE_LAUNCHED_ID = "keel.bakery.bake.launched"
   }
 }


### PR DESCRIPTION
Tagging a bake counter with the appversion so that we can see if we're re-baking the same app version over and over again. I'm going to set up an alert for baking the same appversion like... more than 10 times or something.