### PR TITLE
Chore(validations): Aligning config validations across multiple endpoints

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -1,0 +1,84 @@
+package com.netflix.spinnaker.keel.validators
+
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
+import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
+import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Run validation checks against delivery config to ensure:
+ *
+ * - resources have unique ids
+ * - artifacts have unique references
+ * - depends on environments are unique
+ *
+ * Throws an exception if config fails any checks
+ */
+@Component
+class DeliveryConfigValidator {
+
+  val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  fun validate(config: SubmittedDeliveryConfig) {
+
+    // helper function to get duplicates in a list
+    fun duplicates(ids: List<String>): List<String> =
+      ids.groupingBy { it }
+        .eachCount()
+        .filter { it.value > 1 }
+        .keys
+        .toList()
+
+    /**
+     * check: resources have unique ids
+     */
+
+    val resources = config.environments.map { it.resources }.flatten().map { it.spec.id }
+    val duplicateResources = duplicates(resources)
+
+    if (duplicateResources.isNotEmpty()) {
+      val envToResources: Map<String, MutableList<String>> = config.environments
+        .map { env -> env.name to env.resources.map { it.spec.id }.toMutableList() }.toMap()
+      val envsAndDuplicateResources = envToResources
+        .filterValues { rs: MutableList<String> ->
+          // remove all the resources we don't care about from this mapping
+          rs.removeIf { it !in duplicateResources }
+          // if there are resources left that we care about, leave it in the map
+          rs.isNotEmpty()
+        }
+      log.error("Validation failed for ${config.name}, duplicates resource ids found: $envsAndDuplicateResources")
+      throw DuplicateResourceIdException(duplicateResources, envsAndDuplicateResources)
+    }
+
+    /**
+     * check: artifacts have unique references
+     */
+    val refs = config.artifacts.map { it.reference }
+    val duplicateRefs = duplicates(refs)
+
+    if (duplicateRefs.isNotEmpty()) {
+      val duplicatesArtifactNameToRef: Map<String, String> = config.artifacts
+        .filter { duplicateRefs.contains(it.reference) }
+        .associate { art -> art.name to art.reference }
+
+      log.error("Validation failed for ${config.name}, duplicate artifact references found: $duplicatesArtifactNameToRef")
+      throw DuplicateArtifactReferenceException(duplicatesArtifactNameToRef)
+    }
+
+    /**
+     * check: depends on environments uniqueness
+     */
+    config.environments.forEach { environment ->
+      environment.constraints.forEach { constraint ->
+        if (constraint is DependsOnConstraint) {
+          config.environments.find {
+            it.name == constraint.environment
+          } ?: throw MissingEnvironmentReferenceException(constraint.environment)
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -9,19 +9,22 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
 /**
- * Run validation checks against delivery config to ensure:
- *
- * - resources have unique ids
- * - artifacts have unique references
- * - depends on environments are unique
- *
- * Throws an exception if config fails any checks
+ * Provides delivery config validation functions
  */
 @Component
 class DeliveryConfigValidator {
 
   val log by lazy { LoggerFactory.getLogger(javaClass) }
 
+  /**
+   * Run validation checks against delivery config to ensure:
+   *
+   * - resources have unique ids
+   * - artifacts have unique references
+   * - depends on environments are unique
+   *
+   * Throws an exception if config fails any checks
+   */
   fun validate(config: SubmittedDeliveryConfig) {
 
     // helper function to get duplicates in a list
@@ -35,7 +38,6 @@ class DeliveryConfigValidator {
     /**
      * check: resources have unique ids
      */
-
     val resources = config.environments.map { it.resources }.flatten().map { it.spec.id }
     val duplicateResources = duplicates(resources)
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -1,0 +1,194 @@
+package com.netflix.spinnaker.keel.validators
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.core.api.SubmittedEnvironment
+import com.netflix.spinnaker.keel.core.api.SubmittedResource
+import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
+import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
+import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.TEST_API_V1
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+
+/**
+ * Tests that involve creating, updating, or deleting things from two or more of the three repositories present.
+ *
+ * Tests that only apply to one repository should live in the repository-specific test classes.
+ */
+internal class DeliveryConfigValidatorTests : JUnit5Minutests {
+
+    val configName = "my-config"
+    val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName)
+    val newArtifact = artifact.copy(reference = "myart")
+    val firstResource = resource()
+    val secondResource = resource()
+    val firstEnv = Environment(name = "env1", resources = setOf(firstResource))
+    val secondEnv = Environment(name = "env2", resources = setOf(secondResource))
+    val deliveryConfig = DeliveryConfig(
+      name = configName,
+      application = "fnord",
+      serviceAccount = "keel@spinnaker",
+      artifacts = setOf(artifact),
+      environments = setOf(firstEnv)
+    )
+    val subject = DeliveryConfigValidator()
+
+
+  fun deliveryConfigValidatorTests() = rootContext<DeliveryConfigValidator> {
+    fixture {
+      DeliveryConfigValidator()
+    }
+
+    context("a delivery config with non-unique resource ids errors while persisting") {
+      val submittedConfig = SubmittedDeliveryConfig(
+        name = configName,
+        application = "keel",
+        serviceAccount = "keel@spinnaker",
+        artifacts = setOf(artifact),
+        environments = setOf(
+          SubmittedEnvironment(
+            name = "test",
+            resources = setOf(
+              SubmittedResource(
+                kind = TEST_API_V1.qualify("whatever"),
+                spec = DummyResourceSpec("test", "im a twin", "keel")
+              )
+            ),
+            constraints = emptySet()
+          ),
+          SubmittedEnvironment(
+            name = "prod",
+            resources = setOf(
+              SubmittedResource(
+                kind = TEST_API_V1.qualify("whatever"),
+                spec = DummyResourceSpec("test", "im a twin", "keel")
+              )
+            ),
+            constraints = emptySet()
+          )
+        )
+      )
+
+      test("an error is thrown and config is deleted") {
+        expectCatching {
+          subject.validate(submittedConfig)
+        }.isFailure()
+          .isA<DuplicateResourceIdException>()
+
+       // expectThat(subject.allResourceNames().size).isEqualTo(0)
+      }
+    }
+
+    context("a delivery config with non-unique artifact references errors while persisting") {
+      // Two different artifacts with the same reference
+      val artifacts = setOf(
+        DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing"),
+        DockerArtifact(name = "org/thing-2", deliveryConfigName = configName, reference = "thing")
+      )
+
+      val submittedConfig = SubmittedDeliveryConfig(
+        name = configName,
+        application = "keel",
+        serviceAccount = "keel@spinnaker",
+        artifacts = artifacts,
+        environments = setOf(
+          SubmittedEnvironment(
+            name = "test",
+            resources = setOf(
+              SubmittedResource(
+                metadata = mapOf("serviceAccount" to "keel@spinnaker"),
+                kind = TEST_API_V1.qualify("whatever"),
+                spec = DummyResourceSpec(data = "o hai")
+              )
+            ),
+            constraints = emptySet()
+          )
+        )
+      )
+      test("an error is thrown and config is deleted") {
+        expectCatching {
+          subject.validate(submittedConfig)
+        }.isFailure()
+          .isA<DuplicateArtifactReferenceException>()
+
+       // expectThat(subject.allResourceNames().size).isEqualTo(0)
+      }
+    }
+
+    context("a second delivery config for an app fails to persist") {
+      val submittedConfig1 = SubmittedDeliveryConfig(
+        name = configName,
+        application = "keel",
+        serviceAccount = "keel@spinnaker",
+        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+        environments = setOf(
+          SubmittedEnvironment(
+            name = "test",
+            resources = setOf(
+              SubmittedResource(
+                metadata = mapOf("serviceAccount" to "keel@spinnaker"),
+                kind = TEST_API_V1.qualify("whatever"),
+                spec = DummyResourceSpec(data = "o hai")
+              )
+            ),
+            constraints = emptySet()
+          )
+        )
+      )
+
+      val submittedConfig2 = submittedConfig1.copy(name = "double-trouble")
+//      test("an error is thrown and config is not persisted") {
+//        subject.validate(submittedConfig1)
+//        expectCatching {
+//          subject.validate(submittedConfig2)
+//        }.isFailure()
+//          .isA<TooManyDeliveryConfigsException>()
+//
+//        //expectThat(subject.getDeliveryConfigForApplication("keel").name).isEqualTo(configName)
+//      }
+    }
+
+    context("submitting delivery config with invalid environment name as a constraint") {
+      val submittedConfig = SubmittedDeliveryConfig(
+        name = configName,
+        application = "keel",
+        serviceAccount = "keel@spinnaker",
+        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+        environments = setOf(
+          SubmittedEnvironment(
+            name = "test",
+            resources = emptySet(),
+            constraints = emptySet()
+          ),
+          SubmittedEnvironment(
+            name = "test",
+            resources = emptySet(),
+            constraints = setOf(DependsOnConstraint(environment = "notARealEnvironment"))
+          )
+        )
+      )
+
+      test("an error is thrown and config is not persisted") {
+        expectCatching {
+          subject.validate(submittedConfig)
+        }.isFailure()
+          .isA<MissingEnvironmentReferenceException>()
+
+//        expectCatching {
+//          subject.getDeliveryConfig(configName)
+//        }.isFailure()
+//          .isA<NoSuchDeliveryConfigException>()
+      }
+    }
+  }
+}
+

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -1,7 +1,5 @@
 package com.netflix.spinnaker.keel.validators
 
-import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
@@ -12,36 +10,18 @@ import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.TEST_API_V1
-import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectCatching
 import strikt.assertions.isA
 import strikt.assertions.isFailure
 
-/**
- * Tests that involve creating, updating, or deleting things from two or more of the three repositories present.
- *
- * Tests that only apply to one repository should live in the repository-specific test classes.
- */
 internal class DeliveryConfigValidatorTests : JUnit5Minutests {
 
-    val configName = "my-config"
-    val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName)
-    val newArtifact = artifact.copy(reference = "myart")
-    val firstResource = resource()
-    val secondResource = resource()
-    val firstEnv = Environment(name = "env1", resources = setOf(firstResource))
-    val secondEnv = Environment(name = "env2", resources = setOf(secondResource))
-    val deliveryConfig = DeliveryConfig(
-      name = configName,
-      application = "fnord",
-      serviceAccount = "keel@spinnaker",
-      artifacts = setOf(artifact),
-      environments = setOf(firstEnv)
-    )
-    val subject = DeliveryConfigValidator()
+  private val configName = "my-config"
+  val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName)
 
+  val subject = DeliveryConfigValidator()
 
   fun deliveryConfigValidatorTests() = rootContext<DeliveryConfigValidator> {
     fixture {
@@ -83,8 +63,6 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
           subject.validate(submittedConfig)
         }.isFailure()
           .isA<DuplicateResourceIdException>()
-
-       // expectThat(subject.allResourceNames().size).isEqualTo(0)
       }
     }
 
@@ -119,8 +97,6 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
           subject.validate(submittedConfig)
         }.isFailure()
           .isA<DuplicateArtifactReferenceException>()
-
-       // expectThat(subject.allResourceNames().size).isEqualTo(0)
       }
     }
 
@@ -182,13 +158,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
           subject.validate(submittedConfig)
         }.isFailure()
           .isA<MissingEnvironmentReferenceException>()
-
-//        expectCatching {
-//          subject.getDeliveryConfig(configName)
-//        }.isFailure()
-//          .isA<NoSuchDeliveryConfigException>()
       }
     }
   }
 }
-

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -28,7 +28,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
       DeliveryConfigValidator()
     }
 
-    context("a delivery config with non-unique resource ids errors while persisting") {
+    context("a delivery config with non-unique resource ids fails validation") {
       val submittedConfig = SubmittedDeliveryConfig(
         name = configName,
         application = "keel",
@@ -58,7 +58,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
         )
       )
 
-      test("an error is thrown and config is deleted") {
+      test("an error is thrown") {
         expectCatching {
           subject.validate(submittedConfig)
         }.isFailure()
@@ -66,7 +66,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
       }
     }
 
-    context("a delivery config with non-unique artifact references errors while persisting") {
+    context("a delivery config with non-unique artifact references errors fails validation") {
       // Two different artifacts with the same reference
       val artifacts = setOf(
         DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing"),
@@ -92,45 +92,12 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
           )
         )
       )
-      test("an error is thrown and config is deleted") {
+      test("an error is thrown") {
         expectCatching {
           subject.validate(submittedConfig)
         }.isFailure()
           .isA<DuplicateArtifactReferenceException>()
       }
-    }
-
-    context("a second delivery config for an app fails to persist") {
-      val submittedConfig1 = SubmittedDeliveryConfig(
-        name = configName,
-        application = "keel",
-        serviceAccount = "keel@spinnaker",
-        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
-        environments = setOf(
-          SubmittedEnvironment(
-            name = "test",
-            resources = setOf(
-              SubmittedResource(
-                metadata = mapOf("serviceAccount" to "keel@spinnaker"),
-                kind = TEST_API_V1.qualify("whatever"),
-                spec = DummyResourceSpec(data = "o hai")
-              )
-            ),
-            constraints = emptySet()
-          )
-        )
-      )
-
-      val submittedConfig2 = submittedConfig1.copy(name = "double-trouble")
-//      test("an error is thrown and config is not persisted") {
-//        subject.validate(submittedConfig1)
-//        expectCatching {
-//          subject.validate(submittedConfig2)
-//        }.isFailure()
-//          .isA<TooManyDeliveryConfigsException>()
-//
-//        //expectThat(subject.getDeliveryConfigForApplication("keel").name).isEqualTo(configName)
-//      }
     }
 
     context("submitting delivery config with invalid environment name as a constraint") {
@@ -153,7 +120,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
         )
       )
 
-      test("an error is thrown and config is not persisted") {
+      test("an error is thrown") {
         expectCatching {
           subject.validate(submittedConfig)
         }.isFailure()

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.DeleteMapping
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -89,12 +91,10 @@ class DeliveryConfigController(
     consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
   )
+  @ResponseStatus(value = HttpStatus.NO_CONTENT)
   @PreAuthorize("@authorizationSupport.hasApplicationPermission('READ', 'APPLICATION', #deliveryConfig.application)")
   fun validate(@RequestBody deliveryConfig: SubmittedDeliveryConfig) {
-    // TODO: replace with JSON schema/OpenAPI spec validation when ready (for now, leveraging parsing error handling
-    //  in [ExceptionHandler])
     validator.validate(deliveryConfig)
-    // mapOf("status" to "valid")
   }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/1021.

This is a stab at aligning delivery config validations across endpoints:
POST /delivery-configs (upsert a config)
POST /delivery-configs/diff (diffing a new config to an existing one)
POST /delivery-configs/validate (static validation of config)

My logic was to extract the validation logic to a `DeliveryConfigValidator` class, which will be a centralized class for the different validations. To make it work with all the endpoints above, I've transformed the logic to apply on the `SubmittedDeliveryConfig` object rather than `DeliveryConfig` and wired the validator to the controller class rather than each individual implementation.

Next:
- [ ] Add more validations
- [ ] Clean up code
