### PR TITLE
chore(veto): move veto apis to application controller

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -14,8 +14,8 @@ data class DeliveryConfig(
   val resources: Set<Resource<*>>
     get() = environments.flatMapTo(mutableSetOf()) { it.resources }
 
-  fun matchingArtifactByReference(reference: String, type: ArtifactType): DeliveryArtifact? =
-    artifacts.find { it.reference == reference && it.type == type }
+  fun matchingArtifactByReference(reference: String): DeliveryArtifact? =
+    artifacts.find { it.reference == reference }
 
   fun matchingArtifactByName(name: String, type: ArtifactType): DeliveryArtifact? =
     artifacts.find { it.name == name && it.type == type }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -22,9 +22,9 @@ data class Resource<T : ResourceSpec>(
       // prefer reference-based artifact info
       spec.completeArtifactReferenceOrNull()
         ?.let { ref ->
-          deliveryConfig.matchingArtifactByReference(ref.artifactReference, ref.artifactType)
+          deliveryConfig.matchingArtifactByReference(ref.artifactReference)
         }
-        // if not found, then try old-style image provider info
+      // if not found, then try old-style image provider info
         ?: spec.completeArtifactOrNull()
           ?.let { art ->
             deliveryConfig.matchingArtifactByName(art.artifactName, art.artifactType)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactPin.kt
@@ -19,10 +19,8 @@ data class PinnedEnvironment(
 )
 
 data class EnvironmentArtifactVeto(
-  val deliveryConfigName: String,
   val targetEnvironment: String,
   val reference: String,
-  val type: String,
   val version: String
 )
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -280,8 +280,8 @@ class NoSuchArtifactException(name: String, type: ArtifactType) :
   constructor(artifact: DeliveryArtifact) : this(artifact.name, artifact.type)
 }
 
-class ArtifactReferenceNotFoundException(deliveryConfig: String, reference: String, type: ArtifactType) :
-  NoSuchEntityException("No $type artifact with reference $reference in delivery config $deliveryConfig is registered")
+class ArtifactReferenceNotFoundException(deliveryConfig: String, reference: String) :
+  NoSuchEntityException("No artifact with reference $reference in delivery config $deliveryConfig is registered")
 
 class ArtifactNotFoundException(name: String, type: ArtifactType, reference: String, deliveryConfig: String?) :
   NoSuchEntityException("No $type artifact named $name with reference $reference in delivery config $deliveryConfig is registered") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -133,7 +133,7 @@ class InMemoryArtifactRepository(
         it.deliveryConfigName == deliveryConfigName &&
           it.reference == reference &&
           it.type == type
-      } ?: throw ArtifactReferenceNotFoundException(deliveryConfigName, reference, type)
+      } ?: throw ArtifactReferenceNotFoundException(deliveryConfigName, reference)
 
   override fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus?): Boolean =
     store(artifact.name, artifact.type, version, status)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -162,7 +162,7 @@ class SqlArtifactRepository(
     }
       ?.let { (name, details, reference) ->
         mapToArtifact(name, type, details, reference, deliveryConfigName)
-      } ?: throw ArtifactReferenceNotFoundException(deliveryConfigName, reference, type)
+      } ?: throw ArtifactReferenceNotFoundException(deliveryConfigName, reference)
   }
 
   override fun store(artifact: DeliveryArtifact, version: String, status: ArtifactStatus?): Boolean =

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -3,9 +3,7 @@ package com.netflix.spinnaker.keel.rest
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.deb
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.docker
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.valueOf
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.events.ArtifactEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ArtifactSyncEvent
@@ -16,13 +14,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus.ACCEPTED
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
-import org.springframework.security.access.prepost.PreAuthorize
-import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -68,48 +63,6 @@ class ArtifactController(
   @ResponseStatus(ACCEPTED)
   fun sync() {
     publisher.publishEvent(ArtifactSyncEvent(true))
-  }
-
-  @PostMapping(
-    path = ["/veto"]
-  )
-  @ResponseStatus(ACCEPTED)
-  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #veto.deliveryConfigName)
-    and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #veto.deliveryConfigName)"""
-  )
-  fun veto(
-    @RequestHeader("X-SPINNAKER-USER") user: String,
-    @RequestBody veto: EnvironmentArtifactVeto
-  ) {
-    val deliveryConfig = repository.getDeliveryConfig(veto.deliveryConfigName)
-    val artifact = repository.getArtifact(
-      deliveryConfigName = veto.deliveryConfigName,
-      reference = veto.reference,
-      type = valueOf(veto.type))
-
-    repository.markAsVetoedIn(deliveryConfig, artifact, veto.version, veto.targetEnvironment, true)
-  }
-
-  @DeleteMapping(
-    path = ["/veto/{deliveryConfigName}/{targetEnvironment}/{type}/{reference}/{version}"]
-  )
-  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #deliveryConfigName)
-    and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #deliveryConfigName)"""
-  )
-  fun deleteVeto(
-    @RequestHeader("X-SPINNAKER-USER") user: String,
-    @PathVariable("deliveryConfigName") deliveryConfigName: String,
-    @PathVariable("targetEnvironment") targetEnvironment: String,
-    @PathVariable("type") type: String,
-    @PathVariable("reference") reference: String,
-    @PathVariable("version") version: String
-  ) {
-    val deliveryConfig = repository.getDeliveryConfig(deliveryConfigName)
-    val artifact = repository.getArtifact(
-      deliveryConfigName = deliveryConfigName,
-      reference = reference,
-      type = valueOf(type))
-    repository.deleteVeto(deliveryConfig, artifact, version, targetEnvironment)
   }
 
   @GetMapping(


### PR DESCRIPTION
Moving the apis for vetoing an artifact in an environment to the application controller in preparation for exposing them through gate. Removed the need to specify the artifact type and delivery config name, just like the other apis. 