### PR TITLE
fix(performance): Avoid retrieving all SGs when looking for one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 _**IMPORTANT:** This service is currently under development and is not ready for production use._
 
-
 ---
 
 ![Release](https://github.com/spinnaker/keel/workflows/Release/badge.svg)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -44,13 +44,23 @@ interface CloudDriverService {
     @Query("vpcId") vpcId: String? = null
   ): SecurityGroupModel
 
-  @GET("/securityGroups/{account}/{provider}")
-  suspend fun getSecurityGroupSummaries(
+  @GET("/securityGroups/{account}/{provider}/{region}/{id}?getById=true")
+  suspend fun getSecurityGroupSummaryById(
     @Path("account") account: String,
     @Path("provider") provider: String,
-    @Query("region") region: String,
+    @Path("region") region: String,
+    @Path("id") id: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
-  ): Collection<SecurityGroupSummary>
+  ): SecurityGroupSummary?
+
+  @GET("/securityGroups/{account}/{provider}/{region}/{name}")
+  suspend fun getSecurityGroupSummaryByName(
+    @Path("account") account: String,
+    @Path("provider") provider: String,
+    @Path("region") region: String,
+    @Path("name") name: String,
+    @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
+  ): SecurityGroupSummary?
 
   @GET("/networks")
   suspend fun listNetworks(


### PR DESCRIPTION
This is an attempt to fix #1060.

Our cache for security groups was indexing SGs by ID/name, but using a call to clouddriver that retrieves _all_ SGs for the account+region, which in our case is thousands of objects. Even on a server group with a small number of SGs, that meant repeated calls to that API. This PR changes that behavior to use the existing clouddriver API to retrieve a single SG by name, and a [newly introduced variant of the API to retrieve an SG by ID](https://github.com/spinnaker/clouddriver/pull/4540), which I hope should significantly speed things up.

Depends on https://github.com/spinnaker/clouddriver/pull/4540