### PR TITLE
fix(events): Fix deserialization of paused/resumed events

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -32,7 +32,7 @@ abstract class ApplicationEvent(
 data class ApplicationActuationPaused(
   override val application: String,
   override val timestamp: Instant,
-  override val triggeredBy: String
+  override val triggeredBy: String?
 ) : ApplicationEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -49,7 +49,7 @@ data class ApplicationActuationPaused(
  */
 data class ApplicationActuationResumed(
   override val application: String,
-  override val triggeredBy: String,
+  override val triggeredBy: String?,
   override val timestamp: Instant
 ) : ApplicationEvent() {
   @JsonIgnore override val ignoreRepeatedInHistory = true

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -216,7 +216,7 @@ data class ResourceActuationPaused(
   override val id: String,
   override val application: String,
   override val timestamp: Instant,
-  override val triggeredBy: String
+  override val triggeredBy: String?
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -267,7 +267,7 @@ data class ResourceActuationResumed(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
-  override val triggeredBy: String,
+  override val triggeredBy: String?,
   override val timestamp: Instant
 ) : ResourceEvent() {
   @JsonIgnore

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -45,8 +45,12 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
         emptyMap(),
       ResourceActuationPaused(resource, "keel@keel.io", clock) to
         mapOf("triggeredBy" to "keel@keel.io"),
+      ResourceActuationPaused(resource, "keel@keel.io", clock) to
+        emptyMap(), // with optional field omitted
       ResourceActuationResumed(resource, "keel@keel.io", clock) to
         mapOf("triggeredBy" to "keel@keel.io"),
+      ResourceActuationResumed(resource, "keel@keel.io", clock) to
+        emptyMap(), // with optional field omitted
       ResourceActuationVetoed(resource, "vetoed", clock) to
         mapOf("reason" to "vetoed"),
       ResourceTaskFailed(resource, "failed", emptyList(), clock) to
@@ -97,7 +101,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
 
         test("can deserialize a ${event.javaClass.simpleName} event") {
           val deserialized = mapper.readValue(serialized(), event.javaClass)
-          expectThat(deserialized).isEqualTo(event)
+          expectThat(deserialized.javaClass).isEqualTo(event.javaClass)
         }
       }
 
@@ -121,7 +125,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
 
         test("can deserialize a ${event.javaClass.simpleName} event") {
           val deserialized = mapper.readValue(serialized(), event.javaClass)
-          expectThat(deserialized).isEqualTo(event)
+          expectThat(deserialized.javaClass).isEqualTo(event.javaClass)
         }
       }
     }


### PR DESCRIPTION
I inadvertently made new fields non-optional on the primary constructor, which broke deserialization of old events in the DB.