### PR TITLE
fix(duplicateResources): don't allow resources to be managed in more than 1 config

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
@@ -259,7 +258,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
           context("after an update") {
             before {
               resourcesDueForCheck()
-              subject.upsertResource<ResourceSpec>(resource.copy(spec = DummyResourceSpec(id = resource.spec.id, data = "kthxbye")), deliveryConfig.name)
+              subject.upsertResource(resource.copy(spec = DummyResourceSpec(id = resource.spec.id, data = "kthxbye")), deliveryConfig.name)
             }
 
             test("stores the updated resource") {
@@ -287,7 +286,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
           context("after a no-op update") {
             before {
               resourcesDueForCheck()
-              subject.upsertResource<ResourceSpec>(resource, deliveryConfig.name)
+              subject.upsertResource(resource, deliveryConfig.name)
             }
 
             test("does not record that the resource was updated") {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -316,26 +316,6 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
         expectThrows<NoSuchDeliveryConfigException> { deliveryConfigRepository.get(secondConfigName) }
         expectCatching { resourceRepository.get(firstResource.id) }.isSuccess()
       }
-
-      context("delete the resource from the first config, and try to persist again") {
-        before {
-          val updatedConfig = deliveryConfig.copy(
-            environments = setOf(firstEnv.copy(resources = setOf(secondResource)))
-          )
-          subject.upsertDeliveryConfig(updatedConfig)
-        }
-        test("try to persist the second config") {
-          expectCatching {
-            subject.upsertDeliveryConfig(secondDeliveryConfig)
-          }.isSuccess()
-
-          expectCatching {
-            deliveryConfigRepository.get(secondConfigName)
-          }.isSuccess()
-
-          expectCatching { resourceRepository.get(firstResource.id) }.isSuccess()
-        }
-      }
     }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateManagedResourceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateManagedResourceException.kt
@@ -6,5 +6,5 @@ class DuplicateManagedResourceException(
   newConfig: String
 ) : ValidationException(
   "Resource with id $id exist in a delivery config named ($existingConfig). " +
-    "Please ensure to remove reousrce $id from config named $existingConfig, if you wish this resource to be managed in a $newConfig."
+    "Please ensure to remove reousrce $id from config named $existingConfig, if you wish this resource to be managed in $newConfig."
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateManagedResourceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateManagedResourceException.kt
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.keel.exceptions
+
+class DuplicateManagedResourceException(
+  val id: String,
+  existingConfig: String,
+  newConfig: String
+) : ValidationException(
+  "Resource with id $id exist in a delivery config named ($existingConfig). " +
+    "Please ensure to remove reousrce $id from config named $existingConfig, if you wish this resource to be managed in a $newConfig."
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -99,7 +99,7 @@ class CombinedRepository(
 
     deliveryConfig.resources.forEach { resource ->
 
-      upsertResource<ResourceSpec>(resource = resource, deliveryConfigName = deliveryConfig.name)
+      upsertResource(resource, deliveryConfig.name)
     }
 
     deliveryConfig.artifacts.forEach { artifact ->

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -98,7 +98,8 @@ class CombinedRepository(
     }
 
     deliveryConfig.resources.forEach { resource ->
-      upsert(resource)
+
+      upsertResource<ResourceSpec>(resource = resource, deliveryConfigName = deliveryConfig.name)
     }
 
     deliveryConfig.artifacts.forEach { artifact ->

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
 import com.netflix.spinnaker.keel.events.ResourceUpdated
+import com.netflix.spinnaker.keel.exceptions.DuplicateManagedResourceException
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import java.time.Clock
 import java.time.Duration
@@ -46,13 +47,20 @@ interface KeelRepository {
   @Transactional(propagation = Propagation.REQUIRED)
   fun upsertDeliveryConfig(deliveryConfig: DeliveryConfig): DeliveryConfig
 
-  fun <T : ResourceSpec> upsert(resource: Resource<T>) {
+  fun <T : ResourceSpec> upsertResource(resource: Resource<*>, deliveryConfigName: String) {
     val existingResource = try {
       getResource(resource.id)
     } catch (e: NoSuchResourceException) {
       null
     }
     if (existingResource != null) {
+      // we allow resources to be managed in a single delivery config file
+      val existingConfig = deliveryConfigFor(existingResource.id)
+      if (existingConfig.name != deliveryConfigName) {
+        log.debug("resource $resource is being managed already by delivery config named ${existingConfig.name}")
+        throw DuplicateManagedResourceException(resource.id, existingConfig.name, deliveryConfigName)
+      }
+
       val diff = DefaultResourceDiff(resource.spec, existingResource.spec)
       if (diff.hasChanges()) {
         log.debug("Updating ${resource.id}")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -47,7 +47,7 @@ interface KeelRepository {
   @Transactional(propagation = Propagation.REQUIRED)
   fun upsertDeliveryConfig(deliveryConfig: DeliveryConfig): DeliveryConfig
 
-  fun <T : ResourceSpec> upsertResource(resource: Resource<*>, deliveryConfigName: String) {
+  fun <T : ResourceSpec> upsertResource(resource: Resource<T>, deliveryConfigName: String) {
     val existingResource = try {
       getResource(resource.id)
     } catch (e: NoSuchResourceException) {


### PR DESCRIPTION
fixes https://github.com/spinnaker/keel/issues/1242.

Currently we allow a single resource to be managed by more than 1 delivery config file. This fix is blocking it by making sure the combination of a delivery config name + resource id is unique. 