### PR TITLE
feat(export): Export deployment strategy

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -27,13 +27,13 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
+import com.netflix.spinnaker.keel.tags.EntityTags
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface CloudDriverService {
-
   @GET("/securityGroups/{account}/{type}/{region}/{securityGroupName}")
   suspend fun getSecurityGroup(
     @Header("X-SPINNAKER-USER") user: String,
@@ -155,4 +155,13 @@ interface CloudDriverService {
     @Path("account") account: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): Map<String, Any?>
+
+  @GET("/tags")
+  suspend fun getEntityTags(
+    @Query("cloudProvider") cloudProvider: String,
+    @Query("account") account: String,
+    @Query("application") application: String,
+    @Query("entityType") entityType: String,
+    @Query("entityId") entityId: String
+  ): List<EntityTags>
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
@@ -41,6 +41,20 @@ data class RedBlack(
   @JsonInclude(NON_EMPTY)
   override val stagger: List<StaggeredRegion> = emptyList()
 ) : ClusterDeployStrategy() {
+
+  companion object {
+    fun fromOrcaStageContext(context: Map<String, Any?>) =
+      RedBlack(
+        rollbackOnFailure = context["rollback"]
+          ?.let { it as Map<String, Any> }
+          ?.get("onFailure") as Boolean,
+        resizePreviousToZero = context["scaleDown"] as Boolean,
+        maxServerGroups = context["maxRemainingAsgs"] as Int,
+        delayBeforeDisable = Duration.ofSeconds((context["delayBeforeDisableSec"] as Int).toLong()),
+        delayBeforeScaleDown = Duration.ofSeconds((context["delayBeforeScaleDownSec"] as Int).toLong())
+      )
+  }
+
   override fun toOrcaJobProperties() = mapOf(
     "strategy" to "redblack",
     "maxRemainingAsgs" to maxServerGroups,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
@@ -68,35 +68,15 @@ data class RedBlack(
   )
 
   override val isStaggered: Boolean
-    get() = stagger?.isNotEmpty() ?: false
+    get() = stagger.isNotEmpty() ?: false
 
   override fun withDefaultsOmitted() =
     RedBlack(
-      maxServerGroups = if (maxServerGroups == DEFAULTS.maxServerGroups) {
-        null
-      } else {
-        maxServerGroups
-      },
-      delayBeforeDisable = if (delayBeforeDisable == DEFAULTS.delayBeforeDisable) {
-        null
-      } else {
-        delayBeforeDisable
-      },
-      delayBeforeScaleDown = if (delayBeforeScaleDown == DEFAULTS.delayBeforeScaleDown) {
-        null
-      } else {
-        delayBeforeScaleDown
-      },
-      resizePreviousToZero = if (resizePreviousToZero == DEFAULTS.resizePreviousToZero) {
-        null
-      } else {
-        resizePreviousToZero
-      },
-      rollbackOnFailure = if (rollbackOnFailure == DEFAULTS.rollbackOnFailure) {
-        null
-      } else {
-        rollbackOnFailure
-      }
+      maxServerGroups = nullIfDefault(maxServerGroups, DEFAULTS.maxServerGroups),
+      delayBeforeDisable = nullIfDefault(delayBeforeDisable, DEFAULTS.delayBeforeDisable),
+      delayBeforeScaleDown = nullIfDefault(delayBeforeScaleDown, DEFAULTS.delayBeforeScaleDown),
+      resizePreviousToZero = nullIfDefault(resizePreviousToZero, DEFAULTS.resizePreviousToZero),
+      rollbackOnFailure = nullIfDefault(rollbackOnFailure, DEFAULTS.rollbackOnFailure)
     )
 }
 
@@ -144,3 +124,6 @@ data class StaggeredRegion(
   val allowedHours: Set<Int>
     get() = AllowedTimesConstraintEvaluator.parseHours(hours)
 }
+
+private fun <T> nullIfDefault(value: T, default: T): T? =
+  if (value == default) null else value

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceSpecExportHelper.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceSpecExportHelper.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.plugin
 
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
+import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 
@@ -59,4 +60,14 @@ inline fun <reified T : Any, reified S : Any> buildSpecFromDiff(
   } else {
     ctor.callBy(params)
   }
+}
+
+/**
+ * Helper function to return an instance of any type with all nullable constructor parameters set to null.
+ * Note that this call will fail if any remaining parameters to the primary constructor are not optional.
+ */
+fun <T : Any> emptyShell(klass: KClass<T>): T {
+  val ctor = klass.primaryConstructor!!
+  val params = ctor.parameters.filter { it.type.isMarkedNullable }.associateWith { null }
+  return ctor.callBy(params)
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceSpecExportHelper.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/plugin/ResourceSpecExportHelper.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.plugin
 
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
-import kotlin.reflect.KClass
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 
@@ -60,14 +59,4 @@ inline fun <reified T : Any, reified S : Any> buildSpecFromDiff(
   } else {
     ctor.callBy(params)
   }
-}
-
-/**
- * Helper function to return an instance of any type with all nullable constructor parameters set to null.
- * Note that this call will fail if any remaining parameters to the primary constructor are not optional.
- */
-fun <T : Any> emptyShell(klass: KClass<T>): T {
-  val ctor = klass.primaryConstructor!!
-  val params = ctor.parameters.filter { it.type.isMarkedNullable }.associateWith { null }
-  return ctor.callBy(params)
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.keel.ec2.resource.ApplicationLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import java.time.Clock
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -66,7 +67,8 @@ class EC2Config {
     taskLauncher: TaskLauncher,
     clock: Clock,
     normalizers: List<Resolver<*>>,
-    publisher: ApplicationEventPublisher
+    publisher: ApplicationEventPublisher,
+    clusterExportHelper: ClusterExportHelper
   ): ClusterHandler =
     ClusterHandler(
       cloudDriverService,
@@ -75,7 +77,8 @@ class EC2Config {
       taskLauncher,
       clock,
       publisher,
-      normalizers
+      normalizers,
+      clusterExportHelper
     )
 
   @Bean

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -313,7 +313,7 @@ class ClusterHandler(
     }
 
   override suspend fun export(exportable: Exportable): ClusterSpec {
-    // Get existing infrastructure -- this is a very costly call
+    // Get existing infrastructure
     val serverGroups = cloudDriverService.getServerGroups(
       account = exportable.account,
       moniker = exportable.moniker,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -368,9 +368,7 @@ class ClusterHandler(
       account = exportable.account,
       application = exportable.moniker.app,
       serverGroupName = base.name
-    )
-      ?.withDefaultsOmitted()
-      ?: RedBlack().withDefaultsOmitted()
+    ) ?: RedBlack()
 
     val spec = ClusterSpec(
       moniker = exportable.moniker,
@@ -380,7 +378,7 @@ class ClusterHandler(
         null
       },
       locations = locations,
-      deployWith = deployStrategy,
+      deployWith = deployStrategy.withDefaultsOmitted(),
       _defaults = base.exportSpec(exportable.account, exportable.moniker.app),
       overrides = mutableMapOf()
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -363,6 +363,15 @@ class ClusterHandler(
       regions = subnetAwareRegionSpecs
     ).withDefaultsOmitted()
 
+    val deployStrategy = clusterExportHelper.discoverDeploymentStrategy(
+      cloudProvider = "aws",
+      account = exportable.account,
+      application = exportable.moniker.app,
+      serverGroupName = base.name
+    )
+      ?.withDefaultsOmitted()
+      ?: RedBlack().withDefaultsOmitted()
+
     val spec = ClusterSpec(
       moniker = exportable.moniker,
       imageProvider = if (base.buildInfo?.packageName != null) {
@@ -371,13 +380,7 @@ class ClusterHandler(
         null
       },
       locations = locations,
-      deployWith = clusterExportHelper.discoverDeploymentStrategy(
-        cloudProvider = "aws",
-        account = exportable.account,
-        application = exportable.moniker.app,
-        serverGroupName = base.name
-      ) ?: RedBlack()
-        .let { it.withDefaultsOmitted() },
+      deployWith = deployStrategy,
       _defaults = base.exportSpec(exportable.account, exportable.moniker.app),
       overrides = mutableMapOf()
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -65,7 +65,6 @@ import com.netflix.spinnaker.keel.orca.dependsOn
 import com.netflix.spinnaker.keel.orca.restrictedExecutionWindow
 import com.netflix.spinnaker.keel.orca.waitStage
 import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
-import com.netflix.spinnaker.keel.plugin.emptyShell
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -489,9 +488,6 @@ class ClusterHandler(
         "Only redblack and highlander are supported at this time.")
     }
   }
-
-  private fun ClusterDeployStrategy.withDefaultsOmitted(): ClusterDeployStrategy =
-    buildSpecFromDiff(defaults, this) ?: emptyShell(defaults::class)
 
   private fun ClusterSpec.generateOverrides(account: String, application: String, serverGroups: Map<String, ServerGroup>) =
     serverGroups.forEach { (region, serverGroup) ->

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -74,10 +74,10 @@ internal class ClusterExportTests : JUnit5Minutests {
     combinedRepository,
     publisher
   )
-  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
+  val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
-    val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
+  val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
   val sg1East = SecurityGroupSummary("keel", "sg-279585936", "vpc-1")
@@ -174,7 +174,7 @@ internal class ClusterExportTests : JUnit5Minutests {
         clock,
         publisher,
         normalizers,
-        deploymentStrategyExporter
+        clusterExportHelper
       )
     }
 
@@ -210,7 +210,7 @@ internal class ClusterExportTests : JUnit5Minutests {
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
       coEvery {
-        deploymentStrategyExporter.discoverDeploymentStrategy("aws", "test", "keel", any())
+        clusterExportHelper.discoverDeploymentStrategy("aws", "test", "keel", any())
       } returns RedBlack()
     }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -31,16 +31,11 @@ import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.toCloudDriverResponse
-import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
-import com.netflix.spinnaker.keel.orca.OrcaExecutionStages
-import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus.SUCCEEDED
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
-import com.netflix.spinnaker.keel.tags.EntityRef
-import com.netflix.spinnaker.keel.tags.EntityTag
-import com.netflix.spinnaker.keel.tags.EntityTags
 import com.netflix.spinnaker.keel.test.combinedMockRepository
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -51,7 +46,6 @@ import io.mockk.every
 import io.mockk.mockk
 import java.time.Clock
 import java.time.Duration
-import java.time.Instant
 import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationEventPublisher
@@ -80,9 +74,10 @@ internal class ClusterExportTests : JUnit5Minutests {
     combinedRepository,
     publisher
   )
+  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
-  val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
+    val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
   val sg1East = SecurityGroupSummary("keel", "sg-279585936", "vpc-1")
@@ -169,102 +164,6 @@ internal class ClusterExportTests : JUnit5Minutests {
     kind = SPINNAKER_EC2_API_V1.qualify("cluster")
   )
 
-  private val taskEntityTags = EntityTags(
-    id = "aws:servergroup:${serverGroupEast.name}:1234567890123:${vpcEast.region}",
-    idPattern = "{{cloudProvider}}:{{entityType}}:{{entityId}}:{{account}}:{{region}}",
-    tags = listOf(
-      EntityTag(
-        name = "spinnaker:metadata",
-        namespace = "spinnaker",
-        valueType = "object",
-        value = mapOf(
-          "executionId" to "01E609548XWA7ZBP5M5FGMZ964",
-          "executionType" to "orchestration"
-        )
-      )
-    ),
-    tagsMetadata = emptyList(),
-    entityRef = EntityRef(
-      cloudProvider = "aws",
-      application = "keel",
-      accountId = "1234567890123",
-      account = vpcEast.account,
-      region = vpcEast.region,
-      entityType = "servergroup",
-      entityId = serverGroupEast.name
-    )
-  )
-
-  private val pipelineEntityTags = taskEntityTags.copy(
-    tags = listOf(
-      EntityTag(
-        name = "spinnaker:metadata",
-        namespace = "spinnaker",
-        valueType = "object",
-        value = mapOf(
-          "executionId" to "01E609548XWA7ZBP5M5FGMZ964",
-          "executionType" to "pipeline"
-        )
-      )
-    )
-  )
-
-  private val orcaTaskExecution = ExecutionDetailResponse(
-    id = "01E609548XWA7ZBP5M5FGMZ964",
-    name = "A keel deployment task",
-    application = "keel",
-    buildTime = Instant.now() - Duration.ofHours(1),
-    startTime = Instant.now() - Duration.ofHours(1),
-    endTime = Instant.now() - Duration.ofMinutes(30),
-    status = SUCCEEDED,
-    execution = OrcaExecutionStages(
-      stages = listOf(
-        mapOf(
-          "type" to "createServerGroup",
-          "context" to mapOf(
-            "strategy" to "redblack",
-            "rollback" to mapOf(
-              "onFailure" to true
-            ),
-            "scaleDown" to false,
-            "maxRemainingAsgs" to 3,
-            "delayBeforeDisableSec" to 10,
-            "delayBeforeScaleDownSec" to 10
-          )
-        )
-      )
-    )
-  )
-
-  private val orcaPipelineExecution = ExecutionDetailResponse(
-    id = "01E609548XWA7ZBP5M5FGMZ964",
-    name = "A user's deployment pipeline",
-    application = "keel",
-    buildTime = Instant.now() - Duration.ofHours(1),
-    startTime = Instant.now() - Duration.ofHours(1),
-    endTime = Instant.now() - Duration.ofMinutes(30),
-    status = SUCCEEDED,
-    stages = listOf(
-      mapOf(
-        "type" to "deploy",
-        "context" to mapOf(
-          "clusters" to listOf(
-            mapOf(
-              "strategy" to "redblack",
-              "rollback" to mapOf(
-                "onFailure" to true
-              ),
-              "scaleDown" to false,
-              "maxRemainingAsgs" to 1,
-              "delayBeforeDisableSec" to 5,
-              "delayBeforeScaleDownSec" to 5
-            )
-          )
-        )
-      )
-    )
-  )
-
   fun tests() = rootContext<ClusterHandler> {
     fixture {
       ClusterHandler(
@@ -274,7 +173,8 @@ internal class ClusterExportTests : JUnit5Minutests {
         taskLauncher,
         clock,
         publisher,
-        normalizers
+        normalizers,
+        deploymentStrategyExporter
       )
     }
 
@@ -309,10 +209,9 @@ internal class ClusterExportTests : JUnit5Minutests {
 
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
-
       coEvery {
-        cloudDriverService.getEntityTags("aws", "test", "keel", "servergroup", any())
-      } returns emptyList()
+        deploymentStrategyExporter.discoverDeploymentStrategy("aws", "test", "keel", any())
+      } returns RedBlack()
     }
 
     after {
@@ -322,58 +221,6 @@ internal class ClusterExportTests : JUnit5Minutests {
     context("basic export behavior") {
       before {
         coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
-      }
-
-      context("entity tags indicate deployment done by orchestration task") {
-        before {
-          coEvery {
-            cloudDriverService.getEntityTags("aws", "test", "keel", "servergroup", any())
-          } returns listOf(taskEntityTags)
-          coEvery {
-            orcaService.getOrchestrationExecution("01E609548XWA7ZBP5M5FGMZ964", any())
-          } returns orcaTaskExecution
-        }
-
-        test("retrieves current deployment strategy from task execution") {
-          val cluster = runBlocking {
-            export(exportable.copy(regions = setOf("us-east-1")))
-          }
-
-          expectThat(cluster) {
-            get { locations.regions }.hasSize(1)
-            get { deployWith }.isA<RedBlack>().and {
-              get { maxServerGroups }.isEqualTo(3)
-              get { delayBeforeDisable }.isEqualTo(Duration.ofSeconds(10))
-              get { delayBeforeScaleDown }.isEqualTo(Duration.ofSeconds(10))
-            }
-          }
-        }
-      }
-
-      context("entity tags indicate deployment done by pipeline") {
-        before {
-          coEvery {
-            cloudDriverService.getEntityTags("aws", "test", "keel", "servergroup", any())
-          } returns listOf(pipelineEntityTags)
-          coEvery {
-            orcaService.getPipelineExecution("01E609548XWA7ZBP5M5FGMZ964", any())
-          } returns orcaPipelineExecution
-        }
-
-        test("retrieves current deployment strategy from pipeline execution") {
-          val cluster = runBlocking {
-            export(exportable.copy(regions = setOf("us-east-1")))
-          }
-
-          expectThat(cluster) {
-            get { locations.regions }.hasSize(1)
-            get { deployWith }.isA<RedBlack>().and {
-              get { maxServerGroups }.isEqualTo(1)
-              get { delayBeforeDisable }.isEqualTo(Duration.ofSeconds(5))
-              get { delayBeforeScaleDown }.isEqualTo(Duration.ofSeconds(5))
-            }
-          }
-        }
       }
 
       test("deployment strategy defaults are omitted") {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -664,8 +664,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
           expectThat(slot.captured.job.first()) {
             get("strategy").isEqualTo("redblack")
-            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable.seconds)
-            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown.seconds)
+            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable?.seconds)
+            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown?.seconds)
             get("rollback").isA<Map<String, Any?>>().get("onFailure").isEqualTo(deployWith.rollbackOnFailure)
             get("scaleDown").isEqualTo(deployWith.resizePreviousToZero)
             get("maxRemainingAsgs").isEqualTo(deployWith.maxServerGroups)
@@ -688,8 +688,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
           expectThat(slot.captured.job.first()) {
             get("strategy").isEqualTo("redblack")
-            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable.seconds)
-            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown.seconds)
+            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable?.seconds)
+            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown?.seconds)
             get("rollback").isA<Map<String, Any?>>().get("onFailure").isEqualTo(deployWith.rollbackOnFailure)
             get("scaleDown").isEqualTo(deployWith.resizePreviousToZero)
             get("maxRemainingAsgs").isEqualTo(deployWith.maxServerGroups)

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -95,7 +95,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     combinedRepository,
     publisher
   )
-  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
+  val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
   val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
@@ -195,7 +195,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         clock,
         publisher,
         normalizers,
-        deploymentStrategyExporter
+        clusterExportHelper
       )
     }
 
@@ -231,7 +231,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
       coEvery {
-        deploymentStrategyExporter.discoverDeploymentStrategy("aws", "test", "keel", any())
+        clusterExportHelper.discoverDeploymentStrategy("aws", "test", "keel", any())
       } returns RedBlack()
     }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -42,6 +42,7 @@ import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
@@ -94,6 +95,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     combinedRepository,
     publisher
   )
+  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
   val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
@@ -192,7 +194,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         taskLauncher,
         clock,
         publisher,
-        normalizers
+        normalizers,
+        deploymentStrategyExporter
       )
     }
 
@@ -227,6 +230,9 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
+      coEvery {
+        deploymentStrategyExporter.discoverDeploymentStrategy("aws", "test", "keel", any())
+      } returns RedBlack()
     }
 
     after {

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -2,6 +2,10 @@ package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy
+import com.netflix.spinnaker.keel.core.api.Highlander
+import com.netflix.spinnaker.keel.core.api.RedBlack
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import kotlinx.coroutines.async
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -65,7 +69,7 @@ class ClusterExportHelper(
         when (executionType) {
           "orchestration" -> orcaService.getOrchestrationExecution(executionId)
           "pipeline" -> orcaService.getPipelineExecution(executionId)
-          else -> throw com.netflix.spinnaker.kork.exceptions.SystemException("Unsupported execution type $executionType in Spinnaker metadata.")
+          else -> throw SystemException("Unsupported execution type $executionType in Spinnaker metadata.")
         }
       }.await()
 
@@ -78,11 +82,11 @@ class ClusterExportHelper(
       }
 
       when (val strategy = context?.get("strategy")) {
-        "redblack" -> com.netflix.spinnaker.keel.core.api.RedBlack.fromOrcaStageContext(context)
-        "highlander" -> com.netflix.spinnaker.keel.core.api.Highlander
-        null -> throw com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException("Deployment strategy information not found for server group $serverGroupName " +
+        "redblack" -> RedBlack.fromOrcaStageContext(context)
+        "highlander" -> Highlander
+        null -> throw InvalidRequestException("Deployment strategy information not found for server group $serverGroupName " +
           "in application $application, account $account")
-        else -> throw com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException("Deployment strategy $strategy associated with server group $serverGroupName " +
+        else -> throw InvalidRequestException("Deployment strategy $strategy associated with server group $serverGroupName " +
           "in application $application, account $account is not supported. " +
           "Only redblack and highlander are supported at this time.")
       }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -1,0 +1,106 @@
+package com.netflix.spinnaker.keel.orca
+
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy
+import kotlinx.coroutines.async
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Provides common logic for multiple cloud plugins to export aspects of compute clusters.
+ */
+@Component
+class ClusterExportHelper(
+  private val cloudDriverService: CloudDriverService,
+  private val orcaService: OrcaService
+) {
+  val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  /**
+   * Retrieve server group entity tags from clouddriver to identity the "source" of the server group (pipeline or
+   * orchestration), then retrieve execution details from orca to determine the deployment strategy used for that
+   * server group.
+   */
+  suspend fun discoverDeploymentStrategy(
+    cloudProvider: String,
+    account: String,
+    application: String,
+    serverGroupName: String
+  ): ClusterDeployStrategy? {
+    return kotlinx.coroutines.coroutineScope {
+      val entityTags = async {
+        log.debug("Looking for entity tags on server group $serverGroupName in application $application, " +
+          "account $account in search of pipeline/task correlation.")
+        cloudDriverService.getEntityTags(
+          cloudProvider = "aws",
+          account = account,
+          application = application,
+          entityType = "servergroup",
+          entityId = serverGroupName
+        )
+      }.await()
+
+      if (entityTags.isEmpty()) {
+        log.warn("Unable to find entity tags for server group $serverGroupName in application $application, " +
+          "account $account.")
+        return@coroutineScope null
+      }
+
+      val spinnakerMetadata = entityTags.first().tags
+        .find { it.name == "spinnaker:metadata" }
+        ?.let { it.value as? Map<*, *> }
+
+      if (spinnakerMetadata == null ||
+        spinnakerMetadata["executionType"] == null ||
+        spinnakerMetadata["executionId"] == null
+      ) {
+        log.warn("Unable to find Spinnaker metadata for server group $serverGroupName in application $application, " +
+          "account $account in entity tags.")
+        return@coroutineScope null
+      }
+
+      val executionType = spinnakerMetadata["executionType"]!!.toString()
+      val executionId = spinnakerMetadata["executionId"]!!.toString()
+      val execution = async {
+        when (executionType) {
+          "orchestration" -> orcaService.getOrchestrationExecution(executionId)
+          "pipeline" -> orcaService.getPipelineExecution(executionId)
+          else -> throw com.netflix.spinnaker.kork.exceptions.SystemException("Unsupported execution type $executionType in Spinnaker metadata.")
+        }
+      }.await()
+
+      val context = if (executionType == "pipeline") {
+        // TODO: or clone?
+        execution.getDeployStageContext()
+      } else { // orchestration (i.e. a task)
+        // TODO: or cloneServerGroup?
+        execution.getTaskContext("createServerGroup")
+      }
+
+      when (val strategy = context?.get("strategy")) {
+        "redblack" -> com.netflix.spinnaker.keel.core.api.RedBlack.fromOrcaStageContext(context)
+        "highlander" -> com.netflix.spinnaker.keel.core.api.Highlander
+        null -> throw com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException("Deployment strategy information not found for server group $serverGroupName " +
+          "in application $application, account $account")
+        else -> throw com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException("Deployment strategy $strategy associated with server group $serverGroupName " +
+          "in application $application, account $account is not supported. " +
+          "Only redblack and highlander are supported at this time.")
+      }
+    }
+  }
+
+  private fun ExecutionDetailResponse.getDeployStageContext() =
+    stages
+      ?.find { stage -> stage["type"] == "deploy" }
+      ?.let { stage -> stage["context"] }
+      ?.let { context -> context as? OrcaExecutionStage }
+      ?.let { context ->
+        (context["clusters"] as? List<OrcaExecutionStage>)?.first()
+      }
+
+  private fun ExecutionDetailResponse.getTaskContext(taskType: String) =
+    execution.stages
+      ?.find { stage -> stage["type"] == taskType }
+      ?.let { stage -> stage["context"] }
+      ?.let { context -> context as? Map<String, Any> }
+}

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -84,7 +84,8 @@ data class ExecutionDetailResponse(
   val startTime: Instant?,
   val endTime: Instant?,
   val status: OrcaExecutionStatus,
-  val execution: OrcaExecutionStages = OrcaExecutionStages(emptyList())
+  val execution: OrcaExecutionStages = OrcaExecutionStages(emptyList()),
+  val stages: List<Map<String, Any>>? = emptyList() // for pipelines, stages are not encapsulated in `execution`
 )
 
 data class OrcaExecutionStages(

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -85,11 +85,13 @@ data class ExecutionDetailResponse(
   val endTime: Instant?,
   val status: OrcaExecutionStatus,
   val execution: OrcaExecutionStages = OrcaExecutionStages(emptyList()),
-  val stages: List<Map<String, Any>>? = emptyList() // for pipelines, stages are not encapsulated in `execution`
+  val stages: List<OrcaExecutionStage>? = emptyList() // for pipelines, stages are not encapsulated in `execution`
 )
 
+typealias OrcaExecutionStage = Map<String, Any>
+
 data class OrcaExecutionStages(
-  val stages: List<Map<String, Any>>?
+  val stages: List<OrcaExecutionStage>?
 )
 
 data class GeneralErrorsDetails(

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
@@ -1,0 +1,236 @@
+package com.netflix.spinnaker.keel.orca
+
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
+import com.netflix.spinnaker.keel.clouddriver.model.AutoScalingGroup
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
+import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
+import com.netflix.spinnaker.keel.core.api.Capacity
+import com.netflix.spinnaker.keel.core.api.RedBlack
+import com.netflix.spinnaker.keel.core.parseMoniker
+import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus.SUCCEEDED
+import com.netflix.spinnaker.keel.tags.EntityRef
+import com.netflix.spinnaker.keel.tags.EntityTag
+import com.netflix.spinnaker.keel.tags.EntityTags
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.mockk
+import java.time.Duration
+import java.time.Instant
+import kotlinx.coroutines.runBlocking
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+class ClusterExportHelperTests : JUnit5Minutests {
+  class Fixture {
+    val cloudDriverService = mockk<CloudDriverService>()
+    val orcaService = mockk<OrcaService>()
+
+    val serverGroup = ActiveServerGroup(
+      name = "keel-test-v001",
+      region = "us-east-1",
+      zones = listOf("a", "b", "c").map { "us-east-1$it" }.toSet(),
+      image = ActiveServerGroupImage("foo", "bar", "baz"),
+      launchConfig = LaunchConfig(
+        ramdiskId = "diskId",
+        ebsOptimized = false,
+        imageId = "imageId",
+        instanceType = "instanceType",
+        keyName = "keyPair",
+        iamInstanceProfile = "iamRole",
+        instanceMonitoring = InstanceMonitoring(false)
+      ),
+      asg = AutoScalingGroup(
+        autoScalingGroupName = "keel-test-v001",
+        defaultCooldown = 0,
+        healthCheckType = "EC2",
+        healthCheckGracePeriod = 0,
+        suspendedProcesses = emptySet(),
+        enabledMetrics = emptySet(),
+        tags = emptySet(),
+        terminationPolicies = emptySet(),
+        vpczoneIdentifier = ""
+      ),
+      scalingPolicies = emptyList(),
+      vpcId = "foo",
+      targetGroups = emptySet(),
+      loadBalancers = emptySet(),
+      capacity = Capacity(1, 1),
+      cloudProvider = "aws",
+      securityGroups = emptySet(),
+      accountName = "test",
+      moniker = parseMoniker("keek-test-v001")
+    )
+
+    val taskEntityTags = EntityTags(
+      id = "aws:servergroup:${serverGroup.name}:1234567890123:us-east-1",
+      idPattern = "{{cloudProvider}}:{{entityType}}:{{entityId}}:{{account}}:{{region}}",
+      tags = listOf(
+        EntityTag(
+          name = "spinnaker:metadata",
+          namespace = "spinnaker",
+          valueType = "object",
+          value = mapOf(
+            "executionId" to "01E609548XWA7ZBP5M5FGMZ964",
+            "executionType" to "orchestration"
+          )
+        )
+      ),
+      tagsMetadata = emptyList(),
+      entityRef = EntityRef(
+        cloudProvider = "aws",
+        application = "keel",
+        accountId = "1234567890123",
+        account = "test",
+        region = "us-east-1",
+        entityType = "servergroup",
+        entityId = serverGroup.name
+      )
+    )
+
+    val pipelineEntityTags = taskEntityTags.copy(
+      tags = listOf(
+        EntityTag(
+          name = "spinnaker:metadata",
+          namespace = "spinnaker",
+          valueType = "object",
+          value = mapOf(
+            "executionId" to "01E609548XWA7ZBP5M5FGMZ964",
+            "executionType" to "pipeline"
+          )
+        )
+      )
+    )
+
+    val orcaTaskExecution = ExecutionDetailResponse(
+      id = "01E609548XWA7ZBP5M5FGMZ964",
+      name = "A keel deployment task",
+      application = "keel",
+      buildTime = Instant.now() - Duration.ofHours(1),
+      startTime = Instant.now() - Duration.ofHours(1),
+      endTime = Instant.now() - Duration.ofMinutes(30),
+      status = SUCCEEDED,
+      execution = OrcaExecutionStages(
+        stages = listOf(
+          mapOf(
+            "type" to "createServerGroup",
+            "context" to mapOf(
+              "strategy" to "redblack",
+              "rollback" to mapOf(
+                "onFailure" to true
+              ),
+              "scaleDown" to false,
+              "maxRemainingAsgs" to 3,
+              "delayBeforeDisableSec" to 10,
+              "delayBeforeScaleDownSec" to 10
+            )
+          )
+        )
+      )
+    )
+
+    val orcaPipelineExecution = ExecutionDetailResponse(
+      id = "01E609548XWA7ZBP5M5FGMZ964",
+      name = "A user's deployment pipeline",
+      application = "keel",
+      buildTime = Instant.now() - Duration.ofHours(1),
+      startTime = Instant.now() - Duration.ofHours(1),
+      endTime = Instant.now() - Duration.ofMinutes(30),
+      status = SUCCEEDED,
+      stages = listOf(
+        mapOf(
+          "type" to "deploy",
+          "context" to mapOf(
+            "clusters" to listOf(
+              mapOf(
+                "strategy" to "redblack",
+                "rollback" to mapOf(
+                  "onFailure" to true
+                ),
+                "scaleDown" to false,
+                "maxRemainingAsgs" to 1,
+                "delayBeforeDisableSec" to 5,
+                "delayBeforeScaleDownSec" to 5
+              )
+            )
+          )
+        )
+      )
+    )
+
+    val subject = ClusterExportHelper(cloudDriverService, orcaService)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("discover deployment strategy") {
+      before {
+        coEvery { cloudDriverService.activeServerGroup(any(), "keel", "test", any(), any(), "aws") } returns serverGroup
+      }
+
+      context("when entity tags indicate deployment done by orchestration task") {
+        before {
+          coEvery {
+            cloudDriverService.getEntityTags("aws", "test", "keel", "servergroup", any())
+          } returns listOf(taskEntityTags)
+          coEvery {
+            orcaService.getOrchestrationExecution("01E609548XWA7ZBP5M5FGMZ964", any())
+          } returns orcaTaskExecution
+        }
+
+        test("retrieves current deployment strategy from task execution") {
+          val deploymentStrategy = runBlocking {
+            subject.discoverDeploymentStrategy(
+              cloudProvider = "aws",
+              account = "test",
+              application = "keel",
+              serverGroupName = "keel-test-v001"
+            )
+          }
+
+          expectThat(deploymentStrategy)
+            .isA<RedBlack>()
+            .and {
+              get { maxServerGroups }.isEqualTo(3)
+              get { delayBeforeDisable }.isEqualTo(Duration.ofSeconds(10))
+              get { delayBeforeScaleDown }.isEqualTo(Duration.ofSeconds(10))
+            }
+        }
+      }
+
+      context("when entity tags indicate deployment done by pipeline") {
+        before {
+          coEvery {
+            cloudDriverService.getEntityTags("aws", "test", "keel", "servergroup", any())
+          } returns listOf(pipelineEntityTags)
+          coEvery {
+            orcaService.getPipelineExecution("01E609548XWA7ZBP5M5FGMZ964", any())
+          } returns orcaPipelineExecution
+        }
+
+        test("retrieves current deployment strategy from pipeline execution") {
+          val deploymentStrategy = runBlocking {
+            subject.discoverDeploymentStrategy(
+              cloudProvider = "aws",
+              account = "test",
+              application = "keel",
+              serverGroupName = "keel-test-v001"
+            )
+          }
+
+          expectThat(deploymentStrategy)
+            .isA<RedBlack>()
+            .and {
+              get { maxServerGroups }.isEqualTo(1)
+              get { delayBeforeDisable }.isEqualTo(Duration.ofSeconds(5))
+              get { delayBeforeScaleDown }.isEqualTo(Duration.ofSeconds(5))
+            }
+        }
+      }
+    }
+  }
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import java.time.Clock
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -44,7 +45,8 @@ class TitusConfig {
     clock: Clock,
     taskLauncher: TaskLauncher,
     publisher: ApplicationEventPublisher,
-    resolvers: List<Resolver<*>>
+    resolvers: List<Resolver<*>>,
+    clusterExportHelper: ClusterExportHelper
   ): TitusClusterHandler = TitusClusterHandler(
     cloudDriverService,
     cloudDriverCache,
@@ -52,6 +54,7 @@ class TitusConfig {
     clock,
     taskLauncher,
     publisher,
-    resolvers
+    resolvers,
+    clusterExportHelper
   )
 }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -195,19 +195,22 @@ class TitusClusterHandler(
       }.toSet()
     )
 
+    val deployStrategy = clusterExportHelper.discoverDeploymentStrategy(
+      cloudProvider = "titus",
+      account = exportable.account,
+      application = exportable.moniker.app,
+      serverGroupName = base.name
+    )
+      ?.withDefaultsOmitted()
+      ?: RedBlack().withDefaultsOmitted()
+
     val spec = TitusClusterSpec(
       moniker = exportable.moniker,
       locations = locations,
       _defaults = base.exportSpec(exportable.moniker.app),
       overrides = mutableMapOf(),
       containerProvider = base.container,
-      deployWith = clusterExportHelper.discoverDeploymentStrategy(
-        cloudProvider = "titus",
-        account = exportable.account,
-        application = exportable.moniker.app,
-        serverGroupName = base.name
-      ) ?: RedBlack()
-        .let { it.withDefaultsOmitted() }
+      deployWith = deployStrategy
     )
 
     spec.generateOverrides(

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -200,9 +200,7 @@ class TitusClusterHandler(
       account = exportable.account,
       application = exportable.moniker.app,
       serverGroupName = base.name
-    )
-      ?.withDefaultsOmitted()
-      ?: RedBlack().withDefaultsOmitted()
+    ) ?: RedBlack()
 
     val spec = TitusClusterSpec(
       moniker = exportable.moniker,
@@ -210,7 +208,7 @@ class TitusClusterHandler(
       _defaults = base.exportSpec(exportable.moniker.app),
       overrides = mutableMapOf(),
       containerProvider = base.container,
-      deployWith = deployStrategy
+      deployWith = deployStrategy.withDefaultsOmitted()
     )
 
     spec.generateOverrides(

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -50,6 +50,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
+import com.netflix.spinnaker.keel.core.api.RedBlack
 import com.netflix.spinnaker.keel.core.orcaClusterMoniker
 import com.netflix.spinnaker.keel.core.serverGroup
 import com.netflix.spinnaker.keel.diff.toIndividualDiffs
@@ -59,6 +60,7 @@ import com.netflix.spinnaker.keel.docker.VersionedTagProvider
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.exceptions.ExportError
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
 import com.netflix.spinnaker.keel.retrofit.isNotFound
@@ -82,7 +84,8 @@ class TitusClusterHandler(
   private val clock: Clock,
   private val taskLauncher: TaskLauncher,
   private val publisher: ApplicationEventPublisher,
-  resolvers: List<Resolver<*>>
+  resolvers: List<Resolver<*>>,
+  private val clusterExportHelper: ClusterExportHelper
 ) : ResourceHandler<TitusClusterSpec, Map<String, TitusServerGroup>>(resolvers) {
 
   private val mapper = configuredObjectMapper()
@@ -197,7 +200,14 @@ class TitusClusterHandler(
       locations = locations,
       _defaults = base.exportSpec(exportable.moniker.app),
       overrides = mutableMapOf(),
-      containerProvider = base.container
+      containerProvider = base.container,
+      deployWith = clusterExportHelper.discoverDeploymentStrategy(
+        cloudProvider = "titus",
+        account = exportable.account,
+        application = exportable.moniker.app,
+        serverGroupName = base.name
+      ) ?: RedBlack()
+        .let { it.withDefaultsOmitted() }
     )
 
     spec.generateOverrides(

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -61,7 +61,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
     publisher
   )
   val clock = Clock.systemUTC()
-  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
+  val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
 
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
@@ -140,7 +140,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
         taskLauncher,
         publisher,
         resolvers,
-        deploymentStrategyExporter
+        clusterExportHelper
       )
     }
 
@@ -164,7 +164,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
       coEvery {
-        deploymentStrategyExporter.discoverDeploymentStrategy("titus", "titustest", "keel", any())
+        clusterExportHelper.discoverDeploymentStrategy("titus", "titustest", "keel", any())
       } returns RedBlack()
     }
 

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -20,7 +20,9 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
+import com.netflix.spinnaker.keel.core.api.RedBlack
 import com.netflix.spinnaker.keel.docker.DigestProvider
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
@@ -59,6 +61,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
     publisher
   )
   val clock = Clock.systemUTC()
+  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
 
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
@@ -136,7 +139,8 @@ internal class TitusClusterExportTests : JUnit5Minutests {
         clock,
         taskLauncher,
         publisher,
-        resolvers
+        resolvers,
+        deploymentStrategyExporter
       )
     }
 
@@ -159,6 +163,9 @@ internal class TitusClusterExportTests : JUnit5Minutests {
       }
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
+      coEvery {
+        deploymentStrategyExporter.discoverDeploymentStrategy("titus", "titustest", "keel", any())
+      } returns RedBlack()
     }
 
     after {

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -51,6 +51,7 @@ import com.netflix.spinnaker.keel.docker.DigestProvider
 import com.netflix.spinnaker.keel.docker.VersionedTagProvider
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
@@ -104,6 +105,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
     publisher
   )
   val clock = Clock.systemUTC()
+  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
 
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
@@ -181,7 +183,8 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         clock,
         taskLauncher,
         publisher,
-        resolvers
+        resolvers,
+        deploymentStrategyExporter
       )
     }
 
@@ -204,6 +207,9 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       }
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
+      coEvery {
+        deploymentStrategyExporter.discoverDeploymentStrategy("titus", "titustest", "keel", any())
+      } returns RedBlack()
     }
 
     after {

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -105,7 +105,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
     publisher
   )
   val clock = Clock.systemUTC()
-  val deploymentStrategyExporter = mockk<ClusterExportHelper>(relaxed = true)
+  val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
 
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
@@ -184,7 +184,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         taskLauncher,
         publisher,
         resolvers,
-        deploymentStrategyExporter
+        clusterExportHelper
       )
     }
 
@@ -208,7 +208,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { deliveryConfigRepository.environmentFor(any()) } returns Environment("test")
       coEvery {
-        deploymentStrategyExporter.discoverDeploymentStrategy("titus", "titustest", "keel", any())
+        clusterExportHelper.discoverDeploymentStrategy("titus", "titustest", "keel", any())
       } returns RedBlack()
     }
 

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -369,8 +369,8 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
           expectThat(slot.captured.job.first()) {
             get("strategy").isEqualTo("redblack")
-            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable.seconds)
-            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown.seconds)
+            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable?.seconds)
+            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown?.seconds)
             get("rollback").isA<Map<String, Any?>>().get("onFailure").isEqualTo(deployWith.rollbackOnFailure)
             get("scaleDown").isEqualTo(deployWith.resizePreviousToZero)
             get("maxRemainingAsgs").isEqualTo(deployWith.maxServerGroups)
@@ -393,8 +393,8 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
           expectThat(slot.captured.job.first()) {
             get("strategy").isEqualTo("redblack")
-            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable.seconds)
-            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown.seconds)
+            get("delayBeforeDisableSec").isEqualTo(deployWith.delayBeforeDisable?.seconds)
+            get("delayBeforeScaleDownSec").isEqualTo(deployWith.delayBeforeScaleDown?.seconds)
             get("rollback").isA<Map<String, Any?>>().get("onFailure").isEqualTo(deployWith.rollbackOnFailure)
             get("scaleDown").isEqualTo(deployWith.resizePreviousToZero)
             get("maxRemainingAsgs").isEqualTo(deployWith.maxServerGroups)


### PR DESCRIPTION
Adds support for exporting the deployment strategy associated with a cluster based on information retrieved from pipelines (for not-yet-migrated apps) and tasks (for already-managed apps or clusters created manually in the UI).

Limitations: currently, the export supports `createServerGroup` tasks and `deploy` pipeline stages only. Support for clone operations, if necessary, will be addressed in a separate PR.

Closes #753. As I was working in this area of the code anyway, I've taken the opportunity to also fix #625.