### PR TITLE
Required load balancer veto needs to match account

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterDependencyContainer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterDependencyContainer.kt
@@ -28,6 +28,7 @@ interface ClusterDependencyContainer {
  */
 internal data class RegionalDependency(
   val name: String,
+  val account: String,
   val regions: Set<String>
 )
 
@@ -61,7 +62,7 @@ private fun OverrideableClusterDependencyContainer<*>.dependencyByRegion(fn: (Cl
   return listOf(defaults, overrides)
     .merge()
     .map { (k, v) ->
-      RegionalDependency(k, v)
+      RegionalDependency(k, locations.account, v)
     }
 }
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
@@ -44,10 +44,10 @@ class RequiredSecurityGroupVeto(
     val jobs = mutableListOf<Job>()
     val securityGroupMissingRegions = mutableMapOf<String, MutableList<String>>()
     supervisorScope {
-      spec.securityGroupsInRegions.forEach { (securityGroupName, regions) ->
+      spec.securityGroupsInRegions.forEach { (securityGroupName, account, regions) ->
         regions.forEach { region ->
           launch {
-            if (!securityGroupExists(spec.account, spec.subnet, region, securityGroupName)) {
+            if (!securityGroupExists(account, spec.subnet, region, securityGroupName)) {
               with(securityGroupMissingRegions) {
                 putIfAbsent(securityGroupName, mutableListOf())
                 getValue(securityGroupName).add(region)
@@ -100,7 +100,7 @@ class RequiredSecurityGroupVeto(
       is LoadBalancerSpec ->
         SecurityGroupDependencies(
           securityGroupsInRegions = dependencies.securityGroupNames.map {
-            RegionalDependency(it, locations.regions.map(SubnetAwareRegionSpec::name).toSet())
+            RegionalDependency(it, locations.account, locations.regions.map(SubnetAwareRegionSpec::name).toSet())
           },
           account = locations.account,
           subnet = locations.subnet


### PR DESCRIPTION
The required load balancer veto was only checking CLB / target group name and regions, not ensuring the dependency was in the right account! I discovered this  by accident today when testing something else. This fixes it.