### PR TITLE
chore(config): delete config by app

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -91,6 +91,16 @@ class ApplicationController(
     @PathVariable("application") application: String
   ): DeliveryConfig = applicationService.getDeliveryConfig(application)
 
+  @DeleteMapping(
+    path = ["/{application}/config"]
+  )
+  @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #application)
+    and @authorizationSupport.hasServiceAccountAccess('APPLICATION', #application)"""
+  )
+  fun deleteConfigByApp(@PathVariable("application") application: String) {
+    applicationService.deleteConfigByApp(application)
+  }
+
   @PostMapping(
     path = ["/{application}/environment/{environment}/constraint"],
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -55,6 +55,14 @@ class ApplicationService(
 
   fun getDeliveryConfig(application: String) = repository.getDeliveryConfigForApplication(application)
 
+  fun deleteConfigByApp(application: String) =
+    try {
+      val config = repository.getDeliveryConfigForApplication(application)
+      repository.deleteDeliveryConfig(config.name)
+    } catch (e: NoSuchDeliveryConfigException) {
+      log.debug("No delivery config exists for $application, considering it deleted")
+    }
+
   fun getConstraintStatesFor(application: String) = repository.constraintStateFor(application)
 
   fun getConstraintStatesFor(application: String, environment: String, limit: Int): List<ConstraintState> {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -55,13 +55,7 @@ class ApplicationService(
 
   fun getDeliveryConfig(application: String) = repository.getDeliveryConfigForApplication(application)
 
-  fun deleteConfigByApp(application: String) =
-    try {
-      val config = repository.getDeliveryConfigForApplication(application)
-      repository.deleteDeliveryConfig(config.name)
-    } catch (e: NoSuchDeliveryConfigException) {
-      log.debug("No delivery config exists for $application, considering it deleted")
-    }
+  fun deleteConfigByApp(application: String) = repository.deleteDeliveryConfigByApplication(application)
 
   fun getConstraintStatesFor(application: String) = repository.constraintStateFor(application)
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -597,6 +597,21 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
         }
       }
+
+      context("DELETE /application/fnord/config") {
+        context("with no WRITE access to application") {
+          before {
+            authorizationSupport.denyApplicationAccess(WRITE, APPLICATION)
+          }
+          test("request is forbidden") {
+            val request = delete("/application/fnord/config")
+              .accept(MediaType.APPLICATION_JSON_VALUE)
+              .header("X-SPINNAKER-USER", "keel@keel.io")
+
+            mvc.perform(request).andExpect(status().isForbidden)
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Adding an endpoint to delete delivery configs by app, because it's annoying to have to first make a call to find the config name

I'm not removing the other endpoint for backwards compatibility.