### PR TITLE
fix(deb): export base-os correctly

### DIFF
--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -162,8 +162,8 @@ internal class ClusterExportTests : JUnit5Minutests {
     spec = spec
   )
 
-  val activeServerGroupResponseEast = serverGroupEast.toCloudDriverResponse(vpcEast, listOf(subnet1East, subnet2East, subnet3East), listOf(sg1East, sg2East))
-  val activeServerGroupResponseWest = serverGroupWest.toCloudDriverResponse(vpcWest, listOf(subnet1West, subnet2West, subnet3West), listOf(sg1West, sg2West))
+  val activeServerGroupResponseEast = serverGroupEast.toCloudDriverResponse(vpcEast, listOf(subnet1East, subnet2East, subnet3East), listOf(sg1East, sg2East), image)
+  val activeServerGroupResponseWest = serverGroupWest.toCloudDriverResponse(vpcWest, listOf(subnet1West, subnet2West, subnet3West), listOf(sg1West, sg2West), image)
 
   val exportable = Exportable(
     cloudProvider = "aws",
@@ -242,7 +242,7 @@ internal class ClusterExportTests : JUnit5Minutests {
           that(artifact.name).isEqualTo("keel")
           that(artifact)
             .isA<DebianArtifact>()
-            .get { vmOptions }.isEqualTo(VirtualMachineOptions(regions = setOf("us-east-1"), baseOs = "bionic"))
+            .get { vmOptions }.isEqualTo(VirtualMachineOptions(regions = setOf("us-east-1"), baseOs = "bionic-classic"))
         }
       }
     }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
@@ -27,7 +27,8 @@ import org.apache.commons.lang3.RandomStringUtils
 fun ServerGroup.toCloudDriverResponse(
   vpc: Network,
   subnets: List<Subnet>,
-  securityGroups: List<SecurityGroupSummary>
+  securityGroups: List<SecurityGroupSummary>,
+  image: ActiveServerGroupImage? = null
 ): ActiveServerGroup =
   RandomStringUtils.randomNumeric(3).padStart(3, '0').let { sequence ->
     ActiveServerGroup(
@@ -40,7 +41,7 @@ fun ServerGroup.toCloudDriverResponse(
         baseImageVersion = launchConfiguration.baseImageVersion,
         name = "name",
         imageLocation = "location",
-        description = null
+        description = image?.description
       ),
       LaunchConfig(
         launchConfiguration.ramdiskId,


### PR DESCRIPTION
Step #1 to fixing https://github.com/spinnaker/keel/issues/1167 is guessing the base os more correctly and throwing an error if we can't determine it