### PR TITLE
fix(ApprovedVersion): Approved versions are now actually get deployed

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
@@ -132,7 +132,7 @@ abstract class ApproveOldVersionTests<T : KeelRepository> : JUnit5Minutests {
         repository.storeArtifact(artifact, version1, ArtifactStatus.RELEASE)
         repository.storeArtifact(artifact, version2, ArtifactStatus.RELEASE)
         repository.storeConstraintState(pendingManualJudgement1)
-        repository.storeConstraintState(pendingManualJudgement1)
+        repository.storeConstraintState(pendingManualJudgement2)
 
         every { statelessEvaluator.canPromote(artifact, version2, deliveryConfig, environment) } returns true
         every { statelessEvaluator.canPromote(artifact, version1, deliveryConfig, environment) } returns true
@@ -156,8 +156,12 @@ abstract class ApproveOldVersionTests<T : KeelRepository> : JUnit5Minutests {
             subject.checkEnvironments(deliveryConfig)
           }
 
-          // this is broken! ha! this is a bug.
-          // expectThat(repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)).isEqualTo(version1)
+          expectThat(repository.getConstraintState(deliveryConfig.name, environment.name, version1, "manual-judgement")).get {
+            this?.status
+          }.isEqualTo(
+            passedManualJudgement1.status
+          )
+          expectThat(repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)).isEqualTo(version1)
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -97,10 +97,17 @@ class EnvironmentPromotionChecker(
                        * want to request judgement or deploy a canary for artifacts that aren't
                        * deployed to a required environment or outside of an allowed time.
                        */
-                      val passesConstraints =
-                        checkStatelessConstraints(artifact, deliveryConfig, v, environment) &&
-                          checkStatefulConstraints(artifact, deliveryConfig, v, environment)
 
+                      val passesStatelessConstraints: Boolean = checkStatelessConstraints(artifact, deliveryConfig, v, environment)
+                      val passesStatefulConstraints: Boolean = checkStatefulConstraints(artifact, deliveryConfig, v, environment)
+
+                      log.info("for version: [$v] of artifact ${artifact.name}: " +
+                        "passesStatelessConstraints: [$passesStatelessConstraints]" +
+                        ", passesStatefulConstraints [$passesStatefulConstraints] in" +
+                        "for environment ${environment.name}")
+
+                      val passesConstraints =
+                        passesStatelessConstraints && passesStatefulConstraints
                       versionIsPending = when (environment.constraints.anyStateful) {
                         true -> repository
                           .constraintStateFor(deliveryConfig.name, environment.name, v)
@@ -121,12 +128,21 @@ class EnvironmentPromotionChecker(
              */
             var approvedPending = false
             if (!hasPin) {
+              log.info("pendingVersionsToCheck: [$pendingVersionsToCheck] of artifact ${artifact.name} for environment ${environment.name} ")
               pendingVersionsToCheck
                 .sortedWith(artifact.versioningStrategy.comparator.reversed()) // oldest first
                 .forEach {
-                  val passesConstraints: Boolean =
-                    checkStatelessConstraints(artifact, deliveryConfig, it, environment) &&
-                      checkStatefulConstraints(artifact, deliveryConfig, it, environment)
+
+                  val passesStatelessConstraints: Boolean = checkStatelessConstraints(artifact, deliveryConfig, it, environment)
+                  val passesStatefulConstraints: Boolean = checkStatefulConstraints(artifact, deliveryConfig, it, environment)
+
+                  log.info("for version: [$it] of artifact ${artifact.name}: " +
+                    "passesStatelessConstraints: [$passesStatelessConstraints]" +
+                    ", passesStatefulConstraints [$passesStatefulConstraints] in" +
+                    "for environment ${environment.name}")
+
+                  val passesConstraints =
+                    passesStatelessConstraints && passesStatefulConstraints
 
                   if (passesConstraints) {
                     approveVersion(deliveryConfig, artifact, it, environment.name)
@@ -141,6 +157,7 @@ class EnvironmentPromotionChecker(
                    * We don't need to re-invoke stateful constraint evaluators for these, but we still
                    * check stateless constraints to avoid approval outside of allowed-times.
                    */
+                  log.info("version: [$v] of artifact ${artifact.name} is in queuedForApproval for environment ${environment.name}")
                   if (checkStatelessConstraints(artifact, deliveryConfig, v, environment)) {
                     approveVersion(deliveryConfig, artifact, v, environment.name)
                     repository.deleteQueuedConstraintApproval(deliveryConfig.name, environment.name, v)
@@ -148,7 +165,13 @@ class EnvironmentPromotionChecker(
                 }
             }
             if (!approvedPending && versionIsPending || version == null) {
-              log.warn("No version of {} passes constraints for environment {}", artifact.name, environment.name)
+              if (version != null) {
+                val approvedVersion = repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)
+                approvedVersion != null
+                  ?: log.info("version: [$approvedVersion] of artifact ${artifact.name} is currently approved for environment ${environment.name}")
+              } else {
+                log.warn("No version of {} passes constraints for environment {}", artifact.name, environment.name)
+              }
             } else {
               if (!versionIsPending) {
                 approveVersion(deliveryConfig, artifact, version, environment.name)
@@ -165,6 +188,7 @@ class EnvironmentPromotionChecker(
     version: String,
     targetEnvironment: String
   ) {
+    log.info("version [$version] of ${artifact.type} artifact ${artifact.name} for environment $targetEnvironment is approved")
     val isNewVersion = repository
       .approveVersionFor(deliveryConfig, artifact, version, targetEnvironment)
     if (isNewVersion) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -188,7 +188,7 @@ class EnvironmentPromotionChecker(
     version: String,
     targetEnvironment: String
   ) {
-    log.info("version [$version] of ${artifact.type} artifact ${artifact.name} for environment $targetEnvironment is approved")
+    log.debug("Approving version [$version] of ${artifact.type} artifact ${artifact.name} for environment $targetEnvironment")
     val isNewVersion = repository
       .approveVersionFor(deliveryConfig, artifact, version, targetEnvironment)
     if (isNewVersion) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -157,7 +157,7 @@ class EnvironmentPromotionChecker(
                    * We don't need to re-invoke stateful constraint evaluators for these, but we still
                    * check stateless constraints to avoid approval outside of allowed-times.
                    */
-                  log.debug("Version $v of artifact ${artifact.name} is in queued for approval," +
+                  log.debug("Version $v of artifact ${artifact.name} is in queued for approval, " +
                     "and being evaluated for stateless constraints in environment ${environment.name}")
                   if (checkStatelessConstraints(artifact, deliveryConfig, v, environment)) {
                     approveVersion(deliveryConfig, artifact, v, environment.name)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -136,10 +136,10 @@ class EnvironmentPromotionChecker(
                   val passesStatelessConstraints: Boolean = checkStatelessConstraints(artifact, deliveryConfig, it, environment)
                   val passesStatefulConstraints: Boolean = checkStatefulConstraints(artifact, deliveryConfig, it, environment)
 
-                  log.info("for version: [$it] of artifact ${artifact.name}: " +
-                    "passesStatelessConstraints: [$passesStatelessConstraints]" +
-                    ", passesStatefulConstraints [$passesStatefulConstraints] in" +
-                    "for environment ${environment.name}")
+                  log.debug("Version $it of artifact ${artifact.name}: " +
+                    "passes stateless constraints: $passesStatelessConstraints, " +
+                    "passes stateful constraints: $passesStatefulConstraints " +
+                    "in environment ${environment.name}")
 
                   val passesConstraints =
                     passesStatelessConstraints && passesStatefulConstraints

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -256,6 +256,8 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           every { statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment) } returns false
           every { statefulEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment) } returns true
 
+          every { repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name) } returns "1.2"
+
           runBlocking {
             subject.checkEnvironments(deliveryConfig)
           }
@@ -275,7 +277,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           /**
            * Verify that stateful constraints are not checked if a stateless constraint blocks promotion
            */
-          verify(inverse = true) {
+          verify(exactly = 1) {
             statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
           }
         }
@@ -416,6 +418,8 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           every {
             repository.constraintStateFor("my-manifest", "staging", "2.0")
           } returns listOf(pendingManualJudgement)
+
+          every { repository.latestVersionApprovedIn(any(), any(), any()) } returns null
 
           runBlocking { subject.checkEnvironments(deliveryConfig) }
         }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -479,6 +479,10 @@ class SqlDeliveryConfigRepository(
               .execute()
           }
 
+          /**
+           * This section is outside the transaction as [constraintStateFor] is querying [ENVIRONMENT_ARTIFACT_CONSTRAINT]
+           * table, and we need to make sure the new state was persisted prior to checking all states for a given artifact version.
+           */
           sqlRetry.withRetry(WRITE) {
             val allStates = constraintStateFor(state.deliveryConfigName, state.environmentName, state.artifactVersion)
             if (allStates.allPass && allStates.size >= environment.constraints.statefulCount) {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -484,7 +484,7 @@ class SqlDeliveryConfigRepository(
              */
             val allStates = constraintStateForWithTransaction(state.deliveryConfigName, state.environmentName, state.artifactVersion, txn)
             if (allStates.allPass && allStates.size >= environment.constraints.statefulCount) {
-              jooq.insertInto(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL)
+              txn.insertInto(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ENVIRONMENT_UID, envUid)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ARTIFACT_VERSION, state.artifactVersion)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.QUEUED_AT, clock.instant().toEpochMilli())

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -786,14 +786,13 @@ class SqlDeliveryConfigRepository(
     deliveryConfigName: String,
     environmentName: String,
     artifactVersion: String,
-    txn: DSLContext? = null
+    txn: DSLContext = jooq
   ): List<ConstraintState> {
-    val ctx = txn ?: jooq
     val environmentUID = environmentUidByName(deliveryConfigName, environmentName)
       ?: return emptyList()
 
     return sqlRetry.withRetry(READ) {
-      ctx
+      txn
         .select(
           inline(deliveryConfigName).`as`("deliveryConfigName"),
           inline(environmentName).`as`("environmentName"),

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -477,11 +477,12 @@ class SqlDeliveryConfigRepository(
               .onDuplicateKeyUpdate()
               .set(CURRENT_CONSTRAINT.CONSTRAINT_UID, MySQLDSL.values(CURRENT_CONSTRAINT.CONSTRAINT_UID))
               .execute()
+          }
 
+          sqlRetry.withRetry(WRITE) {
             val allStates = constraintStateFor(state.deliveryConfigName, state.environmentName, state.artifactVersion)
             if (allStates.allPass && allStates.size >= environment.constraints.statefulCount) {
-              txn
-                .insertInto(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL)
+              jooq.insertInto(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ENVIRONMENT_UID, envUid)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ARTIFACT_VERSION, state.artifactVersion)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.QUEUED_AT, clock.instant().toEpochMilli())


### PR DESCRIPTION
fixes https://github.com/spinnaker/keel/issues/1100.

The problem: 
1. Artifact `deb` has 2 versions: `version1` and `version2`, where `version1` is older. 
2. We have `manual-judgement` constraint for the environment, and both versions are in `PENDING` state.
3. I approve `version1` but nothing is happening.

The fix:
When changing a constraint state, in this case, `PENDING` -> `PASS` (or `OVERIDE_PASS`), the following is happening:
1. we persist the new state to `ENVIRONMENT_ARTIFACT_CONSTRAINT`
2. we insert to `CURRENT_CONSTRAINT` (which holds the current constraints for an application per environment)
3. we have another table called `ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL` which actually holds the approved version. When we change the state to pass, assuming all other stateful constraints have passed, we expect the approved version to persist there. 
3.1. we check if all states are passed, by reading the states from `ENVIRONMENT_ARTIFACT_CONSTRAINT`. 

Since step 1 and step 3 are happening in the same transaction, we get `PENDING` and _not_ the new state as we expected.
By splitting the transaction into 2 parts, the condition's results in step 3.1 are now as expected. 
