### PR TITLE
feat(getAllApps): Endpoint to get all managed applications

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
@@ -1,22 +1,14 @@
 package com.netflix.spinnaker.keel.core.api
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
-import com.netflix.spinnaker.keel.api.DeliveryConfig
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(value = ["name", "application", "serviceAccount", "apiVersion", "paused"])
+@JsonPropertyOrder(value = ["name", "application", "serviceAccount", "apiVersion", "isPaused"])
 data class ApplicationSummary(
-  @JsonIgnore val config: DeliveryConfig,
+  val name: String,
+  val application: String,
+  val serviceAccount: String,
+  val apiVersion: String,
   val isPaused: Boolean = false
-) {
-  val name: String
-    get() = config.name
-  val application: String
-    get() = config.application
-  val serviceAccount: String
-    get() = config.serviceAccount
-  val apiVersion: String
-    get() = config.apiVersion
-}
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(value = ["name", "application", "serviceAccount", "apiVersion", "isPaused"])
+@JsonPropertyOrder(value = ["deliveryConfigName", "application", "serviceAccount", "apiVersion", "isPaused"])
 data class ApplicationSummary(
-  val name: String,
+  val deliveryConfigName: String,
   val application: String,
   val serviceAccount: String,
   val apiVersion: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.keel.core.api
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = ["name", "application", "serviceAccount", "apiVersion", "paused"])
+data class ApplicationSummary(
+  @JsonIgnore val config: DeliveryConfig,
+  val isPaused: Boolean = false
+) {
+  val name: String
+    get() = config.name
+  val application: String
+    get() = config.application
+  val serviceAccount: String
+    get() = config.serviceAccount
+  val apiVersion: String
+    get() = config.apiVersion
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
@@ -295,8 +296,8 @@ class CombinedRepository(
   override fun deliveryConfigsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig> =
     deliveryConfigRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
 
-  override fun getAll(): Collection<DeliveryConfig> =
-    deliveryConfigRepository.getAll()
+  override fun getApplicationSummaries(): Collection<ApplicationSummary> =
+    deliveryConfigRepository.getApplicationSummaries()
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -294,6 +294,9 @@ class CombinedRepository(
 
   override fun deliveryConfigsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig> =
     deliveryConfigRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
+
+  override fun getAll(): Collection<DeliveryConfig> =
+    deliveryConfigRepository.getAll()
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -141,6 +141,8 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun getQueuedConstraintApprovals(deliveryConfigName: String, environmentName: String): Set<String>
   fun queueAllConstraintsApproved(deliveryConfigName: String, environmentName: String, artifactVersion: String)
   fun deleteQueuedConstraintApproval(deliveryConfigName: String, environmentName: String, artifactVersion: String)
+
+  fun getAll(): Collection<DeliveryConfig>
 }
 
 abstract class NoSuchDeliveryConfigException(message: String) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -142,7 +143,7 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun queueAllConstraintsApproved(deliveryConfigName: String, environmentName: String, artifactVersion: String)
   fun deleteQueuedConstraintApproval(deliveryConfigName: String, environmentName: String, artifactVersion: String)
 
-  fun getAll(): Collection<DeliveryConfig>
+  fun getApplicationSummaries(): Collection<ApplicationSummary>
 }
 
 abstract class NoSuchDeliveryConfigException(message: String) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
@@ -117,7 +118,7 @@ interface KeelRepository {
 
   fun deliveryConfigsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig>
 
-  fun getAll(): Collection<DeliveryConfig>
+  fun getApplicationSummaries(): Collection<ApplicationSummary>
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -116,6 +116,8 @@ interface KeelRepository {
   fun deleteQueuedConstraintApproval(deliveryConfigName: String, environmentName: String, artifactVersion: String)
 
   fun deliveryConfigsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig>
+
+  fun getAll(): Collection<DeliveryConfig>
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
@@ -226,7 +226,7 @@ class InMemoryDeliveryConfigRepository(
   // Will add it once we'll refactor the db structure
   override fun getApplicationSummaries(): Collection<ApplicationSummary> =
     configs.values.map {
-      ApplicationSummary(name = it.name, application = it.application, apiVersion = it.apiVersion,
+      ApplicationSummary(deliveryConfigName = it.name, application = it.application, apiVersion = it.apiVersion,
         serviceAccount = it.serviceAccount)
       // should also have something like isPaused = paused.contains(InMemoryPausedRepository.Record(APPLICATION, it.application))
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
@@ -221,6 +221,9 @@ class InMemoryDeliveryConfigRepository(
       .map { name -> configs[name] ?: error("No delivery config named $name") }
   }
 
+  override fun getAll(): Collection<DeliveryConfig> =
+    configs.values.toList()
+
   private val Environment.resourceIds: Iterable<String>
     get() = resources.map { it.id }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDeliveryConfigRepository.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
@@ -221,8 +222,14 @@ class InMemoryDeliveryConfigRepository(
       .map { name -> configs[name] ?: error("No delivery config named $name") }
   }
 
-  override fun getAll(): Collection<DeliveryConfig> =
-    configs.values.toList()
+  // TODO[GY]: this does not take into account puased applications, as we can't wire it here.
+  // Will add it once we'll refactor the db structure
+  override fun getApplicationSummaries(): Collection<ApplicationSummary> =
+    configs.values.map {
+      ApplicationSummary(name = it.name, application = it.application, apiVersion = it.apiVersion,
+        serviceAccount = it.serviceAccount)
+      // should also have something like isPaused = paused.contains(InMemoryPausedRepository.Record(APPLICATION, it.application))
+    }
 
   private val Environment.resourceIds: Iterable<String>
     get() = resources.map { it.id }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -987,6 +987,16 @@ class SqlDeliveryConfigRepository(
     }
       ?: throw NoSuchDeliveryConfigName(name)
 
+  override fun getAll(): Collection<DeliveryConfig> =
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_CONFIG.NAME, DELIVERY_CONFIG.APPLICATION, DELIVERY_CONFIG.SERVICE_ACCOUNT, DELIVERY_CONFIG.API_VERSION)
+        .from(DELIVERY_CONFIG)
+        .fetch { (name, application, serviceAccount, apiVersion) ->
+          DeliveryConfig(name = name, application = application, serviceAccount = serviceAccount, apiVersion = apiVersion)
+        }
+    }
+
   private fun Instant.toLocal() = atZone(clock.zone).toLocalDateTime()
 
   companion object {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus.PENDING
 import com.netflix.spinnaker.keel.constraints.allPass
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.core.api.parseUID
 import com.netflix.spinnaker.keel.core.api.randomUID
@@ -20,6 +21,7 @@ import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.OrphanedResourceException
+import com.netflix.spinnaker.keel.persistence.PausedRepository.Scope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.CURRENT_CONSTRAINT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
@@ -30,6 +32,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIF
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
@@ -987,13 +990,14 @@ class SqlDeliveryConfigRepository(
     }
       ?: throw NoSuchDeliveryConfigName(name)
 
-  override fun getAll(): Collection<DeliveryConfig> =
+  override fun getApplicationSummaries(): Collection<ApplicationSummary> =
     sqlRetry.withRetry(READ) {
       jooq
-        .select(DELIVERY_CONFIG.NAME, DELIVERY_CONFIG.APPLICATION, DELIVERY_CONFIG.SERVICE_ACCOUNT, DELIVERY_CONFIG.API_VERSION)
+        .select(DELIVERY_CONFIG.NAME, DELIVERY_CONFIG.APPLICATION, DELIVERY_CONFIG.SERVICE_ACCOUNT, DELIVERY_CONFIG.API_VERSION, PAUSED.NAME)
         .from(DELIVERY_CONFIG)
-        .fetch { (name, application, serviceAccount, apiVersion) ->
-          DeliveryConfig(name = name, application = application, serviceAccount = serviceAccount, apiVersion = apiVersion)
+        .leftOuterJoin(PAUSED).on(PAUSED.NAME.eq(DELIVERY_CONFIG.APPLICATION).and(PAUSED.SCOPE.eq(APPLICATION.toString())))
+        .fetch { (name, application, serviceAccount, apiVersion, paused) ->
+          ApplicationSummary(name = name, application = application, serviceAccount = serviceAccount, apiVersion = apiVersion, isPaused = paused != null)
         }
     }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -997,7 +997,7 @@ class SqlDeliveryConfigRepository(
         .from(DELIVERY_CONFIG)
         .leftOuterJoin(PAUSED).on(PAUSED.NAME.eq(DELIVERY_CONFIG.APPLICATION).and(PAUSED.SCOPE.eq(APPLICATION.toString())))
         .fetch { (name, application, serviceAccount, apiVersion, paused) ->
-          ApplicationSummary(name = name, application = application, serviceAccount = serviceAccount, apiVersion = apiVersion, isPaused = paused != null)
+          ApplicationSummary(deliveryConfigName = name, application = application, serviceAccount = serviceAccount, apiVersion = apiVersion, isPaused = paused != null)
         }
     }
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -1,9 +1,12 @@
 package com.netflix.spinnaker.keel.rest
 
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.http.HttpStatus.NO_CONTENT
+import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
@@ -36,4 +39,14 @@ class AdminController(
   )
   fun getPausedApplications() =
     actuationPauser.pausedApplications()
+
+  @GetMapping(
+    path = ["/applications"],
+    produces = [MediaType.APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  fun getManagedApplications() =
+    repository.getAll().map {
+      ApplicationSummary(config = it,
+        isPaused = actuationPauser.applicationIsPaused(it.application))
+    }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -1,0 +1,28 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.keel.core.api.ApplicationSummary
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class AdminService(
+  private val repository: KeelRepository,
+  private val actuationPauser: ActuationPauser
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  fun deleteApplicationData(application: String) {
+    log.debug("Deleting all data for application: $application")
+    val config = repository.getDeliveryConfigForApplication(application)
+    repository.deleteDeliveryConfig(config.name)
+  }
+
+  fun getPausedApplications() = actuationPauser.pausedApplications()
+
+  fun getManagedApplications(): Collection<ApplicationSummary> {
+    return repository.getApplicationSummaries()
+  }
+}

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
@@ -1,0 +1,177 @@
+package com.netflix.spinnaker.keel.rest
+
+import com.netflix.spinnaker.keel.KeelApplication
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
+import com.ninjasquad.springmockk.MockkBean
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.clearAllMocks
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+class AdminControllerTests {
+
+  @ExtendWith(SpringExtension::class)
+  @SpringBootTest(
+    classes = [KeelApplication::class, MockEurekaConfiguration::class],
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK
+  )
+  @AutoConfigureMockMvc
+  internal class AdminControllerTests : JUnit5Minutests {
+
+    @MockkBean
+    lateinit var authorizationSupport: AuthorizationSupport
+
+    @Autowired
+    lateinit var mvc: MockMvc
+
+    @Autowired
+    lateinit var deliveryConfigRepository: InMemoryDeliveryConfigRepository
+
+    @Autowired
+    lateinit var combinedRepository: KeelRepository
+
+    @Autowired
+    lateinit var actuationPauser: ActuationPauser
+
+    companion object {
+      const val application1 = "fnord"
+      const val application2 = "fnord2"
+    }
+
+    fun tests() = rootContext {
+      after {
+        deliveryConfigRepository.dropAll()
+        clearAllMocks()
+      }
+
+      context("return a single application") {
+        before {
+          val deliveryConfig = DeliveryConfig(
+            name = "$application1-manifest",
+            application = application1,
+            serviceAccount = "keel@spinnaker",
+            artifacts = emptySet(),
+            environments = emptySet()
+          )
+          combinedRepository.upsertDeliveryConfig(deliveryConfig)
+          authorizationSupport.allowAll()
+        }
+
+        test("can get basic summary of unpaused application") {
+          val request = MockMvcRequestBuilders.get("/admin/applications/")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+          mvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().json(
+              """
+              [{
+                "name": "fnord-manifest",
+                "application": "fnord",
+                "serviceAccount": "keel@spinnaker",
+                "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
+                "isPaused":false
+              }]
+            """.trimIndent()
+            ))
+        }
+
+        context("with paused application") {
+          before {
+            actuationPauser.pauseApplication(application1)
+          }
+
+//          after {
+//            actuationPauser.resumeApplication(application)
+//          }
+
+          test("can get basic summary of a pause application") {
+            val request = MockMvcRequestBuilders.get("/admin/applications/")
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+            mvc
+              .perform(request)
+              .andExpect(MockMvcResultMatchers.status().isOk)
+              .andExpect(MockMvcResultMatchers.content().json(
+                """
+              [{
+                "name": "fnord-manifest",
+                "application": "fnord",
+                "serviceAccount": "keel@spinnaker",
+                "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
+                "isPaused":true
+              }]
+            """.trimIndent()
+              ))
+          }
+        }
+
+        context("more than one applications") {
+          before {
+            val deliveryConfig2 = DeliveryConfig(
+              name = "$application2-manifest",
+              application = application2,
+              serviceAccount = "keel@spinnaker",
+              artifacts = emptySet(),
+              environments = emptySet()
+            )
+            combinedRepository.upsertDeliveryConfig(deliveryConfig2)
+            authorizationSupport.allowAll()
+          }
+
+          test("can get basic summary of 2 applications, one paused") {
+            val request = MockMvcRequestBuilders.get("/admin/applications/")
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+            mvc
+              .perform(request)
+              .andExpect(MockMvcResultMatchers.status().isOk)
+              .andExpect(MockMvcResultMatchers.content().json(
+                """
+              [{
+                "name": "fnord-manifest",
+                "application": "fnord",
+                "serviceAccount": "keel@spinnaker",
+                "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
+                "isPaused":true
+              },{
+                "name": "fnord2-manifest",
+                "application": "fnord2",
+                "serviceAccount": "keel@spinnaker",
+                "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
+                "isPaused":false
+                }
+              ]
+            """.trimIndent()
+              ))
+          }
+        }
+      }
+
+      context("no delivery config found") {
+        test("return an empty list") {
+          val request = MockMvcRequestBuilders.get("/admin/applications/")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+          mvc
+            .perform(request)
+            .andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.content().json(
+              """
+              []
+            """.trimIndent()
+            ))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
issue https://github.com/spinnaker/keel/issues/1063.

This is a proposal for an endpoint to retrieve all of the managed applications. 
I've created a new response type called `ApplicationSummary` , 
and the new endpoint will return a list of these. Here's an example:
`    "name": "gyardeni-manifest",
    "application": "gyardeniapp",
    "serviceAccount": "delivery-engineering@netflix.com",
    "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
    "isPaused": true` 