### PR TITLE
feat(artifacts): add pinned info, only use reference

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -14,6 +14,7 @@ import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
+import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -32,6 +33,7 @@ import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNotEqualTo
+import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isTrue
 import strikt.assertions.succeeded
@@ -87,7 +89,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     val pin1 = EnvironmentArtifactPin(
       targetEnvironment = environment2.name, // staging
       reference = artifact2.reference,
-      type = artifact2.type.name,
       version = version4, // the older release build
       pinnedBy = "keel@spinnaker",
       comment = "fnord")
@@ -492,17 +493,62 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             .isNotEqualTo(pin1.version)
         }
 
-        test("latestVersionApprovedIn prefers a pinned version over the latest approved version") {
-          subject.pinEnvironment(manifest, pin1)
-          expectThat(subject.latestVersionApprovedIn(manifest, artifact2, environment2.name))
-            .isEqualTo(version4)
-            .isEqualTo(pin1.version)
+        test("get env artifact version shows that artifact is not pinned") {
+          val envArtifactSummary = subject.getArtifactSummaryInEnvironment(
+            deliveryConfig = manifest,
+            environmentName = pin1.targetEnvironment,
+            artifactReference = artifact2.reference,
+            version = version4
+          )
+          expectThat(envArtifactSummary)
+            .isNotNull()
+            .get { pinned }
+            .isFalse()
         }
 
-        test("pinned version cannot be vetoed") {
-          subject.pinEnvironment(manifest, pin1)
-          expectThat(subject.markAsVetoedIn(manifest, artifact2, pin1.version!!, pin1.targetEnvironment))
-            .isFalse()
+        context("once pinned") {
+          before {
+            subject.pinEnvironment(manifest, pin1)
+          }
+
+          test("latestVersionApprovedIn prefers a pinned version over the latest approved version") {
+            expectThat(subject.latestVersionApprovedIn(manifest, artifact2, environment2.name))
+              .isEqualTo(version4)
+              .isEqualTo(pin1.version)
+          }
+
+          test("pinned version cannot be vetoed") {
+            expectThat(subject.markAsVetoedIn(manifest, artifact2, pin1.version!!, pin1.targetEnvironment))
+              .isFalse()
+          }
+
+          test("getting pinned environments shows the pin") {
+            val pins = subject.getPinnedEnvironments(manifest)
+            expectThat(pins)
+              .hasSize(1)
+              .isEqualTo(listOf(PinnedEnvironment(
+                deliveryConfigName = manifest.name,
+                targetEnvironment = pin1.targetEnvironment,
+                artifact = artifact2,
+                version = version4,
+                pinnedBy = pin1.pinnedBy,
+                pinnedAt = clock.millis(),
+                comment = pin1.comment
+              )))
+          }
+
+          test("get env artifact version shows that artifact is pinned") {
+            val envArtifactSummary = subject.getArtifactSummaryInEnvironment(
+              deliveryConfig = manifest,
+              environmentName = pin1.targetEnvironment,
+              artifactReference = artifact2.reference,
+              version = version4
+            )
+            expectThat(envArtifactSummary)
+              .isNotNull()
+              .get { pinned }
+              .isTrue()
+          }
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -57,9 +57,16 @@ data class ArtifactSummaryInEnvironment(
   val deployedAt: Instant? = null,
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
-  val pinned: Boolean = false,
+  val isPinned: Boolean = false,
+  val pinned: Pinned? = null,
   val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
   val statelessConstraints: List<StatelessConstraintSummary> = emptyList()
+)
+
+data class Pinned(
+  val at: Instant,
+  val by: String?,
+  val comment: String?
 )
 
 @JsonInclude(Include.NON_NULL)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -57,6 +57,7 @@ data class ArtifactSummaryInEnvironment(
   val deployedAt: Instant? = null,
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
+  val pinned: Boolean = false,
   val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
   val statelessConstraints: List<StatelessConstraintSummary> = emptyList()
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
@@ -5,7 +5,6 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 data class EnvironmentArtifactPin(
   val targetEnvironment: String,
   val reference: String,
-  val type: String,
   val version: String?,
   val pinnedBy: String?,
   val comment: String?
@@ -15,7 +14,10 @@ data class PinnedEnvironment(
   val deliveryConfigName: String,
   val targetEnvironment: String,
   val artifact: DeliveryArtifact,
-  val version: String
+  val version: String,
+  val pinnedBy: String?,
+  val pinnedAt: Long?,
+  val comment: String?
 )
 
 data class EnvironmentArtifactVeto(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
@@ -1,11 +1,12 @@
 package com.netflix.spinnaker.keel.core.api
 
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import java.time.Instant
 
 data class EnvironmentArtifactPin(
   val targetEnvironment: String,
   val reference: String,
-  val version: String?,
+  val version: String,
   val pinnedBy: String?,
   val comment: String?
 )
@@ -16,7 +17,7 @@ data class PinnedEnvironment(
   val artifact: DeliveryArtifact,
   val version: String,
   val pinnedBy: String?,
-  val pinnedAt: Long?,
+  val pinnedAt: Instant?,
   val comment: String?
 )
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -51,7 +51,8 @@ data class ArtifactVersions(
   val type: ArtifactType,
   val reference: String,
   val statuses: Set<ArtifactStatus>,
-  val versions: ArtifactVersionStatus
+  val versions: ArtifactVersionStatus,
+  val pinnedVersion: String?
 )
 
 data class ArtifactVersionStatus(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -279,9 +279,6 @@ class NoSuchArtifactException(name: String, type: ArtifactType) :
   constructor(artifact: DeliveryArtifact) : this(artifact.name, artifact.type)
 }
 
-class ArtifactReferenceNotFoundException(deliveryConfig: String, reference: String) :
-  NoSuchEntityException("No artifact with reference $reference in delivery config $deliveryConfig is registered")
-
 class ArtifactNotFoundException(reference: String, deliveryConfig: String?) :
   NoSuchEntityException("No artifact with reference $reference in delivery config $deliveryConfig is registered") {
   constructor(artifact: DeliveryArtifact) : this(artifact.reference, artifact.deliveryConfigName)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -24,7 +24,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
 
   fun get(name: String, type: ArtifactType, reference: String, deliveryConfigName: String): DeliveryArtifact
 
-  fun get(deliveryConfigName: String, reference: String, type: ArtifactType): DeliveryArtifact
+  fun get(deliveryConfigName: String, reference: String): DeliveryArtifact
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
@@ -199,7 +199,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
    * @return list of [PinnedEnvironment]'s if any of the environments in
    * [deliveryConfig] have been pinned to a specific artifact version.
    */
-  fun pinnedEnvironments(deliveryConfig: DeliveryConfig): List<PinnedEnvironment>
+  fun getPinnedEnvironments(deliveryConfig: DeliveryConfig): List<PinnedEnvironment>
 
   /**
    * Removes all artifact pins from [targetEnvironment].
@@ -207,9 +207,9 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String)
 
   /**
-   * Removes a specific pin from [targetEnvironment], by [reference] and [type].
+   * Removes a specific pin from [targetEnvironment], by [reference].
    */
-  fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType)
+  fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String)
 
   /**
    * Given information about a delivery config, environment, artifact and version, returns a summary that can be
@@ -218,8 +218,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
-    artifactName: String,
-    artifactType: ArtifactType,
+    artifactReference: String,
     version: String
   ): ArtifactSummaryInEnvironment?
 
@@ -283,9 +282,9 @@ class NoSuchArtifactException(name: String, type: ArtifactType) :
 class ArtifactReferenceNotFoundException(deliveryConfig: String, reference: String) :
   NoSuchEntityException("No artifact with reference $reference in delivery config $deliveryConfig is registered")
 
-class ArtifactNotFoundException(name: String, type: ArtifactType, reference: String, deliveryConfig: String?) :
-  NoSuchEntityException("No $type artifact named $name with reference $reference in delivery config $deliveryConfig is registered") {
-  constructor(artifact: DeliveryArtifact) : this(artifact.name, artifact.type, artifact.reference, artifact.deliveryConfigName)
+class ArtifactNotFoundException(reference: String, deliveryConfig: String?) :
+  NoSuchEntityException("No artifact with reference $reference in delivery config $deliveryConfig is registered") {
+  constructor(artifact: DeliveryArtifact) : this(artifact.reference, artifact.deliveryConfigName)
 }
 
 class ArtifactAlreadyRegistered(name: String, type: ArtifactType) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -358,8 +358,8 @@ class CombinedRepository(
   override fun getArtifact(name: String, type: ArtifactType, reference: String, deliveryConfigName: String): DeliveryArtifact =
     artifactRepository.get(name, type, reference, deliveryConfigName)
 
-  override fun getArtifact(deliveryConfigName: String, reference: String, type: ArtifactType): DeliveryArtifact =
-    artifactRepository.get(deliveryConfigName, reference, type)
+  override fun getArtifact(deliveryConfigName: String, reference: String): DeliveryArtifact =
+    artifactRepository.get(deliveryConfigName, reference)
 
   override fun isRegistered(name: String, type: ArtifactType): Boolean =
     artifactRepository.isRegistered(name, type)
@@ -410,13 +410,13 @@ class CombinedRepository(
     artifactRepository.pinEnvironment(deliveryConfig, environmentArtifactPin)
 
   override fun pinnedEnvironments(deliveryConfig: DeliveryConfig): List<PinnedEnvironment> =
-    artifactRepository.pinnedEnvironments(deliveryConfig)
+    artifactRepository.getPinnedEnvironments(deliveryConfig)
 
   override fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String) =
     artifactRepository.deletePin(deliveryConfig, targetEnvironment)
 
-  override fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType) =
-    artifactRepository.deletePin(deliveryConfig, targetEnvironment, reference, type)
+  override fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String) =
+    artifactRepository.deletePin(deliveryConfig, targetEnvironment, reference)
 
   override fun vetoedEnvironmentVersions(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactVetoes> =
     artifactRepository.vetoedEnvironmentVersions(deliveryConfig)
@@ -440,11 +440,10 @@ class CombinedRepository(
   override fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
-    artifactName: String,
-    artifactType: ArtifactType,
+    artifactReference: String,
     version: String
   ) = artifactRepository.getArtifactSummaryInEnvironment(
-    deliveryConfig, environmentName, artifactName, artifactType, version
+    deliveryConfig, environmentName, artifactReference, version
   )
 
   // END ArtifactRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -159,7 +159,7 @@ interface KeelRepository {
 
   fun getArtifact(name: String, type: ArtifactType, reference: String, deliveryConfigName: String): DeliveryArtifact
 
-  fun getArtifact(deliveryConfigName: String, reference: String, type: ArtifactType): DeliveryArtifact
+  fun getArtifact(deliveryConfigName: String, reference: String): DeliveryArtifact
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
@@ -197,7 +197,7 @@ interface KeelRepository {
 
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String)
 
-  fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String, type: ArtifactType)
+  fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String)
 
   fun vetoedEnvironmentVersions(deliveryConfig: DeliveryConfig): List<EnvironmentArtifactVetoes>
 
@@ -226,8 +226,7 @@ interface KeelRepository {
   fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
-    artifactName: String,
-    artifactType: ArtifactType,
+    artifactReference: String,
     version: String
   ): ArtifactSummaryInEnvironment?
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -35,6 +35,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
     )
   ) {
     val repository: KeelRepository = mockk(relaxUnitFun = true)
+
     // TODO: add stateful constraint specific tests
     val deliveryConfigRepository = mockk<DeliveryConfigRepository>(relaxUnitFun = true)
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
@@ -315,7 +316,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
 
           every {
             repository.pinnedEnvironments(any())
-          } returns listOf(PinnedEnvironment(deliveryConfig.name, environment.name, artifact, "1.1"))
+          } returns listOf(PinnedEnvironment(deliveryConfig.name, environment.name, artifact, "1.1", null, null, null))
 
           every {
             repository.pendingConstraintVersionsFor(any(), any())

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -145,23 +145,22 @@ class SqlArtifactRepository(
     }
       ?.let { (details, reference) ->
         mapToArtifact(name, type, details, reference, deliveryConfigName)
-      } ?: throw ArtifactNotFoundException(name, type, reference, deliveryConfigName)
+      } ?: throw ArtifactNotFoundException(reference, deliveryConfigName)
   }
 
-  override fun get(deliveryConfigName: String, reference: String, type: ArtifactType): DeliveryArtifact {
+  override fun get(deliveryConfigName: String, reference: String): DeliveryArtifact {
     return sqlRetry.withRetry(READ) {
       jooq
-        .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE)
+        .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE, DELIVERY_ARTIFACT.TYPE)
         .from(DELIVERY_ARTIFACT)
         .where(
           DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfigName),
-          DELIVERY_ARTIFACT.REFERENCE.eq(reference),
-          DELIVERY_ARTIFACT.TYPE.eq(type.name)
+          DELIVERY_ARTIFACT.REFERENCE.eq(reference)
         )
         .fetchOne()
     }
-      ?.let { (name, details, reference) ->
-        mapToArtifact(name, type, details, reference, deliveryConfigName)
+      ?.let { (name, details, reference, type) ->
+        mapToArtifact(name, ArtifactType.valueOf(type), details, reference, deliveryConfigName)
       } ?: throw ArtifactReferenceNotFoundException(deliveryConfigName, reference)
   }
 
@@ -664,6 +663,7 @@ class SqlArtifactRepository(
   }
 
   override fun getEnvironmentSummaries(deliveryConfig: DeliveryConfig): List<EnvironmentSummary> {
+    val pinnedEnvs = getPinnedEnvironments(deliveryConfig)
     return deliveryConfig.environments.map { environment ->
       val artifactVersions = deliveryConfig.artifacts.map { artifact ->
         val versionsInEnvironment = jooq
@@ -761,7 +761,8 @@ class SqlArtifactRepository(
             vetoed = versions[VETOED] ?: emptyList(),
             skipped = removeNewerIfCurrentExists(artifact, currentVersion, versions[PENDING]).plus(versions[SKIPPED]
               ?: emptyList())
-          )
+          ),
+          pinnedVersion = pinnedEnvs.find { it.targetEnvironment == environment.name }?.version
         )
       }.toSet()
       EnvironmentSummary(environment, artifactVersions)
@@ -771,7 +772,7 @@ class SqlArtifactRepository(
   override fun pinEnvironment(deliveryConfig: DeliveryConfig, environmentArtifactPin: EnvironmentArtifactPin) {
     with(environmentArtifactPin) {
       val environment = deliveryConfig.environmentNamed(targetEnvironment)
-      val artifact = get(deliveryConfig.name, reference, ArtifactType.valueOf(type.toLowerCase()))
+      val artifact = get(deliveryConfig.name, reference)
 
       sqlRetry.withRetry(WRITE) {
         jooq.insertInto(ENVIRONMENT_ARTIFACT_PIN)
@@ -791,11 +792,14 @@ class SqlArtifactRepository(
     }
   }
 
-  override fun pinnedEnvironments(deliveryConfig: DeliveryConfig): List<PinnedEnvironment> {
+  override fun getPinnedEnvironments(deliveryConfig: DeliveryConfig): List<PinnedEnvironment> {
     return sqlRetry.withRetry(READ) {
       jooq.select(
         ENVIRONMENT.NAME,
         ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION,
+        ENVIRONMENT_ARTIFACT_PIN.PINNED_AT,
+        ENVIRONMENT_ARTIFACT_PIN.PINNED_BY,
+        ENVIRONMENT_ARTIFACT_PIN.COMMENT,
         DELIVERY_ARTIFACT.NAME,
         DELIVERY_ARTIFACT.TYPE,
         DELIVERY_ARTIFACT.DETAILS,
@@ -809,7 +813,7 @@ class SqlArtifactRepository(
         .innerJoin(DELIVERY_CONFIG)
         .on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
         .where(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
-        .fetch { (environmentName, version, artifactName, type, details, reference) ->
+        .fetch { (environmentName, version, pinnedAt, pinnedBy, comment, artifactName, type, details, reference) ->
           PinnedEnvironment(
             deliveryConfigName = deliveryConfig.name,
             targetEnvironment = environmentName,
@@ -819,7 +823,11 @@ class SqlArtifactRepository(
               details,
               reference,
               deliveryConfig.name),
-            version = version)
+            version = version,
+            pinnedAt = pinnedAt,
+            pinnedBy = pinnedBy,
+            comment = comment
+          )
         }
     }
   }
@@ -842,8 +850,7 @@ class SqlArtifactRepository(
   override fun deletePin(
     deliveryConfig: DeliveryConfig,
     targetEnvironment: String,
-    reference: String,
-    type: ArtifactType
+    reference: String
   ) {
     sqlRetry.withRetry(WRITE) {
       jooq.select(ENVIRONMENT_ARTIFACT_PIN.ENVIRONMENT_UID, ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_UID)
@@ -855,7 +862,6 @@ class SqlArtifactRepository(
         .where(
           DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name),
           DELIVERY_ARTIFACT.REFERENCE.eq(reference),
-          DELIVERY_ARTIFACT.TYPE.eq(type.name),
           ENVIRONMENT.NAME.eq(targetEnvironment),
           ENVIRONMENT.DELIVERY_CONFIG_UID.eq(deliveryConfig.uid))
         .fetch { (envUid, artUid) ->
@@ -867,28 +873,13 @@ class SqlArtifactRepository(
   override fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
-    artifactName: String,
-    artifactType: ArtifactType,
+    artifactReference: String,
     version: String
   ): ArtifactSummaryInEnvironment? {
     return sqlRetry.withRetry(READ) {
 
-      val artifactUid = jooq
-        .select(DELIVERY_ARTIFACT.UID)
-        .from(DELIVERY_ARTIFACT)
-        .where(DELIVERY_ARTIFACT.NAME.eq(artifactName))
-        .and(DELIVERY_ARTIFACT.TYPE.eq(artifactType.name))
-        .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
-        .fetchOne(DELIVERY_ARTIFACT.UID)
-        ?: error("Artifact not found: name=$artifactName, type=$artifactType, deliveryConfig=${deliveryConfig.name}")
-
-      val environmentUid = jooq
-        .select(ENVIRONMENT.UID)
-        .from(ENVIRONMENT)
-        .where(ENVIRONMENT.NAME.eq(environmentName))
-        .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(deliveryConfig.uid))
-        .fetchOne(ENVIRONMENT.UID)
-        ?: error("Environment '$environmentName not found")
+      val artifact = deliveryConfig.artifacts.firstOrNull { it.reference == artifactReference }
+        ?: error("Artifact not found: name=$artifactReference, deliveryConfig=${deliveryConfig.name}")
 
       jooq
         .select(
@@ -899,8 +890,8 @@ class SqlArtifactRepository(
           ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_AT
         )
         .from(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifactUid))
+        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
+        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
         .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.desc())
         .fetchOne { (version, deployedAt, promotionStatus, replacedBy, replacedAt) ->
@@ -910,7 +901,14 @@ class SqlArtifactRepository(
             state = promotionStatus.toLowerCase(),
             deployedAt = deployedAt?.toInstant(ZoneOffset.UTC),
             replacedAt = replacedAt?.toInstant(ZoneOffset.UTC),
-            replacedBy = replacedBy
+            replacedBy = replacedBy,
+            pinned = jooq
+              .fetchExists(
+                ENVIRONMENT_ARTIFACT_PIN,
+                ENVIRONMENT_ARTIFACT_PIN.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName))
+                  .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_UID.eq(artifact.uid))
+                  .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION.eq(version))
+              )
           )
         }
     }
@@ -987,6 +985,12 @@ class SqlArtifactRepository(
       .where(ENVIRONMENT.NAME.eq(environment.name))
       .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
 
+  private fun DeliveryConfig.getUidFor(environmentName: String): Select<Record1<String>> =
+    select(ENVIRONMENT.UID)
+      .from(ENVIRONMENT)
+      .where(ENVIRONMENT.NAME.eq(environmentName))
+      .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
+
   private fun DeliveryConfig.getUidStringFor(environment: Environment): String =
     jooq.select(ENVIRONMENT.UID)
       .from(ENVIRONMENT)
@@ -1003,17 +1007,19 @@ class SqlArtifactRepository(
         .and(DELIVERY_ARTIFACT.REFERENCE.eq(reference)))
 
   private val DeliveryArtifact.uidString: String
-    get() = jooq.select(DELIVERY_ARTIFACT.UID)
-      .from(DELIVERY_ARTIFACT)
-      .where(DELIVERY_ARTIFACT.NAME.eq(name)
-        .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
-        .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfigName))
-        .and(DELIVERY_ARTIFACT.REFERENCE.eq(reference)))
-      .fetchOne(DELIVERY_ARTIFACT.UID) ?: error("artifact not found for " +
-      "name=$name, " +
-      "type=$type, " +
-      "deliveryConfig=$deliveryConfigName, " +
-      "reference=$reference")
+    get() = sqlRetry.withRetry(READ) {
+      jooq.select(DELIVERY_ARTIFACT.UID)
+        .from(DELIVERY_ARTIFACT)
+        .where(DELIVERY_ARTIFACT.NAME.eq(name)
+          .and(DELIVERY_ARTIFACT.TYPE.eq(type.name))
+          .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfigName))
+          .and(DELIVERY_ARTIFACT.REFERENCE.eq(reference)))
+        .fetchOne(DELIVERY_ARTIFACT.UID) ?: error("artifact not found for " +
+        "name=$name, " +
+        "type=$type, " +
+        "deliveryConfig=$deliveryConfigName, " +
+        "reference=$reference")
+    }
 
   private val DeliveryConfig.uid: Select<Record1<String>>
     get() = select(DELIVERY_CONFIG.UID)

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -140,9 +140,6 @@ class ApplicationController(
     @PathVariable("application") application: String,
     @RequestBody pin: EnvironmentArtifactPin
   ) {
-    checkNotNull(pin.version) {
-      "A version to pin is required."
-    }
     applicationService.pin(application, pin, user)
   }
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -4,7 +4,6 @@ import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.StatefulConstraint
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.deb
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.docker
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
@@ -85,7 +84,7 @@ class ApplicationService(
 
   fun deletePin(application: String, pin: EnvironmentArtifactPin) {
     val config = repository.getDeliveryConfigForApplication(application)
-    repository.deletePin(config, pin.targetEnvironment, pin.reference, ArtifactType.valueOf(pin.type))
+    repository.deletePin(config, pin.targetEnvironment, pin.reference)
   }
 
   fun deletePin(application: String, targetEnvironment: String) {
@@ -178,8 +177,7 @@ class ApplicationService(
                 val potentialSummary = repository.getArtifactSummaryInEnvironment(
                   deliveryConfig = deliveryConfig,
                   environmentName = environmentSummary.name,
-                  artifactName = artifact.name,
-                  artifactType = artifact.type,
+                  artifactReference = artifact.reference,
                   version = version
                 )
                 if (potentialSummary == null || potentialSummary.state == "pending") {
@@ -195,8 +193,7 @@ class ApplicationService(
               else -> repository.getArtifactSummaryInEnvironment(
                 deliveryConfig = deliveryConfig,
                 environmentName = environmentSummary.name,
-                artifactName = artifact.name,
-                artifactType = artifact.type,
+                artifactReference = artifact.reference,
                 version = version
               )
             }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -32,7 +32,7 @@ import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
 import com.netflix.spinnaker.keel.core.api.StatelessConstraintSummary
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
 import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
-import com.netflix.spinnaker.keel.persistence.ArtifactReferenceNotFoundException
+import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
 import java.time.Instant
@@ -95,7 +95,7 @@ class ApplicationService(
   fun markAsVetoedIn(application: String, veto: EnvironmentArtifactVeto, force: Boolean) {
     val config = repository.getDeliveryConfigForApplication(application)
     val artifact = config.matchingArtifactByReference(veto.reference)
-      ?: throw ArtifactReferenceNotFoundException(config.name, veto.reference)
+      ?: throw ArtifactNotFoundException(veto.reference, config.name)
 
     repository.markAsVetoedIn(
       deliveryConfig = config,
@@ -109,7 +109,7 @@ class ApplicationService(
   fun deleteVeto(application: String, targetEnvironment: String, reference: String, version: String) {
     val config = repository.getDeliveryConfigForApplication(application)
     val artifact = config.matchingArtifactByReference(reference)
-      ?: throw ArtifactReferenceNotFoundException(config.name, reference)
+      ?: throw ArtifactNotFoundException(reference, config.name)
     repository.deleteVeto(
       deliveryConfig = config,
       artifact = artifact,

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -252,11 +252,11 @@ class ApplicationServiceTests : JUnit5Minutests {
         val expectedProd = EnvironmentSummary(
           deliveryConfig.environments.find { it.name == "production" }!!,
           setOf(ArtifactVersions(
-            artifact.name,
-            artifact.type,
-            artifact.reference,
-            artifact.statuses,
-            ArtifactVersionStatus(
+            name = artifact.name,
+            type = artifact.type,
+            reference = artifact.reference,
+            statuses = artifact.statuses,
+            versions = ArtifactVersionStatus(
               current = version0,
               pending = listOf(version1, version2, version3, version4),
               approved = listOf(),
@@ -265,17 +265,17 @@ class ApplicationServiceTests : JUnit5Minutests {
               deploying = null,
               skipped = listOf()
             ),
-            null
+            pinnedVersion = null
           ))
         )
         val expectedStage = EnvironmentSummary(
           deliveryConfig.environments.find { it.name == "staging" }!!,
           setOf(ArtifactVersions(
-            artifact.name,
-            artifact.type,
-            artifact.reference,
-            artifact.statuses,
-            ArtifactVersionStatus(
+            name = artifact.name,
+            type = artifact.type,
+            reference = artifact.reference,
+            statuses = artifact.statuses,
+            versions = ArtifactVersionStatus(
               current = version2,
               pending = listOf(version3, version4),
               approved = listOf(),
@@ -284,17 +284,17 @@ class ApplicationServiceTests : JUnit5Minutests {
               deploying = null,
               skipped = listOf(version1)
             ),
-            null
+            pinnedVersion = null
           ))
         )
         val expectedTest = EnvironmentSummary(
           deliveryConfig.environments.find { it.name == "test" }!!,
           setOf(ArtifactVersions(
-            artifact.name,
-            artifact.type,
-            artifact.reference,
-            artifact.statuses,
-            ArtifactVersionStatus(
+            name = artifact.name,
+            type = artifact.type,
+            reference = artifact.reference,
+            statuses = artifact.statuses,
+            versions = ArtifactVersionStatus(
               current = version3,
               pending = listOf(),
               approved = listOf(version4),
@@ -303,7 +303,7 @@ class ApplicationServiceTests : JUnit5Minutests {
               deploying = null,
               skipped = listOf(version1)
             ),
-            null
+            pinnedVersion = null
           ))
         )
         expect {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ApplicationServiceTests.kt
@@ -264,7 +264,8 @@ class ApplicationServiceTests : JUnit5Minutests {
               vetoed = listOf(),
               deploying = null,
               skipped = listOf()
-            )
+            ),
+            null
           ))
         )
         val expectedStage = EnvironmentSummary(
@@ -282,7 +283,8 @@ class ApplicationServiceTests : JUnit5Minutests {
               vetoed = listOf(),
               deploying = null,
               skipped = listOf(version1)
-            )
+            ),
+            null
           ))
         )
         val expectedTest = EnvironmentSummary(
@@ -300,7 +302,8 @@ class ApplicationServiceTests : JUnit5Minutests {
               vetoed = listOf(),
               deploying = null,
               skipped = listOf(version1)
-            )
+            ),
+            null
           ))
         )
         expect {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -470,7 +470,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/pin").addData(jsonMapper,
-              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null, null)
+              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", "keel@keel.io")
@@ -485,7 +485,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/pin").addData(jsonMapper,
-              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null, null)
+              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", "keel@keel.io")


### PR DESCRIPTION
I'm doing several things in this PR:
- Change pinning to only need artifact reference, not reference and type. Artifact reference is unique. Artifact name + type is not unique.
- Clean up some methods around ^
- Add pinning data into the summary view: both in the environment summary and the artifact summary

A request to pin an env will now look like:

`POST /application/{appName}/pin`
```json
{
	"targetEnvironment": "testing",
	"reference" : "my-artifact",
	"version" : "master-h13.73d1d93"
}
```
(you don't need the `type` in the body anymore, will update gate in a future PR)