### PR TITLE
refactor(db): standardize timestamp types in all tables

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlAgentLockRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlAgentLockRepository.kt
@@ -21,7 +21,7 @@ class SqlAgentLockRepository(
     var changed = sqlRetry.withRetry(WRITE) {
       jooq.insertInto(AGENT_LOCK)
         .set(AGENT_LOCK.LOCK_NAME, agentName)
-        .set(AGENT_LOCK.EXPIRY, now.plusSeconds(lockTimeoutSeconds).toEpochMilli())
+        .set(AGENT_LOCK.EXPIRY, now.plusSeconds(lockTimeoutSeconds).toTimestamp())
         .onDuplicateKeyIgnore()
         .execute()
     }
@@ -29,10 +29,10 @@ class SqlAgentLockRepository(
     if (changed == 0) {
       changed = sqlRetry.withRetry(WRITE) {
         jooq.update(AGENT_LOCK)
-          .set(AGENT_LOCK.EXPIRY, now.plusSeconds(lockTimeoutSeconds).toEpochMilli())
+          .set(AGENT_LOCK.EXPIRY, now.plusSeconds(lockTimeoutSeconds).toTimestamp())
           .where(
             AGENT_LOCK.LOCK_NAME.eq(agentName),
-            AGENT_LOCK.EXPIRY.lt(now.toEpochMilli())
+            AGENT_LOCK.EXPIRY.lt(now.toTimestamp())
           )
           .execute()
       }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepository.kt
@@ -42,7 +42,7 @@ class SqlDiffFingerprintRepository(
     }
     record?.let { (count, firstDetectionTime, existingHash) ->
       var newCount = 1
-      var newTime = clock.instant().toEpochMilli()
+      var newTime = clock.timestamp()
       if (hash == existingHash) {
         newCount = count + 1
         newTime = firstDetectionTime
@@ -65,7 +65,7 @@ class SqlDiffFingerprintRepository(
         .set(DIFF_FINGERPRINT.ENTITY_ID, entityId)
         .set(DIFF_FINGERPRINT.HASH, hash)
         .set(DIFF_FINGERPRINT.COUNT, 1)
-        .set(DIFF_FINGERPRINT.FIRST_DETECTION_TIME, clock.instant().toEpochMilli())
+        .set(DIFF_FINGERPRINT.FIRST_DETECTION_TIME, clock.timestamp())
         .execute()
     }
   }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepository.kt
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import java.time.Clock
-import java.time.Instant
 import java.time.ZoneOffset
 import org.jooq.DSLContext
 
@@ -83,7 +82,7 @@ class SqlPausedRepository(
         .insertInto(PAUSED)
         .set(PAUSED.SCOPE, scope.name)
         .set(PAUSED.NAME, name)
-        .set(PAUSED.PAUSED_AT, clock.instant().toLocal())
+        .set(PAUSED.PAUSED_AT, clock.instant().toTimestamp())
         .set(PAUSED.PAUSED_BY, user)
         .onDuplicateKeyIgnore()
         .execute()
@@ -119,6 +118,4 @@ class SqlPausedRepository(
         .where(PAUSED.SCOPE.eq(scope.name))
         .fetch(PAUSED.NAME)
     }
-
-  private fun Instant.toLocal() = atZone(clock.zone).toLocalDateTime()
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepository.kt
@@ -18,7 +18,7 @@ class SqlTaskTrackingRepository(
         .set(TASK_TRACKING.SUBJECT, task.subject)
         .set(TASK_TRACKING.TASK_ID, task.id)
         .set(TASK_TRACKING.TASK_NAME, task.name)
-        .set(TASK_TRACKING.TIMESTAMP, clock.instant().toEpochMilli())
+        .set(TASK_TRACKING.TIMESTAMP, clock.timestamp())
         .onDuplicateKeyIgnore()
         .execute()
     }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
@@ -36,9 +36,9 @@ class SqlUnhappyVetoRepository(
       jooq.insertInto(UNHAPPY_VETO)
         .set(UNHAPPY_VETO.RESOURCE_ID, resourceId)
         .set(UNHAPPY_VETO.APPLICATION, application)
-        .set(UNHAPPY_VETO.RECHECK_TIME, calculateExpirationTime(wait).toEpochMilli())
+        .set(UNHAPPY_VETO.RECHECK_TIME, calculateExpirationTime(wait).toTimestamp())
         .onDuplicateKeyUpdate()
-        .set(UNHAPPY_VETO.RECHECK_TIME, calculateExpirationTime(wait).toEpochMilli())
+        .set(UNHAPPY_VETO.RECHECK_TIME, calculateExpirationTime(wait).toTimestamp())
         .execute()
     }
   }
@@ -61,8 +61,8 @@ class SqlUnhappyVetoRepository(
     }
       ?.let { (recheckTime) ->
         return UnhappyVetoStatus(
-          shouldSkip = recheckTime > clock.instant().toEpochMilli(),
-          shouldRecheck = recheckTime < clock.instant().toEpochMilli()
+          shouldSkip = recheckTime > clock.timestamp(),
+          shouldRecheck = recheckTime < clock.timestamp()
         )
       }
 
@@ -71,7 +71,7 @@ class SqlUnhappyVetoRepository(
   }
 
   override fun getAll(): Set<String> {
-    val now = clock.instant().toEpochMilli()
+    val now = clock.timestamp()
     return sqlRetry.withRetry(READ) {
       jooq.select(UNHAPPY_VETO.RESOURCE_ID)
         .from(UNHAPPY_VETO)
@@ -82,7 +82,7 @@ class SqlUnhappyVetoRepository(
   }
 
   override fun getAllForApp(application: String): Set<String> {
-    val now = clock.instant().toEpochMilli()
+    val now = clock.timestamp()
     return sqlRetry.withRetry(READ) {
       jooq.select(UNHAPPY_VETO.RESOURCE_ID)
         .from(UNHAPPY_VETO)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/timestamps.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/timestamps.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.sql
+
+import java.time.Clock
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+
+fun Instant.toTimestamp(): LocalDateTime = atZone(UTC).toLocalDateTime()
+fun Clock.timestamp(): LocalDateTime = instant().toTimestamp()

--- a/keel-sql/src/main/resources/db/changelog/20200522-standardize-timestamps.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200522-standardize-timestamps.yml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+- changeSet:
+    id: event-uid-timestamp-index
+    author: fletch
+    changes:
+    - sql:
+        sql: |
+          alter table agent_lock change column expiry old bigint(13);
+          alter table agent_lock add column expiry timestamp(3) not null;
+          update agent_lock set expiry = from_unixtime(old / 1000);
+          alter table agent_lock drop column old;
+
+          alter table diff_fingerprint change column first_detection_time old bigint(13);
+          alter table diff_fingerprint add column first_detection_time timestamp(3) not null;
+          update diff_fingerprint set first_detection_time = from_unixtime(old / 1000);
+          alter table diff_fingerprint drop column old;
+
+          alter table environment_artifact_pin change column pinned_at old bigint(13);
+          alter table environment_artifact_pin add column pinned_at timestamp(3) not null;
+          update environment_artifact_pin set pinned_at = from_unixtime(old / 1000);
+          alter table environment_artifact_pin drop column old;
+
+          alter table environment_artifact_queued_approval change column queued_at old bigint(13);
+          alter table environment_artifact_queued_approval add column queued_at timestamp(3) not null;
+          update environment_artifact_queued_approval set queued_at = from_unixtime(old / 1000);
+          alter table environment_artifact_queued_approval drop column old;
+
+          alter table task_tracking change column timestamp old bigint(13);
+          alter table task_tracking add column timestamp timestamp(3) not null;
+          update task_tracking set timestamp = from_unixtime(old / 1000);
+          alter table task_tracking drop column old;
+
+          alter table unhappy_veto change column recheck_time old bigint(13);
+          alter table unhappy_veto add column recheck_time timestamp(3) not null;
+          update unhappy_veto set recheck_time = from_unixtime(old / 1000);
+          alter table unhappy_veto drop column old;
+    - sql:
+        sql: |
+          alter table artifact_last_checked modify at timestamp(3) not null;
+          alter table delivery_config_last_checked modify at timestamp(3) not null;
+          alter table environment_artifact_constraint modify created_at timestamp(3) not null;
+          alter table environment_artifact_constraint modify judged_at timestamp(3) null;
+          alter table environment_artifact_versions modify approved_at timestamp(3) null;
+          alter table environment_artifact_versions modify deployed_at timestamp(3) null;
+          alter table environment_artifact_versions modify replaced_at timestamp(3) null;
+          alter table event modify timestamp timestamp(3) not null;
+          alter table paused modify paused_at timestamp(3) null;
+          alter table resource_last_checked modify at timestamp(3) not null;

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -149,3 +149,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200521-drop-cluster-lock-table.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200522-standardize-timestamps.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
We've used a mixture of `bigint` and `timestamp` on our tables. This PR standardizes on the latter. It also ensures we have millisecond precision (which is probably only really important on `event` but makes sense as a standard for compatibility with `java.time` types).