### PR TITLE
feat(deploy): Make red-black wait time configurable, orca stage timeout based on all delays

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
@@ -50,8 +50,6 @@ data class RedBlack(
 ) : ClusterDeployStrategy() {
 
   companion object {
-    val ORCA_STAGE_TIMEOUT_MARGIN: Duration = Duration.ofMinutes(5)
-
     fun fromOrcaStageContext(context: Map<String, Any?>) =
       RedBlack(
         rollbackOnFailure = context["rollback"]
@@ -79,8 +77,7 @@ data class RedBlack(
     "stageTimeoutMs" to (
       (waitForInstancesUp ?: DEFAULT_WAIT_FOR_INSTANCES_UP) +
       (delayBeforeDisable ?: ZERO) +
-      (delayBeforeScaleDown ?: ZERO) +
-      ORCA_STAGE_TIMEOUT_MARGIN
+      (delayBeforeScaleDown ?: ZERO)
     ).toMillis()
   )
 
@@ -101,7 +98,7 @@ data class RedBlack(
 object Highlander : ClusterDeployStrategy() {
   override fun toOrcaJobProperties() = mapOf(
     "strategy" to "highlander",
-    "stageTimeoutMs" to (DEFAULT_WAIT_FOR_INSTANCES_UP + RedBlack.ORCA_STAGE_TIMEOUT_MARGIN).toMillis()
+    "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis()
   )
 
   override fun withDefaultsOmitted() = this

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
@@ -30,6 +30,10 @@ sealed class ClusterDeployStrategy {
   open val stagger: List<StaggeredRegion> = emptyList()
   abstract fun toOrcaJobProperties(): Map<String, Any?>
   abstract fun withDefaultsOmitted(): ClusterDeployStrategy
+
+  companion object {
+    val DEFAULT_WAIT_FOR_INSTANCES_UP: Duration = Duration.ofMinutes(30)
+  }
 }
 
 @JsonTypeName("red-black")
@@ -46,7 +50,6 @@ data class RedBlack(
 ) : ClusterDeployStrategy() {
 
   companion object {
-    val DEFAULT_WAIT_FOR_INSTANCES_UP: Duration = Duration.ofMinutes(30)
     val ORCA_STAGE_TIMEOUT_MARGIN: Duration = Duration.ofMinutes(5)
 
     fun fromOrcaStageContext(context: Map<String, Any?>) =
@@ -98,7 +101,7 @@ data class RedBlack(
 object Highlander : ClusterDeployStrategy() {
   override fun toOrcaJobProperties() = mapOf(
     "strategy" to "highlander",
-    "stageTimeoutMs" to Duration.ofMinutes(30).toMillis()
+    "stageTimeoutMs" to (DEFAULT_WAIT_FOR_INSTANCES_UP + RedBlack.ORCA_STAGE_TIMEOUT_MARGIN).toMillis()
   )
 
   override fun withDefaultsOmitted() = this

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -2,9 +2,9 @@ package com.netflix.spinnaker.keel.api
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy
+import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
 import com.netflix.spinnaker.keel.core.api.Highlander
 import com.netflix.spinnaker.keel.core.api.RedBlack
-import com.netflix.spinnaker.keel.core.api.RedBlack.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
 import com.netflix.spinnaker.keel.core.api.RedBlack.Companion.ORCA_STAGE_TIMEOUT_MARGIN
 import com.netflix.spinnaker.keel.core.api.StaggeredRegion
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -5,7 +5,6 @@ import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
 import com.netflix.spinnaker.keel.core.api.Highlander
 import com.netflix.spinnaker.keel.core.api.RedBlack
-import com.netflix.spinnaker.keel.core.api.RedBlack.Companion.ORCA_STAGE_TIMEOUT_MARGIN
 import com.netflix.spinnaker.keel.core.api.StaggeredRegion
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import dev.minutest.junit.JUnit5Minutests
@@ -100,7 +99,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
                 "delayBeforeScaleDownSec" to strategy.delayBeforeScaleDown?.seconds,
                 "scaleDown" to strategy.resizePreviousToZero,
                 "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
-                "stageTimeoutMs" to (DEFAULT_WAIT_FOR_INSTANCES_UP + ORCA_STAGE_TIMEOUT_MARGIN).toMillis()
+                "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis()
               )
             )
           }
@@ -127,7 +126,6 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
                 "scaleDown" to strategy.resizePreviousToZero,
                 "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
                 "stageTimeoutMs" to (
-                  ORCA_STAGE_TIMEOUT_MARGIN +
                   strategy.delayBeforeDisable!! +
                   strategy.delayBeforeScaleDown!! +
                   strategy.waitForInstancesUp!!

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -1,12 +1,16 @@
 package com.netflix.spinnaker.keel.api
 
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.netflix.spinnaker.keel.core.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.core.api.Highlander
 import com.netflix.spinnaker.keel.core.api.RedBlack
+import com.netflix.spinnaker.keel.core.api.RedBlack.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
+import com.netflix.spinnaker.keel.core.api.RedBlack.Companion.ORCA_STAGE_TIMEOUT_MARGIN
 import com.netflix.spinnaker.keel.core.api.StaggeredRegion
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import java.time.Duration
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
@@ -22,51 +26,116 @@ import strikt.jackson.path
 import strikt.jackson.textValue
 
 internal class ClusterDeployStrategyTests : JUnit5Minutests {
-  object Fixture {
+  data class Fixture(
+    val strategy: ClusterDeployStrategy
+  ) {
     val mapper = configuredObjectMapper()
   }
 
   fun tests() = rootContext<Fixture> {
-    fixture { Fixture }
+    context("highlander") {
+      fixture { Fixture(Highlander) }
 
-    test("highlander serializes to JSON") {
-      expectThat(mapper.writeValueAsString(Highlander))
-        .isEqualTo("""{"strategy":"highlander"}""")
-    }
-
-    test("red-black serializes to JSON") {
-      println(mapper.writeValueAsString(RedBlack()))
-      expectThat<ObjectNode>(mapper.valueToTree(RedBlack())) {
-        path("strategy").textValue() isEqualTo "red-black"
-        path("resizePreviousToZero").booleanValue().isFalse()
-        path("rollbackOnFailure").booleanValue().isTrue()
-        path("maxServerGroups").numberValue().isEqualTo(2)
-        path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
-        path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
-        path("stagger").isMissing()
+      test("serializes to JSON") {
+        expectThat(mapper.writeValueAsString(strategy))
+          .isEqualTo("""{"strategy":"highlander"}""")
       }
     }
 
-    test("red-black with stagger serializes to JSON") {
-      val strategy = RedBlack(
-        stagger = listOf(
-          StaggeredRegion(
-            region = "us-west-2",
-            hours = "12-18")))
+    context("red-black") {
+      fixture { Fixture(RedBlack()) }
 
-      println(mapper.writeValueAsString(strategy))
-      expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
-        path("strategy").textValue() isEqualTo "red-black"
-        path("resizePreviousToZero").booleanValue().isFalse()
-        path("rollbackOnFailure").booleanValue().isTrue()
-        path("maxServerGroups").numberValue().isEqualTo(2)
-        path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
-        path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
-        path("stagger").isArray().hasSize(1)
-        at("/stagger/0/region").isTextual().textValue() isEqualTo "us-west-2"
-        at("/stagger/0/hours").isTextual().textValue() isEqualTo "12-18"
-        at("/stagger/0/allowedHours").isMissing()
-        at("/stagger/0/pauseTime").isMissing()
+      test("serializes to JSON") {
+        println(mapper.writeValueAsString(strategy))
+        expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
+          path("strategy").textValue() isEqualTo "red-black"
+          path("resizePreviousToZero").booleanValue().isFalse()
+          path("rollbackOnFailure").booleanValue().isTrue()
+          path("maxServerGroups").numberValue().isEqualTo(2)
+          path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
+          path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
+          path("stagger").isMissing()
+        }
+      }
+
+      context("with stagger") {
+        fixture {
+          Fixture(
+            RedBlack(
+              stagger = listOf(
+                StaggeredRegion(
+                  region = "us-west-2",
+                  hours = "12-18")
+              )
+            )
+          )
+        }
+
+        test("serializes to JSON") {
+          println(mapper.writeValueAsString(strategy))
+          expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
+            path("strategy").textValue() isEqualTo "red-black"
+            path("resizePreviousToZero").booleanValue().isFalse()
+            path("rollbackOnFailure").booleanValue().isTrue()
+            path("maxServerGroups").numberValue().isEqualTo(2)
+            path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
+            path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
+            path("stagger").isArray().hasSize(1)
+            at("/stagger/0/region").isTextual().textValue() isEqualTo "us-west-2"
+            at("/stagger/0/hours").isTextual().textValue() isEqualTo "12-18"
+            at("/stagger/0/allowedHours").isMissing()
+            at("/stagger/0/pauseTime").isMissing()
+          }
+        }
+      }
+
+      context("conversion to orca job properties") {
+        context("with defaults") {
+          test("includes job properties as expected, stage timeout is default wait + margin") {
+            expectThat((strategy as RedBlack).toOrcaJobProperties()).isEqualTo(
+              mapOf(
+                "strategy" to "redblack",
+                "maxRemainingAsgs" to strategy.maxServerGroups,
+                "delayBeforeDisableSec" to strategy.delayBeforeDisable?.seconds,
+                "delayBeforeScaleDownSec" to strategy.delayBeforeScaleDown?.seconds,
+                "scaleDown" to strategy.resizePreviousToZero,
+                "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
+                "stageTimeoutMs" to (DEFAULT_WAIT_FOR_INSTANCES_UP + ORCA_STAGE_TIMEOUT_MARGIN).toMillis()
+              )
+            )
+          }
+        }
+
+        context("with overrides") {
+          fixture {
+            Fixture(
+              RedBlack(
+                delayBeforeDisable = Duration.ofMinutes(30),
+                delayBeforeScaleDown = Duration.ofMinutes(30),
+                waitForInstancesUp = Duration.ofMinutes(10)
+              )
+            )
+          }
+
+          test("includes job properties as expected, stage timeout is specified delays combined + margin") {
+            expectThat((strategy as RedBlack).toOrcaJobProperties()).isEqualTo(
+              mapOf(
+                "strategy" to "redblack",
+                "maxRemainingAsgs" to strategy.maxServerGroups,
+                "delayBeforeDisableSec" to strategy.delayBeforeDisable?.seconds,
+                "delayBeforeScaleDownSec" to strategy.delayBeforeScaleDown?.seconds,
+                "scaleDown" to strategy.resizePreviousToZero,
+                "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
+                "stageTimeoutMs" to (
+                  ORCA_STAGE_TIMEOUT_MARGIN +
+                  strategy.delayBeforeDisable!! +
+                  strategy.delayBeforeScaleDown!! +
+                  strategy.waitForInstancesUp!!
+                ).toMillis()
+              )
+            )
+          }
+        }
       }
     }
   }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -537,15 +537,6 @@ class ClusterHandler(
           0 -> emptyList()
           else -> listOf(startingRefId.toString())
         },
-        // the 2hr default timeout sort-of? makes sense in an imperative
-        // pipeline world where maybe within 2 hours the environment around
-        // the instances will fix itself and the stage will succeed. Since
-        // we are telling the red/black strategy to roll back on failure,
-        // this will leave us in a position where we will instead keep
-        // reattempting to clone the server group because the rollback
-        // on failure of instances to come up will leave us in a non
-        // converged state...
-        "stageTimeoutMs" to Duration.ofMinutes(30).toMillis(),
         "capacity" to mapOf(
           "min" to capacity.min,
           "max" to capacity.max,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -68,7 +68,6 @@ import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import java.time.Clock
-import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -330,8 +329,6 @@ class TitusClusterHandler(
         "credentials" to location.account,
         "region" to location.region,
         "network" to "default",
-        // todo: does 30 minutes then rollback make sense?
-        "stageTimeoutMs" to Duration.ofMinutes(30).toMillis(),
         "inService" to true,
         "capacity" to mapOf(
           "min" to capacity.min,


### PR DESCRIPTION
Adds a `waitForInstancesUp` configuration to the `red-black` deployment strategy, and replaces the hard-coded 30 minute orca stage timeout for deployment jobs with the sum of this new duration plus existing delay fields in the config (`delayBeforeScaleDown` and `delayBeforeDisable`).

For example, the following config:
```yaml
          deployWith:
            delayBeforeScaleDown: PT1H
            resizePreviousToZero: true
            rollbackOnFailure: false
            strategy: red-black
```
...would translate to a 1 hour delay before scale down + (default) 30 min wait for instances up = 1h30min timeout for the orca task.

Fixes #1180.