### PR TITLE
fix(core): Ensure there's only ever 1 of each type of configured ObjectMapper

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -19,17 +19,20 @@ import de.huxhorn.sulky.ulid.ULID
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
+object ObjectMapperSingleton : ObjectMapper()
+object YamlMapperSingleton : YAMLMapper()
+
 /**
  * Factory method for [ObjectMapper]s configured how we like 'em.
  */
 fun configuredObjectMapper(): ObjectMapper =
-  ObjectMapper().configureMe()
+  ObjectMapperSingleton.configureMe()
 
 /**
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
 fun configuredYamlMapper(): YAMLMapper =
-  YAMLMapper()
+  YamlMapperSingleton
     .configureMe()
     .disable(USE_NATIVE_TYPE_ID)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -19,29 +19,20 @@ import de.huxhorn.sulky.ulid.ULID
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
-class ObjectMapperSingleton private constructor() {
-  companion object {
-    val instance: ObjectMapper by lazy { ObjectMapper().configureMe() }
-  }
-}
-
-class YamlMapperSingleton private constructor() {
-  companion object {
-    val instance: YAMLMapper by lazy { YAMLMapper().configureMe() }
-  }
-}
+private val objectMapperInstance: ObjectMapper by lazy { ObjectMapper().configureMe() }
+private val yamlMapperInstance: YAMLMapper by lazy { YAMLMapper().configureMe() }
 
 /**
  * Factory method for [ObjectMapper]s configured how we like 'em.
  */
 fun configuredObjectMapper(): ObjectMapper =
-  ObjectMapperSingleton.instance
+  objectMapperInstance
 
 /**
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
 fun configuredYamlMapper(): YAMLMapper =
-  YamlMapperSingleton.instance.disable(USE_NATIVE_TYPE_ID)
+  yamlMapperInstance.disable(USE_NATIVE_TYPE_ID)
 
 private fun <T : ObjectMapper> T.configureMe(): T =
   apply {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -19,20 +19,30 @@ import de.huxhorn.sulky.ulid.ULID
 import java.text.SimpleDateFormat
 import java.util.TimeZone
 
-object ObjectMapperSingleton : ObjectMapper()
-object YamlMapperSingleton : YAMLMapper()
+class ObjectMapperSingleton private constructor() {
+  companion object {
+    val instance: ObjectMapper by lazy { ObjectMapper() }
+  }
+}
+
+class YamlMapperSingleton private constructor() {
+  companion object {
+    val instance: YAMLMapper by lazy { YAMLMapper() }
+  }
+}
 
 /**
  * Factory method for [ObjectMapper]s configured how we like 'em.
  */
 fun configuredObjectMapper(): ObjectMapper =
-  ObjectMapperSingleton.configureMe()
+  ObjectMapperSingleton.instance.configureMe()
 
 /**
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
 fun configuredYamlMapper(): YAMLMapper =
   YamlMapperSingleton
+    .instance
     .configureMe()
     .disable(USE_NATIVE_TYPE_ID)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -21,13 +21,13 @@ import java.util.TimeZone
 
 class ObjectMapperSingleton private constructor() {
   companion object {
-    val instance: ObjectMapper by lazy { ObjectMapper() }
+    val instance: ObjectMapper by lazy { ObjectMapper().configureMe() }
   }
 }
 
 class YamlMapperSingleton private constructor() {
   companion object {
-    val instance: YAMLMapper by lazy { YAMLMapper() }
+    val instance: YAMLMapper by lazy { YAMLMapper().configureMe() }
   }
 }
 
@@ -35,16 +35,13 @@ class YamlMapperSingleton private constructor() {
  * Factory method for [ObjectMapper]s configured how we like 'em.
  */
 fun configuredObjectMapper(): ObjectMapper =
-  ObjectMapperSingleton.instance.configureMe()
+  ObjectMapperSingleton.instance
 
 /**
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
 fun configuredYamlMapper(): YAMLMapper =
-  YamlMapperSingleton
-    .instance
-    .configureMe()
-    .disable(USE_NATIVE_TYPE_ID)
+  YamlMapperSingleton.instance.disable(USE_NATIVE_TYPE_ID)
 
 private fun <T : ObjectMapper> T.configureMe(): T =
   apply {


### PR DESCRIPTION
We're calling `configuredObjectMapper()` all over the codebase to obtain an instance of an `ObjectMapper` with our custom configuration. This should generally yield new copies of a mapper with the same configuration, except that in the application startup code we do additional configuration of the ones registered with the Spring context, which exclude all the ones instantiated directly.

This PR ensures that there's only ever a single copy of each type of `ObjectMapper` by using a singleton for each.

Attempt to close https://github.com/spinnaker/keel/issues/1015