### PR TITLE
fix(clouddriver): hasAppVersion edge case

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
@@ -34,10 +34,11 @@ val NamedImage.creationDate: Instant
     }
 
 val NamedImage.hasAppVersion: Boolean
-  get() = tagsByImageId.values.isNotEmpty() &&
-    tagsByImageId
+  get() = tagsByImageId
     .values
-    .all { it != null && it.containsKey("appversion") }
+    .let { vals ->
+      vals.isNotEmpty() && vals.all { it != null && it.containsKey("appversion") }
+      }
 
 val NamedImage.appVersion: String
   get() = tagsByImageId

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
@@ -34,7 +34,8 @@ val NamedImage.creationDate: Instant
     }
 
 val NamedImage.hasAppVersion: Boolean
-  get() = tagsByImageId
+  get() = tagsByImageId.values.isNotEmpty() &&
+    tagsByImageId
     .values
     .all { it != null && it.containsKey("appversion") }
 

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImageTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImageTests.kt
@@ -1,0 +1,54 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+class NamedImageTests : JUnit5Minutests {
+  fun tests() = rootContext<NamedImage> {
+    context("hasAppVersion tests") {
+
+      // Helper function to make a NamedImage fixture
+      fun makeNamedImage(tagsByImageId: Map<String, Map<String, String?>?>) =
+          NamedImage(
+            imageName = "name",
+            attributes = mapOf("foo" to "bar"),
+            accounts = setOf("test"),
+            amis = mapOf("us-east-1" to listOf("ami-12345")),
+            tagsByImageId = tagsByImageId
+        )
+
+      context("properly populated tagsByImageId") {
+        fixture {
+          makeNamedImage(tagsByImageId = mapOf(
+            "ami-abc123" to
+              mapOf(
+                "appversion" to "foo-0.0.1-h123.abcde",
+                "base_ami_version" to "base"
+              )))
+        }
+
+        test("has an app version") {
+          expectThat(hasAppVersion).isTrue()
+        }
+      }
+
+      context("null tagsByImageId values") {
+        fixture { makeNamedImage(tagsByImageId = mapOf("ami-abc123" to null)) }
+
+        test("does not have an app version") {
+          expectThat(hasAppVersion).isFalse()
+        }
+      }
+      context("empty tagsByImageId") {
+        fixture { makeNamedImage(tagsByImageId = emptyMap()) }
+
+        test("does not have an app version") {
+          expectThat(hasAppVersion).isFalse()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fix an edge case in `NamedImage` class where `hasAppVersion` was returning true, even though  app version information was missing.

## Details

Methods in the [ImageService](https://github.com/spinnaker/keel/blob/fa634a154158c6da17cfe0814698dff039fe2bc5/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt#L31) class always call `filter{ it.hasAppVersion }` after calling `cloudDriverService.namedImages` , which means that any returned [NamedImage] object should have a valid appversion field.

However, we are seeing an exception being thrown when reading the `NamedImage.appVersion` property (see stack trace in #1052), which shouldn't be possible given that we always filter on `hasAppVersion`. 

It turned out there was a case where the `hasAppVersion` check returns true, even though there's no app version info in the object.

[NamedImage]: https://github.com/spinnaker/keel/blob/d8007d1664b44122651f36234e7d6ed6ef88c921/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt#L7

Fixes #1052