### PR TITLE
chore(logs): pipeline logs + trigger

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluator.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluator.kt
@@ -155,12 +155,14 @@ class PipelineConstraintEvaluator(
     constraint: PipelineConstraint,
     serviceAccount: String
   ): String {
+    log.info("Triggering pipeline ${constraint.pipelineId} for environment ${environment.name}")
 
     // using java.util.HashMap over kotlin.collections for retrofit2 compatibility
     val trigger = HashMap<String, Any>()
     trigger["type"] = "managed"
     trigger["user"] = "keel"
     trigger["parameters"] = constraint.parameters
+    trigger["linkText"] = "Env ${environment.name}"
 
     if (environment.notifications.isNotEmpty() && !trigger.containsKey("notifications")) {
       trigger["notifications"] = environment.notifications

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
@@ -125,7 +125,8 @@ internal class PipelineConstraintEvaluatorTests : JUnit5Minutests {
               hashMapOf(
                 "parameters" to mapOf<String, Any?>("youSayManaged" to "weSayDelivery"),
                 "type" to "managed",
-                "user" to "keel"
+                "user" to "keel",
+                "linkText" to "Env prod"
               )
             )
         }


### PR DESCRIPTION
Adding a "start pipeline" log and putting the env name in the link text (as `Env {env}`). Any better link text ideas? Trying to find something short but informative 