### PR TITLE
fix(configAuthz): not relying on delivery config name for authorization

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -100,8 +100,7 @@ class AuthorizationSupport(
     withAuthentication(target, identifier) { auth ->
       val application = when (target) {
         RESOURCE -> repository.getResource(identifier).application
-        APPLICATION -> identifier
-        DELIVERY_CONFIG -> repository.getDeliveryConfig(identifier).application
+        APPLICATION, DELIVERY_CONFIG -> identifier
         else -> throw InvalidRequestException("Invalid target type ${target.name} for application permission check")
       }
       AuthenticatedRequest.allowAnonymous {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -74,7 +74,7 @@ class DeliveryConfigController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.name)")
+  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.application)")
   fun diff(@RequestBody deliveryConfig: SubmittedDeliveryConfig): List<EnvironmentDiff> =
     adHocDiffer.calculate(deliveryConfig)
 
@@ -83,7 +83,7 @@ class DeliveryConfigController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.name)")
+  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.application)")
   fun validate(@RequestBody deliveryConfig: SubmittedDeliveryConfig) =
   // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
     //  in [ExceptionHandler])


### PR DESCRIPTION
fixes https://github.com/spinnaker/keel/issues/1153.

The delivery config name is not mandatory anymore, but the application is. So for authorization checks, we will use the application name instead.