### PR TITLE
chore(usability): Use consistent formats for task user

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -153,7 +153,6 @@ class ImageHandler(
               "package" to artifactRef.substringAfterLast("/"),
               "regions" to artifact.vmOptions.regions,
               "storeType" to artifact.vmOptions.storeType.name.toLowerCase(),
-              "user" to "keel",
               "vmType" to "hvm"
             )
           )


### PR DESCRIPTION
This makes the orca task user for a bake look the same as for other tasks launched by keel.