### PR TITLE
Remove UnhappyControl from non-ResourceSpec classes

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -42,9 +42,7 @@ fun ClusterSpec.resolve(): Set<ServerGroup> =
       scaling = resolveScaling(it.name),
       tags = defaults.tags + overrides[it.name]?.tags,
       artifactName = artifactName,
-      artifactVersion = artifactVersion,
-      maxDiffCount = maxDiffCount,
-      unhappyWaitTime = unhappyWaitTime
+      artifactVersion = artifactVersion
     )
   }
     .toSet()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.keel.api.Moniker
-import com.netflix.spinnaker.keel.api.UnhappyControl
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
@@ -29,7 +28,6 @@ import com.netflix.spinnaker.keel.core.api.ClusterDependencies
 import com.netflix.spinnaker.keel.core.parseMoniker
 import de.danielbechler.diff.inclusion.Inclusion.EXCLUDED
 import de.danielbechler.diff.introspection.ObjectDiffProperty
-import java.time.Duration
 
 data class ServerGroup(
   /**
@@ -63,12 +61,8 @@ data class ServerGroup(
   override val artifactType: ArtifactType? = ArtifactType.deb,
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = EXCLUDED)
-  override val artifactVersion: String? = null,
-  @get:ObjectDiffProperty(inclusion = EXCLUDED)
-  override val maxDiffCount: Int? = null,
-  @get:ObjectDiffProperty(inclusion = EXCLUDED)
-  override val unhappyWaitTime: Duration? = null
-) : VersionedArtifactProvider, UnhappyControl {
+  override val artifactVersion: String? = null
+) : VersionedArtifactProvider {
   init {
     require(
       capacity.desired != null && !scaling.hasScalingPolicies() ||

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.keel.api.titus.cluster
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.keel.api.Moniker
-import com.netflix.spinnaker.keel.api.UnhappyControl
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
@@ -31,7 +30,6 @@ import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.docker.DigestProvider
 import de.danielbechler.diff.inclusion.Inclusion
 import de.danielbechler.diff.introspection.ObjectDiffProperty
-import java.time.Duration
 
 data class TitusServerGroup(
   /**
@@ -68,12 +66,8 @@ data class TitusServerGroup(
   override val artifactType: ArtifactType? = ArtifactType.docker,
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
-  override val artifactVersion: String? = null,
-  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
-  override val maxDiffCount: Int? = null,
-  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
-  override val unhappyWaitTime: Duration? = null
-) : VersionedArtifactProvider, UnhappyControl
+  override val artifactVersion: String? = null
+) : VersionedArtifactProvider
 
 val TitusServerGroup.moniker: Moniker
   get() = parseMoniker(name)


### PR DESCRIPTION
`UnhappyControl` is only relevant to resource specs but I noticed it was implemented by a couple of concrete model classes.