### PR TITLE
fix(clouddriver): healthCheckPort as string

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ApplicationLoadBalancerModel.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ApplicationLoadBalancerModel.kt
@@ -68,7 +68,7 @@ data class ApplicationLoadBalancerModel(
     val port: Int,
     val healthCheckEnabled: Boolean,
     val healthCheckTimeoutSeconds: Int,
-    val healthCheckPort: Int,
+    val healthCheckPort: String, // quoted number (e.g., "8080") or "traffic-port"
     val healthCheckProtocol: String,
     val healthCheckPath: String,
     val healthCheckIntervalSeconds: Int,

--- a/keel-clouddriver/src/test/resources/loadBalancers.json
+++ b/keel-clouddriver/src/test/resources/loadBalancers.json
@@ -1039,7 +1039,7 @@
         ],
         "targetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:999999999999:targetgroup/keeldemo-test/abababababababab",
         "healthCheckTimeoutSeconds": 5,
-        "healthCheckPort": "8080",
+        "healthCheckPort": "traffic-port",
         "targetType": "instance",
         "matcher": {
           "httpCode": "200-299"

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -246,7 +246,10 @@ class ApplicationLoadBalancerHandler(
                       port = tg.port,
                       healthCheckEnabled = tg.healthCheckEnabled,
                       healthCheckTimeoutSeconds = Duration.ofSeconds(tg.healthCheckTimeoutSeconds.toLong()),
-                      healthCheckPort = tg.healthCheckPort,
+                      healthCheckPort = when (tg.healthCheckPort) {
+                        "traffic-port" -> tg.port
+                        else -> tg.healthCheckPort.toInt()
+                      },
                       healthCheckProtocol = tg.healthCheckProtocol,
                       healthCheckHttpCode = tg.matcher.httpCode,
                       healthCheckPath = tg.healthCheckPath,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredLoadBalancerVetoTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredLoadBalancerVetoTests.kt
@@ -325,7 +325,7 @@ internal class RequiredLoadBalancerVetoTests : JUnit5Minutests {
               port = 8080,
               healthCheckEnabled = true,
               healthCheckTimeoutSeconds = 30,
-              healthCheckPort = 8080,
+              healthCheckPort = "8080",
               healthCheckProtocol = "https",
               healthCheckPath = "/healthcheck",
               healthCheckIntervalSeconds = 60,


### PR DESCRIPTION
## Summary

Change the `healthCheckPort` field on a clouddriver data model object from `Int` to `String`.

Fixes #1200 

## Problem

When we query clouddriver for an ApplicationLoadBalancer (ALB) model object, one of the model sub-objects, TargetGroup, has a field named `healthCheckPort`.

This field is encoded as a string in the JSON payload, but is almost always a string-quoted integer (e.g., `"8080"`). However, we recently discovered that it is not always an integer: a valid value is the string `"traffic-port"`, which means "just use the same port that the load balancer sends the regular traffic to."

Keel's `TargetGroup` model object currently represents this value as an `Int`, which leads to a deserialization error when an ALB is configured with `"traffic-port"`.

## Solution requirements

To fix this, we need to modify the `TargetGroup` model so that it can deserialize ALB models that have health check port set to the literal string "traffic-port", as well as string-encoded port numbers (e.g., `"8080"`).

## Implemented solution

I changed the field on the ApplicationLoadBalancer model object from `Int` to `String`, and I modified the `CloudDriverService.getApplicationLoadBalancer` method in ApplicationLoadBalancerHandler.kt to convert `"traffic-port"` to the numerical value of the traffic port.

I did **not** modify the corresponding field on the ApplicationLoadBalancerSpec.TargetGroup object, I left it as an `Int`

**Rationale**: I thought that preserving the current data model of the spec object would be less risky: Since the spec objects get persisted to the database, making changes to them carries a risk of the code and data going out of sync.
