### PR TITLE
chore(metrics): remove useless "name" path metrics variable

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -57,7 +57,7 @@ class DefaultConfiguration(
      * Lorin chose these particular variables arbitrarily as potentially useful. Once we start consuming
      * these metrics, we should revisit whether to change these based on usefulness & cardinality
      */
-    val pathVarsToTag = listOf("name", "application")
+    val pathVarsToTag = listOf("application")
 
     val queryParamsToTag = null
 


### PR DESCRIPTION
Several keel REST controllers use "name" as a path variable, so I originally thought it would be useful to report those as tags on the controller invocations metric.

The problem is that "name" is already used as the metric key (`controller.invocations`), and so specifying it as a path variable tag has no effect. This commit removes it from the list of path variables to tag.

Longer term, if we want to capture this information as tags in the metrics, we should rename the variable in the controllers from "name" to something else so we can use it in a tag.