### PR TITLE
fix(export): fix discover deploy strategy

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
@@ -25,6 +25,7 @@ import java.time.Duration.ZERO
 sealed class ClusterDeployStrategy {
   @get:JsonIgnore
   open val isStaggered: Boolean = false
+
   @get:JsonInclude(NON_EMPTY)
   open val stagger: List<StaggeredRegion> = emptyList()
   abstract fun toOrcaJobProperties(): Map<String, Any?>
@@ -50,9 +51,9 @@ data class RedBlack(
           ?.let { it as Map<String, Any> }
           ?.get("onFailure") as Boolean,
         resizePreviousToZero = context["scaleDown"] as Boolean,
-        maxServerGroups = context["maxRemainingAsgs"] as Int,
-        delayBeforeDisable = Duration.ofSeconds((context["delayBeforeDisableSec"] as Int).toLong()),
-        delayBeforeScaleDown = Duration.ofSeconds((context["delayBeforeScaleDownSec"] as Int).toLong())
+        maxServerGroups = context["maxRemainingAsgs"].toString().toInt(),
+        delayBeforeDisable = Duration.ofSeconds((context["delayBeforeDisableSec"].toString().toInt()).toLong()),
+        delayBeforeScaleDown = Duration.ofSeconds((context["delayBeforeScaleDownSec"].toString().toInt()).toLong())
       )
 
     val DEFAULTS = RedBlack()

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -86,7 +86,14 @@ class ClusterExportHelper(
       }
 
       when (val strategy = context?.get("strategy")) {
-        "redblack" -> RedBlack.fromOrcaStageContext(context)
+        "redblack" -> {
+          try {
+            RedBlack.fromOrcaStageContext(context)
+          } catch (e: ClassCastException) {
+            log.error("Could not convert strategy to redblack, context is {}", context)
+            null
+          }
+        }
         "highlander" -> Highlander
         null -> null.also {
           log.error("Deployment strategy information not found for server group $serverGroupName " +


### PR DESCRIPTION
Turns out you can't cast strings to ints with `as` in kotlin. I also added some error handling because orca's context is .... not reliably typed and bound to give us a hard time