### PR TITLE
chore(telemetry): report drift time in seconds

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -139,6 +139,7 @@ class TelemetryListener(
           .between(it.get(), clock.instant())
           .toMillis()
           .toDouble()
+          .div(1000) // convert to seconds
       }
   }
 


### PR DESCRIPTION
We currently report drift time (time since last resource/environment/artifact check) in milliseconds. However, typical drift times are currently on the order of one second, and unhealthy drift times are much higher. 

Here's an example of the three drift metrics for a typical healthy time period (click to embiggen):

![drift-times](https://user-images.githubusercontent.com/446305/80149366-658dad00-856b-11ea-892a-b53fe71bdd83.png)

At this scale, it's easier for me to reason about seconds than thousands of milliseconds. This PR changes the reported drift metrics from milliseconds to seconds, to help make these graphs easier to read.

Note that the reported metric is still a float, so we won't lose any precision.