### PR TITLE
ensure DeliveryArtifact schema is output correctly even if things render in a different order

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/apidocs/SealedClassModelConverter.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/apidocs/SealedClassModelConverter.kt
@@ -6,12 +6,15 @@ import io.swagger.v3.core.converter.ModelConverter
 import io.swagger.v3.core.converter.ModelConverterContext
 import io.swagger.v3.oas.models.media.Schema
 import kotlin.reflect.KClass
+import org.springframework.core.Ordered.HIGHEST_PRECEDENCE
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 
 /**
  * Handles any sealed type by defining its schema as `oneOf` the subtypes.
  */
 @Component
+@Order(HIGHEST_PRECEDENCE) // to prevent it overriding DeliveryArtifactModelConverter
 class SealedClassModelConverter : BaseModelConverter() {
   override fun resolve(annotatedType: AnnotatedType, context: ModelConverterContext, chain: MutableIterator<ModelConverter>): Schema<*>? {
     val type = annotatedType.type

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -272,6 +272,20 @@ class ApiDocTests : JUnit5Minutests {
           )
       }
 
+      test("schema for DeliveryArtifact has a discriminator") {
+        at("/components/schemas/DeliveryArtifact")
+          .isObject()
+          .path("discriminator")
+          .and {
+            path("propertyName").textValue().isEqualTo("type")
+          }
+          .path("mapping")
+          .and {
+            path("deb").textValue().isEqualTo(constructRef("DebianArtifact"))
+            path("docker").textValue().isEqualTo(constructRef("DockerArtifact"))
+          }
+      }
+
       SKIP - test("does not include interim sealed classes in oneOf") {
         at("/components/schemas/ResourceCheckResult/oneOf")
           .isArray()


### PR DESCRIPTION
Fixes failing test in #1050 