### PR TITLE
fix(deps): roll back okhttp and kork

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,7 @@ subprojects {
     exclude("javax.servlet", "servlet-api")
 
     resolutionStrategy {
-      var okHttpVersion = "4.5.0"
+      var okHttpVersion = "4.4.1"
       force(
         "com.squareup.okhttp3:okhttp:$okHttpVersion",
         "com.squareup.okhttp3:okhttp-urlconnection:$okHttpVersion",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 enablePublishing=false
 fiatVersion=1.18.1
 kapt.use.worker.api=true
-korkVersion=7.35.0
+korkVersion=7.34.0
 liquibaseTaskPrefix=liquibase
 org.gradle.parallel=true
 spinnakerGradleVersion=7.11.3


### PR DESCRIPTION
Bumping both okhttp and kork broke prestaging. Roll them both back for now.
