### PR TITLE
fix(config): allow null name, use correctly

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.core.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.netflix.spinnaker.keel.api.Constraint
 import com.netflix.spinnaker.keel.api.NotificationConfig
@@ -13,12 +14,15 @@ const val DEFAULT_SERVICE_ACCOUNT = "keel@spinnaker.io"
 @Description("A manifest specifying the environments and resources that comprise an application.")
 data class SubmittedDeliveryConfig(
   val application: String,
-  val name: String = "$application-manifest",
+  val name: String?,
   @Description("The service account Spinnaker will authenticate with when making changes.")
   val serviceAccount: String,
   val artifacts: Set<DeliveryArtifact> = emptySet(),
   val environments: Set<SubmittedEnvironment> = emptySet()
-)
+) {
+  val safeName: String
+    @JsonIgnore get() = name ?: "$application-manifest"
+}
 
 @JsonDeserialize(using = SubmittedEnvironmentDeserializer::class)
 data class SubmittedEnvironment(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
@@ -72,7 +72,7 @@ class AdHocDiffer(
 
       EnvironmentDiff(
         name = env.name,
-        manifestName = submittedDeliveryConfig.name,
+        manifestName = submittedDeliveryConfig.safeName,
         resourceDiffs = resourceDiffs
       )
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -61,10 +61,10 @@ class CombinedRepository(
   @Transactional(propagation = Propagation.REQUIRED)
   override fun upsertDeliveryConfig(submittedDeliveryConfig: SubmittedDeliveryConfig): DeliveryConfig {
     val new = DeliveryConfig(
-      name = submittedDeliveryConfig.name,
+      name = submittedDeliveryConfig.safeName,
       application = submittedDeliveryConfig.application,
       serviceAccount = submittedDeliveryConfig.serviceAccount,
-      artifacts = submittedDeliveryConfig.artifacts.transform(submittedDeliveryConfig.name),
+      artifacts = submittedDeliveryConfig.artifacts.transform(submittedDeliveryConfig.safeName),
       environments = submittedDeliveryConfig.environments.mapTo(mutableSetOf()) { env ->
         Environment(
           name = env.name,


### PR DESCRIPTION
Even though you can definitely omit the name when submitting to `keel` directly, I'm pretty sure the serialization from gate sends a key with a null value for the name. `keel` does not like that. This change allows a null name, and uses another property to give the correct name if it indeed is null.
