### PR TITLE
fix(clouddriver) LB Action: targetGroupName optional

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ApplicationLoadBalancerModel.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ApplicationLoadBalancerModel.kt
@@ -34,7 +34,7 @@ data class ApplicationLoadBalancerModel(
   data class Action(
     val type: String,
     val order: Int,
-    val targetGroupName: String,
+    val targetGroupName: String?,
     val redirectConfig: RedirectConfig?
   )
 

--- a/keel-clouddriver/src/test/resources/loadBalancers.json
+++ b/keel-clouddriver/src/test/resources/loadBalancers.json
@@ -308,6 +308,18 @@
               }
             },
             "targetGroupName": "keeldemo-prestaging"
+          },
+          {
+            "type": "redirect",
+            "order": 1,
+            "redirectConfig": {
+              "protocol": "HTTPS",
+              "port": "443",
+              "host": "#{host}",
+              "path": "/#{path}",
+              "query": "#{query}",
+              "statusCode": "HTTP_301"
+            }
           }
         ],
         "loadBalancerName": "keeldemo-prestaging-alb",


### PR DESCRIPTION
Make targetGroupName optional in the Action model.

Keel assumed that a load balancer Action field will always have a targetGroupName, but that’s not true for redirect actions.

fixes #1198.
