### PR TITLE
feat(export): export artifacts from clusters

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import org.slf4j.Logger
@@ -136,6 +137,14 @@ abstract class ResourceHandler<S : ResourceSpec, R : Any>(
    */
   open suspend fun export(exportable: Exportable): S {
     TODO("Not implemented")
+  }
+
+  /**
+   * Generates an artifact from a currently existing resource.
+   * Note: this only applies to clusters.
+   */
+  open suspend fun exportArtifact(exportable: Exportable): DeliveryArtifact {
+    TODO("Not implemented or not supported with this handler")
   }
 
   /**

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -37,16 +37,25 @@ fun ActiveServerGroup.subnet(cloudDriverCache: CloudDriverCache): String =
 data class ActiveServerGroupImage(
   val imageId: String,
   val appVersion: String?,
-  val baseImageVersion: String?
+  val baseImageVersion: String?,
+  val name: String,
+  val imageLocation: String,
+  val description: String?
 ) {
   @JsonCreator
   constructor(
     imageId: String,
+    name: String,
+    imageLocation: String,
+    description: String?,
     tags: List<Map<String, Any?>>
   ) : this(
-    imageId,
+    imageId = imageId,
     appVersion = tags.getTag("appversion")?.substringBefore("/"),
-    baseImageVersion = tags.getTag("base_ami_version")
+    baseImageVersion = tags.getTag("base_ami_version"),
+    name = name,
+    imageLocation = imageLocation,
+    description = description
   )
 }
 

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
@@ -413,7 +413,10 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
     image = ActiveServerGroupImage(
       imageId = ami,
       appVersion = "$app-3.16.0-h205.121d4ac",
-      baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+      baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78",
+      description = "name=$app, arch=x86_64, ancestor_name=xenialbase-x86_64-201811142132-ebs, ancestor_id=ami-0fe383ecea7f75eac, ancestor_version=nflx-base-5.308.0-h1044.b4b3f78",
+      imageLocation = "$owner/$app-3.16.0-h205.121d4ac-x86_64-20181115184054-xenial-hvm-sriov-ebs-ebs-ebs",
+      name = "$app-3.16.0-h205.121d4ac-x86_64-20181115184054-xenial-hvm-sriov-ebs-ebs-ebs"
     ),
     launchConfig = LaunchConfig(
       ramdiskId = "",

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.keel.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.UserException
+
+class DockerArtifactExportError(image: String, container: String) :
+  UserException("Unable to determine tag strategy for docker image ($image) from container ($container), please supply a custom regex " +
+  "(see https://www.spinnaker.io/guides/user/managed-delivery/artifacts/#advanced-configuration for more information)")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.UnhappyControl
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
 import com.netflix.spinnaker.keel.clouddriver.model.BuildInfo
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
@@ -48,6 +49,9 @@ data class ServerGroup(
   val health: Health = Health(),
   val scaling: Scaling = Scaling(),
   val tags: Map<String, String> = emptyMap(),
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  val image: ActiveServerGroupImage? = null,
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = EXCLUDED)
   val buildInfo: BuildInfo? = null,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -207,7 +207,7 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
     name = "fnord-prod",
     region = region,
     zones = emptySet(),
-    image = ActiveServerGroupImage("ami-42b", null, null),
+    image = ActiveServerGroupImage(imageId = "ami-42b", name = "name", imageLocation = "location", appVersion = null, description = null, baseImageVersion = null),
     launchConfig = LaunchConfig(
       ramdiskId = null,
       ebsOptimized = true,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -827,6 +827,9 @@ private fun ActiveServerGroup.withMissingAppVersion(): ActiveServerGroup =
   copy(
     image = ActiveServerGroupImage(
       imageId = "ami-573e1b2650a5",
+      name = "name",
+      imageLocation = "location",
+      description = null,
       tags = emptyList()
     )
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
@@ -35,9 +35,12 @@ fun ServerGroup.toCloudDriverResponse(
       location.region,
       location.availabilityZones,
       ActiveServerGroupImage(
-        launchConfiguration.imageId,
-        launchConfiguration.appVersion,
-        launchConfiguration.baseImageVersion
+        imageId = launchConfiguration.imageId,
+        appVersion = launchConfiguration.appVersion,
+        baseImageVersion = launchConfiguration.baseImageVersion,
+        name = "name",
+        imageLocation = "location",
+        description = null
       ),
       LaunchConfig(
         launchConfiguration.ramdiskId,

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
@@ -33,7 +33,7 @@ class ClusterExportHelperTests : JUnit5Minutests {
       name = "keel-test-v001",
       region = "us-east-1",
       zones = listOf("a", "b", "c").map { "us-east-1$it" }.toSet(),
-      image = ActiveServerGroupImage("foo", "bar", "baz"),
+      image = ActiveServerGroupImage(imageId = "foo", appVersion = "bar", baseImageVersion = "baz", name = "name", imageLocation = "location", description = "description"),
       launchConfig = LaunchConfig(
         ramdiskId = "diskId",
         ebsOptimized = false,

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -48,7 +48,6 @@ import com.netflix.spinnaker.keel.core.api.Highlander
 import com.netflix.spinnaker.keel.core.api.RedBlack
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.docker.DigestProvider
-import com.netflix.spinnaker.keel.docker.VersionedTagProvider
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
@@ -78,7 +77,6 @@ import org.springframework.context.ApplicationEventPublisher
 import retrofit2.HttpException
 import retrofit2.Response
 import strikt.api.Assertion
-import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.containsKey
@@ -489,32 +487,6 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       }
       test("semver-job-commit parses to semver version") {
         expectThat(findTagVersioningStrategy(image.copy(tag = "v1.12.3-rc.1-h1196.49b8dc5"))).isEqualTo(SEMVER_JOB_COMMIT_BY_SEMVER)
-      }
-    }
-
-    context("generate container") {
-      val container = DigestProvider(
-        organization = "emburns",
-        image = "spin-titus-demo",
-        digest = "sha:1111"
-      )
-
-      before {
-        coEvery { cloudDriverService.findDockerImages("testregistry", container.repository()) } returns images
-        coEvery { cloudDriverService.getAccountInformation(titusAccount) } returns mapOf("registry" to "testregistry")
-      }
-
-      test("no sha match does not generate an artifact strategy") {
-        expectThat(generateContainer(container, titusAccount)).isEqualTo(container)
-      }
-
-      test("sha match generates a container with a strategy") {
-        val generatedContainer = generateContainer(
-          container = container.copy(digest = "sha:2222"),
-          account = titusAccount)
-        expect {
-          that(generatedContainer).isA<VersionedTagProvider>().get { tagVersionStrategy }.isEqualTo(INCREASING_TAG)
-        }
       }
     }
   }


### PR DESCRIPTION
This PR adds an endpoint to export artifacts given a cluster. The existing cluster export will now return a reference provider with a reference to the name of the artifact instead of the old style full artifact (which is no longer supported)

These endpoints should be used together to produce the artifact and cluster that are both needed to put a cluster correctly in a delivery config.

A `GET /export/artifact/{provider}/{account}/{cluster}` will return something like:
```json
{
  "name": "deb-sample-app-server",
  "reference": "deb-sample-app-server",
  "vmOptions": {
    "baseLabel": "RELEASE",
    "baseOs": "xenial",
    "regions": [
      "us-east-1",
      "us-west-2"
    ],
    "storeType": "EBS"
  },
  "statuses": [],
  "type": "deb"
}
```
Notes:
- Name and reference will be the same, and reference can be excluded or changed.
- (`deb`) I'm guessing the baseOs from netflix naming conventions. Awesome Hackery. Turns out the image details from clouddriver do not tell us what OS an image is.
- (`deb`) No idea how to calculate the store type. This is defaulted.
- (`deb`) No idea how to calculate the statuses. This might need to be a user prompt.
- (`docker`) I'm trying to determine the type of tag versioning strategy to use based on the running tag. This won't work if the cluster is a one-off. I throw an exception in the case I can't determine the strategy, because I don't know how else to signal that the output wouldn't be correct.