### PR TITLE
fix(artifacts): log instead of throw when artifacts have weird statuses

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -14,7 +14,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
-import com.netflix.spinnaker.kork.exceptions.SystemException
+import org.slf4j.LoggerFactory
 
 /**
  * Summarized data about a specific environment, mostly for use by the UI.
@@ -30,6 +30,10 @@ data class EnvironmentSummary(
   val resources: Set<String>
     get() = environment.resources.map { it.id }.toSet()
 
+  companion object {
+    val log = LoggerFactory.getLogger(javaClass)
+  }
+
   fun getArtifactPromotionStatus(artifact: DeliveryArtifact, version: String) =
     artifacts.find { it.name == artifact.name && it.type == artifact.type }
       ?.let {
@@ -41,8 +45,10 @@ data class EnvironmentSummary(
           in it.versions.pending -> PENDING
           in it.versions.vetoed -> VETOED
           in it.versions.skipped -> SKIPPED
-          else -> throw SystemException("Unknown promotion status for artifact ${it.type}:${it.name}@$version in environment ${this.name}"
-          )
+          else -> {
+            log.error("Unknown promotion status for artifact ${it.type}:${it.name}@$version in environment ${this.name}: ${it.versions}")
+            null
+          }
         }
       }
 }


### PR DESCRIPTION
Log an error & cut the artifact out of the summary if we're in a weird edge case.

Problem:
We have a bug where sometimes artifacts get stuck in the "DEPLOYING" state within an environment. When this happens, and we try and generate the summary for that environment, we throw an exception and bork the whole artifacts summary. That's annoying.

This PR changes things so we log an error instead of throwing an exception, and then we return null (which will cut that artifact out of the summary).

I'm still working on fixing the underlying issue, but this is a little bandaid so the view doesn't completely break
