### PR TITLE
fix(constraints): don't evaluate stateful unless stateless pass

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -97,17 +97,9 @@ class EnvironmentPromotionChecker(
                        * want to request judgement or deploy a canary for artifacts that aren't
                        * deployed to a required environment or outside of an allowed time.
                        */
-
-                      val passesStatelessConstraints = checkStatelessConstraints(artifact, deliveryConfig, v, environment)
-                      val passesStatefulConstraints = checkStatefulConstraints(artifact, deliveryConfig, v, environment)
-
-                      log.debug("Version $v of artifact ${artifact.name}: " +
-                        "passes stateless constraints: $passesStatelessConstraints, " +
-                        "passes stateful constraints: $passesStatefulConstraints " +
-                        "in environment ${environment.name}")
-
                       val passesConstraints =
-                        passesStatelessConstraints && passesStatefulConstraints
+                        checkStatelessConstraints(artifact, deliveryConfig, v, environment) &&
+                          checkStatefulConstraints(artifact, deliveryConfig, v, environment)
                       versionIsPending = when (environment.constraints.anyStateful) {
                         true -> repository
                           .constraintStateFor(deliveryConfig.name, environment.name, v)
@@ -132,17 +124,9 @@ class EnvironmentPromotionChecker(
               pendingVersionsToCheck
                 .sortedWith(artifact.versioningStrategy.comparator.reversed()) // oldest first
                 .forEach {
-
-                  val passesStatelessConstraints = checkStatelessConstraints(artifact, deliveryConfig, it, environment)
-                  val passesStatefulConstraints = checkStatefulConstraints(artifact, deliveryConfig, it, environment)
-
-                  log.debug("Version $it of artifact ${artifact.name}: " +
-                    "passes stateless constraints: $passesStatelessConstraints, " +
-                    "passes stateful constraints: $passesStatefulConstraints " +
-                    "in environment ${environment.name}")
-
                   val passesConstraints =
-                    passesStatelessConstraints && passesStatefulConstraints
+                    checkStatelessConstraints(artifact, deliveryConfig, it, environment) &&
+                      checkStatefulConstraints(artifact, deliveryConfig, it, environment)
 
                   if (passesConstraints) {
                     approveVersion(deliveryConfig, artifact, it, environment.name)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -277,7 +277,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           /**
            * Verify that stateful constraints are not checked if a stateless constraint blocks promotion
            */
-          verify(exactly = 1) {
+          verify(inverse = true) {
             statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
           }
         }


### PR DESCRIPTION
Remove logging (sorry @gal-yardeni, I didn't want to take the time to ensure it would log but also not break the ordering), and revert back to only checking stateful if stateless pass.