### PR TITLE
fix(titus): filtering out non matching tags

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -47,6 +47,9 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   /**
    * @returns the versions we have for an artifact, filtering by the artifact status information,
    * and sorting with the artifact's sorting strategy
+   *
+   * This endpoint filters out invalid docker tags (tags that produce 0 or 2+ capture groups according to
+   * the supplied versioning strategy).
    */
   fun versions(
     artifact: DeliveryArtifact

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -176,7 +176,7 @@ class InMemoryArtifactRepository(
           // we only want to give valid versions, so this will filter out tags like "latest"
           // and others that don't fit the chosen versioning strategy.
           try {
-            TagComparator.parseWithRegex(it.version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
+            it.version != "latest" && TagComparator.parseWithRegex(it.version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
           } catch (e: InvalidRegexException) {
             false
           }
@@ -424,7 +424,7 @@ class InMemoryArtifactRepository(
                     artifact.statuses.isEmpty() || it.status in artifact.statuses
                   }
                   is DockerArtifact -> {
-                    TagComparator.parseWithRegex(it.version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
+                    it.version != "latest" && TagComparator.parseWithRegex(it.version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
                   }
                 }
               }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryArtifactRepository.kt
@@ -5,6 +5,8 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.core.TagComparator
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
@@ -21,6 +23,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 import com.netflix.spinnaker.keel.core.comparator
+import com.netflix.spinnaker.keel.exceptions.InvalidRegexException
 import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
@@ -169,6 +172,14 @@ class InMemoryArtifactRepository(
       .filter {
         if (artifact is DebianArtifact && artifact.statuses.isNotEmpty()) {
           it.status in artifact.statuses
+        } else if (artifact is DockerArtifact) {
+          // we only want to give valid versions, so this will filter out tags like "latest"
+          // and others that don't fit the chosen versioning strategy.
+          try {
+            TagComparator.parseWithRegex(it.version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
+          } catch (e: InvalidRegexException) {
+            false
+          }
         } else {
           // select all
           true
@@ -408,8 +419,14 @@ class InMemoryArtifactRepository(
             val currentVersion = statuses.filterValues { it == CURRENT }.keys.firstOrNull()
             val pending = versions[VersionsKey(artifact.name, artifact.type)]
               ?.filter {
-                it.status == null || it.status in ((artifact as? DebianArtifact)?.statuses
-                  ?: emptySet<ArtifactStatus>())
+                when (artifact) {
+                  is DebianArtifact -> {
+                    artifact.statuses.isEmpty() || it.status in artifact.statuses
+                  }
+                  is DockerArtifact -> {
+                    TagComparator.parseWithRegex(it.version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
+                  }
+                }
               }
               ?.map { it.version }
               ?.filter { it !in statuses.keys }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -270,7 +270,7 @@ class SqlArtifactRepository(
   private fun filterDockerVersions(artifact: DockerArtifact, versions: List<String>): List<String> =
     versions.filter { version ->
       try {
-        TagComparator.parseWithRegex(version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
+        version != "latest" && TagComparator.parseWithRegex(version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
       } catch (e: InvalidRegexException) {
         log.warn("Version $version produced more than one capture group based on artifact $artifact, excluding")
         false
@@ -759,7 +759,7 @@ class SqlArtifactRepository(
               }
               is DockerArtifact -> {
                 // filter out invalid docker tags
-                TagComparator.parseWithRegex(version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
+                version != "latest" && TagComparator.parseWithRegex(version, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
               }
             }
           }


### PR DESCRIPTION
Right now, we sort tags based on the docker strategy you've chosen. If you choose the wrong strategy, we don't necessarily care, and even though we can't sort in a meaningful way we don't stop trying! We just put that un-sortable data at the bottom of the list. That seems not great.

This PR filters out non-matching tags based on the versioning strategy you've chosen. One caveat - this doesn't protect from user error. For example, you could tell us that your tag is and will always be a semantic version. Then, you could start pushing tags with colors (or other string garbage). Because you've told us that your whole tag is what we should use to sort, we say "sure! let's do it!". This PR doesn't change that (except that we explicitly ignore the "latest" tag).

If you've given us a custom regex or chosen a strategy with a custom regex (branch-job-commit-by-job, for example), and a tag that you push fails to have something extracted from it with regex (like "latest"), then we will cut that version out for rendering the summary and also approving the artifacts. This is similar functionality to the debian status filtering.