### PR TITLE
feat(admin): recheck endpoint

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
@@ -24,10 +24,12 @@ import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import java.time.Clock
+import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
+import strikt.assertions.succeeded
 
 abstract class DiffFingerprintRepositoryTests<T : DiffFingerprintRepository> : JUnit5Minutests {
   abstract fun factory(clock: Clock): T
@@ -91,6 +93,18 @@ abstract class DiffFingerprintRepositoryTests<T : DiffFingerprintRepository> : J
     context("querying when nothing exists") {
       test("returns 0") {
         expectThat(subject.diffCount(r.id)).isEqualTo(0)
+      }
+    }
+
+    context("deleting hash") {
+      test("deletes successfully when present") {
+        val diff = DefaultResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "bye"))
+        subject.store(r.id, diff)
+        subject.clear(r.id)
+        expectThat(subject.diffCount(r.id)).isEqualTo(0)
+      }
+      test("deletes successfully when not present") {
+        expectCatching { subject.clear(r.id) }.succeeded()
       }
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepository.kt
@@ -31,6 +31,8 @@ interface DiffFingerprintRepository {
 
   fun seen(entityId: String, diff: ResourceDiff<*>): Boolean
 
+  fun clear(entityId: String)
+
   fun ResourceDiff<*>.generateHash(): String {
     val bytes = MessageDigest
       .getInstance("SHA-1")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryDiffFingerprintRepository.kt
@@ -44,6 +44,10 @@ class InMemoryDiffFingerprintRepository(
   override fun seen(entityId: String, diff: ResourceDiff<*>): Boolean =
     hashes[entityId]?.hash == diff.generateHash()
 
+  override fun clear(entityId: String) {
+    hashes.remove(entityId)
+  }
+
   private data class Record(
     val hash: String,
     val timestamp: Instant, // timestamp when diff was first seen

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepository.kt
@@ -92,4 +92,12 @@ class SqlDiffFingerprintRepository(
           .and(DIFF_FINGERPRINT.HASH.eq(diff.generateHash()))
       )
     }
+
+  override fun clear(entityId: String) {
+    sqlRetry.withRetry(WRITE) {
+      jooq.deleteFrom(DIFF_FINGERPRINT)
+        .where(DIFF_FINGERPRINT.ENTITY_ID.eq(entityId))
+        .execute()
+    }
+  }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
@@ -41,4 +42,11 @@ class AdminController(
   )
   fun getManagedApplications() =
     adminService.getManagedApplications()
+
+  @PostMapping(
+    path = ["/recheck/{resourceId}"]
+  )
+  fun triggerRecheck(resourceId: String) {
+    adminService.triggerRecheck(resourceId)
+  }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.services
 
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -9,7 +10,8 @@ import org.springframework.stereotype.Component
 @Component
 class AdminService(
   private val repository: KeelRepository,
-  private val actuationPauser: ActuationPauser
+  private val actuationPauser: ActuationPauser,
+  private val diffFingerprintRepository: DiffFingerprintRepository
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -24,5 +26,10 @@ class AdminService(
 
   fun getManagedApplications(): Collection<ApplicationSummary> {
     return repository.getApplicationSummaries()
+  }
+
+  fun triggerRecheck(resourceId: String) {
+    log.info("Triggering a recheck for $resourceId by clearing our record of the diff")
+    diffFingerprintRepository.clear(resourceId)
   }
 }


### PR DESCRIPTION
Sometimes we might need to trigger a recheck of a resource. This might happen after recovering from an incident or bug (like https://github.com/spinnaker/keel/issues/1090). I created an admin endpoint to do this instead of just going into the database.