### PR TITLE
fix(orca): Fix stupid Retrofit error

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -41,7 +41,7 @@ interface OrcaService {
   suspend fun triggerPipeline(
     @Header("X-SPINNAKER-USER") user: String,
     @Path("pipelineConfigId") pipelineConfigId: String,
-    @Body trigger: Map<String, Any>
+    @Body trigger: HashMap<String, Any>
   ): TaskRefResponse
 
   @GET("/pipelines/{id}")

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
@@ -68,7 +68,7 @@ internal class PipelineConstraintEvaluatorTests : JUnit5Minutests {
     )
     val executionId = randomUID().toString()
     val capturedId = slot<String>()
-    val capturedTrigger = slot<Map<String, Any>>()
+    val capturedTrigger = slot<HashMap<String, Any>>()
     val persistedState = slot<ConstraintState>()
     val subject = PipelineConstraintEvaluator(orcaService, repository, eventPublisher, clock)
 
@@ -122,7 +122,7 @@ internal class PipelineConstraintEvaluatorTests : JUnit5Minutests {
           expectThat(capturedTrigger)
             .captured
             .isEqualTo(
-              mapOf(
+              hashMapOf(
                 "parameters" to mapOf<String, Any?>("youSayManaged" to "weSayDelivery"),
                 "type" to "managed",
                 "user" to "keel"


### PR DESCRIPTION
This really bugs me, but it's a blocker so I've just reverted the change I made. When just using a plain map Retrofit throws a runtime exception ```java.lang.IllegalArgumentException: Parameter type must not include a type variable or wildcard: java.util.Map<java.lang.String, ?> (parameter #3)```