### PR TITLE
fix(validations): fetch the right resource id when looking for duplications

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.validators
 
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.core.api.id
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
@@ -38,7 +39,7 @@ class DeliveryConfigValidator {
     /**
      * check: resources have unique ids
      */
-    val resources = config.environments.map { it.resources }.flatten().map { it.spec.id }
+    val resources = config.environments.map { it.resources }.flatten().map { it.id }
     val duplicateResources = duplicates(resources)
 
     if (duplicateResources.isNotEmpty()) {


### PR DESCRIPTION
when validating a submitted delivery config, generate its unique resource id rather than the spec id.