### PR TITLE
chore(events): add unresolvable state for metrics

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.keel.events.ResourceState.Diff
 import com.netflix.spinnaker.keel.events.ResourceState.Error
 import com.netflix.spinnaker.keel.events.ResourceState.Missing
 import com.netflix.spinnaker.keel.events.ResourceState.Ok
+import com.netflix.spinnaker.keel.events.ResourceState.Unresolvable
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.exceptions.UserException
@@ -364,7 +365,7 @@ data class ResourceCheckUnresolvable(
   override val message: String?
 ) : ResourceCheckResult(message = message) {
   @JsonIgnore
-  override val state = Diff
+  override val state = Unresolvable
 
   @JsonIgnore
   override val ignoreRepeatedInHistory = true

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceState.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceState.kt
@@ -16,5 +16,5 @@
 package com.netflix.spinnaker.keel.events
 
 enum class ResourceState {
-  Ok, Diff, Missing, Error
+  Ok, Diff, Missing, Error, Unresolvable
 }


### PR DESCRIPTION
Previously, both `ResourceDeltaDetected` and `ResourceCheckUnresolvable` events were reported with identical tags in the `keel.resource.checked` metric, which meant we couldn't tell how many times we were getting transient resource check failures.

This change differentiates these two events by introducing a new resource state. I called it `unresolvable` to match the name `ResourceChecekUnresolvable`.