### PR TITLE
fix(core): Fix StackOverflowError caused by new OkHttpClient setup in kork

### DIFF
--- a/keel-retrofit/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/KeelRetrofitConfiguration.kt
+++ b/keel-retrofit/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/KeelRetrofitConfiguration.kt
@@ -25,7 +25,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
-import org.springframework.context.annotation.Lazy
 import org.springframework.core.Ordered
 import org.springframework.core.annotation.Order
 
@@ -49,8 +48,8 @@ class KeelRetrofitConfiguration {
   @Bean
   @ConditionalOnMissingBean
   @Order(Ordered.HIGHEST_PRECEDENCE)
-  fun spinnakerHeadersInterceptor(@Lazy fiatPermissionEvaluator: FiatPermissionEvaluator) =
-    SpinnakerHeadersInterceptor(fiatPermissionEvaluator)
+  fun spinnakerHeadersInterceptor() =
+    SpinnakerHeadersInterceptor()
 
   @Bean
   @ConditionalOnMissingBean

--- a/keel-retrofit/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/SpinnakerHeadersInterceptor.kt
+++ b/keel-retrofit/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/SpinnakerHeadersInterceptor.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.retrofit
 
-import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.kork.common.Header
 import com.netflix.spinnaker.security.AuthenticatedRequest
 import okhttp3.Interceptor
@@ -12,7 +11,7 @@ import org.slf4j.LoggerFactory
  * Okhttp3 interceptor that adds the X-SPINNAKER-* headers to enable authorization and tracing with downstream
  * Spinnaker services.
  */
-class SpinnakerHeadersInterceptor(private val fiatPermissionEvaluator: FiatPermissionEvaluator) : Interceptor {
+class SpinnakerHeadersInterceptor : Interceptor {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun intercept(chain: Chain): Response {
@@ -29,11 +28,15 @@ class SpinnakerHeadersInterceptor(private val fiatPermissionEvaluator: FiatPermi
 
     // add account information so that downstream services can use that as a fallback if fiat is down
     request.header(Header.USER.header)?.also { user ->
+      // TODO: move the call to fiat to retrieve account permission up in the stack to avoid circular dependency
+      //  with new OkHttpClient setup in kork.
+      /*
       AuthenticatedRequest.allowAnonymous {
         val accounts = fiatPermissionEvaluator.getPermission(user).accounts.joinToString(",") { it.name }
         log.trace("Adding X-SPINNAKER-ACCOUNTS: $accounts to ${request.method} ${request.url}")
         headers[Header.ACCOUNTS.header] = accounts
       }
+      */
     }
 
     request = request.newBuilder().let { builder ->

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -12,6 +12,8 @@ import com.netflix.spinnaker.keel.integration.AuthPropagationTests.MockFiat
 import com.netflix.spinnaker.kork.common.Header.ACCOUNTS
 import com.netflix.spinnaker.kork.common.Header.USER
 import com.netflix.spinnaker.kork.common.Header.USER_ORIGIN
+import dev.minutest.experimental.SKIP
+import dev.minutest.experimental.minus
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -114,7 +116,8 @@ internal class AuthPropagationTests : JUnit5Minutests {
           .isEqualTo("keel@spinnaker.io")
       }
 
-      test("includes ${ACCOUNTS.header} header") {
+      // TODO: reenable when issue in SpinnakerHeadersInterceptor is addressed
+      SKIP - test("includes ${ACCOUNTS.header} header") {
         expectThat(server.takeRequest())
           .describedAs("recorded request")
           .getHeader(ACCOUNTS.header)


### PR DESCRIPTION
Undo changes by @srekapalli to change the initialization of `SpinnakerHeadersInterceptor`, and remove the dependency on `FiatPermissionEvaluator` in that interceptor to avoid the circular dependency on the `OkHttpClient` introduced by the latest versions of kork.

This has the side-effect that we no longer include the `X-SPINNAKER-ACCOUNTS` header in downstream calls and hence have these warnings in the logs:
```
c.n.s.okhttp.OkHttp3MetricsInterceptor   : [] Request GET:https://<redacted>/securityGroups/test/aws/us-east-1/<redacted>?getById=true is missing [X-SPINNAKER-ACCOUNTS] authentication headers and will be treated as anonymous.
```

I will follow up with a separate PR to address that (see https://github.com/spinnaker/keel/issues/1175).