### PR TITLE
fix(deliveryConfig): support both application and config name

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -74,7 +74,7 @@ class DeliveryConfigController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.application)")
+  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'APPLICATION', #deliveryConfig.application)")
   fun diff(@RequestBody deliveryConfig: SubmittedDeliveryConfig): List<EnvironmentDiff> =
     adHocDiffer.calculate(deliveryConfig)
 
@@ -83,7 +83,7 @@ class DeliveryConfigController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
-  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'DELIVERY_CONFIG', #deliveryConfig.application)")
+  @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'APPLICATION', #deliveryConfig.application)")
   fun validate(@RequestBody deliveryConfig: SubmittedDeliveryConfig) =
   // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
     //  in [ExceptionHandler])


### PR DESCRIPTION
following PR https://github.com/spinnaker/keel/pull/1163/, fixing the endpoints that take the application names as the identifier to use `application` as the target, instead of `deliveryConfig`