### PR TITLE
fix(export): Fix launch config export

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -922,7 +922,7 @@ class ClusterHandler(
     )
 
     val thisSpec = ServerGroupSpec(
-      launchConfiguration = launchConfiguration.exportSpec(account, location.region, application, launchConfiguration.instanceType),
+      launchConfiguration = launchConfiguration.exportSpec(account, location.region, application),
       capacity = capacity,
       dependencies = dependencies,
       health = health.toSpecWithoutDefaults(),
@@ -943,15 +943,13 @@ class ClusterHandler(
   private fun LaunchConfiguration.exportSpec(
     account: String,
     region: String,
-    application: String,
-    instanceType: String
+    application: String
   ): LaunchConfigurationSpec? {
     val defaults = LaunchConfigurationSpec(
       ebsOptimized = false,
       iamRole = LaunchConfiguration.defaultIamRoleFor(application),
       instanceMonitoring = false,
-      keyPair = defaultKeypair(account, region),
-      instanceType = instanceType
+      keyPair = defaultKeypair(account, region)
     )
     val thisSpec: LaunchConfigurationSpec = mapper.convertValue(this)
     return buildSpecFromDiff(defaults, thisSpec)

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -280,7 +280,7 @@ internal class ClusterExportTests : JUnit5Minutests {
             get { ebsOptimized }.isNull()
             get { instanceMonitoring }.isNull()
             get { ramdiskId }.isNull()
-            get { instanceType }.isNull()
+            get { instanceType }.isNotNull()
             get { iamRole }.isNotNull()
             get { keyPair }.isNotNull()
           }


### PR DESCRIPTION
The code to export a launch config was including the server group's own instance type to compare with itself, which... er... would always be the same, and therefore get omitted. 🤦 

Fixes #918