### PR TITLE
fix(events): Simplify resource event history

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -238,11 +238,10 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
           }
 
           test("the event is not included in the resource history") {
-            expectThat(subject.eventHistory(resource.id))
-              .and {
-                first().isA<ResourceValid>()
-                second().not().isA<ResourceValid>()
-              }
+            expectThat(subject.eventHistory(resource.id)) {
+              first().isA<ResourceValid>()
+              second().not().isA<ResourceValid>()
+            }
           }
         }
 
@@ -255,11 +254,10 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
           }
 
           test("the events are included in the resource history") {
-            expectThat(subject.eventHistory(resource.id))
-              .and {
-                first().isA<ApplicationActuationResumed>()
-                second().isA<ApplicationActuationPaused>()
-              }
+            expectThat(subject.eventHistory(resource.id)) {
+              first().isA<ApplicationActuationResumed>()
+              second().isA<ApplicationActuationPaused>()
+            }
           }
         }
 
@@ -276,13 +274,12 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
           }
 
           test("the event is included in the resource history") {
-            expectThat(subject.eventHistory(resource.id))
-              .and {
-                first().isA<ResourceValid>()
-                second().isA<ApplicationActuationResumed>()
-                third().isA<ApplicationActuationPaused>()
-                fourth().isA<ResourceValid>()
-              }
+            expectThat(subject.eventHistory(resource.id)) {
+              first().isA<ResourceValid>()
+              second().isA<ApplicationActuationResumed>()
+              third().isA<ApplicationActuationPaused>()
+              fourth().isA<ResourceValid>()
+            }
           }
         }
       }
@@ -363,7 +360,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         }
 
         test("event history includes relevant application events") {
-          expectThat(subject.eventHistory(resource.id)).and {
+          expectThat(subject.eventHistory(resource.id)) {
             first().isA<ApplicationActuationResumed>()
             second().isA<ApplicationActuationPaused>()
           }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -17,7 +17,10 @@ package com.netflix.spinnaker.keel.persistence
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
+import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
@@ -69,6 +72,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
       application = "toast",
       serviceAccount = "keel@spinnaker"
     ),
+    val user: String = "keel@keel.io",
     val subject: T,
     val callback: (ResourceHeader) -> Unit = mockk(relaxed = true) // has to be relaxed due to https://github.com/mockk/mockk/issues/272
   )
@@ -177,70 +181,116 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         }
       }
 
-      context("updating the state of the resource") {
-        context("an event that should be persisted in history") {
+      context("updating the event history of the resource") {
+        context("appending a resource event") {
           before {
             tick()
-            // TODO: ensure persisting a map with actual data
-            subject.appendHistory(ResourceUpdated(resource, emptyMap(), clock))
+            subject.appendHistory(ResourceUpdated(resource, mapOf("delta" to "some-difference"), clock))
           }
 
-          test("the event is included in the history") {
+          test("the event is included in the resource history") {
             expectThat(subject.eventHistory(resource.id))
               .hasSize(2)
               .first()
               .isA<ResourceUpdated>()
+              .get { delta }.isEqualTo(mapOf("delta" to "some-difference"))
+          }
+        }
+
+        context("appending an identical resource event with duplicates allowed") {
+          before {
+            tick()
+            subject.appendHistory(ResourceUpdated(resource, emptyMap(), clock))
+            tick()
+            subject.appendHistory(ResourceUpdated(resource, emptyMap(), clock))
           }
 
-          context("updating the state again") {
-            before {
-              tick()
-              subject.appendHistory(ResourceValid(resource, clock))
-            }
-
-            test("the event is included in the history") {
-              expectThat(subject.eventHistory(resource.id))
-                .hasSize(3)
-                .first()
-                .isA<ResourceValid>()
-            }
-
-            context("a subsequent identical event that should be ignored") {
-              before {
-                tick()
-                subject.appendHistory(ResourceValid(resource, clock))
+          test("the event is included in the resource history") {
+            expectThat(subject.eventHistory(resource.id))
+              .hasSize(3)
+              .and {
+                first().isA<ResourceUpdated>()
+                second().isA<ResourceUpdated>()
               }
+          }
+        }
 
-              test("the event is not included in the history") {
-                expectThat(subject.eventHistory(resource.id))
-                  .and {
-                    first().isA<ResourceValid>()
-                    second().not().isA<ResourceValid>()
-                  }
-              }
-            }
+        context("appending a resource event with duplicates disallowed the first time") {
+          before {
+            tick()
+            subject.appendHistory(ResourceValid(resource, clock))
           }
 
-          context("a subsequent identical event") {
-            before {
-              tick()
-              subject.appendHistory(ResourceUpdated(resource, emptyMap(), clock))
-            }
+          test("the event is included in the resource history") {
+            expectThat(subject.eventHistory(resource.id))
+              .hasSize(2)
+              .first()
+              .isA<ResourceValid>()
+          }
+        }
 
-            test("the new state is included in the history") {
-              expectThat(subject.eventHistory(resource.id))
-                .hasSize(3)
-                .and {
-                  first().isA<ResourceUpdated>()
-                  second().isA<ResourceUpdated>()
-                }
-            }
+        context("appending an identical resource event with duplicates disallowed the second time") {
+          before {
+            tick()
+            subject.appendHistory(ResourceValid(resource, clock))
+            tick()
+            subject.appendHistory(ResourceValid(resource, clock))
+          }
+
+          test("the event is not included in the resource history") {
+            expectThat(subject.eventHistory(resource.id))
+              .and {
+                first().isA<ResourceValid>()
+                second().not().isA<ResourceValid>()
+              }
+          }
+        }
+
+        context("appending application events that affect resource history") {
+          before {
+            tick()
+            subject.appendHistory(ApplicationActuationPaused(resource.application, user, clock))
+            tick()
+            subject.appendHistory(ApplicationActuationResumed(resource.application, user, clock))
+          }
+
+          test("the events are included in the resource history") {
+            expectThat(subject.eventHistory(resource.id))
+              .and {
+                first().isA<ApplicationActuationResumed>()
+                second().isA<ApplicationActuationPaused>()
+              }
+          }
+        }
+
+        context("appending a resource event identical to the last resource event, but with a relevant application events in between") {
+          before {
+            tick()
+            subject.appendHistory(ResourceValid(resource, clock))
+            tick()
+            subject.appendHistory(ApplicationActuationPaused(resource.application, user, clock))
+            tick()
+            subject.appendHistory(ApplicationActuationResumed(resource.application, user, clock))
+            tick()
+            subject.appendHistory(ResourceValid(resource, clock))
+          }
+
+          test("the event is included in the resource history") {
+            expectThat(subject.eventHistory(resource.id))
+              .and {
+                first().isA<ResourceValid>()
+                second().isA<ApplicationActuationResumed>()
+                third().isA<ApplicationActuationPaused>()
+                fourth().isA<ResourceValid>()
+              }
           }
         }
       }
 
       context("deleting the resource") {
         before {
+          subject.appendHistory(ApplicationActuationPaused(resource.application, user, clock))
+          subject.appendHistory(ApplicationActuationResumed(resource.application, user, clock))
           subject.delete(resource.id)
         }
 
@@ -261,18 +311,27 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
             subject.eventHistory(resource.id)
           }
         }
+
+        test("events for the resource's parent application remain") {
+          expectThat(
+            subject.applicationEventHistory(resource.application)
+          ).hasSize(2)
+        }
       }
 
       context("fetching event history for the resource") {
         before {
           repeat(3) {
-            clock.incrementBy(TEN_MINUTES)
+            tick()
             subject.appendHistory(ResourceUpdated(resource, emptyMap(), clock))
             subject.appendHistory(ResourceDeltaDetected(resource, emptyMap(), clock))
             subject.appendHistory(ResourceActuationLaunched(resource, "whatever", emptyList(), clock))
             subject.appendHistory(ResourceDeltaResolved(resource, clock))
           }
-          clock.incrementBy(TEN_MINUTES)
+          tick()
+          subject.appendHistory(ApplicationActuationPaused(resource.application, user, clock))
+          tick()
+          subject.appendHistory(ApplicationActuationResumed(resource.application, user, clock))
         }
 
         test("default limit is 10 events") {
@@ -288,7 +347,7 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
 
         test("the limit can be higher than the default") {
           expectThat(subject.eventHistory(resource.id, limit = 20))
-            .hasSize(13)
+            .hasSize(15)
         }
 
         test("zero limit is not allowed") {
@@ -302,17 +361,23 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
             .isFailure()
             .isA<IllegalArgumentException>()
         }
+
+        test("event history includes relevant application events") {
+          expectThat(subject.eventHistory(resource.id)).and {
+            first().isA<ApplicationActuationResumed>()
+            second().isA<ApplicationActuationPaused>()
+          }
+        }
       }
     }
   }
 
   private fun tick() {
-    clock.incrementBy(ONE_SECOND)
+    clock.incrementBy(ONE_MINUTE)
   }
 
   companion object {
-    val ONE_SECOND: Duration = Duration.ofSeconds(1)
-    val TEN_MINUTES: Duration = Duration.ofMinutes(10)
+    val ONE_MINUTE: Duration = Duration.ofMinutes(1)
   }
 
   fun <T : Iterable<E>, E : ResourceEvent> Assertion.Builder<T>.areNoOlderThan(age: Period): Assertion.Builder<T> =
@@ -332,6 +397,12 @@ fun <T : Any> Assertion.Builder<T>.isNotIn(expected: Collection<T>) =
 
 fun <T : List<E>, E> Assertion.Builder<T>.second(): Assertion.Builder<E> =
   get("second element %s") { this[1] }
+
+fun <T : List<E>, E> Assertion.Builder<T>.third(): Assertion.Builder<E> =
+  get("third element %s") { this[2] }
+
+fun <T : List<E>, E> Assertion.Builder<T>.fourth(): Assertion.Builder<E> =
+  get("fourth element %s") { this[3] }
 
 fun randomString(length: Int = 8) =
   randomUUID()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -33,7 +33,7 @@ data class ApplicationActuationPaused(
   override val application: String,
   override val timestamp: Instant,
   override val triggeredBy: String?
-) : ApplicationEvent() {
+) : ApplicationEvent(), ResourceHistoryEvent {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
 
@@ -51,7 +51,7 @@ data class ApplicationActuationResumed(
   override val application: String,
   override val triggeredBy: String?,
   override val timestamp: Instant
-) : ApplicationEvent() {
+) : ApplicationEvent(), ResourceHistoryEvent {
   @JsonIgnore override val ignoreRepeatedInHistory = true
 
   constructor(application: String, triggeredBy: String, clock: Clock = Companion.clock) : this(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
@@ -13,8 +13,8 @@ import java.time.Instant
   include = JsonTypeInfo.As.PROPERTY
 )
 @JsonSubTypes(
-  JsonSubTypes.Type(value = ApplicationEvent::class, name = "application"),
-  JsonSubTypes.Type(value = ResourceEvent::class, name = "resource")
+  JsonSubTypes.Type(value = ApplicationEvent::class),
+  JsonSubTypes.Type(value = ResourceEvent::class)
 )
 abstract class PersistentEvent {
   abstract val scope: Scope
@@ -33,4 +33,25 @@ abstract class PersistentEvent {
     @JsonProperty("resource") RESOURCE,
     @JsonProperty("application") APPLICATION
   }
+}
+
+/**
+ * Common interface implemented by all [ResourceEvent]s and certain [ApplicationEvent]s that affect all the
+ * application's resources, such as pausing and resuming.
+ */
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  property = "type",
+  include = JsonTypeInfo.As.PROPERTY
+)
+@JsonSubTypes(
+  JsonSubTypes.Type(value = ResourceEvent::class),
+  JsonSubTypes.Type(value = ApplicationActuationPaused::class),
+  JsonSubTypes.Type(value = ApplicationActuationResumed::class)
+)
+interface ResourceHistoryEvent {
+  val scope: PersistentEvent.Scope
+  val uid: String // the resource ID or application name
+  val ignoreRepeatedInHistory: Boolean
+  val timestamp: Instant
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory
 abstract class ResourceEvent(
   open val message: String? = null,
   override val triggeredBy: String? = null
-) : PersistentEvent() {
+) : PersistentEvent(), ResourceHistoryEvent {
   override val scope = Scope.RESOURCE
   abstract val kind: ResourceKind
   abstract val id: String

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.core.api.normalize
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
@@ -333,7 +334,7 @@ class CombinedRepository(
   override fun allResources(callback: (ResourceHeader) -> Unit) =
     resourceRepository.allResources(callback)
 
-  override fun getResource(id: String): Resource<out ResourceSpec> =
+  override fun getResource(id: String): Resource<ResourceSpec> =
     resourceRepository.get(id)
 
   override fun hasManagedResources(application: String): Boolean =
@@ -357,10 +358,10 @@ class CombinedRepository(
   override fun applicationEventHistory(application: String, downTo: Instant): List<ApplicationEvent> =
     resourceRepository.applicationEventHistory(application, downTo)
 
-  override fun resourceEventHistory(id: String, limit: Int): List<ResourceEvent> =
+  override fun resourceEventHistory(id: String, limit: Int): List<ResourceHistoryEvent> =
     resourceRepository.eventHistory(id, limit)
 
-  override fun resourceLastEvent(id: String): ResourceEvent? =
+  override fun lastResourceHistoryEvent(id: String): ResourceHistoryEvent? =
     resourceRepository.lastEvent(id)
 
   override fun appendResourceHistory(event: ResourceEvent) =
@@ -369,7 +370,7 @@ class CombinedRepository(
   override fun appendApplicationHistory(event: ApplicationEvent) =
     resourceRepository.appendHistory(event)
 
-  override fun resourcesDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<out ResourceSpec>> =
+  override fun resourcesDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<ResourceSpec>> =
     resourceRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
 
   override fun artifactsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact> =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -21,7 +21,9 @@ import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
 import com.netflix.spinnaker.keel.events.ResourceUpdated
+import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -127,7 +129,7 @@ interface KeelRepository {
   // START ResourceRepository methods
   fun allResources(callback: (ResourceHeader) -> Unit)
 
-  fun getResource(id: String): Resource<out ResourceSpec>
+  fun getResource(id: String): Resource<ResourceSpec>
 
   fun hasManagedResources(application: String): Boolean
 
@@ -139,19 +141,19 @@ interface KeelRepository {
 
   fun deleteResource(id: String)
 
-  fun applicationEventHistory(application: String, limit: Int): List<ApplicationEvent>
+  fun applicationEventHistory(application: String, limit: Int = DEFAULT_MAX_EVENTS): List<ApplicationEvent>
 
   fun applicationEventHistory(application: String, downTo: Instant): List<ApplicationEvent>
 
-  fun resourceEventHistory(id: String, limit: Int): List<ResourceEvent>
+  fun resourceEventHistory(id: String, limit: Int = DEFAULT_MAX_EVENTS): List<ResourceHistoryEvent>
 
-  fun resourceLastEvent(id: String): ResourceEvent?
+  fun lastResourceHistoryEvent(id: String): ResourceHistoryEvent?
 
   fun appendResourceHistory(event: ResourceEvent)
 
   fun appendApplicationHistory(event: ApplicationEvent)
 
-  fun resourcesDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<out ResourceSpec>>
+  fun resourcesDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<ResourceSpec>>
 
   fun artifactsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact>
   // END ResourceRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -93,12 +94,12 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
   fun applicationEventHistory(application: String, after: Instant): List<ApplicationEvent>
 
   /**
-   * Retrieves the history of state change events for the resource represented by [uid].
+   * Retrieves the history of state change events for the resource represented by [id].
    *
    * @param id the resource id.
    * @param limit the maximum number of events to return.
    */
-  fun eventHistory(id: String, limit: Int = DEFAULT_MAX_EVENTS): List<ResourceEvent>
+  fun eventHistory(id: String, limit: Int = DEFAULT_MAX_EVENTS): List<ResourceHistoryEvent>
 
   /**
    * Retrieves the last event from the history of state change events for the resource represented by [id] or null if
@@ -106,7 +107,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<out Resour
    *
    * @param id the resource id.
    */
-  fun lastEvent(id: String): ResourceEvent? = eventHistory(id, 1).firstOrNull()
+  fun lastEvent(id: String): ResourceHistoryEvent? = eventHistory(id, 1).firstOrNull()
 
   /**
    * Records an event associated with a resource.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -46,7 +46,7 @@ import org.springframework.stereotype.Component
 @Component
 class ApplicationService(
   private val repository: KeelRepository,
-  private val resourceHistoryService: ResourceHistoryService,
+  private val resourceStatusService: ResourceStatusService,
   constraintEvaluators: List<ConstraintEvaluator<*>>
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -126,7 +126,7 @@ class ApplicationService(
   fun getResourceSummariesFor(application: String): List<ResourceSummary> {
     return try {
       val deliveryConfig = repository.getDeliveryConfigForApplication(application)
-      resourceHistoryService.getResourceSummariesFor(deliveryConfig)
+      resourceStatusService.getResourceSummariesFor(deliveryConfig)
     } catch (e: NoSuchDeliveryConfigException) {
       emptyList()
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -3,11 +3,17 @@ package com.netflix.spinnaker.keel.services
 import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Locatable
+import com.netflix.spinnaker.keel.api.Monikered
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.StatefulConstraint
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.deb
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType.docker
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintEvaluator
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.constraints.ConstraintStatus
@@ -28,6 +34,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.GitMetadata
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
+import com.netflix.spinnaker.keel.core.api.ResourceArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.core.api.StatefulConstraintSummary
 import com.netflix.spinnaker.keel.core.api.StatelessConstraintSummary
@@ -126,11 +133,37 @@ class ApplicationService(
   fun getResourceSummariesFor(application: String): List<ResourceSummary> {
     return try {
       val deliveryConfig = repository.getDeliveryConfigForApplication(application)
-      resourceStatusService.getResourceSummariesFor(deliveryConfig)
+      return deliveryConfig.resources.map { resource ->
+        resource.toResourceSummary(deliveryConfig)
+      }
     } catch (e: NoSuchDeliveryConfigException) {
       emptyList()
     }
   }
+
+  private fun Resource<*>.toResourceSummary(deliveryConfig: DeliveryConfig) =
+    ResourceSummary(
+      resource = this,
+      status = resourceStatusService.getStatus(id),
+      moniker = if (spec is Monikered) {
+        (spec as Monikered).moniker
+      } else {
+        null
+      },
+      locations = if (spec is Locatable<*>) {
+        SimpleLocations(
+          account = (spec as Locatable<*>).locations.account,
+          vpc = (spec as Locatable<*>).locations.vpc,
+          regions = (spec as Locatable<*>).locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
+        )
+      } else {
+        null
+      },
+      artifact = findAssociatedArtifact(deliveryConfig)
+        ?.let {
+          ResourceArtifactSummary(it.name, it.type, it.reference)
+        }
+    )
 
   /**
    * Returns a list of [EnvironmentSummary] for the specific application.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryService.kt
@@ -10,11 +10,8 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.ResourceArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ResourceSummary
-import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
-import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
-import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
 import com.netflix.spinnaker.keel.events.ResourceCheckError
@@ -22,13 +19,13 @@ import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
+import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
 import com.netflix.spinnaker.keel.events.ResourceMissing
 import com.netflix.spinnaker.keel.events.ResourceTaskFailed
 import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
-import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
@@ -48,21 +45,9 @@ import org.springframework.stereotype.Component
  */
 @Component
 class ResourceHistoryService(
-  private val repository: KeelRepository,
+  private val resourceRepository: ResourceRepository,
   private val actuationPauser: ActuationPauser
 ) {
-
-  /**
-   * Returns the history of events associated with the specified resource from the database, plus any applicable
-   * application-level pause/resume events.
-   */
-  fun getEnrichedEventHistory(id: String, limit: Int = DEFAULT_MAX_EVENTS): List<PersistentEvent> {
-    val resource = repository.getResource(id)
-    return repository.resourceEventHistory(id, limit)
-      .let { events ->
-        actuationPauser.addApplicationActuationEvents(events, resource)
-      }
-  }
 
   /**
    * Returns the status of the specified resource by first checking whether or not it or the parent application are
@@ -77,7 +62,7 @@ class ResourceHistoryService(
       return PAUSED
     }
 
-    val history = getEnrichedEventHistory(id, 10)
+    val history = resourceRepository.eventHistory(id, 10)
     return when {
       history.isHappy() -> HAPPY
       history.isUnhappy() -> UNHAPPY
@@ -92,53 +77,44 @@ class ResourceHistoryService(
     }
   }
 
-  private fun List<PersistentEvent>.isHappy(): Boolean {
+  private fun List<ResourceHistoryEvent>.isHappy(): Boolean {
     return first() is ResourceValid || first() is ResourceDeltaResolved
   }
 
-  private fun List<PersistentEvent>.isActuating(): Boolean {
+  private fun List<ResourceHistoryEvent>.isActuating(): Boolean {
     return first() is ResourceActuationLaunched || first() is ResourceTaskSucceeded ||
       // we might want to move ResourceTaskFailed to isError later on
       first() is ResourceTaskFailed
   }
 
-  private fun List<PersistentEvent>.isError(): Boolean {
+  private fun List<ResourceHistoryEvent>.isError(): Boolean {
     return first() is ResourceCheckError
   }
 
-  private fun List<PersistentEvent>.isCreated(): Boolean {
+  private fun List<ResourceHistoryEvent>.isCreated(): Boolean {
     return first() is ResourceCreated
   }
 
-  private fun List<PersistentEvent>.isDiff(): Boolean {
+  private fun List<ResourceHistoryEvent>.isDiff(): Boolean {
     return first() is ResourceDeltaDetected || first() is ResourceMissing
   }
 
-  private fun List<PersistentEvent>.isPaused(): Boolean {
-    val appPaused = firstOrNull { it is ApplicationActuationPaused }?.timestamp
-    val appResumed = firstOrNull { it is ApplicationActuationResumed }?.timestamp
-
-    return first() is ResourceActuationPaused ||
-      // If the app was paused and has not yet resumed
-      (appPaused != null && (appResumed == null || appResumed.isBefore(appPaused)))
-  }
-
-  private fun List<PersistentEvent>.isVetoed(): Boolean {
+  private fun List<ResourceHistoryEvent>.isVetoed(): Boolean {
     return first() is ResourceActuationVetoed
   }
 
-  private fun List<PersistentEvent>.isResumed(): Boolean {
+  private fun List<ResourceHistoryEvent>.isResumed(): Boolean {
     return first() is ResourceActuationResumed || first() is ApplicationActuationResumed
   }
 
-  private fun List<PersistentEvent>.isCurrentlyUnresolvable(): Boolean {
+  private fun List<ResourceHistoryEvent>.isCurrentlyUnresolvable(): Boolean {
     return first() is ResourceCheckUnresolvable
   }
 
   /**
    * Checks last 10 events for flapping between only ResourceActuationLaunched and ResourceDeltaDetected
    */
-  private fun List<PersistentEvent>.isUnhappy(): Boolean {
+  private fun List<ResourceHistoryEvent>.isUnhappy(): Boolean {
     val recentSliceOfHistory = this.subList(0, Math.min(10, this.size))
     val filteredHistory = recentSliceOfHistory.filter { it is ResourceDeltaDetected || it is ResourceActuationLaunched }
     if (filteredHistory.size != recentSliceOfHistory.size) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
@@ -1,15 +1,6 @@
 package com.netflix.spinnaker.keel.services
 
-import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.api.Locatable
-import com.netflix.spinnaker.keel.api.Monikered
-import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.SimpleLocations
-import com.netflix.spinnaker.keel.api.SimpleRegionSpec
-import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.core.api.ResourceArtifactSummary
-import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
@@ -123,38 +114,4 @@ class ResourceStatusService(
     }
     return true
   }
-
-  /**
-   * Returns a list of [ResourceSummary] for the specified application.
-   */
-  fun getResourceSummariesFor(deliveryConfig: DeliveryConfig): List<ResourceSummary> {
-    return deliveryConfig.resources.map { resource ->
-      resource.toResourceSummary(deliveryConfig)
-    }
-  }
-
-  private fun Resource<*>.toResourceSummary(deliveryConfig: DeliveryConfig) =
-    ResourceSummary(
-      resource = this,
-      status = getStatus(id),
-      moniker = if (spec is Monikered) {
-        (spec as Monikered).moniker
-      } else {
-        null
-      },
-      locations = if (spec is Locatable<*>) {
-        SimpleLocations(
-          account = (spec as Locatable<*>).locations.account,
-          vpc = (spec as Locatable<*>).locations.vpc,
-          regions = (spec as Locatable<*>).locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
-        )
-      } else {
-        null
-      },
-      artifact = deliveryConfig.let {
-        findAssociatedArtifact(it)?.toResourceArtifactSummary()
-      }
-    )
-
-  private fun DeliveryArtifact.toResourceArtifactSummary() = ResourceArtifactSummary(name, type, reference)
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
@@ -44,7 +44,7 @@ import org.springframework.stereotype.Component
  * Service object that offers high-level APIs around resource (event) history and status.
  */
 @Component
-class ResourceHistoryService(
+class ResourceStatusService(
   private val resourceRepository: ResourceRepository,
   private val actuationPauser: ActuationPauser
 ) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -33,7 +33,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
 import com.netflix.spinnaker.keel.persistence.memory.InMemoryPausedRepository
-import com.netflix.spinnaker.keel.services.ResourceHistoryService
+import com.netflix.spinnaker.keel.services.ResourceStatusService
 import com.netflix.spinnaker.keel.test.combinedInMemoryRepository
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.time.MutableClock
@@ -50,7 +50,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val repository = combinedInMemoryRepository(clock)
     val pausedRepository = InMemoryPausedRepository()
     val actuationPauser = ActuationPauser(repository.resourceRepository, pausedRepository, repository.publisher, clock)
-    val resourceHistoryService = ResourceHistoryService(repository.resourceRepository, actuationPauser)
+    val resourceHistoryService = ResourceStatusService(repository.resourceRepository, actuationPauser)
     val resource = resource()
     val createdEvent = ResourceCreated(resource)
     val missingEvent = ResourceMissing(resource)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/events/ResourceStatusTests.kt
@@ -50,7 +50,7 @@ internal class ResourceStatusTests : JUnit5Minutests {
     val repository = combinedInMemoryRepository(clock)
     val pausedRepository = InMemoryPausedRepository()
     val actuationPauser = ActuationPauser(repository.resourceRepository, pausedRepository, repository.publisher, clock)
-    val resourceHistoryService = ResourceHistoryService(repository, actuationPauser)
+    val resourceHistoryService = ResourceHistoryService(repository.resourceRepository, actuationPauser)
     val resource = resource()
     val createdEvent = ResourceCreated(resource)
     val missingEvent = ResourceMissing(resource)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.SKIPPED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.test.artifactReferenceResource
 import com.netflix.spinnaker.keel.test.versionedArtifactResource
 import com.netflix.spinnaker.time.MutableClock
@@ -484,6 +485,22 @@ class ApplicationServiceTests : JUnit5Minutests {
             }
           }
         }
+      }
+    }
+
+    context("resource summaries by application") {
+      before {
+        every { resourceStatusService.getStatus(any()) } returns CREATED
+      }
+
+      test("includes all resources within the delivery config") {
+        val summaries = applicationService.getResourceSummariesFor(application)
+        expectThat(summaries.size).isEqualTo(deliveryConfig.resources.size)
+      }
+
+      test("sets the resource status as returned by ResourceStatusService") {
+        val summaries = applicationService.getResourceSummariesFor(application)
+        expectThat(summaries.map { it.status }.all { it == CREATED }).isTrue()
       }
     }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -54,7 +54,7 @@ class ApplicationServiceTests : JUnit5Minutests {
       ZoneId.of("UTC")
     )
     val repository: KeelRepository = mockk()
-    val resourceHistoryService: ResourceHistoryService = mockk()
+    val resourceStatusService: ResourceStatusService = mockk()
 
     val application = "fnord"
     val artifact = DebianArtifact(
@@ -113,7 +113,7 @@ class ApplicationServiceTests : JUnit5Minutests {
     }
 
     // subject
-    val applicationService = ApplicationService(repository, resourceHistoryService, listOf(dependsOnEvaluator))
+    val applicationService = ApplicationService(repository, resourceStatusService, listOf(dependsOnEvaluator))
   }
 
   fun applicationServiceTests() = rootContext<Fixture> {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceHistoryServiceTests.kt
@@ -2,42 +2,56 @@ package com.netflix.spinnaker.keel.services
 
 import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
+import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.PersistentEvent
-import com.netflix.spinnaker.keel.events.ResourceActuationPaused
+import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
+import com.netflix.spinnaker.keel.events.ResourceActuationResumed
+import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
+import com.netflix.spinnaker.keel.events.ResourceCheckError
+import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCreated
+import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
+import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
 import com.netflix.spinnaker.keel.events.ResourceEvent
+import com.netflix.spinnaker.keel.events.ResourceMissing
+import com.netflix.spinnaker.keel.events.ResourceTaskFailed
+import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.CURRENTLY_UNRESOLVABLE
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.PAUSED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.RESUMED
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.UNHAPPY
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.VETOED
 import com.netflix.spinnaker.keel.test.combinedInMemoryRepository
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.slot
-import java.time.Duration
 import strikt.api.expect
 import strikt.api.expectThat
-import strikt.assertions.containsExactly
-import strikt.assertions.isA
 import strikt.assertions.isEqualTo
-import strikt.assertions.map
 
 class ResourceHistoryServiceTests : JUnit5Minutests {
   companion object Fixture {
     val clock = MutableClock()
     val repository = combinedInMemoryRepository(clock)
     val actuationPauser = ActuationPauser(repository.resourceRepository, repository.pausedRepository, repository.publisher, clock)
-    val resourceHistoryService = ResourceHistoryService(repository, actuationPauser)
+    val subject = ResourceHistoryService(repository.resourceRepository, actuationPauser)
     val resource = resource()
     val deliveryConfig = deliveryConfig(resource)
     val user = "keel@keel.io"
-    val TEN_MINUTES: Duration = Duration.ofMinutes(10)
   }
 
   fun tests() = rootContext<Fixture> {
@@ -70,124 +84,176 @@ class ResourceHistoryServiceTests : JUnit5Minutests {
       }
 
       test("can get resource summary by delivery config") {
-        val summaries = resourceHistoryService.getResourceSummariesFor(deliveryConfig)
+        val summaries = subject.getResourceSummariesFor(deliveryConfig)
 
         expect {
           that(summaries.size).isEqualTo(1)
           that(summaries.map { it.status }.filter { it == CREATED }.size).isEqualTo(1)
         }
       }
-    }
 
-    context("enriched resource event history") {
-      context("with application paused at various times after resource creation") {
-        before {
-          repository.storeResource(resource)
-          repository.appendResourceHistory(ResourceCreated(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          repository.appendResourceHistory(ResourceValid(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application, user)
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.resumeApplication(resource.application, user)
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseApplication(resource.application, user)
+      context("resource status") {
+        context("when resource is paused") {
+          before {
+            actuationPauser.pauseResource(resource.id, user)
+          }
+
+          test("returns PAUSED") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(PAUSED)
+          }
         }
 
-        test("has application paused and resumed events injected in the right positions") {
-          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
-          expectThat(events)
-            .map { it.javaClass }
-            .containsExactly(
-              ApplicationActuationPaused::class.java,
-              ApplicationActuationResumed::class.java,
-              ApplicationActuationPaused::class.java,
-              ResourceValid::class.java,
-              ResourceCreated::class.java
-            )
-        }
-      }
+        context("when resource's parent application is paused") {
+          before {
+            actuationPauser.pauseApplication(resource.application, user)
+          }
 
-      context("with a new resource created after the application is paused") {
-        before {
-          actuationPauser.pauseApplication(resource.application, user)
-          clock.incrementBy(TEN_MINUTES)
-          repository.storeResource(resource)
-          repository.appendResourceHistory(ResourceCreated(resource, clock))
+          test("returns PAUSED") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(PAUSED)
+          }
         }
 
-        test("has application paused event injected before resource creation") {
-          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
-          expectThat(events)
-            .map { it.javaClass }
-            .containsExactly(
-              ResourceCreated::class.java,
-              ApplicationActuationPaused::class.java
-            )
+        context("when last event is ResourceCreated") {
+          before {
+            repository.appendResourceHistory(ResourceCreated(resource, clock))
+          }
+
+          test("returns CREATED") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(CREATED)
+          }
         }
 
-        test("paused event specifies who paused the application") {
-          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
-          expectThat(events.last())
-            .isA<ApplicationActuationPaused>()
-            .get { triggeredBy }
-            .isEqualTo(user)
-        }
-      }
+        context("when last event is ResourceValid") {
+          before {
+            repository.appendResourceHistory(ResourceValid(resource, clock))
+          }
 
-      context("with previous event history wiped and a new resource created after the application is paused") {
-        before {
-          repository.storeResource(resource)
-          repository.appendResourceHistory(ResourceCreated(resource, clock))
-          repository.deleteResource(resource.id)
-          actuationPauser.pauseApplication(resource.application, user)
-          clock.incrementBy(TEN_MINUTES)
-          repository.resourceRepository.clearResourceEvents(resource.id)
-          repository.resourceRepository.clearApplicationEvents(resource.application)
-          repository.storeResource(resource)
-          repository.appendResourceHistory(ResourceCreated(resource, clock))
+          test("returns HAPPY") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(HAPPY)
+          }
         }
 
-        test("still has application paused event injected before resource creation") {
-          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
-          expectThat(events)
-            .map { it.javaClass }
-            .containsExactly(
-              ResourceCreated::class.java,
-              ApplicationActuationPaused::class.java
-            )
-        }
-      }
+        context("when last event is ResourceDeltaResolved") {
+          before {
+            repository.appendResourceHistory(ResourceDeltaResolved(resource, clock))
+          }
 
-      context("with a resource recreated after being paused and deleted") {
-        before {
-          repository.storeResource(resource)
-          repository.appendResourceHistory(ResourceCreated(resource, clock))
-          clock.incrementBy(TEN_MINUTES)
-          actuationPauser.pauseResource(resource.id, user)
-          clock.incrementBy(TEN_MINUTES)
-          repository.deleteResource(resource.id)
-          clock.incrementBy(TEN_MINUTES)
-          repository.storeResource(resource)
-          repository.appendResourceHistory(ResourceCreated(resource, clock))
+          test("returns HAPPY") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(HAPPY)
+          }
         }
 
-        test("has resource paused event injected before resource creation") {
-          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
-          expectThat(events)
-            .map { it.javaClass }
-            .containsExactly(
-              ResourceCreated::class.java,
-              ResourceActuationPaused::class.java
-            )
+        context("when last event is ResourceActuationLaunched") {
+          before {
+            repository.appendResourceHistory(ResourceActuationLaunched(resource, "plugin", emptyList(), clock))
+          }
+
+          test("returns ACTUATING") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(ACTUATING)
+          }
         }
 
-        test("paused event specifies who paused the resource") {
-          val events = resourceHistoryService.getEnrichedEventHistory(resource.id)
-          expectThat(events.last())
-            .isA<ResourceActuationPaused>()
-            .get { triggeredBy }
-            .isEqualTo(user)
+        context("when last event is ResourceTaskSucceeded") {
+          before {
+            repository.appendResourceHistory(ResourceTaskSucceeded(resource, emptyList(), clock))
+          }
+
+          test("returns HAPPY") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(ACTUATING)
+          }
+        }
+
+        context("when last event is ResourceTaskFailed") {
+          before {
+            repository.appendResourceHistory(ResourceTaskFailed(resource, "plugin", emptyList(), clock))
+          }
+
+          test("returns ACTUATING") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(ACTUATING)
+          }
+        }
+
+        context("when last event is ResourceCheckError") {
+          before {
+            repository.appendResourceHistory(ResourceCheckError(resource, object : SpinnakerException() {}, clock))
+          }
+
+          test("returns ERROR") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(ERROR)
+          }
+        }
+
+        context("when last event is ResourceDeltaDetected") {
+          before {
+            repository.appendResourceHistory(ResourceDeltaDetected(resource, emptyMap(), clock))
+          }
+
+          test("returns DIFF") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(DIFF)
+          }
+        }
+
+        context("when last event is ResourceMissing") {
+          before {
+            repository.appendResourceHistory(ResourceMissing(resource, clock))
+          }
+
+          test("returns DIFF") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(DIFF)
+          }
+        }
+
+        context("when last event is ResourceActuationVetoed") {
+          before {
+            repository.appendResourceHistory(ResourceActuationVetoed(resource, "vetoed", clock))
+          }
+
+          test("returns VETOED") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(VETOED)
+          }
+        }
+
+        context("when last event is ResourceActuationResumed") {
+          before {
+            repository.appendResourceHistory(ResourceActuationResumed(resource, user, clock))
+          }
+
+          test("returns RESUMED") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(RESUMED)
+          }
+        }
+
+        context("when last event is ApplicationActuationResumed") {
+          before {
+            repository.appendApplicationHistory(ApplicationActuationResumed(resource.application, user, clock))
+          }
+
+          test("returns RESUMED") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(RESUMED)
+          }
+        }
+
+        context("when last event is ResourceCheckUnresolvable") {
+          before {
+            repository.appendResourceHistory(ResourceCheckUnresolvable(resource, object : ResourceCurrentlyUnresolvable("") {}, clock))
+          }
+
+          test("returns CURRENTLY_UNRESOLVABLE") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(CURRENTLY_UNRESOLVABLE)
+          }
+        }
+
+        context("when last several events alternate between ResourceDeltaDetected and ResourceActuationLaunched") {
+          before {
+            (1..5).forEach { _ ->
+              repository.appendResourceHistory(ResourceDeltaDetected(resource, emptyMap(), clock))
+              repository.appendResourceHistory(ResourceActuationLaunched(resource, "plugin", emptyList(), clock))
+            }
+          }
+
+          test("returns UNHAPPY") {
+            expectThat(subject.getStatus(resource.id)).isEqualTo(UNHAPPY)
+          }
         }
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
@@ -43,12 +43,12 @@ import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
-class ResourceHistoryServiceTests : JUnit5Minutests {
+class ResourceStatusServiceTests : JUnit5Minutests {
   companion object Fixture {
     val clock = MutableClock()
     val repository = combinedInMemoryRepository(clock)
     val actuationPauser = ActuationPauser(repository.resourceRepository, repository.pausedRepository, repository.publisher, clock)
-    val subject = ResourceHistoryService(repository.resourceRepository, actuationPauser)
+    val subject = ResourceStatusService(repository.resourceRepository, actuationPauser)
     val resource = resource()
     val deliveryConfig = deliveryConfig(resource)
     val user = "keel@keel.io"

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
@@ -39,7 +39,6 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.slot
-import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 
@@ -81,15 +80,6 @@ class ResourceStatusServiceTests : JUnit5Minutests {
       before {
         repository.upsertDeliveryConfig(deliveryConfig)
         repository.appendResourceHistory(ResourceCreated(resource, clock))
-      }
-
-      test("can get resource summary by delivery config") {
-        val summaries = subject.getResourceSummariesFor(deliveryConfig)
-
-        expect {
-          that(summaries.size).isEqualTo(1)
-          that(summaries.map { it.status }.filter { it == CREATED }.size).isEqualTo(1)
-        }
       }
 
       context("resource status") {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/EventController.kt
@@ -1,8 +1,8 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.netflix.spinnaker.keel.events.PersistentEvent
+import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
+import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
-import com.netflix.spinnaker.keel.services.ResourceHistoryService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/resources/events"])
 class EventController(
-  private val resourceHistoryService: ResourceHistoryService
+  private val resourceRepository: ResourceRepository
 ) {
   private val log by lazy { getLogger(javaClass) }
 
@@ -31,8 +31,8 @@ class EventController(
   fun eventHistory(
     @PathVariable("id") id: String,
     @RequestParam("limit") limit: Int?
-  ): List<PersistentEvent> {
+  ): List<ResourceHistoryEvent> {
     log.debug("Getting state history for: $id")
-    return resourceHistoryService.getEnrichedEventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
+    return resourceRepository.eventHistory(id, limit ?: DEFAULT_MAX_EVENTS)
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ResourceController.kt
@@ -22,7 +22,7 @@ import com.netflix.spinnaker.keel.diff.DiffResult
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
-import com.netflix.spinnaker.keel.services.ResourceHistoryService
+import com.netflix.spinnaker.keel.services.ResourceStatusService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -43,7 +43,7 @@ class ResourceController(
   private val repository: KeelRepository,
   private val actuationPauser: ActuationPauser,
   private val adHocDiffer: AdHocDiffer,
-  private val resourceHistoryService: ResourceHistoryService
+  private val resourceStatusService: ResourceStatusService
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -68,7 +68,7 @@ class ResourceController(
     and @authorizationSupport.hasCloudAccountPermission('READ', 'RESOURCE', #id)"""
   )
   fun getStatus(@PathVariable("id") id: String): ResourceStatus =
-    resourceHistoryService.getStatus(id)
+    resourceStatusService.getStatus(id)
 
   @PostMapping(
     path = ["/{id}/pause"],


### PR DESCRIPTION
Attempt to fix an issue identified recently where resources got stuck in RESUMED status, and hopefully prevent future pitfalls around resource events/status.

The cause of this particular problem was that we look at the event history to determine status, and, in this case, there were `ApplicationActuationResumed` events appearing last in the event history for those resources. (We also noticed the application paused/resumed events were not displayed on the UI, making the experience even more confusing, but that’s a separate issue).

Upon investigation, we discovered that keel behaved as expected after an application is resumed and proceeded to check the resources and emitted `ResourceValid` events. The problem was that these events have the `ignoreRepeatedInHistory` flag set to `true`, which causes them not to be persisted in the database if the last resource event is of the same type (which it was). In other words, we were ignoring those application-level events when checking for duplicates in the resource event history, and so a new `ResourceValid` event was never written to the DB.

This PR introduces the following changes to simplify the handling and interaction between resource events and application events that affect resource status, without going into a full-blown refactoring of this area of the system:
- Accept and embrace the fact that we have a single table in the database for all events and modify SQL queries around events so that we include _both_ resource events _and_ those application events that affect resource status. This allowed me to remove all the hacky event injection stuff (with certain assumptions, see below).
- To clearly indicate what events belong in the resource history, introduce a new `ResourceHistoryEvent` interface, which is implemented by all resource events, and only those application events that affect resource status (currently `ApplicationActuationPaused` and `ApplicationActuationResumed`).
- Change functions in related repository interfaces to use the new `ResourceHistoryEvent` type above.
- Refactored tests around resource event history in attempt to make them easier to read and understand.

Assumptions:
- When a resource is paused, and then deleted, the expectation is that the resource stops being managed, and so the pause record for that resource should also be deleted from the database. If the resource is later resubmitted, keel will start managing it.
- When an application is paused, and an associated delivery config is deleted, we cannot make the same assumption about an application pause record because, although we currently have a 1:1 mapping between applications and delivery configs, the UX does not expose the concept of delivery configs, only applications, and the user never explicitly unpaused the application, so we leave it alone.
- Similarly, resource events are deleted when a resource is deleted, but application events are not when a delivery config is deleted.

I hope these are reasonable assumptions and this PR provides an acceptable short-term compromise until we can redesign this further.

@erikmunson Tagging you to review the assumptions above.