### PR TITLE
feat(configs): fetch config by app

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -17,6 +17,7 @@
  */
 package com.netflix.spinnaker.keel.rest
 
+import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
@@ -80,6 +81,15 @@ class ApplicationController(
       }
     }
   }
+
+  @GetMapping(
+    path = ["/{application}/config"],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('READ', 'APPLICATION', #application)""")
+  fun getConfigByApplication(
+    @PathVariable("application") application: String
+  ): DeliveryConfig = applicationService.getDeliveryConfig(application)
 
   @PostMapping(
     path = ["/{application}/environment/{environment}/constraint"],

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -53,6 +53,8 @@ class ApplicationService(
 
   fun hasManagedResources(application: String) = repository.hasManagedResources(application)
 
+  fun getDeliveryConfig(application: String) = repository.getDeliveryConfigForApplication(application)
+
   fun getConstraintStatesFor(application: String) = repository.constraintStateFor(application)
 
   fun getConstraintStatesFor(application: String, environment: String, limit: Int): List<ConstraintState> {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -583,6 +583,20 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
         }
       }
+      context("GET /application/fnord/config") {
+        context("with no READ access to application") {
+          before {
+            authorizationSupport.denyApplicationAccess(READ, APPLICATION)
+          }
+          test("request is forbidden") {
+            val request = get("/application/fnord/config")
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+              .header("X-SPINNAKER-USER", "keel@keel.io")
+
+            mvc.perform(request).andExpect(status().isForbidden)
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I keep wanting to look up a delivery config by app instead of by manifest name. So I made that api.