### PR TITLE
feat(status): vetoed resources get history event + unhappy status

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -141,6 +141,7 @@ class ResourceActuator(
               resource.spec.application,
               response.message,
               response.vetoName,
+              response.suggestedStatus,
               clock.instant()))
           return@withTracingContext
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -94,6 +94,7 @@ class ResourceActuator(
            * containing [resource]. This ensures that the environment will be fully restored to
            * a prior good-state.
            */
+          // todo eb: limit this to not roll back forever
           if (response.vetoArtifact && resource.spec is VersionedArtifactProvider) {
             try {
               val versionedArtifact = when (desired) {
@@ -139,6 +140,7 @@ class ResourceActuator(
               resource.id,
               resource.spec.application,
               response.message,
+              response.vetoName,
               clock.instant()))
           return@withTracingContext
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.keel.events.ResourceState.Error
 import com.netflix.spinnaker.keel.events.ResourceState.Missing
 import com.netflix.spinnaker.keel.events.ResourceState.Ok
 import com.netflix.spinnaker.keel.events.ResourceState.Unresolvable
+import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.exceptions.UserException
@@ -238,25 +239,27 @@ data class ResourceActuationPaused(
  * Actuation on the managed resource has been vetoed.
  *
  * @property reason The reason why actuation was vetoed.
- * @property vetoer The veto that vetoed this resource
+ * @property veto The veto that vetoed this resource
  */
 data class ResourceActuationVetoed(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
   val reason: String?,
-  val vetoer: String? = null,
+  val veto: String? = null,
+  val suggestedStatus: ResourceStatus? = null,
   override val timestamp: Instant
 ) : ResourceEvent(message = reason) {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, reason: String?, vetoer: String? = null, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, reason: String?, veto: String? = null, suggestedStatus: ResourceStatus? = null, clock: Clock = Companion.clock) : this(
     resource.kind,
     resource.id,
     resource.application,
     reason,
-    vetoer,
+    veto,
+    suggestedStatus,
     clock.instant()
   )
 }
@@ -395,8 +398,10 @@ data class ResourceCheckUnresolvable(
 enum class ResourceCheckErrorOrigin {
   @JsonProperty("user")
   USER,
+
   @JsonProperty("system")
   SYSTEM,
+
   @JsonProperty("unknown")
   UNKNOWN;
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -238,22 +238,25 @@ data class ResourceActuationPaused(
  * Actuation on the managed resource has been vetoed.
  *
  * @property reason The reason why actuation was vetoed.
+ * @property vetoer The veto that vetoed this resource
  */
 data class ResourceActuationVetoed(
   override val kind: ResourceKind,
   override val id: String,
   override val application: String,
   val reason: String?,
+  val vetoer: String? = null,
   override val timestamp: Instant
 ) : ResourceEvent(message = reason) {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
-  constructor(resource: Resource<*>, reason: String?, clock: Clock = Companion.clock) : this(
+  constructor(resource: Resource<*>, reason: String?, vetoer: String? = null, clock: Clock = Companion.clock) : this(
     resource.kind,
     resource.id,
     resource.application,
     reason,
+    vetoer,
     clock.instant()
   )
 }
@@ -390,9 +393,12 @@ data class ResourceCheckUnresolvable(
 }
 
 enum class ResourceCheckErrorOrigin {
-  @JsonProperty("user") USER,
-  @JsonProperty("system") SYSTEM,
-  @JsonProperty("unknown") UNKNOWN;
+  @JsonProperty("user")
+  USER,
+  @JsonProperty("system")
+  SYSTEM,
+  @JsonProperty("unknown")
+  UNKNOWN;
 
   companion object {
     val log: Logger by lazy { LoggerFactory.getLogger(ResourceCheckErrorOrigin::class.java) }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -145,5 +145,15 @@ class NoSuchResourceId(id: String) :
   NoSuchResourceException("No resource with id $id exists in the database")
 
 enum class ResourceStatus {
-  HAPPY, ACTUATING, UNHAPPY, CREATED, DIFF, ERROR, CURRENTLY_UNRESOLVABLE, PAUSED, VETOED, RESUMED, UNKNOWN
+  CREATED,
+  DIFF,
+  ACTUATING,
+  HAPPY,
+  UNHAPPY,
+  MISSING_DEPENDENCY,
+  CURRENTLY_UNRESOLVABLE,
+  ERROR,
+  PAUSED,
+  RESUMED,
+  UNKNOWN
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
@@ -137,8 +137,7 @@ class ResourceStatusService(
 
   /**
    * Looks at the veto event and determines if it was vetoed by any of the [Required*Veto]s, which indicate a
-   * missing dependency.
-   * Looks at both the [veto] and the [reason] for backwards compatibility.
+   * missing dependency. Parses this information from the [reason]. This is used for backwards compatibility.
    */
   private fun ResourceActuationVetoed.isMissingDependency(): Boolean =
     reason?.contains("is not found in", true) ?: false

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/Veto.kt
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.keel.veto
 
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.persistence.ResourceStatus
 
 /**
  * Implement this interface to create a veto that will be consulted
@@ -45,7 +46,9 @@ interface Veto {
   /**
    * Pass a message to a veto.
    */
-  fun passMessage(message: Map<String, Any>) { TODO("not implemented") }
+  fun passMessage(message: Map<String, Any>) {
+    TODO("not implemented")
+  }
 
   /**
    * What's currently being vetoed.
@@ -60,13 +63,14 @@ interface Veto {
   fun allowedResponse(): VetoResponse =
     VetoResponse(allowed = true, vetoName = name())
 
-  fun deniedResponse(message: String, vetoArtifact: Boolean = true): VetoResponse =
-    VetoResponse(allowed = false, vetoName = name(), vetoArtifact = vetoArtifact, message = message)
+  fun deniedResponse(message: String, vetoArtifact: Boolean = true, suggestedStatus: ResourceStatus? = null): VetoResponse =
+    VetoResponse(allowed = false, vetoName = name(), vetoArtifact = vetoArtifact, message = message, suggestedStatus = suggestedStatus)
 }
 
 data class VetoResponse(
   val allowed: Boolean,
   val vetoName: String,
   val vetoArtifact: Boolean = false,
-  val message: String? = null
+  val message: String? = null,
+  val suggestedStatus: ResourceStatus? = null
 )

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceEventSerializationTests.kt
@@ -51,7 +51,7 @@ internal class ResourceEventSerializationTests : JUnit5Minutests {
         mapOf("triggeredBy" to "keel@keel.io"),
       ResourceActuationResumed(resource, "keel@keel.io", clock) to
         emptyMap(), // with optional field omitted
-      ResourceActuationVetoed(resource, "vetoed", clock) to
+      ResourceActuationVetoed(resource = resource, reason = "vetoed", clock = clock) to
         mapOf("reason" to "vetoed"),
       ResourceTaskFailed(resource, "failed", emptyList(), clock) to
         mapOf("reason" to "failed"),

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
@@ -192,7 +192,7 @@ class ResourceStatusServiceTests : JUnit5Minutests {
           }
         }
 
-        context("when last event is ResourceActuationVetoed because unhappy") {
+        context("when last event is ResourceActuationVetoed with no status provided") {
           before {
             repository.appendResourceHistory(ResourceActuationVetoed(resource, "vetoed", "UnhappyVeto", null, clock))
           }
@@ -202,17 +202,7 @@ class ResourceStatusServiceTests : JUnit5Minutests {
           }
         }
 
-        context("when last event is ResourceActuationVetoed because new veto that doesn't provide a status") {
-          before {
-            repository.appendResourceHistory(ResourceActuationVetoed(resource, "oh no", "meeeee", null, clock))
-          }
-
-          test("returns UNHAPPY") {
-            expectThat(subject.getStatus(resource.id)).isEqualTo(UNHAPPY)
-          }
-        }
-
-        context("when last event is ResourceActuationVetoed because missing dependency") {
+        context("when last event is ResourceActuationVetoed due to a missing dependency") {
           before {
             repository.appendResourceHistory(ResourceActuationVetoed(resource, "vetoed", "RequiredBlahVeto", MISSING_DEPENDENCY, clock))
           }
@@ -222,7 +212,7 @@ class ResourceStatusServiceTests : JUnit5Minutests {
           }
         }
 
-        context("when last event is ResourceActuationVetoed because missing dependency, but an older version of keel saved this code") {
+        context("when last event is ResourceActuationVetoed because missing dependency, but an older version of keel saved this event") {
           before {
             repository.appendResourceHistory(ResourceActuationVetoed(resource, "Load balancer blah is not found in test / us-west-2", "RequiredBlahVeto", null, clock))
           }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredLoadBalancerVeto.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredLoadBalancerVeto.kt
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.AmazonLoadBalancer
 import com.netflix.spinnaker.keel.clouddriver.model.ApplicationLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.ClassicLoadBalancerModel
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.MISSING_DEPENDENCY
 import com.netflix.spinnaker.keel.veto.Veto
 import com.netflix.spinnaker.keel.veto.VetoResponse
 import kotlinx.coroutines.Dispatchers.IO
@@ -17,10 +18,6 @@ import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
-/**
- * Note: when resources are vetoed by this veto the [ResourceStatusService] infers the
- * correct status by string matching the name of the veto.
- */
 @Component
 class RequiredLoadBalancerVeto(
   private val cloudDriver: CloudDriverService,
@@ -45,7 +42,8 @@ class RequiredLoadBalancerVeto(
     } else {
       deniedResponse(
         message = missingLoadBalancers.joinToString(separator = "\n", transform = MissingDependency::message),
-        vetoArtifact = false
+        vetoArtifact = false,
+        suggestedStatus = MISSING_DEPENDENCY
       )
     }
   }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredLoadBalancerVeto.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredLoadBalancerVeto.kt
@@ -17,6 +17,10 @@ import kotlinx.coroutines.withContext
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
+/**
+ * Note: when resources are vetoed by this veto the [ResourceStatusService] infers the
+ * correct status by string matching the name of the veto.
+ */
 @Component
 class RequiredLoadBalancerVeto(
   private val cloudDriver: CloudDriverService,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
@@ -11,8 +11,8 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.MISSING_DEPENDENCY
 import com.netflix.spinnaker.keel.veto.Veto
-import com.netflix.spinnaker.keel.veto.VetoResponse
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -20,10 +20,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import retrofit2.HttpException
 
-/**
- * Note: when resources are vetoed by this veto the [ResourceStatusService] infers the
- * correct status by string matching the name of the veto.
- */
 @Component
 class RequiredSecurityGroupVeto(
   private val cloudDriver: CloudDriverService,
@@ -35,14 +31,18 @@ class RequiredSecurityGroupVeto(
     resource.spec.toSecurityGroupDependencies()
       ?.let {
         val missingSecurityGroupRegions = checkSecurityGroups(it)
-        VetoResponse(
-          allowed = missingSecurityGroupRegions.isEmpty(),
-          vetoName = name(),
-          message = missingSecurityGroupRegions.entries.joinToString(separator = "\n") { (securityGroup, missingRegions) ->
-            "Security group $securityGroup is not found in ${missingRegions.joinToString()}"
-          }
-        )
-      } ?: VetoResponse(true, name())
+        if (missingSecurityGroupRegions.isNotEmpty()) {
+          deniedResponse(
+            message = missingSecurityGroupRegions.entries.joinToString(separator = "\n") { (securityGroup, missingRegions) ->
+              "Security group $securityGroup is not found in ${missingRegions.joinToString()}"
+            },
+            suggestedStatus = MISSING_DEPENDENCY,
+            vetoArtifact = false
+          )
+        } else {
+          allowedResponse()
+        }
+      } ?: allowedResponse()
 
   private suspend fun checkSecurityGroups(spec: SecurityGroupDependencies): Map<String, List<String>> {
     val jobs = mutableListOf<Job>()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
@@ -20,6 +20,10 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import retrofit2.HttpException
 
+/**
+ * Note: when resources are vetoed by this veto the [ResourceStatusService] infers the
+ * correct status by string matching the name of the veto.
+ */
 @Component
 class RequiredSecurityGroupVeto(
   private val cloudDriver: CloudDriverService,


### PR DESCRIPTION
I was investigating https://github.com/spinnaker/keel/issues/1126 (which I can't reproduce locally). I found it frustrating that we weren't persisting veto events for flapping resources, so i updated our code to add that event and then determine whether a resource is unhappy by either the fact that it's vetoed or that it has been flapping.

This means that a resource that is vetoed because it's flapping or because it doesn't have the required resources (sec group or lb) will have a history event that says vetoed and a status of `unhappy`. @erikmunson and I thought that `unhappy` was clearer to users than `vetoed`.

Thoughts?

UPDATE:
added a `MISSING_DEPENDENCY` status to be specific for the missing load balancer and missing sg stuff. 
 