### PR TITLE
fix(export): we now look at deb status in a hacky way

### DIFF
--- a/keel-core/src/main/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParser.java
+++ b/keel-core/src/main/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParser.java
@@ -1,0 +1,57 @@
+package com.netflix.rocket.api.artifact.internal.debian;
+
+import static com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
+import static org.apache.commons.lang3.StringUtils.substringBetween;
+
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+
+public class DebianArtifactParser {
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(DebianArtifactParser.class);
+
+  public ArtifactStatus parseStatus(String raw) {
+    String version = parseVersion(raw);
+    if (version == null) {
+      // we got passed the version
+      version = raw;
+    }
+    String[] parts = version.split("-");
+    if (parts.length < 2) {
+      return ArtifactStatus.UNKNOWN;
+    }
+    String status = parts[0];
+    if (status.matches("\\S+dev\\.\\d+[+.0-9a-z]*$")) {
+      return ArtifactStatus.SNAPSHOT;
+    }
+    if (status.matches("\\S+~rc\\.\\d+$")) {
+      return ArtifactStatus.CANDIDATE;
+    }
+    if (status.matches("\\d+\\.\\d+\\.\\d+$") || status.matches("\\d+\\.\\d+$")) {
+      return RELEASE;
+    }
+    if (status.matches("\\d+\\.\\d+\\.\\d+[r]+\\d+$")) {
+      return ArtifactStatus.RELEASE;
+    }
+
+    return ArtifactStatus.UNKNOWN;
+  }
+
+  public String parseName(String raw) {
+    String last = substringAfterLast(raw, "/");
+    return substringBefore(last, "_");
+  }
+
+  public String parseVersion(String raw) {
+    String last = substringAfterLast(raw, "/");
+    return substringBetween(last, "_");
+  }
+
+  public String parseArchitecture(String raw) {
+    String last = substringAfterLast(raw, "/");
+    String debianWithoutExtenstion = StringUtils.removeEnd(last, ".deb");
+    return StringUtils.substringAfterLast(debianWithoutExtenstion, "_");
+  }
+}

--- a/keel-core/src/test/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParserTests.java
+++ b/keel-core/src/test/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParserTests.java
@@ -1,0 +1,130 @@
+package com.netflix.rocket.api.artifact.internal.debian;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus;
+import org.junit.jupiter.api.Test;
+
+public class DebianArtifactParserTests {
+  private DebianArtifactParser parser = new DebianArtifactParser();
+
+  @Test
+  void shouldParseStandardVersionString() {
+    String rawVersion =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.1.2-h2.afc245_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.RELEASE);
+  }
+
+  @Test
+  void shouldParseLegacyVersionString() {
+    String rawVersion = "debian-local:pool/t/test-java-legacy_1.1-h1.9e74f98_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.RELEASE);
+  }
+
+  @Test
+  void shouldReturnReleaseForLocalReleaseBuild() {
+    String rawVersion =
+        "debian-local:pool/o/mypackage-server/mypackage-server_1.100.5-LOCAL_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.RELEASE);
+  }
+
+  @Test
+  void shouldParseCandidateVersionString() {
+    String rawVersion =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.1.2~rc.11-h2.afc245_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.CANDIDATE);
+  }
+
+  @Test
+  void shouldReturnCandidateForLocalFinalBuild() {
+    String rawVersion =
+        "debian-local:pool/o/mypackage-server/mypackage-server_1.100.5~rc.23-LOCAL_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.CANDIDATE);
+  }
+
+  @Test
+  void shouldParseSnapshotVersionString() {
+    String rawVersion =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176~dev.34267+2345af-h1886.4246bc3_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.SNAPSHOT);
+  }
+
+  @Test
+  void shouldParseLocallyPublishedSnapshot() {
+    String raw =
+        "debian-local:pool/g/bottle-netflix-web/bottle-netflix-web_4.1.0~dev.294.uncommitted-LOCAL_all.deb";
+
+    ArtifactStatus status = parser.parseStatus(raw);
+
+    assertThat(status).isEqualTo(ArtifactStatus.SNAPSHOT);
+  }
+
+  @Test
+  void shouldParseSnapshotAfterCandidateVersionString() {
+    String rawVersion =
+        "debian-local:pool/g/bottle-netflix-web/bottle-netflix-web_4.0.1~rc.1.dev.1-h250.1c1dacc_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.SNAPSHOT);
+  }
+
+  @Test
+  void shouldParseTopcoatReleases() {
+    String rawVersion =
+        "debian-local:pool/n/nflx-metadata:astrid/topcoat_6.0.4r3-1~bionic-LOCAL_amd64.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.RELEASE);
+  }
+
+  @Test
+  void shouldReturnUnknownForUnparseableString() {
+    String rawVersion = "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.UNKNOWN);
+  }
+
+  @Test
+  void shouldParseArtifactoryDebianNameString() {
+    String raw =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_all.deb";
+
+    assertThat(parser.parseName(raw)).isEqualTo("mypackage-server");
+  }
+
+  @Test
+  void shouldParseArtifactoryDebianVersionString() {
+    String raw =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_all.deb";
+
+    assertThat(parser.parseVersion(raw)).isEqualTo("0.0.1176-h1886.4246bc3");
+  }
+
+  @Test
+  void shouldParseArtifactoryDebianArchitectureString() {
+    String raw =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_all.deb";
+
+    assertThat(parser.parseArchitecture(raw)).isEqualTo("all");
+  }
+
+  @Test
+  void shouldParseArtifactoryDebianArchitectureStringForAmd64() {
+    String raw =
+        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_amd64.deb";
+
+    assertThat(parser.parseArchitecture(raw)).isEqualTo("amd64");
+  }
+
+  @Test
+  void shouldDefaultToUnknownForUnrecognizedVersion() {
+    String rawVersion =
+        "debian-local:pool/o/mypackage-server/mypackage-server_1.100.HOTFIX-LOCAL_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.UNKNOWN);
+  }
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
 import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
@@ -238,11 +239,11 @@ internal class ClusterExportTests : JUnit5Minutests {
           exportArtifact(exportable.copy(regions = setOf("us-east-1")))
         }
 
-        expect {
-          that(artifact.name).isEqualTo("keel")
-          that(artifact)
-            .isA<DebianArtifact>()
-            .get { vmOptions }.isEqualTo(VirtualMachineOptions(regions = setOf("us-east-1"), baseOs = "bionic-classic"))
+        expectThat(artifact) {
+          get { name }.isEqualTo("keel")
+          isA<DebianArtifact>()
+            .and { get { vmOptions }.isEqualTo(VirtualMachineOptions(regions = setOf("us-east-1"), baseOs = "bionic-classic")) }
+            .and { get { statuses }.isEqualTo(setOf(RELEASE)) }
         }
       }
     }


### PR DESCRIPTION
Part # 2 to https://github.com/spinnaker/keel/issues/1167

We now use a class adapted from the rocket team to give ourselves a hacky guess at what the debian status is. This is fine for now. 

Note: if you have a flow where you are deploying snapshot artifacts to feature branch clusters, you'll still need to edit your delivery config by hand. This change will just actually capture that you have two different statuses.