### PR TITLE
fix(events): Fix paused events, again

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -48,13 +48,12 @@ import strikt.assertions.isTrue
  *
  * Tests that only apply to one repository should live in the repository-specific test classes.
  */
-abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : ResourceRepository, A : ArtifactRepository, P : PausedRepository> :
+abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : ResourceRepository, A : ArtifactRepository> :
   JUnit5Minutests {
 
   abstract fun createDeliveryConfigRepository(resourceSpecIdentifier: ResourceSpecIdentifier): D
   abstract fun createResourceRepository(resourceSpecIdentifier: ResourceSpecIdentifier): R
   abstract fun createArtifactRepository(): A
-  abstract fun createPausedRepository(): P
 
   open fun flush() {}
 
@@ -73,11 +72,10 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
     environments = setOf(firstEnv)
   )
 
-  data class Fixture<D : DeliveryConfigRepository, R : ResourceRepository, A : ArtifactRepository, P : PausedRepository>(
+  data class Fixture<D : DeliveryConfigRepository, R : ResourceRepository, A : ArtifactRepository>(
     val deliveryConfigRepositoryProvider: (ResourceSpecIdentifier) -> D,
     val resourceRepositoryProvider: (ResourceSpecIdentifier) -> R,
-    val artifactRepositoryProvider: () -> A,
-    val pausedRepositoryProvider: () -> P
+    val artifactRepositoryProvider: () -> A
   ) {
     internal val clock = MutableClock()
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
@@ -85,15 +83,13 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
     internal val deliveryConfigRepository: D = deliveryConfigRepositoryProvider(DummyResourceSpecIdentifier)
     internal val resourceRepository: R = resourceRepositoryProvider(DummyResourceSpecIdentifier)
     internal val artifactRepository: A = artifactRepositoryProvider()
-    internal val pausedRepository: P = pausedRepositoryProvider()
 
     val subject = CombinedRepository(
       deliveryConfigRepository,
       artifactRepository,
       resourceRepository,
       clock,
-      publisher,
-      ActuationPauser(resourceRepository, pausedRepository, publisher, clock)
+      publisher
     )
 
     fun resourcesDueForCheck() =
@@ -106,13 +102,12 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
         }
   }
 
-  fun tests() = rootContext<Fixture<D, R, A, P>> {
+  fun tests() = rootContext<Fixture<D, R, A>> {
     fixture {
       Fixture(
         deliveryConfigRepositoryProvider = this@CombinedRepositoryTests::createDeliveryConfigRepository,
         resourceRepositoryProvider = this@CombinedRepositoryTests::createResourceRepository,
-        artifactRepositoryProvider = this@CombinedRepositoryTests::createArtifactRepository,
-        pausedRepositoryProvider = this@CombinedRepositoryTests::createPausedRepository
+        artifactRepositoryProvider = this@CombinedRepositoryTests::createArtifactRepository
       )
     }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -17,7 +17,6 @@ import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceUpdated
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
-import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.test.DummyResourceSpec

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PausedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PausedRepositoryTests.kt
@@ -55,7 +55,7 @@ abstract class PausedRepositoryTests<T : PausedRepository> : JUnit5Minutests {
 
     context("application paused") {
       before {
-        subject.pauseApplication(application)
+        subject.pauseApplication(application, "keel@keel.io")
       }
 
       test("app appears in list of paused apps") {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
@@ -54,7 +53,6 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isGreaterThanOrEqualTo
 import strikt.assertions.isNotEmpty
-import strikt.assertions.isNotNull
 import strikt.assertions.map
 
 abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests {
@@ -159,18 +157,6 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
 
         test("full resource returned for the application") {
           expectThat(subject.getResourcesByApplication("toast")).hasSize(1)
-        }
-
-        test("resource summary is formatted correctly") {
-          val summaries = subject.getResourceSummaries(deliveryConfig)
-
-          expectThat(summaries) {
-            hasSize(1)
-            with(first()) {
-              get(ResourceSummary::id).isEqualTo(lr.id)
-              get(ResourceSummary::locations).isNotNull()
-            }
-          }
         }
       }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -15,7 +15,9 @@ import java.time.Instant
   JsonSubTypes.Type(value = ApplicationActuationPaused::class, name = "ApplicationActuationPaused"),
   JsonSubTypes.Type(value = ApplicationActuationResumed::class, name = "ApplicationActuationResumed")
 )
-abstract class ApplicationEvent : PersistentEvent() {
+abstract class ApplicationEvent(
+  override val triggeredBy: String? = null
+) : PersistentEvent() {
   override val scope = Scope.APPLICATION
 
   override val uid: String
@@ -29,14 +31,16 @@ abstract class ApplicationEvent : PersistentEvent() {
  */
 data class ApplicationActuationPaused(
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val triggeredBy: String
 ) : ApplicationEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(application: String, clock: Clock = Companion.clock) : this(
+  constructor(application: String, triggeredBy: String, clock: Clock = Companion.clock) : this(
     application,
-    clock.instant()
+    clock.instant(),
+    triggeredBy
   )
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -49,12 +49,14 @@ data class ApplicationActuationPaused(
  */
 data class ApplicationActuationResumed(
   override val application: String,
+  override val triggeredBy: String,
   override val timestamp: Instant
 ) : ApplicationEvent() {
   @JsonIgnore override val ignoreRepeatedInHistory = true
 
-  constructor(application: String, clock: Clock = Companion.clock) : this(
+  constructor(application: String, triggeredBy: String, clock: Clock = Companion.clock) : this(
     application,
+    triggeredBy,
     clock.instant()
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
@@ -21,6 +21,7 @@ abstract class PersistentEvent {
   abstract val application: String
   abstract val uid: String // The unique ID of the thing associated with the scope. Defined in sub-classes.
   abstract val timestamp: Instant
+  abstract val triggeredBy: String?
   @JsonIgnore
   open val ignoreRepeatedInHistory: Boolean = false
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -219,10 +219,15 @@ data class ResourceActuationPaused(
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, timestamp: Instant) : this(
     resource.kind,
     resource.id,
     resource.application,
+    timestamp
+  )
+
+  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
+    resource,
     clock.instant()
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -65,7 +65,8 @@ import org.slf4j.LoggerFactory
   Type(value = ResourceTaskSucceeded::class, name = "ResourceTaskSucceeded")
 )
 abstract class ResourceEvent(
-  open val message: String? = null
+  open val message: String? = null,
+  override val triggeredBy: String? = null
 ) : PersistentEvent() {
   override val scope = Scope.RESOURCE
   abstract val kind: ResourceKind
@@ -214,21 +215,24 @@ data class ResourceActuationPaused(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val triggeredBy: String
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, timestamp: Instant) : this(
+  constructor(resource: Resource<*>, timestamp: Instant, triggeredBy: String) : this(
     resource.kind,
     resource.id,
     resource.application,
-    timestamp
+    timestamp,
+    triggeredBy
   )
 
-  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, triggeredBy: String, clock: Clock = Companion.clock) : this(
     resource,
-    clock.instant()
+    clock.instant(),
+    triggeredBy
   )
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -267,15 +267,17 @@ data class ResourceActuationResumed(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
+  override val triggeredBy: String,
   override val timestamp: Instant
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, triggeredBy: String, clock: Clock = Companion.clock) : this(
     resource.kind,
     resource.id,
     resource.application,
+    triggeredBy,
     clock.instant()
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListener.kt
@@ -1,14 +1,30 @@
 package com.netflix.spinnaker.keel.events
 
+import com.netflix.spinnaker.keel.api.serviceAccount
+import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import java.time.Clock
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
-class ResourceHistoryListener(private val resourceRepository: ResourceRepository) {
+class ResourceHistoryListener(
+  private val resourceRepository: ResourceRepository,
+  private val actuationPauser: ActuationPauser,
+  private val clock: Clock
+) {
 
   @EventListener(ResourceEvent::class)
   fun onResourceEvent(event: ResourceEvent) {
     resourceRepository.appendHistory(event)
+
+    // Account for the case where a resource was paused, then deleted (i.e. removed from management), then
+    // resubmitted, where we don't want to inadvertently resume actuation without the user knowing and giving
+    // explicit consent, by injecting a ResourceActuationPaused event.
+    // ApplicationActuationPaused events are injected in the resource event history dynamically.
+    if (event is ResourceCreated && actuationPauser.resourceIsPaused(event.id)) {
+      val resource = resourceRepository.get(event.id)
+      resourceRepository.appendHistory(ResourceActuationPaused(resource, resource.serviceAccount, clock))
+    }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListener.kt
@@ -1,30 +1,16 @@
 package com.netflix.spinnaker.keel.events
 
-import com.netflix.spinnaker.keel.api.serviceAccount
-import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
-import java.time.Clock
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 @Component
 class ResourceHistoryListener(
-  private val resourceRepository: ResourceRepository,
-  private val actuationPauser: ActuationPauser,
-  private val clock: Clock
+  private val resourceRepository: ResourceRepository
 ) {
 
   @EventListener(ResourceEvent::class)
   fun onResourceEvent(event: ResourceEvent) {
     resourceRepository.appendHistory(event)
-
-    // Account for the case where a resource was paused, then deleted (i.e. removed from management), then
-    // resubmitted, where we don't want to inadvertently resume actuation without the user knowing and giving
-    // explicit consent, by injecting a ResourceActuationPaused event.
-    // ApplicationActuationPaused events are injected in the resource event history dynamically.
-    if (event is ResourceCreated && actuationPauser.resourceIsPaused(event.id)) {
-      val resource = resourceRepository.get(event.id)
-      resourceRepository.appendHistory(ResourceActuationPaused(resource, resource.serviceAccount, clock))
-    }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
@@ -72,10 +72,10 @@ class ActuationPauser(
     publisher.publishEvent(ApplicationActuationPaused(application, user, clock))
   }
 
-  fun resumeApplication(application: String) {
+  fun resumeApplication(application: String, user: String) {
     log.info("Resuming application $application")
     pausedRepository.resumeApplication(application)
-    publisher.publishEvent(ApplicationActuationResumed(application, clock))
+    publisher.publishEvent(ApplicationActuationResumed(application, user, clock))
   }
 
   fun pauseResource(id: String, user: String) {
@@ -84,10 +84,10 @@ class ActuationPauser(
     publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id), user, clock))
   }
 
-  fun resumeResource(id: String) {
+  fun resumeResource(id: String, user: String) {
     log.info("Resuming resource $id")
     pausedRepository.resumeResource(id)
-    publisher.publishEvent(ResourceActuationResumed(resourceRepository.get(id), clock))
+    publisher.publishEvent(ResourceActuationResumed(resourceRepository.get(id), user, clock))
   }
 
   fun pausedApplications(): List<String> =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
@@ -70,7 +70,7 @@ class ActuationPauser(
   fun pauseApplication(application: String, user: String) {
     log.info("Pausing application $application")
     pausedRepository.pauseApplication(application, user)
-    publisher.publishEvent(ApplicationActuationPaused(application, clock))
+    publisher.publishEvent(ApplicationActuationPaused(application, user, clock))
   }
 
   fun resumeApplication(application: String) {
@@ -82,7 +82,7 @@ class ActuationPauser(
   fun pauseResource(id: String, user: String) {
     log.info("Pausing resource $id")
     pausedRepository.pauseResource(id, user)
-    publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id), clock))
+    publisher.publishEvent(ResourceActuationPaused(resourceRepository.get(id), user, clock))
   }
 
   fun resumeResource(id: String) {
@@ -112,13 +112,13 @@ class ActuationPauser(
           // If the app was paused before the resource was created, and hasn't yet been resumed,
           // we add that event to the history so the resource event history makes sense against its status
           if (appPause != null && appPause.pausedAt.isBefore(oldestResourceEvent.timestamp)) {
-            events.add(ApplicationActuationPaused(resource.application, appPause.pausedAt))
+            events.add(ApplicationActuationPaused(resource.application, appPause.pausedAt, appPause.pausedBy))
           }
 
           // Similarly, if the resource itself had been paused, then was deleted and recreated,
           // we add a corresponding event to the history
           if (resourcePause != null && resourcePause.pausedAt.isBefore(oldestResourceEvent.timestamp)) {
-            events.add(ResourceActuationPaused(resource, resourcePause.pausedAt))
+            events.add(ResourceActuationPaused(resource, resourcePause.pausedAt, resourcePause.pausedBy))
           }
         }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
@@ -38,7 +38,6 @@ import org.springframework.stereotype.Component
 
 @Component
 class ActuationPauser(
-  // TODO: replace use of individual repos with KeelRepository
   val resourceRepository: ResourceRepository,
   val pausedRepository: PausedRepository,
   val publisher: ApplicationEventPublisher,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/Pause.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/Pause.kt
@@ -1,0 +1,18 @@
+package com.netflix.spinnaker.keel.pause
+
+import java.time.Instant
+
+/**
+ * A pause in an application or resource's actuation, requested by a user.
+ */
+data class Pause(
+  val scope: PauseScope,
+  val name: String,
+  val pausedBy: String,
+  val pausedAt: Instant
+)
+
+// todo eb: add environment
+enum class PauseScope {
+  APPLICATION, RESOURCE
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
-import com.netflix.spinnaker.keel.pause.ActuationPauser
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -53,8 +52,7 @@ class CombinedRepository(
   val artifactRepository: ArtifactRepository,
   val resourceRepository: ResourceRepository,
   override val clock: Clock,
-  override val publisher: ApplicationEventPublisher,
-  val actuationPauser: ActuationPauser
+  override val publisher: ApplicationEventPublisher
 ) : KeelRepository {
 
   override val log by lazy { LoggerFactory.getLogger(javaClass) }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -51,10 +51,10 @@ import org.springframework.transaction.annotation.Transactional
 class CombinedRepository(
   val deliveryConfigRepository: DeliveryConfigRepository,
   val artifactRepository: ArtifactRepository,
-  override val resourceRepository: ResourceRepository,
+  val resourceRepository: ResourceRepository,
   override val clock: Clock,
   override val publisher: ApplicationEventPublisher,
-  override val actuationPauser: ActuationPauser
+  val actuationPauser: ActuationPauser
 ) : KeelRepository {
 
   override val log by lazy { LoggerFactory.getLogger(javaClass) }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
@@ -71,7 +72,7 @@ interface KeelRepository {
       // resubmitted, where we don't want to inadvertently resume actuation without the user knowing and giving
       // explicit consent. Application paused events are injected in the resource event history dynamically.
       if (actuationPauser.resourceIsPaused(resource.id)) {
-        publisher.publishEvent(ResourceActuationPaused(resource, clock))
+        publisher.publishEvent(ResourceActuationPaused(resource, resource.serviceAccount, clock))
       }
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceUpdated
-import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -136,11 +135,11 @@ interface KeelRepository {
 
   fun deleteResource(id: String)
 
-  fun applicationEventHistory(application: String, limit: Int = DEFAULT_MAX_EVENTS): List<ApplicationEvent>
+  fun applicationEventHistory(application: String, limit: Int): List<ApplicationEvent>
 
   fun applicationEventHistory(application: String, downTo: Instant): List<ApplicationEvent>
 
-  fun resourceEventHistory(id: String, limit: Int = DEFAULT_MAX_EVENTS): List<ResourceEvent>
+  fun resourceEventHistory(id: String, limit: Int): List<ResourceEvent>
 
   fun resourceLastEvent(id: String): ResourceEvent?
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PausedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PausedRepository.kt
@@ -17,24 +17,27 @@
  */
 package com.netflix.spinnaker.keel.persistence
 
+import com.netflix.spinnaker.keel.pause.Pause
+import com.netflix.spinnaker.keel.pause.PauseScope
+import java.time.Clock
+
 /**
  * A repository to track what scopes are paused, starting with application
  */
 interface PausedRepository {
+  val clock: Clock
+    get() = Clock.systemUTC()
 
-  fun pauseApplication(application: String)
+  fun getPause(scope: PauseScope, name: String): Pause?
+
+  fun pauseApplication(application: String, user: String)
   fun resumeApplication(application: String)
   fun applicationPaused(application: String): Boolean
 
-  fun pauseResource(id: String)
+  fun pauseResource(id: String, user: String)
   fun resumeResource(id: String)
   fun resourcePaused(id: String): Boolean
 
   fun getPausedApplications(): List<String>
   fun getPausedResources(): List<String>
-
-  // todo eb: add environment
-  enum class Scope {
-    APPLICATION, RESOURCE;
-  }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -15,44 +15,13 @@
  */
 package com.netflix.spinnaker.keel.persistence
 
-import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.api.Locatable
-import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.SimpleLocations
-import com.netflix.spinnaker.keel.api.SimpleRegionSpec
-import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.core.api.ResourceArtifactSummary
-import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.events.ApplicationEvent
-import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
-import com.netflix.spinnaker.keel.events.ResourceActuationPaused
-import com.netflix.spinnaker.keel.events.ResourceActuationResumed
-import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
-import com.netflix.spinnaker.keel.events.ResourceCheckError
-import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
-import com.netflix.spinnaker.keel.events.ResourceCreated
-import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
-import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceEvent
-import com.netflix.spinnaker.keel.events.ResourceMissing
-import com.netflix.spinnaker.keel.events.ResourceTaskFailed
-import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
-import com.netflix.spinnaker.keel.events.ResourceValid
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.CURRENTLY_UNRESOLVABLE
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNKNOWN
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.VETOED
+import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 
@@ -67,6 +36,9 @@ data class ResourceHeader(
 }
 
 interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out ResourceSpec>> {
+  val clock: Clock
+    get() = Clock.systemUTC()
+
   /**
    * Invokes [callback] once with each registered resource.
    */
@@ -93,11 +65,6 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
   fun getResourcesByApplication(application: String): List<Resource<*>>
 
   /**
-   * Fetches resource summary, including the status
-   */
-  fun getResourceSummaries(deliveryConfig: DeliveryConfig): List<ResourceSummary>
-
-  /**
    * Persists a resource.
    *
    * @return the `uid` of the stored resource.
@@ -121,9 +88,9 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
    * Retrieves the history of persisted events for [application].
    *
    * @param application the name of the application.
-   * @param until the time of the oldest event to return.
+   * @param after the time of the oldest event to return (events are returned in descending order of timestamp).
    */
-  fun applicationEventHistory(application: String, until: Instant): List<ApplicationEvent>
+  fun applicationEventHistory(application: String, after: Instant): List<ApplicationEvent>
 
   /**
    * Retrieves the history of state change events for the resource represented by [uid].
@@ -161,99 +128,6 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
    */
   override fun itemsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<out ResourceSpec>>
 
-  fun getStatus(id: String): ResourceStatus {
-    val history = eventHistory(id, 10)
-    return when {
-      history.isHappy() -> HAPPY
-      history.isUnhappy() -> UNHAPPY
-      history.isDiff() -> DIFF
-      history.isActuating() -> ACTUATING
-      history.isError() -> ERROR
-      history.isCreated() -> CREATED
-      history.isPaused() -> PAUSED
-      history.isVetoed() -> VETOED
-      history.isResumed() -> RESUMED
-      history.isCurrentlyUnresolvable() -> CURRENTLY_UNRESOLVABLE
-      else -> UNKNOWN
-    }
-  }
-
-  private fun List<ResourceEvent>.isHappy(): Boolean {
-    return first() is ResourceValid || first() is ResourceDeltaResolved
-  }
-
-  private fun List<ResourceEvent>.isActuating(): Boolean {
-    return first() is ResourceActuationLaunched || first() is ResourceTaskSucceeded ||
-      // we might want to move ResourceTaskFailed to isError later on
-      first() is ResourceTaskFailed
-  }
-
-  private fun List<ResourceEvent>.isError(): Boolean {
-    return first() is ResourceCheckError
-  }
-
-  private fun List<ResourceEvent>.isCreated(): Boolean {
-    return first() is ResourceCreated
-  }
-
-  private fun List<ResourceEvent>.isDiff(): Boolean {
-    return first() is ResourceDeltaDetected || first() is ResourceMissing
-  }
-
-  private fun List<ResourceEvent>.isPaused(): Boolean {
-    return first() is ResourceActuationPaused
-  }
-
-  private fun List<ResourceEvent>.isVetoed(): Boolean {
-    return first() is ResourceActuationVetoed
-  }
-
-  private fun List<ResourceEvent>.isResumed(): Boolean {
-    return first() is ResourceActuationResumed
-  }
-
-  private fun List<ResourceEvent>.isCurrentlyUnresolvable(): Boolean {
-    return first() is ResourceCheckUnresolvable
-  }
-
-  /**
-   * Checks last 10 events for flapping between only ResourceActuationLaunched and ResourceDeltaDetected
-   */
-  private fun List<ResourceEvent>.isUnhappy(): Boolean {
-    val recentSliceOfHistory = this.subList(0, Math.min(10, this.size))
-    val filteredHistory = recentSliceOfHistory.filter { it is ResourceDeltaDetected || it is ResourceActuationLaunched }
-    if (filteredHistory.size != recentSliceOfHistory.size) {
-      // there are other events, we're not thrashing.
-      return false
-    }
-    return true
-  }
-
-  fun Resource<*>.toResourceSummary(deliveryConfig: DeliveryConfig) =
-    ResourceSummary(
-      resource = this,
-      status = getStatus(id), // todo eb: this will become expensive
-      moniker = if (spec is Monikered) {
-        (spec as Monikered).moniker
-      } else {
-        null
-      },
-      locations = if (spec is Locatable<*>) {
-        SimpleLocations(
-          account = (spec as Locatable<*>).locations.account,
-          vpc = (spec as Locatable<*>).locations.vpc,
-          regions = (spec as Locatable<*>).locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
-        )
-      } else {
-        null
-      },
-      artifact = deliveryConfig.let {
-        findAssociatedArtifact(it)?.toResourceArtifactSummary()
-      }
-    )
-
-  private fun DeliveryArtifact.toResourceArtifactSummary() = ResourceArtifactSummary(name, type, reference)
-
   companion object {
     const val DEFAULT_MAX_EVENTS: Int = 10
   }
@@ -268,9 +142,6 @@ abstract class NoSuchResourceException(override val message: String?) :
 
 class NoSuchResourceId(id: String) :
   NoSuchResourceException("No resource with id $id exists in the database")
-
-class NoSuchApplication(application: String) :
-  NoSuchEntityException("No resource with application name $application exists in the database")
 
 enum class ResourceStatus {
   HAPPY, ACTUATING, UNHAPPY, CREATED, DIFF, ERROR, CURRENTLY_UNRESOLVABLE, PAUSED, VETOED, RESUMED, UNKNOWN

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -27,7 +27,6 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.GitMetadata
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
-import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
 import com.netflix.spinnaker.keel.core.api.StatelessConstraintSummary
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
@@ -120,19 +119,6 @@ class ApplicationService(
       version = version,
       targetEnvironment = targetEnvironment)
   }
-
-  /**
-   * Returns a list of [ResourceSummary] for the specified application.
-   *
-   * This function assumes there's a single delivery config associated with the application.
-   */
-  fun getResourceSummariesFor(application: String): List<ResourceSummary> =
-    try {
-      val config = repository.getDeliveryConfigForApplication(application)
-      repository.getResourceSummaries(config)
-    } catch (e: NoSuchDeliveryConfigException) {
-      emptyList()
-    }
 
   /**
    * Returns a list of [EnvironmentSummary] for the specific application.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.GitMetadata
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
+import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
 import com.netflix.spinnaker.keel.core.api.StatelessConstraintSummary
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
@@ -44,6 +45,7 @@ import org.springframework.stereotype.Component
 @Component
 class ApplicationService(
   private val repository: KeelRepository,
+  private val resourceHistoryService: ResourceHistoryService,
   constraintEvaluators: List<ConstraintEvaluator<*>>
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -118,6 +120,18 @@ class ApplicationService(
       artifact = artifact,
       version = version,
       targetEnvironment = targetEnvironment)
+  }
+
+  /**
+   * Returns a list of [ResourceSummary] for the specified application.
+   */
+  fun getResourceSummariesFor(application: String): List<ResourceSummary> {
+    return try {
+      val deliveryConfig = repository.getDeliveryConfigForApplication(application)
+      resourceHistoryService.getResourceSummariesFor(deliveryConfig)
+    } catch (e: NoSuchDeliveryConfigException) {
+      emptyList()
+    }
   }
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -337,6 +337,9 @@ class ApplicationService(
       }
     }
 
+  fun getApplicationEventHistory(application: String, limit: Int) =
+    repository.applicationEventHistory(application, limit)
+
   private val ArtifactVersions.key: String
     get() = "${type.name}:$name"
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryService.kt
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
@@ -152,14 +151,9 @@ class ResourceHistoryService(
   /**
    * Returns a list of [ResourceSummary] for the specified application.
    */
-  fun getResourceSummariesFor(application: String): List<ResourceSummary> {
-    return try {
-      val deliveryConfig = repository.getDeliveryConfigForApplication(application)
-      deliveryConfig.resources.map { resource ->
-        resource.toResourceSummary(deliveryConfig)
-      }
-    } catch (e: NoSuchDeliveryConfigException) {
-      emptyList()
+  fun getResourceSummariesFor(deliveryConfig: DeliveryConfig): List<ResourceSummary> {
+    return deliveryConfig.resources.map { resource ->
+      resource.toResourceSummary(deliveryConfig)
     }
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryService.kt
@@ -45,10 +45,10 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.VETOED
 import org.springframework.stereotype.Component
 
 /**
- * Service object that offers high-level APIs for resource-related operations.
+ * Service object that offers high-level APIs around resource (event) history and status.
  */
 @Component
-class ResourceService(
+class ResourceHistoryService(
   private val repository: KeelRepository,
   private val actuationPauser: ActuationPauser
 ) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceService.kt
@@ -1,0 +1,192 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.Monikered
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.core.api.ResourceArtifactSummary
+import com.netflix.spinnaker.keel.core.api.ResourceSummary
+import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
+import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
+import com.netflix.spinnaker.keel.events.PersistentEvent
+import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
+import com.netflix.spinnaker.keel.events.ResourceActuationPaused
+import com.netflix.spinnaker.keel.events.ResourceActuationResumed
+import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
+import com.netflix.spinnaker.keel.events.ResourceCheckError
+import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
+import com.netflix.spinnaker.keel.events.ResourceCreated
+import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
+import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
+import com.netflix.spinnaker.keel.events.ResourceMissing
+import com.netflix.spinnaker.keel.events.ResourceTaskFailed
+import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
+import com.netflix.spinnaker.keel.events.ResourceValid
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
+import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
+import com.netflix.spinnaker.keel.persistence.ResourceStatus
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CURRENTLY_UNRESOLVABLE
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNKNOWN
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.VETOED
+import org.springframework.stereotype.Component
+
+/**
+ * Service object that offers high-level APIs for resource-related operations.
+ */
+@Component
+class ResourceService(
+  private val repository: KeelRepository,
+  private val actuationPauser: ActuationPauser
+) {
+
+  /**
+   * Returns the history of events associated with the specified resource from the database, plus any applicable
+   * application-level pause/resume events.
+   */
+  fun getEnrichedEventHistory(id: String, limit: Int = DEFAULT_MAX_EVENTS): List<PersistentEvent> {
+    val resource = repository.getResource(id)
+    return repository.resourceEventHistory(id, limit)
+      .let { events ->
+        actuationPauser.addApplicationActuationEvents(events, resource)
+      }
+  }
+
+  /**
+   * Returns the status of the specified resource by first checking whether or not it or the parent application are
+   * paused, then looking into the last few events in the resource's history.
+   */
+  fun getStatus(id: String): ResourceStatus {
+    // For the PAUSED status, we look at the `paused` table as opposed to events, since these records
+    // persist even when a delivery config/resource (and associated events) have been deleted. We do
+    // this so we don't inadvertently start actuating on a resource that had been previously paused,
+    // without explicit action from the user to resume.
+    if (actuationPauser.isPaused(id)) {
+      return PAUSED
+    }
+
+    val history = getEnrichedEventHistory(id, 10)
+    return when {
+      history.isHappy() -> HAPPY
+      history.isUnhappy() -> UNHAPPY
+      history.isDiff() -> DIFF
+      history.isActuating() -> ACTUATING
+      history.isError() -> ERROR
+      history.isCreated() -> CREATED
+      history.isVetoed() -> VETOED
+      history.isResumed() -> RESUMED
+      history.isCurrentlyUnresolvable() -> CURRENTLY_UNRESOLVABLE
+      else -> UNKNOWN
+    }
+  }
+
+  private fun List<PersistentEvent>.isHappy(): Boolean {
+    return first() is ResourceValid || first() is ResourceDeltaResolved
+  }
+
+  private fun List<PersistentEvent>.isActuating(): Boolean {
+    return first() is ResourceActuationLaunched || first() is ResourceTaskSucceeded ||
+      // we might want to move ResourceTaskFailed to isError later on
+      first() is ResourceTaskFailed
+  }
+
+  private fun List<PersistentEvent>.isError(): Boolean {
+    return first() is ResourceCheckError
+  }
+
+  private fun List<PersistentEvent>.isCreated(): Boolean {
+    return first() is ResourceCreated
+  }
+
+  private fun List<PersistentEvent>.isDiff(): Boolean {
+    return first() is ResourceDeltaDetected || first() is ResourceMissing
+  }
+
+  private fun List<PersistentEvent>.isPaused(): Boolean {
+    val appPaused = firstOrNull { it is ApplicationActuationPaused }?.timestamp
+    val appResumed = firstOrNull { it is ApplicationActuationResumed }?.timestamp
+
+    return first() is ResourceActuationPaused ||
+      // If the app was paused and has not yet resumed
+      (appPaused != null && (appResumed == null || appResumed.isBefore(appPaused)))
+  }
+
+  private fun List<PersistentEvent>.isVetoed(): Boolean {
+    return first() is ResourceActuationVetoed
+  }
+
+  private fun List<PersistentEvent>.isResumed(): Boolean {
+    return first() is ResourceActuationResumed || first() is ApplicationActuationResumed
+  }
+
+  private fun List<PersistentEvent>.isCurrentlyUnresolvable(): Boolean {
+    return first() is ResourceCheckUnresolvable
+  }
+
+  /**
+   * Checks last 10 events for flapping between only ResourceActuationLaunched and ResourceDeltaDetected
+   */
+  private fun List<PersistentEvent>.isUnhappy(): Boolean {
+    val recentSliceOfHistory = this.subList(0, Math.min(10, this.size))
+    val filteredHistory = recentSliceOfHistory.filter { it is ResourceDeltaDetected || it is ResourceActuationLaunched }
+    if (filteredHistory.size != recentSliceOfHistory.size) {
+      // there are other events, we're not thrashing.
+      return false
+    }
+    return true
+  }
+
+  /**
+   * Returns a list of [ResourceSummary] for the specified application.
+   *
+   * This function assumes there's a single delivery config associated with the application.
+   */
+  fun getResourceSummariesFor(application: String): List<ResourceSummary> {
+    return try {
+      val deliveryConfig = repository.getDeliveryConfigForApplication(application)
+      deliveryConfig.resources.map { resource ->
+        resource.toResourceSummary(deliveryConfig)
+      }
+    } catch (e: NoSuchDeliveryConfigException) {
+      emptyList()
+    }
+  }
+
+  private fun Resource<*>.toResourceSummary(deliveryConfig: DeliveryConfig) =
+    ResourceSummary(
+      resource = this,
+      status = getStatus(id),
+      moniker = if (spec is Monikered) {
+        (spec as Monikered).moniker
+      } else {
+        null
+      },
+      locations = if (spec is Locatable<*>) {
+        SimpleLocations(
+          account = (spec as Locatable<*>).locations.account,
+          vpc = (spec as Locatable<*>).locations.vpc,
+          regions = (spec as Locatable<*>).locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
+        )
+      } else {
+        null
+      },
+      artifact = deliveryConfig.let {
+        findAssociatedArtifact(it)?.toResourceArtifactSummary()
+      }
+    )
+
+  private fun DeliveryArtifact.toResourceArtifactSummary() = ResourceArtifactSummary(name, type, reference)
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceService.kt
@@ -151,8 +151,6 @@ class ResourceService(
 
   /**
    * Returns a list of [ResourceSummary] for the specified application.
-   *
-   * This function assumes there's a single delivery config associated with the application.
    */
   fun getResourceSummariesFor(application: String): List<ResourceSummary> {
     return try {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.keel.api.UnhappyControl
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
-import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
 import com.netflix.spinnaker.keel.veto.Veto
 import com.netflix.spinnaker.keel.veto.VetoResponse
@@ -39,7 +38,6 @@ import org.springframework.stereotype.Component
  */
 @Component
 class UnhappyVeto(
-  private val resourceRepository: ResourceRepository,
   private val diffFingerprintRepository: DiffFingerprintRepository,
   private val unhappyVetoRepository: UnhappyVetoRepository,
   private val dynamicConfigService: DynamicConfigService,

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -76,7 +76,6 @@ class IntermittentFailureTests : JUnit5Minutests {
     }
 
     val veto = UnhappyVeto(
-      resourceRepository,
       diffFingerprintRepository,
       vetoRepository,
       dynamicConfigService,

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -114,7 +114,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
         context("management is paused for that resource") {
           before {
-            resourceRepository.appendHistory(ResourceActuationPaused(resource))
+            resourceRepository.appendHistory(ResourceActuationPaused(resource, "keel@keel.io"))
             every { actuationPauser.isPaused(resource) } returns true
             runBlocking {
               subject.checkResource(resource)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -43,10 +43,10 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
         mapOf("exceptionType" to SpinnakerException::class.java, "exceptionMessage" to "oops!"),
       ResourceCheckUnresolvable(resource, object : ResourceCurrentlyUnresolvable("oops!") {}, clock) to
         emptyMap(),
-      ResourceActuationPaused(resource, clock) to
-        emptyMap(),
-      ResourceActuationResumed(resource, clock) to
-        emptyMap(),
+      ResourceActuationPaused(resource, "keel@keel.io", clock) to
+        mapOf("triggeredBy" to "keel@keel.io"),
+      ResourceActuationResumed(resource, "keel@keel.io", clock) to
+        mapOf("triggeredBy" to "keel@keel.io"),
       ResourceActuationVetoed(resource, "vetoed", clock) to
         mapOf("reason" to "vetoed"),
       ResourceTaskFailed(resource, "failed", emptyList(), clock) to

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListenerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListenerTests.kt
@@ -1,0 +1,73 @@
+package com.netflix.spinnaker.keel.events
+
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Clock
+
+class ResourceHistoryListenerTests : JUnit5Minutests {
+  object Fixture {
+    val clock = Clock.systemUTC()
+    val resourceRepository: ResourceRepository = mockk()
+    val actuationPauser: ActuationPauser = mockk()
+    val listener = ResourceHistoryListener(resourceRepository, actuationPauser, clock)
+    val resource = resource()
+    val resourceValidEvent = ResourceValid(resource)
+    val resourceCreatedEvent = ResourceCreated(resource)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture
+    }
+
+    context("resource event received") {
+      before {
+        every {
+          resourceRepository.appendHistory(any() as ResourceEvent)
+        } just Runs
+
+        listener.onResourceEvent(resourceValidEvent)
+      }
+
+      test("event is persisted") {
+        verify(exactly = 1) {
+          resourceRepository.appendHistory(resourceValidEvent)
+        }
+      }
+    }
+
+    context("resource created event received and resource is paused") {
+      before {
+        every {
+          resourceRepository.appendHistory(any() as ResourceEvent)
+        } just Runs
+
+        every {
+          actuationPauser.resourceIsPaused(resource.id)
+        } returns true
+
+        every {
+          resourceRepository.get(resource.id)
+        } returns resource
+
+        listener.onResourceEvent(resourceCreatedEvent)
+      }
+
+      test("resource created and paused events are persisted") {
+        verify(exactly = 1) {
+          resourceRepository.appendHistory(resourceCreatedEvent)
+          resourceRepository.appendHistory(ofType(ResourceActuationPaused::class))
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListenerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceHistoryListenerTests.kt
@@ -1,7 +1,5 @@
 package com.netflix.spinnaker.keel.events
 
-import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -11,17 +9,13 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.Clock
 
 class ResourceHistoryListenerTests : JUnit5Minutests {
   object Fixture {
-    val clock = Clock.systemUTC()
     val resourceRepository: ResourceRepository = mockk()
-    val actuationPauser: ActuationPauser = mockk()
-    val listener = ResourceHistoryListener(resourceRepository, actuationPauser, clock)
+    val listener = ResourceHistoryListener(resourceRepository)
     val resource = resource()
     val resourceValidEvent = ResourceValid(resource)
-    val resourceCreatedEvent = ResourceCreated(resource)
   }
 
   fun tests() = rootContext<Fixture> {
@@ -41,31 +35,6 @@ class ResourceHistoryListenerTests : JUnit5Minutests {
       test("event is persisted") {
         verify(exactly = 1) {
           resourceRepository.appendHistory(resourceValidEvent)
-        }
-      }
-    }
-
-    context("resource created event received and resource is paused") {
-      before {
-        every {
-          resourceRepository.appendHistory(any() as ResourceEvent)
-        } just Runs
-
-        every {
-          actuationPauser.resourceIsPaused(resource.id)
-        } returns true
-
-        every {
-          resourceRepository.get(resource.id)
-        } returns resource
-
-        listener.onResourceEvent(resourceCreatedEvent)
-      }
-
-      test("resource created and paused events are persisted") {
-        verify(exactly = 1) {
-          resourceRepository.appendHistory(resourceCreatedEvent)
-          resourceRepository.appendHistory(ofType(ResourceActuationPaused::class))
         }
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -33,7 +33,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryPausedRepository
-import com.netflix.spinnaker.keel.services.ResourceService
+import com.netflix.spinnaker.keel.services.ResourceHistoryService
 import com.netflix.spinnaker.keel.test.combinedInMemoryRepository
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.time.MutableClock
@@ -50,7 +50,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val repository = combinedInMemoryRepository(clock)
     val pausedRepository = InMemoryPausedRepository()
     val actuationPauser = ActuationPauser(repository.resourceRepository, pausedRepository, repository.publisher, clock)
-    val resourceService = ResourceService(repository, actuationPauser)
+    val resourceHistoryService = ResourceHistoryService(repository, actuationPauser)
     val resource = resource()
     val createdEvent = ResourceCreated(resource)
     val missingEvent = ResourceMissing(resource)
@@ -87,7 +87,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
 
     context("resource created") {
       test("returns created status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(CREATED)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(CREATED)
       }
     }
 
@@ -97,7 +97,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns diff status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(DIFF)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(DIFF)
       }
     }
 
@@ -108,7 +108,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns diff status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(DIFF)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(DIFF)
       }
     }
 
@@ -120,7 +120,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns actuating status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(ACTUATING)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(ACTUATING)
       }
     }
 
@@ -140,7 +140,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns unhappy status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(UNHAPPY)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(UNHAPPY)
       }
     }
 
@@ -161,7 +161,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns happy status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(HAPPY)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
 
@@ -174,7 +174,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns happy status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(HAPPY)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
 
@@ -184,7 +184,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns happy status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(HAPPY)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
 
@@ -194,7 +194,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns error status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(ERROR)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(ERROR)
       }
     }
 
@@ -204,7 +204,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns paused status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(PAUSED)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(PAUSED)
       }
     }
 
@@ -216,7 +216,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns resumed status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(RESUMED)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(RESUMED)
       }
     }
 
@@ -227,7 +227,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns diff status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(CURRENTLY_UNRESOLVABLE)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(CURRENTLY_UNRESOLVABLE)
       }
     }
 
@@ -238,7 +238,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         }
 
         test("returns paused status") {
-          expectThat(resourceService.getStatus(resource.id)).isEqualTo(PAUSED)
+          expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(PAUSED)
         }
       }
 
@@ -252,7 +252,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         }
 
         test("returns paused status") {
-          expectThat(resourceService.getStatus(resource.id)).isEqualTo(PAUSED)
+          expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(PAUSED)
         }
       }
 
@@ -268,7 +268,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
         }
 
         test("returns resumed status") {
-          expectThat(resourceService.getStatus(resource.id)).isEqualTo(RESUMED)
+          expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(RESUMED)
         }
       }
     }
@@ -281,7 +281,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       }
 
       test("returns resumed status") {
-        expectThat(resourceService.getStatus(resource.id)).isEqualTo(RESUMED)
+        expectThat(resourceHistoryService.getStatus(resource.id)).isEqualTo(RESUMED)
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -18,9 +18,11 @@
 package com.netflix.spinnaker.keel.events
 
 import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.exceptions.InvalidResourceFormatException
+import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CURRENTLY_UNRESOLVABLE
@@ -30,16 +32,25 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
-import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryPausedRepository
+import com.netflix.spinnaker.keel.services.ResourceService
+import com.netflix.spinnaker.keel.test.combinedInMemoryRepository
 import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.slot
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
 internal class ResourceStatusTests : JUnit5Minutests {
   object Fixture {
-    val resourceRepository = InMemoryResourceRepository()
+    val clock = MutableClock()
+    val repository = combinedInMemoryRepository(clock)
+    val pausedRepository = InMemoryPausedRepository()
+    val actuationPauser = ActuationPauser(repository.resourceRepository, pausedRepository, repository.publisher, clock)
+    val resourceService = ResourceService(repository, actuationPauser)
     val resource = resource()
     val createdEvent = ResourceCreated(resource)
     val missingEvent = ResourceMissing(resource)
@@ -48,8 +59,6 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val deltaResolvedEvent = ResourceDeltaResolved(resource)
     val dependencyMissingEvent = ResourceCheckUnresolvable(resource, object : ResourceCurrentlyUnresolvable("I guess I can't find the AMI or something") {})
     val errorEvent = ResourceCheckError(resource, InvalidResourceFormatException("bad resource", "who knows"))
-    val actuationPausedEvent = ResourceActuationPaused(resource)
-    val actuationResumedEvent = ResourceActuationResumed(resource)
     val resourceValidEvent = ResourceValid(resource)
   }
 
@@ -57,156 +66,222 @@ internal class ResourceStatusTests : JUnit5Minutests {
     fixture { Fixture }
 
     before {
-      resourceRepository.store(resource)
-      resourceRepository.appendHistory(createdEvent)
+      repository.storeResource(resource)
+      repository.appendResourceHistory(createdEvent)
+
+      val event = slot<PersistentEvent>()
+      every {
+        repository.publisher.publishEvent(capture(event))
+      } answers {
+        if (event.captured is ApplicationEvent) {
+          repository.appendApplicationHistory(event.captured as ApplicationEvent)
+        } else {
+          repository.appendResourceHistory(event.captured as ResourceEvent)
+        }
+      }
     }
 
     after {
-      resourceRepository.dropAll()
+      repository.dropAll()
     }
 
     context("resource created") {
       test("returns created status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(CREATED)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(CREATED)
       }
     }
 
     context("resource missing") {
       before {
-        resourceRepository.appendHistory(missingEvent)
+        repository.appendResourceHistory(missingEvent)
       }
 
       test("returns diff status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(DIFF)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(DIFF)
       }
     }
 
     context("resource delta was detected") {
       before {
-        resourceRepository.appendHistory(missingEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(missingEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
       }
 
       test("returns diff status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(DIFF)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(DIFF)
       }
     }
 
     context("resource actuation launched") {
       before {
-        resourceRepository.appendHistory(missingEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(missingEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
       }
 
       test("returns actuating status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(ACTUATING)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(ACTUATING)
       }
     }
 
     context("resource is flapping") {
       before {
-        resourceRepository.appendHistory(missingEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(missingEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
       }
 
       test("returns unhappy status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(UNHAPPY)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(UNHAPPY)
       }
     }
 
     context("resource converged finally") {
       before {
-        resourceRepository.appendHistory(missingEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaResolvedEvent)
+        repository.appendResourceHistory(missingEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaResolvedEvent)
       }
 
       test("returns happy status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
 
     context("resource delta resolved") {
       before {
-        resourceRepository.appendHistory(missingEvent)
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(actuationLaunchedEvent)
-        resourceRepository.appendHistory(deltaResolvedEvent)
+        repository.appendResourceHistory(missingEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(actuationLaunchedEvent)
+        repository.appendResourceHistory(deltaResolvedEvent)
       }
 
       test("returns happy status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
 
     context("resource valid") {
       before {
-        resourceRepository.appendHistory(resourceValidEvent)
+        repository.appendResourceHistory(resourceValidEvent)
       }
 
       test("returns happy status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(HAPPY)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(HAPPY)
       }
     }
 
     context("resource in error state") {
       before {
-        resourceRepository.appendHistory(errorEvent)
+        repository.appendResourceHistory(errorEvent)
       }
 
       test("returns error status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(ERROR)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(ERROR)
       }
     }
 
     context("resource actuation paused") {
       before {
-        resourceRepository.appendHistory(actuationPausedEvent)
+        actuationPauser.pauseResource(resource.id, "keel@keel.io")
       }
 
       test("returns paused status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(PAUSED)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(PAUSED)
       }
     }
 
     context("resource actuation resumed") {
       before {
-        resourceRepository.appendHistory(actuationPausedEvent)
-        resourceRepository.appendHistory(actuationResumedEvent)
+        actuationPauser.pauseResource(resource.id, "keel@keel.io")
+        clock.tickMinutes(10)
+        actuationPauser.resumeResource(resource.id)
       }
 
       test("returns resumed status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(RESUMED)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(RESUMED)
       }
     }
 
     context("resource dependency is missing") {
       before {
-        resourceRepository.appendHistory(deltaDetectedEvent)
-        resourceRepository.appendHistory(dependencyMissingEvent)
+        repository.appendResourceHistory(deltaDetectedEvent)
+        repository.appendResourceHistory(dependencyMissingEvent)
       }
 
       test("returns diff status") {
-        expectThat(resourceRepository.getStatus(resource.id)).isEqualTo(CURRENTLY_UNRESOLVABLE)
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(CURRENTLY_UNRESOLVABLE)
+      }
+    }
+
+    context("application actuation paused") {
+      context("after resource created") {
+        before {
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+        }
+
+        test("returns paused status") {
+          expectThat(resourceService.getStatus(resource.id)).isEqualTo(PAUSED)
+        }
+      }
+
+      context("before resource created") {
+        before {
+          repository.deleteResource(resource.id)
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          clock.tickMinutes(10)
+          repository.storeResource(resource)
+          repository.appendResourceHistory(createdEvent)
+        }
+
+        test("returns paused status") {
+          expectThat(resourceService.getStatus(resource.id)).isEqualTo(PAUSED)
+        }
+      }
+
+      context("before resource created, but resumed after") {
+        before {
+          repository.deleteResource(resource.id)
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          clock.tickMinutes(10)
+          repository.storeResource(resource)
+          repository.appendResourceHistory(createdEvent)
+          clock.tickMinutes(10)
+          actuationPauser.resumeApplication(resource.application)
+        }
+
+        test("returns resumed status") {
+          expectThat(resourceService.getStatus(resource.id)).isEqualTo(RESUMED)
+        }
+      }
+    }
+
+    context("application actuation paused and resumed after resource created") {
+      before {
+        actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+        clock.tickMinutes(10)
+        actuationPauser.resumeApplication(resource.application)
+      }
+
+      test("returns resumed status") {
+        expectThat(resourceService.getStatus(resource.id)).isEqualTo(RESUMED)
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -84,6 +84,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
 
     after {
       repository.dropAll()
+      pausedRepository.flush()
     }
 
     context("resource created") {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -60,6 +60,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val dependencyMissingEvent = ResourceCheckUnresolvable(resource, object : ResourceCurrentlyUnresolvable("I guess I can't find the AMI or something") {})
     val errorEvent = ResourceCheckError(resource, InvalidResourceFormatException("bad resource", "who knows"))
     val resourceValidEvent = ResourceValid(resource)
+    val user = "keel@keel.io"
   }
 
   fun tests() = rootContext<Fixture> {
@@ -200,7 +201,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
 
     context("resource actuation paused") {
       before {
-        actuationPauser.pauseResource(resource.id, "keel@keel.io")
+        actuationPauser.pauseResource(resource.id, user)
       }
 
       test("returns paused status") {
@@ -210,9 +211,9 @@ internal class ResourceStatusTests : JUnit5Minutests {
 
     context("resource actuation resumed") {
       before {
-        actuationPauser.pauseResource(resource.id, "keel@keel.io")
+        actuationPauser.pauseResource(resource.id, user)
         clock.tickMinutes(10)
-        actuationPauser.resumeResource(resource.id)
+        actuationPauser.resumeResource(resource.id, user)
       }
 
       test("returns resumed status") {
@@ -234,7 +235,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     context("application actuation paused") {
       context("after resource created") {
         before {
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
         }
 
         test("returns paused status") {
@@ -245,7 +246,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
       context("before resource created") {
         before {
           repository.deleteResource(resource.id)
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
           clock.tickMinutes(10)
           repository.storeResource(resource)
           repository.appendResourceHistory(createdEvent)
@@ -259,12 +260,12 @@ internal class ResourceStatusTests : JUnit5Minutests {
       context("before resource created, but resumed after") {
         before {
           repository.deleteResource(resource.id)
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
           clock.tickMinutes(10)
           repository.storeResource(resource)
           repository.appendResourceHistory(createdEvent)
           clock.tickMinutes(10)
-          actuationPauser.resumeApplication(resource.application)
+          actuationPauser.resumeApplication(resource.application, user)
         }
 
         test("returns resumed status") {
@@ -275,9 +276,9 @@ internal class ResourceStatusTests : JUnit5Minutests {
 
     context("application actuation paused and resumed after resource created") {
       before {
-        actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+        actuationPauser.pauseApplication(resource.application, user)
         clock.tickMinutes(10)
-        actuationPauser.resumeApplication(resource.application)
+        actuationPauser.resumeApplication(resource.application, user)
       }
 
       test("returns resumed status") {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryCombinedRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryCombinedRepositoryTests.kt
@@ -3,10 +3,11 @@ package com.netflix.spinnaker.keel.persistence.memory
 import com.netflix.spinnaker.keel.persistence.CombinedRepositoryTests
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 
-class InMemoryCombinedRepositoryTests : CombinedRepositoryTests<InMemoryDeliveryConfigRepository, InMemoryResourceRepository, InMemoryArtifactRepository>() {
+class InMemoryCombinedRepositoryTests : CombinedRepositoryTests<InMemoryDeliveryConfigRepository, InMemoryResourceRepository, InMemoryArtifactRepository, InMemoryPausedRepository>() {
   private val deliveryConfigRepository = InMemoryDeliveryConfigRepository()
   private val resourceRepository = InMemoryResourceRepository()
   private val artifactRepository = InMemoryArtifactRepository()
+  private val pausedRepository = InMemoryPausedRepository()
 
   override fun createDeliveryConfigRepository(resourceSpecIdentifier: ResourceSpecIdentifier) =
     deliveryConfigRepository
@@ -17,9 +18,13 @@ class InMemoryCombinedRepositoryTests : CombinedRepositoryTests<InMemoryDelivery
   override fun createArtifactRepository() =
     artifactRepository
 
+  override fun createPausedRepository() =
+    pausedRepository
+
   override fun flush() {
     deliveryConfigRepository.dropAll()
     resourceRepository.dropAll()
     artifactRepository.dropAll()
+    pausedRepository.flush()
   }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryCombinedRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryCombinedRepositoryTests.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.persistence.memory
 import com.netflix.spinnaker.keel.persistence.CombinedRepositoryTests
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 
-class InMemoryCombinedRepositoryTests : CombinedRepositoryTests<InMemoryDeliveryConfigRepository, InMemoryResourceRepository, InMemoryArtifactRepository, InMemoryPausedRepository>() {
+class InMemoryCombinedRepositoryTests : CombinedRepositoryTests<InMemoryDeliveryConfigRepository, InMemoryResourceRepository, InMemoryArtifactRepository>() {
   private val deliveryConfigRepository = InMemoryDeliveryConfigRepository()
   private val resourceRepository = InMemoryResourceRepository()
   private val artifactRepository = InMemoryArtifactRepository()
@@ -17,9 +17,6 @@ class InMemoryCombinedRepositoryTests : CombinedRepositoryTests<InMemoryDelivery
 
   override fun createArtifactRepository() =
     artifactRepository
-
-  override fun createPausedRepository() =
-    pausedRepository
 
   override fun flush() {
     deliveryConfigRepository.dropAll()

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepositoryTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepositoryTests.kt
@@ -24,8 +24,4 @@ class InMemoryDiffFingerprintRepositoryTests : DiffFingerprintRepositoryTests<In
   override fun factory(clock: Clock): InMemoryDiffFingerprintRepository {
     return InMemoryDiffFingerprintRepository(clock)
   }
-
-  override fun InMemoryDiffFingerprintRepository.flush() {
-    flush()
-  }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -62,6 +62,7 @@ class ApplicationServiceTests : JUnit5Minutests {
       resourceRepository = resourceRepository,
       clock = clock
     )
+    val resourceHistoryService = ResourceHistoryService(repository, mockk(relaxed = true))
 
     val application = "fnord"
     val artifact = DebianArtifact(
@@ -113,7 +114,7 @@ class ApplicationServiceTests : JUnit5Minutests {
     val dependsOnEvaluator = DependsOnConstraintEvaluator(artifactRepository, mockk())
 
     // subject
-    val applicationService = ApplicationService(repository, listOf(dependsOnEvaluator))
+    val applicationService = ApplicationService(repository, resourceHistoryService, listOf(dependsOnEvaluator))
   }
 
   fun applicationServiceTests() = rootContext<Fixture> {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
@@ -28,12 +28,12 @@ import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.map
 
-class ResourceServiceTests : JUnit5Minutests {
+class ResourceHistoryServiceTests : JUnit5Minutests {
   companion object Fixture {
     val clock = MutableClock()
     val repository = combinedInMemoryRepository(clock)
     val actuationPauser = ActuationPauser(repository.resourceRepository, repository.pausedRepository, repository.publisher, clock)
-    val resourceService = ResourceService(repository, actuationPauser)
+    val resourceHistoryService = ResourceHistoryService(repository, actuationPauser)
     val resource = resource()
     val deliveryConfig = deliveryConfig(resource)
     val TEN_MINUTES: Duration = Duration.ofMinutes(10)
@@ -69,7 +69,7 @@ class ResourceServiceTests : JUnit5Minutests {
       }
 
       test("can get resource summary by application") {
-        val summaries = resourceService.getResourceSummariesFor(resource.application)
+        val summaries = resourceHistoryService.getResourceSummariesFor(resource.application)
 
         expect {
           that(summaries.size).isEqualTo(1)
@@ -94,7 +94,7 @@ class ResourceServiceTests : JUnit5Minutests {
         }
 
         test("has application paused and resumed events injected in the right positions") {
-          val events = resourceService.getEnrichedEventHistory(resource.id)
+          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
           expectThat(events)
             .map { it.javaClass }
             .containsExactly(
@@ -116,7 +116,7 @@ class ResourceServiceTests : JUnit5Minutests {
         }
 
         test("has application paused event injected before resource creation") {
-          val events = resourceService.getEnrichedEventHistory(resource.id)
+          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
           expectThat(events)
             .map { it.javaClass }
             .containsExactly(
@@ -126,7 +126,7 @@ class ResourceServiceTests : JUnit5Minutests {
         }
 
         test("paused event specifies who paused the application") {
-          val events = resourceService.getEnrichedEventHistory(resource.id)
+          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
           expectThat(events.last())
             .isA<ApplicationActuationPaused>()
             .get { triggeredBy }
@@ -148,7 +148,7 @@ class ResourceServiceTests : JUnit5Minutests {
         }
 
         test("still has application paused event injected before resource creation") {
-          val events = resourceService.getEnrichedEventHistory(resource.id)
+          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
           expectThat(events)
             .map { it.javaClass }
             .containsExactly(
@@ -172,7 +172,7 @@ class ResourceServiceTests : JUnit5Minutests {
         }
 
         test("has resource paused event injected before resource creation") {
-          val events = resourceService.getEnrichedEventHistory(resource.id)
+          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
           expectThat(events)
             .map { it.javaClass }
             .containsExactly(
@@ -182,7 +182,7 @@ class ResourceServiceTests : JUnit5Minutests {
         }
 
         test("paused event specifies who paused the resource") {
-          val events = resourceService.getEnrichedEventHistory(resource.id)
+          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
           expectThat(events.last())
             .isA<ResourceActuationPaused>()
             .get { triggeredBy }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
@@ -69,8 +69,8 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
         repository.appendResourceHistory(ResourceCreated(resource, clock))
       }
 
-      test("can get resource summary by application") {
-        val summaries = resourceHistoryService.getResourceSummariesFor(resource.application)
+      test("can get resource summary by delivery config") {
+        val summaries = resourceHistoryService.getResourceSummariesFor(deliveryConfig)
 
         expect {
           that(summaries.size).isEqualTo(1)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
@@ -36,6 +36,7 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
     val resourceHistoryService = ResourceHistoryService(repository, actuationPauser)
     val resource = resource()
     val deliveryConfig = deliveryConfig(resource)
+    val user = "keel@keel.io"
     val TEN_MINUTES: Duration = Duration.ofMinutes(10)
   }
 
@@ -86,11 +87,11 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
           clock.incrementBy(TEN_MINUTES)
           repository.appendResourceHistory(ResourceValid(resource, clock))
           clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
           clock.incrementBy(TEN_MINUTES)
-          actuationPauser.resumeApplication(resource.application)
+          actuationPauser.resumeApplication(resource.application, user)
           clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
         }
 
         test("has application paused and resumed events injected in the right positions") {
@@ -109,7 +110,7 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
 
       context("with a new resource created after the application is paused") {
         before {
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
           clock.incrementBy(TEN_MINUTES)
           repository.storeResource(resource)
           repository.appendResourceHistory(ResourceCreated(resource, clock))
@@ -130,7 +131,7 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
           expectThat(events.last())
             .isA<ApplicationActuationPaused>()
             .get { triggeredBy }
-            .isEqualTo("keel@keel.io")
+            .isEqualTo(user)
         }
       }
 
@@ -139,7 +140,7 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
           repository.storeResource(resource)
           repository.appendResourceHistory(ResourceCreated(resource, clock))
           repository.deleteResource(resource.id)
-          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          actuationPauser.pauseApplication(resource.application, user)
           clock.incrementBy(TEN_MINUTES)
           repository.resourceRepository.clearResourceEvents(resource.id)
           repository.resourceRepository.clearApplicationEvents(resource.application)
@@ -163,7 +164,7 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
           repository.storeResource(resource)
           repository.appendResourceHistory(ResourceCreated(resource, clock))
           clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseResource(resource.id, "keel@keel.io")
+          actuationPauser.pauseResource(resource.id, user)
           clock.incrementBy(TEN_MINUTES)
           repository.deleteResource(resource.id)
           clock.incrementBy(TEN_MINUTES)
@@ -186,7 +187,7 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
           expectThat(events.last())
             .isA<ResourceActuationPaused>()
             .get { triggeredBy }
-            .isEqualTo("keel@keel.io")
+            .isEqualTo(user)
         }
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceServiceTests.kt
@@ -24,6 +24,7 @@ import java.time.Duration
 import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
+import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.map
 
@@ -123,6 +124,14 @@ class ResourceServiceTests : JUnit5Minutests {
               ApplicationActuationPaused::class.java
             )
         }
+
+        test("paused event specifies who paused the application") {
+          val events = resourceService.getEnrichedEventHistory(resource.id)
+          expectThat(events.last())
+            .isA<ApplicationActuationPaused>()
+            .get { triggeredBy }
+            .isEqualTo("keel@keel.io")
+        }
       }
 
       context("with previous event history wiped and a new resource created after the application is paused") {
@@ -170,6 +179,14 @@ class ResourceServiceTests : JUnit5Minutests {
               ResourceCreated::class.java,
               ResourceActuationPaused::class.java
             )
+        }
+
+        test("paused event specifies who paused the resource") {
+          val events = resourceService.getEnrichedEventHistory(resource.id)
+          expectThat(events.last())
+            .isA<ResourceActuationPaused>()
+            .get { triggeredBy }
+            .isEqualTo("keel@keel.io")
         }
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceServiceTests.kt
@@ -1,0 +1,177 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.keel.api.application
+import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
+import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
+import com.netflix.spinnaker.keel.events.ApplicationEvent
+import com.netflix.spinnaker.keel.events.PersistentEvent
+import com.netflix.spinnaker.keel.events.ResourceActuationPaused
+import com.netflix.spinnaker.keel.events.ResourceCreated
+import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.events.ResourceValid
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
+import com.netflix.spinnaker.keel.test.combinedInMemoryRepository
+import com.netflix.spinnaker.keel.test.deliveryConfig
+import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.slot
+import java.time.Duration
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isEqualTo
+import strikt.assertions.map
+
+class ResourceServiceTests : JUnit5Minutests {
+  companion object Fixture {
+    val clock = MutableClock()
+    val repository = combinedInMemoryRepository(clock)
+    val actuationPauser = ActuationPauser(repository.resourceRepository, repository.pausedRepository, repository.publisher, clock)
+    val resourceService = ResourceService(repository, actuationPauser)
+    val resource = resource()
+    val deliveryConfig = deliveryConfig(resource)
+    val TEN_MINUTES: Duration = Duration.ofMinutes(10)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture
+    }
+
+    before {
+      val event = slot<PersistentEvent>()
+      every {
+        repository.publisher.publishEvent(capture(event))
+      } answers {
+        if (event.captured is ApplicationEvent) {
+          repository.appendApplicationHistory(event.captured as ApplicationEvent)
+        } else {
+          repository.appendResourceHistory(event.captured as ResourceEvent)
+        }
+      }
+    }
+
+    after {
+      repository.dropAll()
+      clock.reset()
+    }
+
+    context("a delivery config with a resource exists") {
+      before {
+        repository.upsertDeliveryConfig(deliveryConfig)
+        repository.appendResourceHistory(ResourceCreated(resource, clock))
+      }
+
+      test("can get resource summary by application") {
+        val summaries = resourceService.getResourceSummariesFor(resource.application)
+
+        expect {
+          that(summaries.size).isEqualTo(1)
+          that(summaries.map { it.status }.filter { it == CREATED }.size).isEqualTo(1)
+        }
+      }
+    }
+
+    context("enriched resource event history") {
+      context("with application paused at various times after resource creation") {
+        before {
+          repository.storeResource(resource)
+          repository.appendResourceHistory(ResourceCreated(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          repository.appendResourceHistory(ResourceValid(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.resumeApplication(resource.application)
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+        }
+
+        test("has application paused and resumed events injected in the right positions") {
+          val events = resourceService.getEnrichedEventHistory(resource.id)
+          expectThat(events)
+            .map { it.javaClass }
+            .containsExactly(
+              ApplicationActuationPaused::class.java,
+              ApplicationActuationResumed::class.java,
+              ApplicationActuationPaused::class.java,
+              ResourceValid::class.java,
+              ResourceCreated::class.java
+            )
+        }
+      }
+
+      context("with a new resource created after the application is paused") {
+        before {
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          clock.incrementBy(TEN_MINUTES)
+          repository.storeResource(resource)
+          repository.appendResourceHistory(ResourceCreated(resource, clock))
+        }
+
+        test("has application paused event injected before resource creation") {
+          val events = resourceService.getEnrichedEventHistory(resource.id)
+          expectThat(events)
+            .map { it.javaClass }
+            .containsExactly(
+              ResourceCreated::class.java,
+              ApplicationActuationPaused::class.java
+            )
+        }
+      }
+
+      context("with previous event history wiped and a new resource created after the application is paused") {
+        before {
+          repository.storeResource(resource)
+          repository.appendResourceHistory(ResourceCreated(resource, clock))
+          repository.deleteResource(resource.id)
+          actuationPauser.pauseApplication(resource.application, "keel@keel.io")
+          clock.incrementBy(TEN_MINUTES)
+          repository.resourceRepository.clearResourceEvents(resource.id)
+          repository.resourceRepository.clearApplicationEvents(resource.application)
+          repository.storeResource(resource)
+          repository.appendResourceHistory(ResourceCreated(resource, clock))
+        }
+
+        test("still has application paused event injected before resource creation") {
+          val events = resourceService.getEnrichedEventHistory(resource.id)
+          expectThat(events)
+            .map { it.javaClass }
+            .containsExactly(
+              ResourceCreated::class.java,
+              ApplicationActuationPaused::class.java
+            )
+        }
+      }
+
+      context("with a resource recreated after being paused and deleted") {
+        before {
+          repository.storeResource(resource)
+          repository.appendResourceHistory(ResourceCreated(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
+          actuationPauser.pauseResource(resource.id, "keel@keel.io")
+          clock.incrementBy(TEN_MINUTES)
+          repository.deleteResource(resource.id)
+          clock.incrementBy(TEN_MINUTES)
+          repository.storeResource(resource)
+          repository.appendResourceHistory(ResourceCreated(resource, clock))
+        }
+
+        test("has resource paused event injected before resource creation") {
+          val events = resourceService.getEnrichedEventHistory(resource.id)
+          expectThat(events)
+            .map { it.javaClass }
+            .containsExactly(
+              ResourceCreated::class.java,
+              ResourceActuationPaused::class.java
+            )
+        }
+      }
+    }
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -85,7 +85,7 @@ class SqlConfiguration {
   @Bean
   fun pausedRepository(
     jooq: DSLContext
-  ) = SqlPausedRepository(jooq, SqlRetry(sqlRetryProperties))
+  ) = SqlPausedRepository(jooq, SqlRetry(sqlRetryProperties), clock)
 
   @Bean
   fun taskTrackingRepository(

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -17,11 +17,11 @@ import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.core.api.parseUID
 import com.netflix.spinnaker.keel.core.api.randomUID
+import com.netflix.spinnaker.keel.pause.PauseScope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.OrphanedResourceException
-import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.CURRENT_CONSTRAINT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -2,13 +2,11 @@ package com.netflix.spinnaker.keel.sql
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.PersistentEvent.Scope
@@ -38,7 +36,7 @@ import org.jooq.impl.DSL.select
 
 open class SqlResourceRepository(
   private val jooq: DSLContext,
-  private val clock: Clock,
+  override val clock: Clock,
   private val resourceSpecIdentifier: ResourceSpecIdentifier,
   private val specMigrators: List<SpecMigrator<*, *>>,
   private val objectMapper: ObjectMapper,
@@ -119,24 +117,6 @@ open class SqlResourceRepository(
     }
   }
 
-  override fun getResourceSummaries(deliveryConfig: DeliveryConfig): List<ResourceSummary> {
-    val resourceSummaries: List<ResourceSummary> = sqlRetry.withRetry(READ) {
-      jooq
-        .select(RESOURCE.KIND, RESOURCE.METADATA, RESOURCE.SPEC)
-        .from(RESOURCE)
-        .where(RESOURCE.APPLICATION.eq(deliveryConfig.application))
-        .fetch()
-        .map { (kind, metadata, spec) ->
-          Resource(
-            kind = parseKind(kind),
-            metadata = objectMapper.readValue<Map<String, Any?>>(metadata).asResourceMetadata(),
-            spec = objectMapper.readValue(spec, resourceSpecIdentifier.identify(parseKind(kind)))
-          ).toResourceSummary(deliveryConfig)
-        }
-    }
-    return resourceSummaries
-  }
-
   // todo: this is not retryable due to overall repository structure: https://github.com/spinnaker/keel/issues/740
   override fun store(resource: Resource<*>) {
     val uid = jooq.select(RESOURCE.UID)
@@ -187,14 +167,14 @@ open class SqlResourceRepository(
     }
   }
 
-  override fun applicationEventHistory(application: String, until: Instant): List<ApplicationEvent> {
+  override fun applicationEventHistory(application: String, after: Instant): List<ApplicationEvent> {
     return sqlRetry.withRetry(READ) {
       jooq
         .select(EVENT.JSON)
         .from(EVENT)
         .where(EVENT.SCOPE.eq(Scope.APPLICATION.name))
         .and(EVENT.UID.eq(application))
-        .and(EVENT.TIMESTAMP.lessOrEqual(LocalDateTime.ofInstant(until, ZoneOffset.UTC)))
+        .and(EVENT.TIMESTAMP.lessOrEqual(LocalDateTime.ofInstant(after, ZoneOffset.UTC)))
         .orderBy(EVENT.TIMESTAMP.desc())
         .fetch()
         .map { (json) ->

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -174,7 +174,7 @@ open class SqlResourceRepository(
         .from(EVENT)
         .where(EVENT.SCOPE.eq(Scope.APPLICATION.name))
         .and(EVENT.UID.eq(application))
-        .and(EVENT.TIMESTAMP.lessOrEqual(LocalDateTime.ofInstant(after, ZoneOffset.UTC)))
+        .and(EVENT.TIMESTAMP.greaterOrEqual(LocalDateTime.ofInstant(after, ZoneOffset.UTC)))
         .orderBy(EVENT.TIMESTAMP.desc())
         .fetch()
         .map { (json) ->

--- a/keel-sql/src/main/resources/db/changelog/20200427-add-info-to-paused-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200427-add-info-to-paused-table.yml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-timestamp-to-paused-table
+      author: lpollo
+      changes:
+        - addColumn:
+            tableName: paused
+            columns:
+              - column:
+                  name: paused_by
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: paused_at
+                  type: timestamp(3)
+                  constraints:
+                    nullable: true
+  # No rollback needed as liquibase can handle column deletions automatically

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -128,3 +128,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200410-rename-diff-fingerprint-column.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200427-add-info-to-paused-table.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
@@ -9,7 +9,7 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
 
-internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository, SqlPausedRepository>() {
+internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository>() {
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredObjectMapper()
@@ -25,9 +25,6 @@ internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDelivery
 
   override fun createArtifactRepository(): SqlArtifactRepository =
     SqlArtifactRepository(jooq, clock, objectMapper, sqlRetry)
-
-  override fun createPausedRepository(): SqlPausedRepository =
-    SqlPausedRepository(jooq, sqlRetry, clock)
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
@@ -9,21 +9,25 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 import org.junit.jupiter.api.AfterAll
 
-internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository>() {
+internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository, SqlPausedRepository>() {
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredObjectMapper()
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+  private val clock = Clock.systemUTC()
 
   override fun createDeliveryConfigRepository(resourceSpecIdentifier: ResourceSpecIdentifier): SqlDeliveryConfigRepository =
-    SqlDeliveryConfigRepository(jooq, Clock.systemUTC(), resourceSpecIdentifier, objectMapper, sqlRetry)
+    SqlDeliveryConfigRepository(jooq, clock, resourceSpecIdentifier, objectMapper, sqlRetry)
 
   override fun createResourceRepository(resourceSpecIdentifier: ResourceSpecIdentifier): SqlResourceRepository =
-    SqlResourceRepository(jooq, Clock.systemUTC(), resourceSpecIdentifier, emptyList(), objectMapper, sqlRetry)
+    SqlResourceRepository(jooq, clock, resourceSpecIdentifier, emptyList(), objectMapper, sqlRetry)
 
   override fun createArtifactRepository(): SqlArtifactRepository =
-    SqlArtifactRepository(jooq, Clock.systemUTC(), objectMapper, sqlRetry)
+    SqlArtifactRepository(jooq, clock, objectMapper, sqlRetry)
+
+  override fun createPausedRepository(): SqlPausedRepository =
+    SqlPausedRepository(jooq, sqlRetry, clock)
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepositoryTests.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.keel.persistence.PausedRepositoryTests
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import java.time.Clock
 import org.junit.jupiter.api.AfterAll
 
 internal object SqlPausedRepositoryTests : PausedRepositoryTests<SqlPausedRepository>() {
@@ -30,7 +31,7 @@ internal object SqlPausedRepositoryTests : PausedRepositoryTests<SqlPausedReposi
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun factory(): SqlPausedRepository =
-    SqlPausedRepository(jooq, sqlRetry)
+    SqlPausedRepository(jooq, sqlRetry, Clock.systemUTC())
 
   override fun SqlPausedRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
@@ -1,30 +1,62 @@
 package com.netflix.spinnaker.keel.test
 
+import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.CombinedRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.PausedRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryPausedRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import io.mockk.mockk
 import java.time.Clock
+import org.springframework.context.ApplicationEventPublisher
+
+class InMemoryCombinedRepository(
+  override val clock: Clock = Clock.systemUTC(),
+  override val deliveryConfigRepository: InMemoryDeliveryConfigRepository = InMemoryDeliveryConfigRepository(clock),
+  override val artifactRepository: InMemoryArtifactRepository = InMemoryArtifactRepository(clock),
+  override val resourceRepository: InMemoryResourceRepository = InMemoryResourceRepository(clock),
+  val pausedRepository: InMemoryPausedRepository = InMemoryPausedRepository(clock),
+  private val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true),
+  override val actuationPauser: ActuationPauser = ActuationPauser(resourceRepository, pausedRepository, eventPublisher, clock)
+) : CombinedRepository(
+  deliveryConfigRepository,
+  artifactRepository,
+  resourceRepository,
+  clock,
+  eventPublisher,
+  actuationPauser
+) {
+  fun dropAll() {
+    deliveryConfigRepository.dropAll()
+    artifactRepository.dropAll()
+    resourceRepository.dropAll()
+    pausedRepository.flush()
+  }
+}
 
 /**
  * A util for generating a combined repository with in memory implementations for tests
  */
 fun combinedInMemoryRepository(
   clock: Clock = Clock.systemUTC(),
-  deliveryConfigRepository: DeliveryConfigRepository = InMemoryDeliveryConfigRepository(clock),
-  artifactRepository: ArtifactRepository = InMemoryArtifactRepository(clock),
-  resourceRepository: ResourceRepository = InMemoryResourceRepository(clock)
-): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, mockk(relaxed = true))
+  deliveryConfigRepository: InMemoryDeliveryConfigRepository = InMemoryDeliveryConfigRepository(clock),
+  artifactRepository: InMemoryArtifactRepository = InMemoryArtifactRepository(clock),
+  resourceRepository: InMemoryResourceRepository = InMemoryResourceRepository(clock),
+  pausedRepository: InMemoryPausedRepository = InMemoryPausedRepository(clock)
+): InMemoryCombinedRepository =
+  InMemoryCombinedRepository(clock, deliveryConfigRepository, artifactRepository, resourceRepository, pausedRepository)
 
 fun combinedMockRepository(
   deliveryConfigRepository: DeliveryConfigRepository = mockk(relaxed = true),
   artifactRepository: ArtifactRepository = mockk(relaxed = true),
   resourceRepository: ResourceRepository = mockk(relaxed = true),
-  clock: Clock = Clock.systemUTC()
+  pausedRepository: PausedRepository = mockk(relaxed = true),
+  clock: Clock = Clock.systemUTC(),
+  publisher: ApplicationEventPublisher = mockk(relaxed = true),
+  actuationPauser: ActuationPauser = ActuationPauser(resourceRepository, pausedRepository, publisher, clock)
 ): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, mockk(relaxed = true))
+  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, publisher, actuationPauser)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/CombinedRepository.kt
@@ -1,10 +1,8 @@
 package com.netflix.spinnaker.keel.test
 
-import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.CombinedRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
-import com.netflix.spinnaker.keel.persistence.PausedRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryArtifactRepository
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
@@ -20,15 +18,13 @@ class InMemoryCombinedRepository(
   override val artifactRepository: InMemoryArtifactRepository = InMemoryArtifactRepository(clock),
   override val resourceRepository: InMemoryResourceRepository = InMemoryResourceRepository(clock),
   val pausedRepository: InMemoryPausedRepository = InMemoryPausedRepository(clock),
-  private val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true),
-  override val actuationPauser: ActuationPauser = ActuationPauser(resourceRepository, pausedRepository, eventPublisher, clock)
+  eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
 ) : CombinedRepository(
   deliveryConfigRepository,
   artifactRepository,
   resourceRepository,
   clock,
-  eventPublisher,
-  actuationPauser
+  eventPublisher
 ) {
   fun dropAll() {
     deliveryConfigRepository.dropAll()
@@ -54,9 +50,7 @@ fun combinedMockRepository(
   deliveryConfigRepository: DeliveryConfigRepository = mockk(relaxed = true),
   artifactRepository: ArtifactRepository = mockk(relaxed = true),
   resourceRepository: ResourceRepository = mockk(relaxed = true),
-  pausedRepository: PausedRepository = mockk(relaxed = true),
   clock: Clock = Clock.systemUTC(),
-  publisher: ApplicationEventPublisher = mockk(relaxed = true),
-  actuationPauser: ActuationPauser = ActuationPauser(resourceRepository, pausedRepository, publisher, clock)
+  publisher: ApplicationEventPublisher = mockk(relaxed = true)
 ): CombinedRepository =
-  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, publisher, actuationPauser)
+  CombinedRepository(deliveryConfigRepository, artifactRepository, resourceRepository, clock, publisher)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.test
 
 import com.netflix.spinnaker.keel.api.ApiVersion
+import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
@@ -122,6 +123,36 @@ fun <T : ResourceSpec> submittedResource(
     spec = spec
   )
 
+fun versionedArtifactResource(
+  kind: ResourceKind = TEST_API_V1.qualify("versionedArtifact"),
+  id: String = randomString(),
+  application: String = "fnord"
+): Resource<DummyArtifactVersionedResourceSpec> =
+  DummyArtifactVersionedResourceSpec(id = id, application = application)
+    .let { spec ->
+      resource(
+        kind = kind,
+        spec = spec,
+        id = spec.id,
+        application = application
+      )
+    }
+
+fun artifactReferenceResource(
+  kind: ResourceKind = TEST_API_V1.qualify("artifactReference"),
+  id: String = randomString(),
+  application: String = "fnord"
+): Resource<DummyArtifactReferenceResourceSpec> =
+  DummyArtifactReferenceResourceSpec(id = id, application = application)
+    .let { spec ->
+      resource(
+        kind = kind,
+        spec = spec,
+        id = spec.id,
+        application = application
+      )
+    }
+
 enum class DummyEnum { VALUE }
 
 data class DummyResourceSpec(
@@ -155,6 +186,15 @@ data class DummyArtifactVersionedResourceSpec(
   override val artifactName: String? = "fnord",
   override val artifactType: ArtifactType? = ArtifactType.deb
 ) : ResourceSpec, VersionedArtifactProvider
+
+data class DummyArtifactReferenceResourceSpec(
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  override val id: String = randomString(),
+  val data: String = randomString(),
+  override val application: String = "fnord",
+  override val artifactType: ArtifactType? = ArtifactType.deb,
+  override val artifactReference: String? = "fnord"
+) : ResourceSpec, ArtifactReferenceProvider
 
 data class DummyResource(
   val id: String = randomString(),

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.services.ApplicationService
-import com.netflix.spinnaker.keel.services.ResourceService
+import com.netflix.spinnaker.keel.services.ResourceHistoryService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import org.slf4j.LoggerFactory
@@ -48,7 +48,7 @@ import org.springframework.web.bind.annotation.RestController
 class ApplicationController(
   private val actuationPauser: ActuationPauser,
   private val applicationService: ApplicationService,
-  private val resourceService: ResourceService
+  private val resourceHistoryService: ResourceHistoryService
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -75,7 +75,7 @@ class ApplicationController(
       }
       entities.forEach { entity ->
         results[entity] = when (entity) {
-          "resources" -> resourceService.getResourceSummariesFor(application)
+          "resources" -> resourceHistoryService.getResourceSummariesFor(application)
           "environments" -> applicationService.getEnvironmentSummariesFor(application)
           "artifacts" -> applicationService.getArtifactSummariesFor(application)
           else -> throw InvalidRequestException("Unknown entity type: $entity")

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.services.ApplicationService
-import com.netflix.spinnaker.keel.services.ResourceHistoryService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import com.netflix.spinnaker.kork.web.exceptions.InvalidRequestException
 import org.slf4j.LoggerFactory
@@ -47,8 +46,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping(path = ["/application"])
 class ApplicationController(
   private val actuationPauser: ActuationPauser,
-  private val applicationService: ApplicationService,
-  private val resourceHistoryService: ResourceHistoryService
+  private val applicationService: ApplicationService
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -75,7 +73,7 @@ class ApplicationController(
       }
       entities.forEach { entity ->
         results[entity] = when (entity) {
-          "resources" -> resourceHistoryService.getResourceSummariesFor(application)
+          "resources" -> applicationService.getResourceSummariesFor(application)
           "environments" -> applicationService.getEnvironmentSummariesFor(application)
           "artifacts" -> applicationService.getArtifactSummariesFor(application)
           else -> throw InvalidRequestException("Unknown entity type: $entity")

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -136,7 +136,10 @@ class ApplicationController(
     path = ["/{application}/pause"]
   )
   @PreAuthorize("@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #application)")
-  fun pause(@PathVariable("application") application: String, @RequestHeader("X-SPINNAKER-USER") user: String) {
+  fun pause(
+    @PathVariable("application") application: String,
+    @RequestHeader("X-SPINNAKER-USER") user: String
+  ) {
     actuationPauser.pauseApplication(application, user)
   }
 
@@ -146,8 +149,11 @@ class ApplicationController(
   @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #application)
     and @authorizationSupport.hasServiceAccountAccess('APPLICATION', #application)"""
   )
-  fun resume(@PathVariable("application") application: String) {
-    actuationPauser.resumeApplication(application)
+  fun resume(
+    @PathVariable("application") application: String,
+    @RequestHeader("X-SPINNAKER-USER") user: String
+  ) {
+    actuationPauser.resumeApplication(application, user)
   }
 
   @PostMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
+import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.services.ApplicationService
@@ -228,4 +229,14 @@ class ApplicationController(
   ) {
     applicationService.deleteVeto(application, targetEnvironment, reference, version)
   }
+
+  @GetMapping(
+    path = ["/{application}/events"],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('READ', 'APPLICATION', #application)""")
+  fun getEvents(
+    @PathVariable("application") application: String,
+    @RequestParam("limit") limit: Int?
+  ): List<ApplicationEvent> = applicationService.getApplicationEventHistory(application, limit ?: DEFAULT_MAX_EVENTS)
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -1,9 +1,8 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.events.PersistentEvent
-import com.netflix.spinnaker.keel.pause.ActuationPauser
-import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
+import com.netflix.spinnaker.keel.services.ResourceService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -17,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/resources/events"])
 class EventController(
-  private val repository: KeelRepository,
-  private val actuationPauser: ActuationPauser
+  private val resourceService: ResourceService
 ) {
   private val log by lazy { getLogger(javaClass) }
 
+  // TODO: move this to ResourceController since the request path belongs there
   @GetMapping(
     path = ["/{id}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
@@ -34,8 +33,6 @@ class EventController(
     @RequestParam("limit") limit: Int?
   ): List<PersistentEvent> {
     log.debug("Getting state history for: $id")
-    val resource = repository.getResource(id)
-    val events = repository.resourceEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
-    return actuationPauser.addApplicationActuationEvents(events, resource)
+    return resourceService.getEnrichedEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
-import com.netflix.spinnaker.keel.services.ResourceService
+import com.netflix.spinnaker.keel.services.ResourceHistoryService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/resources/events"])
 class EventController(
-  private val resourceService: ResourceService
+  private val resourceHistoryService: ResourceHistoryService
 ) {
   private val log by lazy { getLogger(javaClass) }
 
@@ -33,6 +33,6 @@ class EventController(
     @RequestParam("limit") limit: Int?
   ): List<PersistentEvent> {
     log.debug("Getting state history for: $id")
-    return resourceService.getEnrichedEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
+    return resourceHistoryService.getEnrichedEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.keel.diff.DiffResult
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
-import com.netflix.spinnaker.keel.services.ResourceService
+import com.netflix.spinnaker.keel.services.ResourceHistoryService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -43,7 +43,7 @@ class ResourceController(
   private val repository: KeelRepository,
   private val actuationPauser: ActuationPauser,
   private val adHocDiffer: AdHocDiffer,
-  private val resourceService: ResourceService
+  private val resourceHistoryService: ResourceHistoryService
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -68,7 +68,7 @@ class ResourceController(
     and @authorizationSupport.hasCloudAccountPermission('READ', 'RESOURCE', #id)"""
   )
   fun getStatus(@PathVariable("id") id: String): ResourceStatus =
-    resourceService.getStatus(id)
+    resourceHistoryService.getStatus(id)
 
   @PostMapping(
     path = ["/{id}/pause"],

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -75,7 +75,10 @@ class ResourceController(
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
   @PreAuthorize("@authorizationSupport.hasApplicationPermission('WRITE', 'RESOURCE', #id)")
-  fun pauseResource(@PathVariable("id") id: String, @RequestHeader("X-SPINNAKER-USER") user: String) {
+  fun pauseResource(
+    @PathVariable("id") id: String,
+    @RequestHeader("X-SPINNAKER-USER") user: String
+  ) {
     actuationPauser.pauseResource(id, user)
   }
 
@@ -86,8 +89,11 @@ class ResourceController(
   @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'RESOURCE', #id)
     and @authorizationSupport.hasServiceAccountAccess('RESOURCE', #id)"""
   )
-  fun resumeResource(@PathVariable("id") id: String) {
-    actuationPauser.resumeResource(id)
+  fun resumeResource(
+    @PathVariable("id") id: String,
+    @RequestHeader("X-SPINNAKER-USER") user: String
+  ) {
+    actuationPauser.resumeResource(id, user)
   }
 
   @PostMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.keel.diff.DiffResult
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
-import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
+import com.netflix.spinnaker.keel.services.ResourceService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -33,6 +33,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
@@ -41,7 +42,8 @@ import org.springframework.web.bind.annotation.RestController
 class ResourceController(
   private val repository: KeelRepository,
   private val actuationPauser: ActuationPauser,
-  private val adHocDiffer: AdHocDiffer
+  private val adHocDiffer: AdHocDiffer,
+  private val resourceService: ResourceService
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -66,19 +68,15 @@ class ResourceController(
     and @authorizationSupport.hasCloudAccountPermission('READ', 'RESOURCE', #id)"""
   )
   fun getStatus(@PathVariable("id") id: String): ResourceStatus =
-    if (actuationPauser.isPaused(id)) { // todo eb: we could make determining status easier and more straight forward.
-      PAUSED
-    } else {
-      repository.getResourceStatus(id)
-    }
+    resourceService.getStatus(id)
 
   @PostMapping(
     path = ["/{id}/pause"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
   @PreAuthorize("@authorizationSupport.hasApplicationPermission('WRITE', 'RESOURCE', #id)")
-  fun pauseResource(@PathVariable("id") id: String) {
-    actuationPauser.pauseResource(id)
+  fun pauseResource(@PathVariable("id") id: String, @RequestHeader("X-SPINNAKER-USER") user: String) {
+    actuationPauser.pauseResource(id, user)
   }
 
   @DeleteMapping(

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -110,6 +110,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
 
   companion object {
     const val application = "fnord"
+    const val user = "keel@keel.io"
   }
 
   class Fixture {
@@ -218,11 +219,11 @@ internal class ApplicationControllerTests : JUnit5Minutests {
 
       context("with paused application") {
         before {
-          actuationPauser.pauseApplication(application, "keel@keel.io")
+          actuationPauser.pauseApplication(application, user)
         }
 
         after {
-          actuationPauser.resumeApplication(application)
+          actuationPauser.resumeApplication(application, user)
         }
 
         test("reflects application paused status in basic summary") {
@@ -354,7 +355,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/application/fnord")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -367,7 +368,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/application/fnord")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -381,7 +382,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/application/fnord/environment/prod/constraints")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -398,7 +399,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -413,7 +414,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -427,7 +428,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = post("/application/fnord/pause")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -442,7 +443,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/application/fnord/pause")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -455,7 +456,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/application/fnord/pause")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -473,7 +474,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -488,7 +489,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -503,7 +504,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/application/fnord/pin/test")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -516,7 +517,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/application/fnord/pin/test")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -534,7 +535,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               EnvironmentArtifactVeto("test", "ref", "0.0.1")
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -549,7 +550,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               EnvironmentArtifactVeto("test", "ref", "0.0.1")
             )
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -564,7 +565,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/application/fnord/veto/test/ref/0.0.1")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -577,7 +578,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/application/fnord/veto/test/ref/0.0.1")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -591,7 +592,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/application/fnord/config")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -218,7 +218,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
 
       context("with paused application") {
         before {
-          actuationPauser.pauseApplication(application)
+          actuationPauser.pauseApplication(application, "keel@keel.io")
         }
 
         after {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -5,18 +5,14 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.actuation.Task
-import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
-import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
-import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceUpdated
-import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryResourceRepository
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
@@ -105,20 +101,18 @@ internal class EventControllerTests : JUnit5Minutests {
     context("a resource exists with events") {
       before {
         authorizationSupport.allowAll()
-        with(resourceRepository) {
-          store(resource)
-          appendHistory(ResourceCreated(resource, clock))
+        resourceRepository.store(resource)
+        resourceRepository.appendHistory(ResourceCreated(resource, clock))
+        clock.incrementBy(TEN_MINUTES)
+        repeat(3) {
+          resourceRepository.appendHistory(ResourceUpdated(resource, emptyMap(), clock))
           clock.incrementBy(TEN_MINUTES)
-          repeat(3) {
-            appendHistory(ResourceUpdated(resource, emptyMap(), clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ResourceDeltaDetected(resource, emptyMap(), clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ResourceActuationLaunched(resource, "a-plugin", listOf(Task(id = randomUID().toString(), name = "i did a thing")), clock))
-            clock.incrementBy(TEN_MINUTES)
-            appendHistory(ResourceDeltaResolved(resource, clock))
-            clock.incrementBy(TEN_MINUTES)
-          }
+          resourceRepository.appendHistory(ResourceDeltaDetected(resource, emptyMap(), clock))
+          clock.incrementBy(TEN_MINUTES)
+          resourceRepository.appendHistory(ResourceActuationLaunched(resource, "a-plugin", listOf(Task(id = randomUID().toString(), name = "i did a thing")), clock))
+          clock.incrementBy(TEN_MINUTES)
+          resourceRepository.appendHistory(ResourceDeltaResolved(resource, clock))
+          clock.incrementBy(TEN_MINUTES)
         }
       }
 
@@ -180,100 +174,6 @@ internal class EventControllerTests : JUnit5Minutests {
         expectThat(result.response.contentAsTree)
           .isArray()
           .hasSize(limit)
-      }
-    }
-
-    context("with application paused at various times") {
-      before {
-        authorizationSupport.allowAll()
-        with(resourceRepository) {
-          dropAll()
-          store(resource)
-          appendHistory(ResourceCreated(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          appendHistory(ResourceValid(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application)
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.resumeApplication(resource.application)
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application)
-        }
-      }
-
-      test("has application paused and resumed events injected in the right positions") {
-        val request = get(eventsUri).accept(APPLICATION_YAML)
-        val result = mvc
-          .perform(request)
-          .andReturn()
-        expectThat(result.response.contentAs<List<PersistentEvent>>())
-          .map { it.javaClass }
-          .containsExactly(
-            ApplicationActuationPaused::class.java,
-            ApplicationActuationResumed::class.java,
-            ApplicationActuationPaused::class.java,
-            ResourceValid::class.java,
-            ResourceCreated::class.java
-          )
-      }
-    }
-
-    context("with a new resource created AFTER the application is paused") {
-      before {
-        authorizationSupport.allowAll()
-        with(resourceRepository) {
-          dropAll()
-          actuationPauser.pauseApplication(resource.application)
-          clock.incrementBy(TEN_MINUTES)
-          store(resource)
-          appendHistory(ResourceCreated(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.resumeApplication(resource.application)
-        }
-      }
-
-      test("has application resumed event injected in the right position") {
-        val request = get(eventsUri).accept(APPLICATION_YAML)
-        val result = mvc
-          .perform(request)
-          .andReturn()
-        expectThat(result.response.contentAs<List<PersistentEvent>>())
-          .map { it.javaClass }
-          .containsExactly(
-            ApplicationActuationResumed::class.java,
-            ResourceCreated::class.java
-          )
-      }
-    }
-
-    context("with application pauses BEFORE and AFTER a new resource is created") {
-      before {
-        authorizationSupport.allowAll()
-        with(resourceRepository) {
-          dropAll()
-          actuationPauser.pauseApplication(resource.application)
-          clock.incrementBy(TEN_MINUTES)
-          store(resource)
-          appendHistory(ResourceCreated(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.resumeApplication(resource.application)
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application)
-        }
-      }
-
-      test("has matching resource paused events injected in the right positions") {
-        val request = get(eventsUri).accept(APPLICATION_YAML)
-        val result = mvc
-          .perform(request)
-          .andReturn()
-        expectThat(result.response.contentAs<List<PersistentEvent>>())
-          .map { it.javaClass }
-          .containsExactly(
-            ApplicationActuationPaused::class.java,
-            ApplicationActuationResumed::class.java,
-            ResourceCreated::class.java
-          )
       }
     }
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -59,6 +59,8 @@ internal class ResourceControllerTests : JUnit5Minutests {
 
   var resource = resource()
 
+  val user = "keel@keel.io"
+
   fun tests() = rootContext {
     before {
       every { authorizationSupport.hasApplicationPermission(READ.name, RESOURCE.name, any()) } returns true
@@ -119,7 +121,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/resources/test:${resource.id}")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -132,7 +134,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/resources/test:${resource.id}")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -147,7 +149,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/resources/test:${resource.id}/status")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -160,7 +162,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = get("/resources/test:${resource.id}/status")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -174,7 +176,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = post("/resources/test:${resource.id}/pause")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -189,7 +191,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/resources/test:${resource.id}/pause")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -202,7 +204,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = delete("/resources/test:${resource.id}/pause")
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -216,7 +218,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
           test("request is forbidden") {
             val request = post("/resources/diff").addData(jsonMapper, submittedResource())
               .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+              .header("X-SPINNAKER-USER", user)
 
             mvc.perform(request).andExpect(status().isForbidden)
           }


### PR DESCRIPTION
This PR fixes #1043, as follows:
- Revisits the logic in `ActuationPauser` that adds application pause/resume events to resource history by looking _before_ the oldest resource event in the list to see if the application or the resource had been paused and not yet resumed, in which case an `ApplicationActuationPaused` or `ResourceActuationPaused` event with a timestamp matching the time of the pause is added as the last of the events. 

  This is to account for cases where an application or resource is paused, the delivery config subsequently deleted, and then resubmitted before the application or resource is unpaused, in which case the resource status should remain paused.

- Moves business logic around resource status out of `ResourceRepository` and into a new `ResourceHistoryService` bean, which can interact both with repositories as well as other service beans like the `ActuationPauser`.

- Refactors (by moving them into test classes matching the responsible beans) and adds additional tests around resource events and statuses

I've also moved `ApplicationService` out of `keel-web` and into `keel-core`, alongside `ResourceService` for consistency, and simplified its tests so it doesn't depend on `keel-ec2-plugin` by adding easy-to-use new dummy resources with artifacts.
