### PR TITLE
Revert "fix(performance): Avoid retrieving all SGs when looking for o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 _**IMPORTANT:** This service is currently under development and is not ready for production use._
 
+
 ---
 
 ![Release](https://github.com/spinnaker/keel/workflows/Release/badge.svg)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -45,23 +45,13 @@ interface CloudDriverService {
     @Query("vpcId") vpcId: String? = null
   ): SecurityGroupModel
 
-  @GET("/securityGroups/{account}/{provider}/{region}/{id}?getById=true")
-  suspend fun getSecurityGroupSummaryById(
+  @GET("/securityGroups/{account}/{provider}")
+  suspend fun getSecurityGroupSummaries(
     @Path("account") account: String,
     @Path("provider") provider: String,
-    @Path("region") region: String,
-    @Path("id") id: String,
+    @Query("region") region: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
-  ): SecurityGroupSummary?
-
-  @GET("/securityGroups/{account}/{provider}/{region}/{name}")
-  suspend fun getSecurityGroupSummaryByName(
-    @Path("account") account: String,
-    @Path("provider") provider: String,
-    @Path("region") region: String,
-    @Path("name") name: String,
-    @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
-  ): SecurityGroupSummary?
+  ): Collection<SecurityGroupSummary>
 
   @GET("/networks")
   suspend fun listNetworks(

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
@@ -19,10 +19,10 @@ object MemoryCloudDriverCacheTest {
   val cloudDriver = mockk<CloudDriverService>()
   val subject = MemoryCloudDriverCache(cloudDriver)
 
-  val sg1 = SecurityGroupSummary("foo", "sg-1", "vpc-1")
-  val sg2 = SecurityGroupSummary("bar", "sg-2", "vpc-1")
-
-  val securityGroupSummaries = setOf(sg1, sg2)
+  val securityGroupSummaries = setOf(
+    SecurityGroupSummary("foo", "sg-1", "vpc-1"),
+    SecurityGroupSummary("bar", "sg-2", "vpc-1")
+  )
 
   val vpcs = setOf(
     Network("aws", "vpc-1", "vpcName", "prod", "us-west-2"),
@@ -50,8 +50,8 @@ object MemoryCloudDriverCacheTest {
   @Test
   fun `security groups are looked up from CloudDriver when accessed by id`() {
     coEvery {
-      cloudDriver.getSecurityGroupSummaryById("prod", "aws", "us-east-1", "sg-2")
-    } returns sg2
+      cloudDriver.getSecurityGroupSummaries("prod", "aws", "us-east-1")
+    } returns securityGroupSummaries
     coEvery {
       cloudDriver.getCredential("prod")
     } returns Credential("prod", "aws")
@@ -67,16 +67,16 @@ object MemoryCloudDriverCacheTest {
   @Test
   fun `security groups are looked up from CloudDriver when accessed by name`() {
     coEvery {
-      cloudDriver.getSecurityGroupSummaryByName("prod", "aws", "us-east-1", "foo")
-    } returns sg1
+      cloudDriver.getSecurityGroupSummaries("prod", "aws", "us-east-1")
+    } returns securityGroupSummaries
     coEvery {
       cloudDriver.getCredential("prod")
     } returns Credential("prod", "aws")
 
-    subject.securityGroupByName("prod", "us-east-1", "foo").let { securityGroupSummary ->
+    subject.securityGroupByName("prod", "us-east-1", "bar").let { securityGroupSummary ->
       expectThat(securityGroupSummary) {
-        get { name }.isEqualTo("foo")
-        get { id }.isEqualTo("sg-1")
+        get { name }.isEqualTo("bar")
+        get { id }.isEqualTo("sg-2")
       }
     }
   }
@@ -84,8 +84,8 @@ object MemoryCloudDriverCacheTest {
   @Test
   fun `an invalid security group id throws an exception`() {
     coEvery {
-      cloudDriver.getSecurityGroupSummaryById("prod", "aws", "us-east-1", "sg-4")
-    } returns null
+      cloudDriver.getSecurityGroupSummaries("prod", "aws", "us-east-1")
+    } returns securityGroupSummaries
 
     expectThrows<ResourceNotFound> {
       subject.securityGroupById("prod", "us-east-1", "sg-4")


### PR DESCRIPTION
…ne (#1062)"

This reverts commit 704972ba933ca7ffcf0b331df3680e985c8d37fe.

Reverting so that we don't have a dependency on promoting clouddriver before promoting keel. We can un-revert once we're confident that master of clouddriver is stable and running in our prod env.