### PR TITLE
fix(status): Account for unexpected empty event history

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.services
 
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
@@ -55,6 +54,7 @@ class ResourceStatusService(
 
     val history = resourceRepository.eventHistory(id, 10)
     return when {
+      history.isEmpty() -> UNKNOWN // shouldn't happen, but is a safeguard since events are persisted asynchronously
       history.isHappy() -> HAPPY
       history.isUnhappy() -> UNHAPPY
       history.isDiff() -> DIFF

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
@@ -79,7 +79,6 @@ class ResourceStatusServiceTests : JUnit5Minutests {
     context("a delivery config with a resource exists") {
       before {
         repository.upsertDeliveryConfig(deliveryConfig)
-        repository.appendResourceHistory(ResourceCreated(resource, clock))
       }
 
       context("resource status") {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -37,6 +37,7 @@ import java.time.ZoneOffset
 import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.impl.DSL
+import org.slf4j.LoggerFactory
 
 open class SqlResourceRepository(
   private val jooq: DSLContext,
@@ -50,6 +51,8 @@ open class SqlResourceRepository(
   companion object {
     val EVENT_JSON_APPLICATION: Field<String> = field("json->'$.application'")
   }
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun allResources(callback: (ResourceHeader) -> Unit) {
     sqlRetry.withRetry(READ) {
@@ -231,6 +234,7 @@ open class SqlResourceRepository(
   }
 
   private fun doAppendHistory(event: PersistentEvent, ref: String) {
+    log.debug("Appending event: $event")
     jooq.transaction { config ->
       val txn = DSL.using(config)
 


### PR DESCRIPTION
While refactoring `SqlResourceRepository` in #1159, I removed a check that threw a `NoSuchResourceId` if the event history for a resource was empty, because I assumed that would be accounted for by the call in the same function to `get(id)`. However, we started seeing exceptions in the logs when trying to determine resource status because the event history is empty, so I suspect the original behavior was masking the fact that we end up with an empty list under certain conditions.

Given that persisting events is asynchronous and could fail for a variety of reasons, this PR accounts for an empty event list by resolving the resource status to `UNKNOWN` in that case.

I also added debug logs to event persistence which will hopefully help troubleshoot this further if any future problems occur.