### PR TITLE
feat(admin): redo constraint evaluation

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NoSuchEnvironmentException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NoSuchEnvironmentException.kt
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.keel.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.UserException
+
+class NoSuchEnvironmentException(env: String, application: String) : UserException("No environment $env exists in config for $application")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -39,8 +39,8 @@ class AdminService(
    * Removes the stored state we have for any stateful constraints for an environment
    * so they will evaluate again
    */
-  fun redoConstraints(application: String, environment: String, type: String? = null) {
-    log.info("[app=$application, env=$environment] Triggering a redo of stateful constraints.")
+  fun reevaluateConstraints(application: String, environment: String, type: String? = null) {
+    log.info("[app=$application, env=$environment] Triggering reevaluation of stateful constraints.")
     if (type != null) {
       log.info("[app=$application, env=$environment] Triggering only type $type")
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -2,10 +2,10 @@ package com.netflix.spinnaker.keel.services
 
 import com.netflix.spinnaker.keel.api.StatefulConstraint
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
+import com.netflix.spinnaker.keel.exceptions.NoSuchEnvironmentException
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.kork.exceptions.UserException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -39,15 +39,15 @@ class AdminService(
    * Removes the stored state we have for any stateful constraints for an environment
    * so they will evaluate again
    */
-  fun reevaluateConstraints(application: String, environment: String, type: String? = null) {
-    log.info("[app=$application, env=$environment] Triggering reevaluation of stateful constraints.")
+  fun forceConstraintReevaluation(application: String, environment: String, type: String? = null) {
+    log.info("[app=$application, env=$environment] Forcing reevaluation of stateful constraints.")
     if (type != null) {
-      log.info("[app=$application, env=$environment] Triggering only type $type")
+      log.info("[app=$application, env=$environment] Forcing only type $type")
     }
 
     val deliveryConfig = repository.getDeliveryConfigForApplication(application)
     val env = deliveryConfig.environments.find { it.name == environment }
-      ?: throw UserException("No environment $environment in config for $application")
+      ?: throw NoSuchEnvironmentException(environment, application)
     env.constraints.forEach { constraint ->
       if (constraint is StatefulConstraint) {
         if (type == null || type == constraint.type) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -1,9 +1,11 @@
 package com.netflix.spinnaker.keel.services
 
+import com.netflix.spinnaker.keel.api.StatefulConstraint
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.kork.exceptions.UserException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -31,5 +33,28 @@ class AdminService(
   fun triggerRecheck(resourceId: String) {
     log.info("Triggering a recheck for $resourceId by clearing our record of the diff")
     diffFingerprintRepository.clear(resourceId)
+  }
+
+  /**
+   * Removes the stored state we have for any stateful constraints for an environment
+   * so they will evaluate again
+   */
+  fun redoConstraints(application: String, environment: String, type: String? = null) {
+    log.info("[app=$application, env=$environment] Triggering a redo of stateful constraints.")
+    if (type != null) {
+      log.info("[app=$application, env=$environment] Triggering only type $type")
+    }
+
+    val deliveryConfig = repository.getDeliveryConfigForApplication(application)
+    val env = deliveryConfig.environments.find { it.name == environment }
+      ?: throw UserException("No environment $environment in config for $application")
+    env.constraints.forEach { constraint ->
+      if (constraint is StatefulConstraint) {
+        if (type == null || type == constraint.type) {
+          log.info("[app=$application, env=$environment] Deleting constraint state for ${constraint.type}.")
+          repository.deleteConstraintState(deliveryConfig.name, environment, constraint.type)
+        }
+      }
+    }
   }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
@@ -1,0 +1,77 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.keel.core.api.PipelineConstraint
+import com.netflix.spinnaker.keel.core.api.TimeWindow
+import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
+import com.netflix.spinnaker.keel.pause.ActuationPauser
+import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+class AdminServiceTests : JUnit5Minutests {
+  class Fixture {
+    val repository: KeelRepository = mockk(relaxed = true)
+    val diffFingerprintRepository: DiffFingerprintRepository = mockk()
+    val actuationPauser: ActuationPauser = mockk()
+
+    val application = "leapp"
+
+    val environment = Environment(
+      name = "test",
+      constraints = setOf(
+        ManualJudgementConstraint(),
+        PipelineConstraint(pipelineId = "wowapipeline"),
+        TimeWindowConstraint(windows = listOf(TimeWindow(days = "Monday")))
+      )
+    )
+
+    val deliveryConfig = DeliveryConfig(
+      name = "manifest",
+      application = application,
+      serviceAccount = "keel@spinnaker",
+      artifacts = setOf(),
+      environments = setOf(environment)
+    )
+
+    val subject = AdminService(
+      repository,
+      actuationPauser,
+      diffFingerprintRepository
+    )
+  }
+
+  fun adminServiceTests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    before {
+      every { repository.getDeliveryConfigForApplication(application) } returns deliveryConfig
+    }
+
+    context("redoing environment constraints") {
+      test("clears state only for stateful constraints") {
+        subject.redoConstraints(application, environment.name)
+
+        verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "manual-judgement") }
+        verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "pipeline") }
+        verify(exactly = 0) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "allowed-times") }
+      }
+
+      test("clears a specific constraint type when asked to") {
+        subject.redoConstraints(application, environment.name, "pipeline")
+
+        verify(exactly = 0) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "manual-judgement") }
+        verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "pipeline") }
+        verify(exactly = 0) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "allowed-times") }
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
@@ -56,9 +56,9 @@ class AdminServiceTests : JUnit5Minutests {
       every { repository.getDeliveryConfigForApplication(application) } returns deliveryConfig
     }
 
-    context("reevaluating environment constraints") {
+    context("forcing environment constraint reevaluation") {
       test("clears state only for stateful constraints") {
-        subject.reevaluateConstraints(application, environment.name)
+        subject.forceConstraintReevaluation(application, environment.name)
 
         verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "manual-judgement") }
         verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "pipeline") }
@@ -66,7 +66,7 @@ class AdminServiceTests : JUnit5Minutests {
       }
 
       test("clears a specific constraint type when asked to") {
-        subject.reevaluateConstraints(application, environment.name, "pipeline")
+        subject.forceConstraintReevaluation(application, environment.name, "pipeline")
 
         verify(exactly = 0) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "manual-judgement") }
         verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "pipeline") }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
@@ -56,9 +56,9 @@ class AdminServiceTests : JUnit5Minutests {
       every { repository.getDeliveryConfigForApplication(application) } returns deliveryConfig
     }
 
-    context("redoing environment constraints") {
+    context("reevaluating environment constraints") {
       test("clears state only for stateful constraints") {
-        subject.redoConstraints(application, environment.name)
+        subject.reevaluateConstraints(application, environment.name)
 
         verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "manual-judgement") }
         verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "pipeline") }
@@ -66,7 +66,7 @@ class AdminServiceTests : JUnit5Minutests {
       }
 
       test("clears a specific constraint type when asked to") {
-        subject.redoConstraints(application, environment.name, "pipeline")
+        subject.reevaluateConstraints(application, environment.name, "pipeline")
 
         verify(exactly = 0) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "manual-judgement") }
         verify(exactly = 1) { repository.deleteConstraintState(deliveryConfig.name, environment.name, "pipeline") }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -54,11 +54,11 @@ class AdminController(
   @PostMapping(
     path = ["/application/{application}/environment/{environment}/reevaluate"]
   )
-  fun reevaluateConstraints(
+  fun forceConstraintReevaluation(
     @PathVariable("application") application: String,
     @PathVariable("environment") environment: String,
     @RequestParam("type", required = false) type: String? = null
   ) {
-    adminService.reevaluateConstraints(application, environment, type)
+    adminService.forceConstraintReevaluation(application, environment, type)
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -52,13 +52,13 @@ class AdminController(
   }
 
   @PostMapping(
-    path = ["/application/{application}/environment/{environment}/redo"]
+    path = ["/application/{application}/environment/{environment}/reevaluate"]
   )
-  fun redoConstraints(
+  fun reevaluateConstraints(
     @PathVariable("application") application: String,
     @PathVariable("environment") environment: String,
     @RequestParam("type", required = false) type: String? = null
   ) {
-    adminService.redoConstraints(application, environment, type)
+    adminService.reevaluateConstraints(application, environment, type)
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -48,5 +49,16 @@ class AdminController(
   )
   fun triggerRecheck(@PathVariable("resourceId") resourceId: String) {
     adminService.triggerRecheck(resourceId)
+  }
+
+  @PostMapping(
+    path = ["/application/{application}/environment/{environment}/redo"]
+  )
+  fun redoConstraints(
+    @PathVariable("application") application: String,
+    @PathVariable("environment") environment: String,
+    @RequestParam("type", required = false) type: String? = null
+  ) {
+    adminService.redoConstraints(application, environment, type)
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -17,6 +17,7 @@ import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
 import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
+import com.netflix.spinnaker.keel.exceptions.NoSuchEnvironmentException
 import com.netflix.spinnaker.keel.exceptions.ValidationException
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
@@ -64,7 +65,14 @@ class ExceptionHandler(
     return ApiError(UNPROCESSABLE_ENTITY, e)
   }
 
-  @ExceptionHandler(NoSuchArtifactException::class, ResourceNotFound::class, NoSuchResourceException::class, InvalidConstraintException::class, NoSuchDeliveryConfigException::class)
+  @ExceptionHandler(
+    NoSuchArtifactException::class,
+    ResourceNotFound::class,
+    NoSuchResourceException::class,
+    InvalidConstraintException::class,
+    NoSuchDeliveryConfigException::class,
+    NoSuchEnvironmentException::class
+  )
   @ResponseStatus(NOT_FOUND)
   fun onNotFound(e: Exception): ApiError {
     log.error(e.message)


### PR DESCRIPTION
closes https://github.com/spinnaker/keel/issues/1174

An endpoint to redo the evaluation of all stateful constraints for an environment, with the option to specifically trigger only one type. This is useful for recovering from a bad state.