### PR TITLE
fix(events): Update events that disallow duplicates instead of ignoring

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -205,23 +205,24 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
                 .isA<ResourceValid>()
             }
 
-            context("a subsequent identical event that should be ignored") {
+            context("a subsequent identical event with duplicates disallowed") {
               before {
                 tick()
                 subject.appendHistory(ResourceValid(resource, clock))
               }
 
-              test("the event is not included in the history") {
+              test("the existing event's timestamp is updated") {
                 expectThat(subject.eventHistory(resource.id))
                   .and {
                     first().isA<ResourceValid>()
+                      .and { get { timestamp }.isEqualTo(clock.instant()) }
                     second().not().isA<ResourceValid>()
                   }
               }
             }
           }
 
-          context("a subsequent identical event") {
+          context("a subsequent identical event with duplicates allowed") {
             before {
               tick()
               subject.appendHistory(ResourceUpdated(resource, emptyMap(), clock))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/memory/InMemoryResourceRepository.kt
@@ -120,13 +120,19 @@ class InMemoryResourceRepository(
     appendHistory(applicationEvents, event)
   }
 
-  private fun <T : PersistentEvent> appendHistory(eventList: MutableMap<String, MutableList<T>>, event: T) {
+  private fun <T : PersistentEvent> appendHistory(
+    eventList: MutableMap<String, MutableList<T>>,
+    event: T
+  ) {
     eventList.computeIfAbsent(event.uid) {
       mutableListOf()
     }
       .let {
         val mostRecentEvent = it.firstOrNull() // we get the first because the list is in descending order
-        if (!event.ignoreRepeatedInHistory || event.javaClass != mostRecentEvent?.javaClass) {
+        if (event.javaClass == mostRecentEvent?.javaClass && event.ignoreRepeatedInHistory) {
+          it.removeAt(0)
+          it.add(0, event)
+        } else {
           it.add(0, event)
         }
       }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -259,6 +259,8 @@ open class SqlResourceRepository(
           txn
             .update(EVENT)
             .set(EVENT.TIMESTAMP, event.timestamp.atZone(clock.zone).toLocalDateTime())
+            // we udpate the JSON as well because it also contains a timestamp
+            .set(EVENT.JSON, objectMapper.writeValueAsString(event))
             .where(EVENT.SCOPE.eq(Scope.RESOURCE.name))
             .and(EVENT.UID.eq(resourceUid))
             .orderBy(EVENT.TIMESTAMP.desc())


### PR DESCRIPTION
This PR is an attempt to fix the issue we found today where resources got stuck in `RESUMED` status. 

The cause of the problem was that we look at the event history to determine status, and, in this case, there were `ApplicationActuationResumed` events appearing last in the event history for those resources. (We also noticed the application paused/resumed events were not displayed on the UI, making the experience even more confusing, but that’s a separate issue). 

Upon investigation, we discovered that keel behaved as expected after an application is resumed and proceeded to check the resources and emitted `ResourceValid` events. The problem was that these events have the `ignoreRepeatedInHistory` flag set to `true`, which causes them not to be persisted in the database if the last resource event is of the same type (which it was). In other words, we were ignoring those application-level events when checking for duplicates in the resource event history, and so a new `ResourceValid` event was never written to the DB.

Based on a suggestion from @emjburns, this PR changes the behavior around the `ignoreRepeatedInHistory` flag by updating the timestamp of a matching equivalent event in the last position in history, as opposed to skipping the event altogether. The side-effect this will have, which we thought was probably a good bonus, is that the timestamp of that last event in history will "catch up" every time we check, until a new event comes along, which seemed good because it will be apparent to the user that we're doing something.

@erikmunson Curious if you have any objections to the above.