### PR TITLE
fix(bake): nice string rather than a garbage string

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -154,7 +154,7 @@ class ImageHandler(
         ),
         artifacts = listOf(artifactPayload)
       )
-      publisher.publishEvent(BakeLaunched(appVersion.toString()))
+      publisher.publishEvent(BakeLaunched(desiredVersion))
       return listOf(Task(id = taskRef.id, name = description))
     } catch (e: Exception) {
       log.error("Error launching bake for: ${description.toLowerCase()}")


### PR DESCRIPTION
I included a string that renders as such hot trash in metric view. Let's just use the desired version. 