### PR TITLE
Disambiguate 404s

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
@@ -35,3 +35,4 @@ interface CloudDriverCache {
 }
 
 class ResourceNotFound(message: String) : IntegrationException(message)
+class CacheLoadingException(message: String, cause: Throwable) : IntegrationException(message, cause)

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-slf4j")
 
   testImplementation(project(":keel-test"))
+  testImplementation(project(":keel-retrofit-test-support"))
   testImplementation("io.strikt:strikt-jackson")
   testImplementation("dev.minutest:minutest")
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -37,7 +37,6 @@ import com.netflix.spinnaker.keel.core.api.RedBlack
 import com.netflix.spinnaker.keel.core.api.StaggeredRegion
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
@@ -47,6 +46,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.retrofit.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.test.combinedMockRepository
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -44,7 +44,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.ec2.SPINNAKER_EC2_API_V1
 import com.netflix.spinnaker.keel.model.Job
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
@@ -52,6 +51,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryDeliveryConfigRepository
+import com.netflix.spinnaker.keel.retrofit.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.test.combinedMockRepository
 import com.netflix.spinnaker.keel.test.resource

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVetoTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVetoTests.kt
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.ec2.EC2_CLUSTER_V1
 import com.netflix.spinnaker.keel.ec2.EC2_SECURITY_GROUP_V1
-import com.netflix.spinnaker.keel.ec2.RETROFIT_NOT_FOUND
+import com.netflix.spinnaker.keel.retrofit.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.veto.VetoResponse
 import dev.minutest.junit.JUnit5Minutests

--- a/keel-retrofit-test-support/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/errors.kt
+++ b/keel-retrofit-test-support/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/errors.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.ec2
+package com.netflix.spinnaker.keel.retrofit
 
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -7,4 +7,8 @@ import retrofit2.Response.error
 
 val RETROFIT_NOT_FOUND = HttpException(
   error<Any>(404, "".toResponseBody("application/json".toMediaTypeOrNull()))
+)
+
+val RETROFIT_SERVICE_UNAVAILABLE = HttpException(
+  error<Any>(503, "".toResponseBody("application/json".toMediaTypeOrNull()))
 )


### PR DESCRIPTION
We have an issue in that `CloudDriverCache` is frequently called as part of determining the current state of a resource. Usually this is for converting ids to names for things like subnets and security groups. If the cache is not primed, we make a call to CloudDriver. If that call throws a `RetrofitException` it will propagate out of the `CloudDriverCache` method and be handled in the resource handler. If the exception is a 404 we can misinterpret that as meaning the resource itself was not found. 

For example, look at https://github.com/spinnaker/keel/blob/master/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt#L261-L267 where if we catch an `HttpException` with a code of 404, we return `null` for the current state of the ALB resource. That's fine when the exception was thrown from the CloudDriver endpoint we are using to get the load balancer itself, but there are `CloudDriverCache` calls inside of that `try` block that may themselves throw `HttpException` because, for example a security group does not exist. Those 2 different 404s are _not_ the same thing. One means the resource doesn't exist, one is probably an integration exception talking to CloudDriver or some lag with CloudDriver's cache.

This PR disambiguates the 2 conditions by ensuring `HttpException` does not get thrown from `CloudDriverCache`.