### PR TITLE
feat(import): API to import delivery config from source

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -9,7 +9,8 @@ data class DeliveryConfig(
   val serviceAccount: String,
   val artifacts: Set<DeliveryArtifact> = emptySet(),
   val environments: Set<Environment> = emptySet(),
-  val apiVersion: String = "delivery.config.spinnaker.netflix.com/v1"
+  val apiVersion: String = "delivery.config.spinnaker.netflix.com/v1",
+  val metadata: Map<String, Any?> = emptyMap()
 ) {
   val resources: Set<Resource<*>>
     get() = environments.flatMapTo(mutableSetOf()) { it.resources }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
@@ -18,7 +18,8 @@ data class SubmittedDeliveryConfig(
   @Description("The service account Spinnaker will authenticate with when making changes.")
   val serviceAccount: String,
   val artifacts: Set<DeliveryArtifact> = emptySet(),
-  val environments: Set<SubmittedEnvironment> = emptySet()
+  val environments: Set<SubmittedEnvironment> = emptySet(),
+  val metadata: Map<String, Any?>? = emptyMap()
 ) {
   val safeName: String
     @JsonIgnore get() = name ?: "$application-manifest"

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -73,7 +73,8 @@ class CombinedRepository(
           constraints = env.constraints,
           notifications = env.notifications
         )
-      }
+      },
+      metadata = submittedDeliveryConfig.metadata ?: emptyMap()
     )
     return upsertDeliveryConfig(new)
   }

--- a/keel-igor/keel-igor.gradle.kts
+++ b/keel-igor/keel-igor.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
   testImplementation(project(":keel-spring-test-support"))
+  testImplementation(project(":keel-test"))
 }

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
@@ -3,6 +3,8 @@ package com.netflix.spinnaker.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.igor.ScmService
+import com.netflix.spinnaker.keel.services.DeliveryConfigImporter
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.springframework.beans.factory.BeanCreationException
@@ -20,15 +22,33 @@ class IgorConfiguration {
       ?: throw BeanCreationException("Invalid URL: $igorBaseUrl")
 
   @Bean
-  fun igorService(
+  fun artifactService(
     igorEndpoint: HttpUrl,
     objectMapper: ObjectMapper,
     clientProvider: OkHttpClientProvider
-  ): ArtifactService =
-    Retrofit.Builder()
-      .addConverterFactory(JacksonConverterFactory.create(objectMapper))
-      .baseUrl(igorEndpoint)
-      .client(clientProvider.getClient(DefaultServiceEndpoint("igor", igorEndpoint.toString())))
-      .build()
-      .create(ArtifactService::class.java)
+  ): ArtifactService = buildService(objectMapper, igorEndpoint, clientProvider)
+
+  @Bean
+  fun scmService(
+    igorEndpoint: HttpUrl,
+    objectMapper: ObjectMapper,
+    clientProvider: OkHttpClientProvider
+  ): ScmService = buildService(objectMapper, igorEndpoint, clientProvider)
+
+  @Bean
+  fun deliveryConfigImporter(
+    objectMapper: ObjectMapper,
+    scmService: ScmService
+  ) = DeliveryConfigImporter(objectMapper, scmService)
+
+  private inline fun <reified T> buildService(
+    objectMapper: ObjectMapper,
+    igorEndpoint: HttpUrl,
+    clientProvider: OkHttpClientProvider
+  ): T = Retrofit.Builder()
+    .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+    .baseUrl(igorEndpoint)
+    .client(clientProvider.getClient(DefaultServiceEndpoint("igor", igorEndpoint.toString())))
+    .build()
+    .create(T::class.java)
 }

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ScmService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ScmService.kt
@@ -1,0 +1,18 @@
+package com.netflix.spinnaker.igor
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * Igor methods related to Source Control Management (SCM) operations.
+ */
+interface ScmService {
+  @GET("/delivery-config/manifest")
+  suspend fun getDeliveryConfigManifest(
+    @Query("scmType") repoType: String,
+    @Query("project") projectKey: String,
+    @Query("repository") repositorySlug: String,
+    @Query("manifest") manifestPath: String,
+    @Query("ref") ref: String? = null
+  ): Map<String, Any?>
+}

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ScmService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ScmService.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.igor
 
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -7,6 +8,18 @@ import retrofit2.http.Query
  * Igor methods related to Source Control Management (SCM) operations.
  */
 interface ScmService {
+  /**
+   * Retrieves a delivery config manifest from a source control repository.
+   *
+   * @param repoType The type of SCM repository (e.g. "stash", "github")
+   * @param projectKey The "project" within the SCM system where the repository exists, which can be a user's personal
+   *        area (e.g. "SPKR", "~lpollo")
+   * @param repositorySlug The repository name (e.g. "myapp")
+   * @param manifestPath The path of the manifest file, relative to the base-path configured by the Spinnaker operator
+   *        in igor (which defaults to ".spinnaker"), for example "mydir/spinnaker.yml". The full path to the file
+   *        is determined by concatenating the base path with this relative path (e.g. ".spinnaker/mydir/spinnaker.yml").
+   * @param ref The git reference at which to retrieve to file (e.g. a commit hash, or a reference like "refs/heads/mybranch").
+   */
   @GET("/delivery-config/manifest")
   suspend fun getDeliveryConfigManifest(
     @Query("scmType") repoType: String,
@@ -14,5 +27,5 @@ interface ScmService {
     @Query("repository") repositorySlug: String,
     @Query("manifest") manifestPath: String,
     @Query("ref") ref: String? = null
-  ): Map<String, Any?>
+  ): SubmittedDeliveryConfig
 }

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporter.kt
@@ -1,0 +1,44 @@
+package com.netflix.spinnaker.keel.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.igor.ScmService
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * Provides functionality to import delivery config manifests from source control repositories (via igor).
+ */
+@Component
+class DeliveryConfigImporter(
+  private val jsonMapper: ObjectMapper,
+  private val scmService: ScmService
+) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  /**
+   * Imports a delivery config from source control via igor.
+   */
+  fun import(
+    repoType: String,
+    projectKey: String,
+    repoSlug: String,
+    manifestPath: String,
+    ref: String
+  ): SubmittedDeliveryConfig {
+    val manifestLocation = "$repoType://project:$projectKey/repo:$repoSlug/manifest:$manifestPath@$ref"
+
+    log.debug("Retrieving delivery config from $manifestLocation")
+    val submittedDeliveryConfig = runBlocking {
+      scmService.getDeliveryConfigManifest(repoType, projectKey, repoSlug, manifestPath, ref)
+        .let {
+          jsonMapper.convertValue<SubmittedDeliveryConfig>(it)
+        }
+    }
+
+    log.debug("Successfully retrieved delivery config from $manifestLocation.")
+    return submittedDeliveryConfig
+  }
+}

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporter.kt
@@ -39,6 +39,16 @@ class DeliveryConfigImporter(
     }
 
     log.debug("Successfully retrieved delivery config from $manifestLocation.")
-    return submittedDeliveryConfig
+    return submittedDeliveryConfig.copy(
+      metadata = mapOf("importedFrom" to
+        mapOf(
+          "repoType" to repoType,
+          "projectKey" to projectKey,
+          "repoSlug" to repoSlug,
+          "manifestPath" to manifestPath,
+          "ref" to ref
+        )
+      )
+    )
   }
 }

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporter.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.igor.ScmService
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import kotlinx.coroutines.runBlocking
@@ -33,9 +32,6 @@ class DeliveryConfigImporter(
     log.debug("Retrieving delivery config from $manifestLocation")
     val submittedDeliveryConfig = runBlocking {
       scmService.getDeliveryConfigManifest(repoType, projectKey, repoSlug, manifestPath, ref)
-        .let {
-          jsonMapper.convertValue<SubmittedDeliveryConfig>(it)
-        }
     }
 
     log.debug("Successfully retrieved delivery config from $manifestLocation.")

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
@@ -17,7 +17,6 @@ import retrofit.RetrofitError
 import retrofit.client.Response
 import strikt.api.expectCatching
 import strikt.api.expectThat
-import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 
@@ -67,28 +66,6 @@ class DeliveryConfigImporterTests : JUnit5Minutests {
               )
             )
           )
-        }
-      }
-
-      context("with an invalid delivery config in source control") {
-        before {
-          every {
-            scmService.getDeliveryConfigManifest("stash", "proj", "repo", "spinnaker.yml", any())
-          } returns mapOf("foo" to "bar")
-        }
-
-        test("throws an exception") {
-          expectCatching {
-            importer.import(
-              repoType = "stash",
-              projectKey = "proj",
-              repoSlug = "repo",
-              manifestPath = "spinnaker.yml",
-              ref = "refs/heads/master"
-            )
-          }
-            .isFailure()
-            .isA<IllegalArgumentException>()
         }
       }
 

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
@@ -1,0 +1,110 @@
+package com.netflix.spinnaker.keel.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.igor.ScmService
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.deliveryConfig
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery as every
+import io.mockk.mockk
+import retrofit.RetrofitError
+import retrofit.client.Response
+import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFailure
+
+class DeliveryConfigImporterTests : JUnit5Minutests {
+  object Fixture {
+    val jsonMapper: ObjectMapper = configuredObjectMapper()
+      .also {
+        it.registerSubtypes(
+          NamedType(DummyResourceSpec::class.java, "test/whatever@v1")
+        )
+      }
+    val scmService: ScmService = mockk()
+    val deliveryConfig: DeliveryConfig = deliveryConfig()
+    val submittedDeliveryConfig: SubmittedDeliveryConfig = jsonMapper.convertValue(deliveryConfig)
+    val importer = DeliveryConfigImporter(jsonMapper, scmService)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    context("import") {
+      fixture { Fixture }
+
+      context("with a valid delivery config in source control") {
+        before {
+          every {
+            scmService.getDeliveryConfigManifest("stash", "proj", "repo", "spinnaker.yml", any())
+          } returns jsonMapper.convertValue(submittedDeliveryConfig)
+        }
+
+        test("succeeds") {
+          val result = importer.import(
+            repoType = "stash",
+            projectKey = "proj",
+            repoSlug = "repo",
+            manifestPath = "spinnaker.yml",
+            ref = "refs/heads/master"
+          )
+          expectThat(result).isEqualTo(submittedDeliveryConfig)
+        }
+      }
+
+      context("with an invalid delivery config in source control") {
+        before {
+          every {
+            scmService.getDeliveryConfigManifest("stash", "proj", "repo", "spinnaker.yml", any())
+          } returns mapOf("foo" to "bar")
+        }
+
+        test("throws an exception") {
+          expectCatching {
+            importer.import(
+              repoType = "stash",
+              projectKey = "proj",
+              repoSlug = "repo",
+              manifestPath = "spinnaker.yml",
+              ref = "refs/heads/master"
+            )
+          }
+            .isFailure()
+            .isA<IllegalArgumentException>()
+        }
+      }
+
+      context("with HTTP error retrieving delivery config from igor") {
+        val retrofitError = RetrofitError.httpError("http://igor",
+          Response("http://igor", 404, "not found", emptyList(), null),
+          null, null)
+
+        before {
+          every {
+            scmService.getDeliveryConfigManifest("stash", "proj", "repo", "spinnaker.yml", any())
+          } throws retrofitError
+        }
+
+        test("bubbles up HTTP error") {
+          expectCatching {
+            importer.import(
+              repoType = "stash",
+              projectKey = "proj",
+              repoSlug = "repo",
+              manifestPath = "spinnaker.yml",
+              ref = "refs/heads/master"
+            )
+          }
+            .isFailure()
+            .isEqualTo(retrofitError)
+        }
+      }
+    }
+  }
+}

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
@@ -46,7 +46,7 @@ class DeliveryConfigImporterTests : JUnit5Minutests {
           } returns jsonMapper.convertValue(submittedDeliveryConfig)
         }
 
-        test("succeeds") {
+        test("succeeds and includes import metadata") {
           val result = importer.import(
             repoType = "stash",
             projectKey = "proj",
@@ -54,7 +54,19 @@ class DeliveryConfigImporterTests : JUnit5Minutests {
             manifestPath = "spinnaker.yml",
             ref = "refs/heads/master"
           )
-          expectThat(result).isEqualTo(submittedDeliveryConfig)
+          expectThat(result).isEqualTo(
+            submittedDeliveryConfig.copy(
+              metadata = mapOf("importedFrom" to
+                mapOf(
+                  "repoType" to "stash",
+                  "projectKey" to "proj",
+                  "repoSlug" to "repo",
+                  "manifestPath" to "spinnaker.yml",
+                  "ref" to "refs/heads/master"
+                )
+              )
+            )
+          )
         }
       }
 

--- a/keel-sql/src/main/resources/db/changelog/20200603-add-delivery-config-metadata.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200603-add-delivery-config-metadata.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-delivery-config-metadata
+      author: lpollo
+      changes:
+        - addColumn:
+            tableName: delivery_config
+            columns:
+              - name: metadata
+                type: json
+                constraints:
+                  nullable: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -155,3 +155,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200528-add-veto-info.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200603-add-delivery-config-metadata.yml
+      relativeToChangelogFile: true

--- a/keel-test/keel-test.gradle.kts
+++ b/keel-test/keel-test.gradle.kts
@@ -5,4 +5,5 @@ plugins {
 dependencies {
   api(project(":keel-core"))
   implementation("io.mockk:mockk")
+  implementation(project(":keel-spring-test-support"))
 }

--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
   api(project(":keel-sql"))
   api(project(":keel-docker"))
   api(project(":keel-echo"))
+  api(project(":keel-igor"))
 
   implementation(project(":keel-bakery-plugin"))
   implementation(project(":keel-ec2-plugin"))

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -11,7 +11,6 @@ import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import com.netflix.spinnaker.kork.web.interceptors.MetricsInterceptor
 import de.huxhorn.sulky.ulid.ULID
 import java.time.Clock
-import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.web.servlet.FilterRegistrationBean
@@ -61,13 +60,11 @@ class DefaultConfiguration(
   @Bean
   fun idGenerator(): ULID = ULID()
 
-  @Bean
+  @Bean(name = ["jsonMapper", "objectMapper"])
   @Primary
-  @Qualifier("jsonMapper")
   fun objectMapper(): ObjectMapper = configuredObjectMapper()
 
-  @Bean
-  @Qualifier("yamlMapper")
+  @Bean(name = ["yamlMapper"])
   fun yamlMapper(): YAMLMapper = configuredYamlMapper()
 
   @Bean

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -38,7 +38,7 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
 /**
- * Support for authorization of REST API calls.
+ * Support for authorization of API calls.
  *
  * @see https://github.com/spinnaker/keel/blob/master/docs/authorization.md
  */

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -47,15 +47,17 @@ class ExceptionHandler(
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
-  @ExceptionHandler(HttpMessageConversionException::class, HttpMessageNotReadableException::class)
+  @ExceptionHandler(HttpMessageConversionException::class, HttpMessageNotReadableException::class, JsonMappingException::class)
   @ResponseStatus(BAD_REQUEST)
   fun onParseFailure(e: Exception): ApiError {
     log.error(e.message)
-    return when (e.cause) {
-      null -> ApiError(BAD_REQUEST, e)
-      is JsonMappingException ->
+    return when {
+      e is JsonMappingException ->
+        ApiError(BAD_REQUEST, e, e.toDetails())
+      e.cause is JsonMappingException ->
         ApiError(BAD_REQUEST, e, (e.cause as JsonMappingException).toDetails())
-      else -> ApiError(BAD_REQUEST, e)
+      else ->
+        ApiError(BAD_REQUEST, e)
     }
   }
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -20,6 +20,7 @@ import dev.minutest.rootContext
 import io.mockk.every
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
@@ -31,7 +32,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delet
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import strikt.api.Assertion
+import strikt.api.Assertion.Builder
 import strikt.api.DescribeableBuilder
 import strikt.api.expectThat
 import strikt.assertions.isNotNull
@@ -52,6 +53,7 @@ internal class ResourceControllerTests : JUnit5Minutests {
   @MockkBean
   lateinit var authorizationSupport: AuthorizationSupport
 
+  @Qualifier("jsonMapper")
   @Autowired
   lateinit var jsonMapper: ObjectMapper
 
@@ -228,11 +230,11 @@ internal class ResourceControllerTests : JUnit5Minutests {
   }
 }
 
-private val Assertion.Builder<MockHttpServletResponse>.contentType: DescribeableBuilder<MediaType?>
+private val Builder<MockHttpServletResponse>.contentType: DescribeableBuilder<MediaType?>
   get() = get { contentType?.let(MediaType::parseMediaType) }
 
 @Suppress("UNCHECKED_CAST")
-private fun <T : MediaType?> Assertion.Builder<T>.isCompatibleWith(expected: MediaType): Assertion.Builder<MediaType> =
+private fun <T : MediaType?> Builder<T>.isCompatibleWith(expected: MediaType): Builder<MediaType> =
   assertThat("is compatible with $expected") {
     it?.isCompatibleWith(expected) ?: false
-  } as Assertion.Builder<MediaType>
+  } as Builder<MediaType>


### PR DESCRIPTION
Implements a new `POST /delivery-configs/import` API that performs the same steps as the orca `ImportDeliveryConfigTask`, namely retrieving a specified delivery config from source control via igor, and upserting the delivery config into the keel database.

This PR also takes advantage of the fact that we now have metadata available in keel about the provenance of the delivery config, and adds a `metadata` column to the `delivery_config` table to store that information.

The goal of this PR is to make progress towards #870 and provide a more self-contained way to test the import flow locally by avoiding as many dependencies and steps as possible in the manual test flow. For example, with this change, it's straightforward to replicate the error from #1262 locally.
