### PR TITLE
fix(resourceEvent): emit ResourceDeltaResolved when actually needed

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -97,9 +97,6 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       resourceRepository.dropAll()
     }
 
-    context("resource events are ") {
-    }
-
     context("a managed resource exists") {
       val resource = artifactVersionedResource(
         kind = parseKind("plugin1/foo@v1")
@@ -201,7 +198,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
               }
             }
 
-            context("when the a actuation launched event exists in resource history, check other events before publishing ResourceDeltaResolved") {
+            context("when there is an actuation launched event in history, check other events before publishing ResourceDeltaResolved") {
               before {
                 resourceRepository.appendHistory(ResourceActuationLaunched(resource, plugin1.name, emptyList()))
                 runBlocking {
@@ -219,7 +216,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
                     subject.checkResource(resource)
                   }
                 }
-                test("a telemetry event is published") {
+                test("a resource delta resolved event is published") {
                   verify { publisher.publishEvent(ofType<ResourceDeltaResolved>()) }
                 }
               }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceMissing
+import com.netflix.spinnaker.keel.events.ResourceTaskFailed
+import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
@@ -93,6 +95,9 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
     after {
       resourceRepository.dropAll()
+    }
+
+    context("resource events are ") {
     }
 
     context("a managed resource exists") {
@@ -193,6 +198,42 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
               test("a telemetry event is published") {
                 verify { publisher.publishEvent(ofType<ResourceDeltaResolved>()) }
+              }
+            }
+
+            context("when the a actuation launched event exists in resource history, check other events before publishing ResourceDeltaResolved") {
+              before {
+                resourceRepository.appendHistory(ResourceActuationLaunched(resource, plugin1.name, emptyList()))
+                runBlocking {
+                  subject.checkResource(resource)
+                }
+              }
+              test("ResourceDeltaResolved was not published since the task is still running") {
+                verify(exactly = 0) { publisher.publishEvent(ofType<ResourceDeltaResolved>()) }
+              }
+
+              context("the task was finished successfully") {
+                before {
+                  resourceRepository.appendHistory(ResourceTaskSucceeded(resource, emptyList()))
+                  runBlocking {
+                    subject.checkResource(resource)
+                  }
+                }
+                test("a telemetry event is published") {
+                  verify { publisher.publishEvent(ofType<ResourceDeltaResolved>()) }
+                }
+              }
+
+              context("the task was finished with an error") {
+                before {
+                  resourceRepository.appendHistory(ResourceTaskFailed(resource, "error", emptyList()))
+                  runBlocking {
+                    subject.checkResource(resource)
+                  }
+                }
+                test("a telemetry event is published") {
+                  verify { publisher.publishEvent(ofType<ResourceDeltaResolved>()) }
+                }
               }
             }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -228,7 +228,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
                     subject.checkResource(resource)
                   }
                 }
-                test("a telemetry event is published") {
+                test("a resource delta resolved event is published") {
                   verify { publisher.publishEvent(ofType<ResourceDeltaResolved>()) }
                 }
               }


### PR DESCRIPTION
fixes https://github.com/spinnaker/keel/issues/295.

We observe some event mismatch behavior in the resource history API - for some resources, the event chain is `Drift detected` --> `valid` without `ResourceDeltaResolved` prior to `valid` (see screenshot).

Solution: prior to emitting `ResourceDeltaResolved` event, we check what was the resource last event? 
`ResourceActuationLaunched`? -- do nothing and wait for task completion.
`ResourceTaskSucceeded` or `ResourceTaskFailed`? --> emit the `resolved` event (as we have a clear status and the delta is resolved).
`ResourceDeltaDetected`? but no actuation was launched, emit the `resolved` event (as probably we resolved it without taking any explicit action).

<img width="1409" alt="Screen Shot 2020-04-13 at 10 03 21 AM" src="https://user-images.githubusercontent.com/55253849/79160480-b0027300-7d8e-11ea-9d14-44f09ab8e079.png">
<img width="784" alt="Screen Shot 2020-04-13 at 10 03 58 AM" src="https://user-images.githubusercontent.com/55253849/79160485-b1cc3680-7d8e-11ea-8211-b5b68fbb97e7.png">
