### PR TITLE
chore(artifacts): write test for approving old version

### DIFF
--- a/keel-api-jackson/src/test/kotlin/com/netflix/spinnaker/keel/api/ConstraintTests.kt
+++ b/keel-api-jackson/src/test/kotlin/com/netflix/spinnaker/keel/api/ConstraintTests.kt
@@ -69,7 +69,7 @@ internal class ConstraintTests : JUnit5Minutests {
   data class Fixture(val json: String) {
     val mapper = configuredObjectMapper().apply {
       registerSubtypes(NamedType(DependsOnConstraint::class.java, "depends-on"))
-      registerSubtypes(NamedType(ManualJudgementConstraint::class.java, "manual-judgment"))
+      registerSubtypes(NamedType(ManualJudgementConstraint::class.java, "manual-judgement"))
     }
 
     inline fun <reified T> parse(): T = mapper.readValue<T>(json)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
@@ -1,0 +1,165 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.netflix.spinnaker.keel.actuation.EnvironmentPromotionChecker
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
+import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.plugins.kind
+import com.netflix.spinnaker.keel.constraints.ArtifactUsedConstraintEvaluator
+import com.netflix.spinnaker.keel.constraints.ConstraintEvaluator
+import com.netflix.spinnaker.keel.constraints.ConstraintState
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus.OVERRIDE_PASS
+import com.netflix.spinnaker.keel.constraints.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.constraints.ManualJudgementConstraintEvaluator
+import com.netflix.spinnaker.keel.constraints.SupportedConstraintType
+import com.netflix.spinnaker.keel.core.api.ArtifactUsedConstraint
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+abstract class ApproveOldVersionTests<T : KeelRepository> : JUnit5Minutests {
+
+  abstract fun createKeelRepository(resourceSpecIdentifier: ResourceSpecIdentifier, mapper: ObjectMapper): T
+
+  open fun flush() {}
+
+  class Fixture<T : KeelRepository>(
+    val repositoryProvider: (ResourceSpecIdentifier, ObjectMapper) -> T
+  ) {
+
+    val mapper: ObjectMapper = configuredObjectMapper().apply {
+      registerSubtypes(NamedType(ManualJudgementConstraint::class.java, "manual-judgement"))
+    }
+
+    private val resourceSpecIdentifier: ResourceSpecIdentifier =
+      ResourceSpecIdentifier(
+        kind<DummyResourceSpec>("ec2/security-group@v1"),
+        kind<DummyResourceSpec>("ec2/cluster@v1")
+      )
+
+    internal val repository = repositoryProvider(resourceSpecIdentifier, mapper)
+
+    val environment: Environment = Environment(
+      name = "test",
+      constraints = setOf(ManualJudgementConstraint())
+    )
+
+    val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
+    val statelessEvaluator = mockk<ConstraintEvaluator<*>>() {
+      every { supportedType } returns SupportedConstraintType<DependsOnConstraint>("depends-on")
+      every { isImplicit() } returns false
+    }
+    val statefulEvaluator = ManualJudgementConstraintEvaluator(repository, MutableClock(), publisher)
+
+    val implicitStatelessEvaluator = mockk<ArtifactUsedConstraintEvaluator>() {
+      every { supportedType } returns SupportedConstraintType<ArtifactUsedConstraint>("artifact-type")
+      every { isImplicit() } returns true
+      every { canPromote(any(), any(), any(), any()) } returns true
+    }
+    val subject = EnvironmentPromotionChecker(
+      repository,
+      listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator),
+      publisher
+    )
+
+    val artifact = DebianArtifact(
+      name = "fnord",
+      deliveryConfigName = "my-manifest",
+      vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2"))
+    )
+    val deliveryConfig = DeliveryConfig(
+      name = "my-manifest",
+      application = "fnord",
+      serviceAccount = "keel@spinnaker",
+      environments = setOf(environment),
+      artifacts = setOf(artifact)
+    )
+
+    val version1 = "fnord-0.0.1~dev.93-h93.3333333"
+    val version2 = "fnord-0.0.1~dev.94-h94.4444444"
+
+    val pendingManualJudgement1 = ConstraintState(
+      deliveryConfig.name,
+      environment.name,
+      version1,
+      "manual-judgement",
+      PENDING
+    )
+
+    val pendingManualJudgement2 = ConstraintState(
+      deliveryConfig.name,
+      environment.name,
+      version2,
+      "manual-judgement",
+      PENDING
+    )
+
+    val passedManualJudgement1 = ConstraintState(
+      deliveryConfig.name,
+      environment.name,
+      version1,
+      "manual-judgement",
+      OVERRIDE_PASS
+    )
+  }
+
+  fun tests() = rootContext<Fixture<T>> {
+    fixture {
+      Fixture(
+        repositoryProvider = this@ApproveOldVersionTests::createKeelRepository
+      )
+    }
+
+    context("two versions of an artifact exist") {
+      before {
+        repository.register(artifact)
+        repository.storeDeliveryConfig(deliveryConfig)
+        repository.storeArtifact(artifact, version1, ArtifactStatus.RELEASE)
+        repository.storeArtifact(artifact, version2, ArtifactStatus.RELEASE)
+        repository.storeConstraintState(pendingManualJudgement1)
+        repository.storeConstraintState(pendingManualJudgement1)
+
+        every { statelessEvaluator.canPromote(artifact, version2, deliveryConfig, environment) } returns true
+        every { statelessEvaluator.canPromote(artifact, version1, deliveryConfig, environment) } returns true
+      }
+
+      test("no version is approved, so the latest approved version is null") {
+        runBlocking {
+          subject.checkEnvironments(deliveryConfig)
+        }
+
+        expectThat(repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)).isEqualTo(null)
+      }
+
+      context("old version is approved") {
+        before {
+          repository.storeConstraintState(passedManualJudgement1)
+        }
+
+        test("so it is the latest approved version") {
+          runBlocking {
+            subject.checkEnvironments(deliveryConfig)
+          }
+
+          // this is broken! ha! this is a bug.
+          // expectThat(repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)).isEqualTo(version1)
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -44,7 +44,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
       every { isImplicit() } returns false
     }
     val statefulEvaluator = mockk<StatefulConstraintEvaluator<*>>() {
-      every { supportedType } returns SupportedConstraintType<ManualJudgementConstraint>("manual-judgment")
+      every { supportedType } returns SupportedConstraintType<ManualJudgementConstraint>("manual-judegment")
       every { isImplicit() } returns false
     }
     val implicitStatelessEvaluator = mockk<ArtifactUsedConstraintEvaluator>() {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
@@ -1,0 +1,37 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.persistence.ApproveOldVersionTests
+import com.netflix.spinnaker.keel.persistence.CombinedRepository
+import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import io.mockk.mockk
+import java.time.Clock
+
+class SqlApproveOldVersionTests : ApproveOldVersionTests<CombinedRepository>() {
+
+  private val testDatabase = initTestDatabase()
+  private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+  private val clock = Clock.systemUTC()
+
+  override fun createKeelRepository(resourceSpecIdentifier: ResourceSpecIdentifier, mapper: ObjectMapper): CombinedRepository {
+    val deliveryConfigRepository = SqlDeliveryConfigRepository(jooq, clock, resourceSpecIdentifier, mapper, sqlRetry)
+    val resourceRepository = SqlResourceRepository(jooq, clock, resourceSpecIdentifier, emptyList(), mapper, sqlRetry)
+    val artifactRepository = SqlArtifactRepository(jooq, clock, mapper, sqlRetry)
+    return CombinedRepository(
+      deliveryConfigRepository,
+      artifactRepository,
+      resourceRepository,
+      clock,
+      mockk(relaxed = true)
+    )
+  }
+
+  override fun flush() {
+    SqlTestUtil.cleanupDb(jooq)
+  }
+}


### PR DESCRIPTION
A test that reproduces https://github.com/spinnaker/keel/issues/1100

note: this behavior only fails in the sql implementation, not the in memory implementation. cc @lorin in case you were curious.

Note: test is commented out because it's breaking. Putting this up for @gal-yardeni  to use, but it's probably a needed test because this flow is COMPLICATED!

...also, I can't spell judgement...