### PR TITLE
fix(validation): Throw an exception when referencing a non existing env

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -437,7 +437,10 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
           }.failed()
             .isA<MissingEnvironmentReferenceException>()
 
-          expectThat(subject.allResourceNames().size).isEqualTo(0)
+          expectCatching {
+            subject.getDeliveryConfig(configName)
+          }.failed()
+            .isA<NoSuchDeliveryConfigException>()
         }
       }
     }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -426,7 +426,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
               SubmittedEnvironment(
               name = "test",
             resources = emptySet(),
-            constraints = setOf(DependsOnConstraint(environment = "notRealEnvironment"))
+            constraints = setOf(DependsOnConstraint(environment = "notARealEnvironment"))
           )
           )
         )
@@ -434,12 +434,12 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
         test("an error is thrown and config is not persisted") {
           expectCatching {
             subject.upsertDeliveryConfig(submittedConfig)
-          }.failed()
+          }.isFailure()
             .isA<MissingEnvironmentReferenceException>()
 
           expectCatching {
             subject.getDeliveryConfig(configName)
-          }.failed()
+          }.isFailure()
             .isA<NoSuchDeliveryConfigException>()
         }
       }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.SubmittedEnvironment
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
@@ -16,6 +17,7 @@ import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceUpdated
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
+import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.TEST_API_V1
@@ -406,6 +408,48 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
             .isA<TooManyDeliveryConfigsException>()
 
           expectThat(subject.getDeliveryConfigForApplication("keel").name).isEqualTo(configName)
+        }
+      }
+
+      context("submitting delivery config with invalid environment name as a constraint") {
+        val submittedConfig = SubmittedDeliveryConfig(
+          name = configName,
+          application = "keel",
+          serviceAccount = "keel@spinnaker",
+          artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+          environments = setOf(
+            SubmittedEnvironment(
+              name = "test",
+              resources = setOf(
+                SubmittedResource(
+                  metadata = mapOf("serviceAccount" to "keel@spinnaker"),
+                  kind = TEST_API_V1.qualify("whatever"),
+                  spec = DummyResourceSpec(data = "o hai")
+                )
+              ),
+              constraints = emptySet()
+            ),
+              SubmittedEnvironment(
+              name = "test",
+            resources = setOf(
+              SubmittedResource(
+                metadata = mapOf("serviceAccount" to "keel@spinnaker"),
+                kind = TEST_API_V1.qualify("whatever"),
+                spec = DummyResourceSpec(data = "o hai")
+              )
+            ),
+            constraints = setOf(DependsOnConstraint(environment = "notRealEnvironment"))
+          )
+          )
+        )
+
+        test("an error is thrown and config is not persisted") {
+          expectCatching {
+            subject.upsertDeliveryConfig(submittedConfig)
+          }.failed()
+            .isA<MissingEnvironmentReferenceException>()
+
+          expectThat(subject.allResourceNames().size).isEqualTo(0)
         }
       }
     }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -420,24 +420,12 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
           environments = setOf(
             SubmittedEnvironment(
               name = "test",
-              resources = setOf(
-                SubmittedResource(
-                  metadata = mapOf("serviceAccount" to "keel@spinnaker"),
-                  kind = TEST_API_V1.qualify("whatever"),
-                  spec = DummyResourceSpec(data = "o hai")
-                )
-              ),
+              resources = emptySet(),
               constraints = emptySet()
             ),
               SubmittedEnvironment(
               name = "test",
-            resources = setOf(
-              SubmittedResource(
-                metadata = mapOf("serviceAccount" to "keel@spinnaker"),
-                kind = TEST_API_V1.qualify("whatever"),
-                spec = DummyResourceSpec(data = "o hai")
-              )
-            ),
+            resources = emptySet(),
             constraints = setOf(DependsOnConstraint(environment = "notRealEnvironment"))
           )
           )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/MissingEnvironmentReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/MissingEnvironmentReferenceException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.exceptions
+
+class MissingEnvironmentReferenceException(
+  private val environmentName: String
+) : ValidationException(
+  "The depend-on environment named: $environmentName " +
+    "is missing in the config. Please ensure you reference to the right environment."
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/MissingEnvironmentReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/MissingEnvironmentReferenceException.kt
@@ -4,5 +4,5 @@ class MissingEnvironmentReferenceException(
   private val environmentName: String
 ) : ValidationException(
   "The depend-on environment named: $environmentName " +
-    "is missing in the config. Please ensure you reference to the right environment."
+    "is missing in the config. Please ensure you reference the right environment."
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -239,12 +239,10 @@ class CombinedRepository(
      */
     config.environments.forEach { environment ->
       environment.constraints.forEach { constraint ->
-        when (constraint is DependsOnConstraint) {
-          true -> {
-            config.environments.find {
-              it.name == constraint.environment
-            } ?: throw MissingEnvironmentReferenceException(constraint.environment)
-          }
+        if (constraint is DependsOnConstraint) {
+          config.environments.find {
+            it.name == constraint.environment
+          } ?: throw MissingEnvironmentReferenceException(constraint.environment)
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
@@ -25,6 +26,7 @@ import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
+import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -230,6 +232,21 @@ class CombinedRepository(
 
       log.error("Validation failed for ${config.name}, duplicate artifact references found: $duplicatesArtifactNameToRef")
       throw DuplicateArtifactReferenceException(duplicatesArtifactNameToRef)
+    }
+
+    /**
+     * validating depends on environments
+     */
+    config.environments.forEach { environment ->
+      environment.constraints.forEach { constraint ->
+        when (constraint is DependsOnConstraint) {
+          true -> {
+            config.environments.find {
+              it.name == constraint.environment
+            } ?: throw MissingEnvironmentReferenceException(constraint.environment)
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
fixes https://github.com/spinnaker/keel/issues/936.

Adding a validation for the depends on constraint - if referencing to a non-existing environment, throw a bad request exception. 

I'm planning on extracting the delivery config validation into a new service but will do it in a separate PR.