### PR TITLE
fix(export): ignore latest tag

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
@@ -3,5 +3,5 @@ package com.netflix.spinnaker.keel.exceptions
 import com.netflix.spinnaker.kork.exceptions.UserException
 
 class DockerArtifactExportError(tags: List<String>, container: String) :
-  UserException("Unable to determine tag strategy for docker images with tags $tags from container ($container), please supply a custom regex " +
+  UserException("Unable to determine tag strategy for docker images with tags ${tags.joinToString()} from container ($container), please supply a custom regex " +
     "(see https://www.spinnaker.io/guides/user/managed-delivery/artifacts/#advanced-configuration for more information)")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
@@ -2,6 +2,6 @@ package com.netflix.spinnaker.keel.exceptions
 
 import com.netflix.spinnaker.kork.exceptions.UserException
 
-class DockerArtifactExportError(image: String, container: String) :
-  UserException("Unable to determine tag strategy for docker image ($image) from container ($container), please supply a custom regex " +
-  "(see https://www.spinnaker.io/guides/user/managed-delivery/artifacts/#advanced-configuration for more information)")
+class DockerArtifactExportError(tags: List<String>, container: String) :
+  UserException("Unable to determine tag strategy for docker images with tags $tags from container ($container), please supply a custom regex " +
+    "(see https://www.spinnaker.io/guides/user/managed-delivery/artifacts/#advanced-configuration for more information)")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -245,28 +245,52 @@ class TitusClusterHandler(
       user = DEFAULT_SERVICE_ACCOUNT
     )
 
-    val image = images.find { it.digest == container.digest }
-      ?: throw ExportError("Unable to find matching image (searching by digest) in registry ($registry) for $container")
-    val tagVersionStrategy = findTagVersioningStrategy(image)
-      ?: throw DockerArtifactExportError(image.toString(), container.toString())
+    val matchingImages = images.filter { it.digest == container.digest }
+    if (matchingImages.isEmpty()) {
+      throw ExportError("Unable to find matching image (searching by digest) in registry ($registry) for $container")
+    }
+    val versionStrategy = guessVersioningStrategy(matchingImages)
+      ?: throw DockerArtifactExportError(matchingImages.map { it.tag }, container.toString())
 
     return DockerArtifact(
       name = container.repository(),
-      tagVersionStrategy = tagVersionStrategy
+      tagVersionStrategy = versionStrategy
     )
   }
 
-  fun findTagVersioningStrategy(image: DockerImage): TagVersionStrategy? {
-    if (image.tag.toIntOrNull() != null) {
+  /**
+   * Tries to find a matching versioning strategy from a list of docker tags that correspond to the same digest.
+   */
+  fun guessVersioningStrategy(images: List<DockerImage>): TagVersionStrategy? {
+    val versioningStrategies = mutableSetOf<TagVersionStrategy>()
+
+    images.forEach { image ->
+      val versionStrategy = calculateVersioningStrategyFrom(image.tag)
+      if (versionStrategy != null) {
+        versioningStrategies.add(versionStrategy)
+      }
+    }
+    return when (versioningStrategies.size) {
+      1 -> versioningStrategies.first()
+      0 -> null
+      else -> {
+        log.warn("Multiple versioning strategies apply for image, returning first")
+        versioningStrategies.first()
+      }
+    }
+  }
+
+  fun calculateVersioningStrategyFrom(tag: String): TagVersionStrategy? {
+    if (tag.toIntOrNull() != null) {
       return INCREASING_TAG
     }
-    if (Regex(SEMVER_JOB_COMMIT_BY_SEMVER.regex).find(image.tag) != null) {
+    if (Regex(SEMVER_JOB_COMMIT_BY_SEMVER.regex).find(tag) != null) {
       return SEMVER_JOB_COMMIT_BY_SEMVER
     }
-    if (Regex(BRANCH_JOB_COMMIT_BY_JOB.regex).find(image.tag) != null) {
+    if (Regex(BRANCH_JOB_COMMIT_BY_JOB.regex).find(tag) != null) {
       return BRANCH_JOB_COMMIT_BY_JOB
     }
-    if (isSemver(image.tag)) {
+    if (isSemver(tag)) {
       return SEMVER_TAG
     }
     return null

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -265,7 +265,7 @@ class TitusClusterHandler(
     val versioningStrategies = mutableSetOf<TagVersionStrategy>()
 
     images.forEach { image ->
-      val versionStrategy = calculateVersioningStrategyFrom(image.tag)
+      val versionStrategy = deriveVersioningStrategy(image.tag)
       if (versionStrategy != null) {
         versioningStrategies.add(versionStrategy)
       }
@@ -280,7 +280,7 @@ class TitusClusterHandler(
     }
   }
 
-  fun calculateVersioningStrategyFrom(tag: String): TagVersionStrategy? {
+  fun deriveVersioningStrategy(tag: String): TagVersionStrategy? {
     if (tag.toIntOrNull() != null) {
       return INCREASING_TAG
     }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -136,6 +136,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
   )
 
   val branchJobShaImages = listOf(
+    image.copy(tag = "latest"),
     image.copy(tag = "master-h10.62bbbd6"),
     image.copy(tag = "master-h11.4e26fbd", digest = "sha:2222")
   )

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -474,19 +474,19 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         digest = "sha:1111"
       )
       test("number") {
-        expectThat(findTagVersioningStrategy(image)).isEqualTo(INCREASING_TAG)
+        expectThat(calculateVersioningStrategyFrom(image.tag)).isEqualTo(INCREASING_TAG)
       }
       test("semver with v") {
-        expectThat(findTagVersioningStrategy(image.copy(tag = "v1.12.3-rc.1"))).isEqualTo(SEMVER_TAG)
+        expectThat(calculateVersioningStrategyFrom("v1.12.3-rc.1")).isEqualTo(SEMVER_TAG)
       }
       test("semver without v") {
-        expectThat(findTagVersioningStrategy(image.copy(tag = "1.12.3-rc.1"))).isEqualTo(SEMVER_TAG)
+        expectThat(calculateVersioningStrategyFrom("1.12.3-rc.1")).isEqualTo(SEMVER_TAG)
       }
       test("branch-job-commit") {
-        expectThat(findTagVersioningStrategy(image.copy(tag = "master-h3.2317144"))).isEqualTo(BRANCH_JOB_COMMIT_BY_JOB)
+        expectThat(calculateVersioningStrategyFrom("master-h3.2317144")).isEqualTo(BRANCH_JOB_COMMIT_BY_JOB)
       }
       test("semver-job-commit parses to semver version") {
-        expectThat(findTagVersioningStrategy(image.copy(tag = "v1.12.3-rc.1-h1196.49b8dc5"))).isEqualTo(SEMVER_JOB_COMMIT_BY_SEMVER)
+        expectThat(calculateVersioningStrategyFrom("v1.12.3-rc.1-h1196.49b8dc5")).isEqualTo(SEMVER_JOB_COMMIT_BY_SEMVER)
       }
     }
   }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -474,19 +474,19 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         digest = "sha:1111"
       )
       test("number") {
-        expectThat(calculateVersioningStrategyFrom(image.tag)).isEqualTo(INCREASING_TAG)
+        expectThat(deriveVersioningStrategy(image.tag)).isEqualTo(INCREASING_TAG)
       }
       test("semver with v") {
-        expectThat(calculateVersioningStrategyFrom("v1.12.3-rc.1")).isEqualTo(SEMVER_TAG)
+        expectThat(deriveVersioningStrategy("v1.12.3-rc.1")).isEqualTo(SEMVER_TAG)
       }
       test("semver without v") {
-        expectThat(calculateVersioningStrategyFrom("1.12.3-rc.1")).isEqualTo(SEMVER_TAG)
+        expectThat(deriveVersioningStrategy("1.12.3-rc.1")).isEqualTo(SEMVER_TAG)
       }
       test("branch-job-commit") {
-        expectThat(calculateVersioningStrategyFrom("master-h3.2317144")).isEqualTo(BRANCH_JOB_COMMIT_BY_JOB)
+        expectThat(deriveVersioningStrategy("master-h3.2317144")).isEqualTo(BRANCH_JOB_COMMIT_BY_JOB)
       }
       test("semver-job-commit parses to semver version") {
-        expectThat(calculateVersioningStrategyFrom("v1.12.3-rc.1-h1196.49b8dc5")).isEqualTo(SEMVER_JOB_COMMIT_BY_SEMVER)
+        expectThat(deriveVersioningStrategy("v1.12.3-rc.1-h1196.49b8dc5")).isEqualTo(SEMVER_JOB_COMMIT_BY_SEMVER)
       }
     }
   }


### PR DESCRIPTION
When exporting docker artifacts I was ignoring the possibility that a currently running container might have two tags (like `latest`). This fixes that problem.