### PR TITLE
feat(mark-as-bad): add comment, show comment

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
@@ -94,7 +95,6 @@ class ResourceActuator(
            * containing [resource]. This ensures that the environment will be fully restored to
            * a prior good-state.
            */
-          // todo eb: limit this to not roll back forever
           if (response.vetoArtifact && resource.spec is VersionedArtifactProvider) {
             try {
               val versionedArtifact = when (desired) {
@@ -121,9 +121,14 @@ class ResourceActuator(
 
                   artifactRepository.markAsVetoedIn(
                     deliveryConfig = deliveryConfig,
-                    artifact = artifact,
-                    version = artifactVersion,
-                    targetEnvironment = environment)
+                    veto = EnvironmentArtifactVeto(
+                      reference = artifact.reference,
+                      version = artifactVersion,
+                      targetEnvironment = environment,
+                      vetoedBy = "Spinnaker",
+                      comment = "Automatically vetoed because deployment of this version failed."
+                    )
+                  )
                   // TODO: emit event + metric
                 }
               }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -126,7 +126,7 @@ class ResourceActuator(
                       version = artifactVersion,
                       targetEnvironment = environment,
                       vetoedBy = "Spinnaker",
-                      comment = "Automatically vetoed because deployment of this version failed."
+                      comment = "Automatically vetoed because multiple deployments of this version failed."
                     )
                   )
                   // TODO: emit event + metric

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -57,10 +57,10 @@ data class ArtifactSummaryInEnvironment(
   val deployedAt: Instant? = null,
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
-  val isPinned: Boolean = false,
   val pinned: ActionMetadata? = null,
-  val isVetoed: Boolean = false,
+  val isPinned: Boolean = pinned != null,
   val vetoed: ActionMetadata? = null,
+  val isVetoed: Boolean = vetoed != null,
   val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
   val statelessConstraints: List<StatelessConstraintSummary> = emptyList()
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -58,12 +58,14 @@ data class ArtifactSummaryInEnvironment(
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
   val isPinned: Boolean = false,
-  val pinned: Pinned? = null,
+  val pinned: ActionMetadata? = null,
+  val isVetoed: Boolean = false,
+  val vetoed: ActionMetadata? = null,
   val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
   val statelessConstraints: List<StatelessConstraintSummary> = emptyList()
 )
 
-data class Pinned(
+data class ActionMetadata(
   val at: Instant,
   val by: String?,
   val comment: String?

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactVeto.kt
@@ -3,20 +3,27 @@ package com.netflix.spinnaker.keel.core.api
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import java.time.Instant
 
-data class EnvironmentArtifactPin(
+data class EnvironmentArtifactVeto(
   val targetEnvironment: String,
   val reference: String,
   val version: String,
-  val pinnedBy: String?,
+  val vetoedBy: String?,
   val comment: String?
 )
 
-data class PinnedEnvironment(
+data class VetoedArtifact(
   val deliveryConfigName: String,
   val targetEnvironment: String,
   val artifact: DeliveryArtifact,
   val version: String,
-  val pinnedBy: String?,
-  val pinnedAt: Instant?,
+  val vetoedBy: String?,
+  val vetoedAt: Instant?,
   val comment: String?
+)
+
+data class EnvironmentArtifactVetoes(
+  val deliveryConfigName: String,
+  val targetEnvironment: String,
+  val artifact: DeliveryArtifact,
+  val versions: MutableSet<String>
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentArtifactVeto.kt
@@ -1,23 +1,15 @@
 package com.netflix.spinnaker.keel.core.api
 
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import java.time.Instant
 
+/**
+ * The request body of an artifact veto
+ */
 data class EnvironmentArtifactVeto(
   val targetEnvironment: String,
   val reference: String,
   val version: String,
   val vetoedBy: String?,
-  val comment: String?
-)
-
-data class VetoedArtifact(
-  val deliveryConfigName: String,
-  val targetEnvironment: String,
-  val artifact: DeliveryArtifact,
-  val version: String,
-  val vetoedBy: String?,
-  val vetoedAt: Instant?,
   val comment: String?
 )
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidVetoException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidVetoException.kt
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.keel.exceptions
+
+import org.omg.CORBA.UserException
+
+class InvalidVetoException(application: String, environment: String, reference: String, version: String) :
+  UserException("Unable to veto artifact version $version with reference $reference in environment " +
+  "$environment and application $application. Is this version pinned?")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidVetoException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidVetoException.kt
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.keel.exceptions
 
-import org.omg.CORBA.UserException
+import com.netflix.spinnaker.kork.exceptions.UserException
 
 class InvalidVetoException(application: String, environment: String, reference: String, version: String) :
   UserException("Unable to veto artifact version $version with reference $reference in environment " +
-  "$environment and application $application. Is this version pinned?")
+    "$environment and application $application. Is this version pinned?")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
@@ -161,9 +162,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
    */
   fun markAsVetoedIn(
     deliveryConfig: DeliveryConfig,
-    artifact: DeliveryArtifact,
-    version: String,
-    targetEnvironment: String,
+    veto: EnvironmentArtifactVeto,
     force: Boolean = false
   ): Boolean
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
@@ -384,12 +385,10 @@ class CombinedRepository(
 
   override fun markAsVetoedIn(
     deliveryConfig: DeliveryConfig,
-    artifact: DeliveryArtifact,
-    version: String,
-    targetEnvironment: String,
+    veto: EnvironmentArtifactVeto,
     force: Boolean
   ): Boolean =
-    artifactRepository.markAsVetoedIn(deliveryConfig, artifact, version, targetEnvironment, force)
+    artifactRepository.markAsVetoedIn(deliveryConfig, veto, force)
 
   override fun deleteVeto(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String) =
     artifactRepository.deleteVeto(deliveryConfig, artifact, version, targetEnvironment)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.constraints.ConstraintState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
@@ -215,9 +216,7 @@ interface KeelRepository {
 
   fun markAsVetoedIn(
     deliveryConfig: DeliveryConfig,
-    artifact: DeliveryArtifact,
-    version: String,
-    targetEnvironment: String,
+    veto: EnvironmentArtifactVeto,
     force: Boolean = false
   ): Boolean
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -102,18 +102,14 @@ class ApplicationService(
     // TODO: publish ArtifactUnpinnedEvent
   }
 
-  fun markAsVetoedIn(application: String, veto: EnvironmentArtifactVeto, force: Boolean) {
+  fun markAsVetoedIn(user: String, application: String, veto: EnvironmentArtifactVeto, force: Boolean): Boolean {
     val config = repository.getDeliveryConfigForApplication(application)
-    val artifact = config.matchingArtifactByReference(veto.reference)
-      ?: throw ArtifactNotFoundException(veto.reference, config.name)
-
-    repository.markAsVetoedIn(
+    return repository.markAsVetoedIn(
       deliveryConfig = config,
-      artifact = artifact,
-      version = veto.version,
-      targetEnvironment = veto.targetEnvironment,
+      veto = veto.copy(vetoedBy = user),
       force = force
     )
+    // TODO: publish ArtifactVetoedEvent
   }
 
   fun deleteVeto(application: String, targetEnvironment: String, reference: String, version: String) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
@@ -336,9 +337,9 @@ internal class ResourceActuatorTests : JUnit5Minutests {
                 val event = slot<ResourceCheckResult>()
                 verify { publisher.publishEvent(capture(event)) }
                 expectThat(event.captured)
-                    .isA<ResourceCheckError>()
-                    .get { exceptionType }
-                    .isEqualTo(UserException::class.java)
+                  .isA<ResourceCheckError>()
+                  .get { exceptionType }
+                  .isEqualTo(UserException::class.java)
               }
             }
 
@@ -356,9 +357,9 @@ internal class ResourceActuatorTests : JUnit5Minutests {
                 val event = slot<ResourceCheckResult>()
                 verify { publisher.publishEvent(capture(event)) }
                 expectThat(event.captured)
-                    .isA<ResourceCheckError>()
-                    .get { exceptionType }
-                    .isEqualTo(SystemException::class.java)
+                  .isA<ResourceCheckError>()
+                  .get { exceptionType }
+                  .isEqualTo(SystemException::class.java)
               }
             }
           }
@@ -471,7 +472,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
         }
 
         test("the desired artifact version is vetoed from the target environment") {
-          verify { artifactRepository.markAsVetoedIn(any(), any(), "fnord-42.0", "staging", false) }
+          verify { artifactRepository.markAsVetoedIn(any(), EnvironmentArtifactVeto("staging", "fnord", "fnord-42.0", "Spinnaker", "Automatically vetoed because deployment of this version failed."), false) }
           verify { publisher.publishEvent(ofType<ResourceActuationVetoed>()) }
         }
       }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -472,7 +472,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
         }
 
         test("the desired artifact version is vetoed from the target environment") {
-          verify { artifactRepository.markAsVetoedIn(any(), EnvironmentArtifactVeto("staging", "fnord", "fnord-42.0", "Spinnaker", "Automatically vetoed because deployment of this version failed."), false) }
+          verify { artifactRepository.markAsVetoedIn(any(), EnvironmentArtifactVeto("staging", "fnord", "fnord-42.0", "Spinnaker", "Automatically vetoed because multiple deployments of this version failed."), false) }
           verify { publisher.publishEvent(ofType<ResourceActuationVetoed>()) }
         }
       }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -1004,9 +1004,7 @@ class SqlArtifactRepository(
             deployedAt = deployedAt?.toInstant(UTC),
             replacedAt = replacedAt?.toInstant(UTC),
             replacedBy = replacedBy,
-            isPinned = pinned != null,
             pinned = pinned,
-            isVetoed = vetoed != null,
             vetoed = vetoed
           )
         }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -9,13 +9,14 @@ import com.netflix.spinnaker.keel.api.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.TagComparator
+import com.netflix.spinnaker.keel.core.api.ActionMetadata
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
-import com.netflix.spinnaker.keel.core.api.Pinned
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.api.PromotionStatus
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.APPROVED
@@ -39,6 +40,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG_A
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_PIN
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VERSIONS
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VETO
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import java.security.MessageDigest
@@ -535,16 +537,16 @@ class SqlArtifactRepository(
 
   override fun markAsVetoedIn(
     deliveryConfig: DeliveryConfig,
-    artifact: DeliveryArtifact,
-    version: String,
-    targetEnvironment: String,
+    veto: EnvironmentArtifactVeto,
     force: Boolean
   ): Boolean {
+    val artifact = deliveryConfig.matchingArtifactByReference(veto.reference)
+      ?: throw ArtifactNotFoundException(veto.reference, deliveryConfig.name)
 
     val (envUid, artUid) = sqlRetry.withRetry(READ) {
       Pair(
         deliveryConfig.getUidStringFor(
-          deliveryConfig.environmentNamed(targetEnvironment)),
+          deliveryConfig.environmentNamed(veto.targetEnvironment)),
         artifact.uidString)
     }
 
@@ -554,15 +556,15 @@ class SqlArtifactRepository(
           ENVIRONMENT_ARTIFACT_PIN,
           ENVIRONMENT_ARTIFACT_PIN.ENVIRONMENT_UID.eq(envUid)
             .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_UID.eq(artUid))
-            .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION.eq(version)))
+            .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION.eq(veto.version)))
     }
 
     if (isPinned) {
       log.warn(
         "Pinned artifact version cannot be vetoed: " +
           "deliveryConfig=${deliveryConfig.name}, " +
-          "environment=$targetEnvironment, " +
-          "artifactVersion=$version")
+          "environment=${veto.targetEnvironment}, " +
+          "artifactVersion=${veto.version}")
       return false
     }
 
@@ -574,31 +576,44 @@ class SqlArtifactRepository(
       .where(
         ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envUid),
         ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artUid),
-        ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
+        ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(veto.version))
       .fetchOne { (_, reference) ->
         if (reference != null && !force) {
           log.warn(
             "Not vetoing artifact version as it appears to have already been an automated rollback target: " +
               "deliveryConfig=${deliveryConfig.name}, " +
-              "environment=$targetEnvironment, " +
-              "artifactVersion=$version, " +
+              "environment=${veto.targetEnvironment}, " +
+              "artifactVersion=${veto.version}, " +
               "priorVersionReference=$reference")
           return@fetchOne false
         }
 
-        val prior = priorVersionDeployedIn(envUid, artUid, version)
+        val prior = priorVersionDeployedIn(envUid, artUid, veto.version)
 
         sqlRetry.withRetry(WRITE) {
           jooq.transaction { config ->
             val txn = DSL.using(config)
             txn.update(ENVIRONMENT_ARTIFACT_VERSIONS)
               .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, VETOED.name)
-              .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, prior ?: version)
+              .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, prior ?: veto.version)
               .where(
                 ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envUid),
                 ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artUid),
-                ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version)
+                ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(veto.version)
               )
+              .execute()
+
+            txn.insertInto(ENVIRONMENT_ARTIFACT_VETO)
+              .set(ENVIRONMENT_ARTIFACT_VETO.ENVIRONMENT_UID, envUid)
+              .set(ENVIRONMENT_ARTIFACT_VETO.ARTIFACT_UID, artUid)
+              .set(ENVIRONMENT_ARTIFACT_VETO.ARTIFACT_VERSION, veto.version)
+              .set(ENVIRONMENT_ARTIFACT_VETO.VETOED_AT, clock.timestamp())
+              .set(ENVIRONMENT_ARTIFACT_VETO.VETOED_BY, veto.vetoedBy)
+              .set(ENVIRONMENT_ARTIFACT_VETO.COMMENT, veto.comment)
+              .onDuplicateKeyUpdate()
+              .set(ENVIRONMENT_ARTIFACT_VETO.VETOED_AT, clock.timestamp())
+              .set(ENVIRONMENT_ARTIFACT_VETO.VETOED_BY, veto.vetoedBy)
+              .set(ENVIRONMENT_ARTIFACT_VETO.COMMENT, veto.comment)
               .execute()
 
             /**
@@ -610,7 +625,7 @@ class SqlArtifactRepository(
              */
             if (prior != null) {
               txn.update(ENVIRONMENT_ARTIFACT_VERSIONS)
-                .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, version)
+                .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, veto.version)
                 .where(
                   ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envUid),
                   ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artUid),
@@ -632,6 +647,7 @@ class SqlArtifactRepository(
   ) {
     val envId = deliveryConfig.getUidFor(
       deliveryConfig.environmentNamed(targetEnvironment))
+    val artId = artifact.uidString
 
     sqlRetry.withRetry(WRITE) {
       val referenceVersion: String? = jooq.select(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE)
@@ -654,7 +670,7 @@ class SqlArtifactRepository(
             .from(ENVIRONMENT_ARTIFACT_VERSIONS)
             .where(
               ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envId),
-              ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid),
+              ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artId),
               ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(referenceVersion))
             .fetchOne(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE)
         }
@@ -668,7 +684,7 @@ class SqlArtifactRepository(
           .setNull(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE)
           .where(
             ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envId),
-            ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid),
+            ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artId),
             ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
           .execute()
 
@@ -677,10 +693,16 @@ class SqlArtifactRepository(
             .setNull(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE)
             .where(
               ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envId),
-              ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid),
+              ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artId),
               ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(referenceVersion))
             .execute()
         }
+
+        txn.deleteFrom(ENVIRONMENT_ARTIFACT_VETO)
+          .where(ENVIRONMENT_ARTIFACT_VETO.ENVIRONMENT_UID.eq(envId))
+          .and(ENVIRONMENT_ARTIFACT_VETO.ARTIFACT_UID.eq(artId))
+          .and(ENVIRONMENT_ARTIFACT_VETO.ARTIFACT_VERSION.eq(version))
+          .execute()
       }
     }
   }
@@ -952,15 +974,28 @@ class SqlArtifactRepository(
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
         .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.desc())
         .fetchOne { (version, deployedAt, promotionStatus, replacedBy, replacedAt) ->
-          val pinned: Pinned? = jooq
-            .select(ENVIRONMENT_ARTIFACT_PIN.PINNED_BY, ENVIRONMENT_ARTIFACT_PIN.PINNED_AT, ENVIRONMENT_ARTIFACT_PIN.COMMENT)
-            .from(ENVIRONMENT_ARTIFACT_PIN)
-            .where(ENVIRONMENT_ARTIFACT_PIN.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
-            .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_UID.eq(artifact.uid))
-            .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION.eq(version))
-            .fetchOne { (pinnedBy, pinnedAt, comment) ->
-              Pinned(at = pinnedAt.toInstant(UTC), by = pinnedBy, comment = comment)
+          val vetoed: ActionMetadata? = jooq
+            .select(ENVIRONMENT_ARTIFACT_VETO.VETOED_AT, ENVIRONMENT_ARTIFACT_VETO.VETOED_BY, ENVIRONMENT_ARTIFACT_VETO.COMMENT)
+            .from(ENVIRONMENT_ARTIFACT_VETO)
+            .where(ENVIRONMENT_ARTIFACT_VETO.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
+            .and(ENVIRONMENT_ARTIFACT_VETO.ARTIFACT_UID.eq(artifact.uid))
+            .and(ENVIRONMENT_ARTIFACT_VETO.ARTIFACT_VERSION.eq(version))
+            .fetchOne { (vetoedAt, vetoedBy, comment) ->
+              ActionMetadata(at = vetoedAt.toInstant(UTC), by = vetoedBy, comment = comment)
             }
+          var pinned: ActionMetadata? = null
+          if (vetoed == null) {
+            // a version can't be vetoed and pinned
+            pinned = jooq
+              .select(ENVIRONMENT_ARTIFACT_PIN.PINNED_BY, ENVIRONMENT_ARTIFACT_PIN.PINNED_AT, ENVIRONMENT_ARTIFACT_PIN.COMMENT)
+              .from(ENVIRONMENT_ARTIFACT_PIN)
+              .where(ENVIRONMENT_ARTIFACT_PIN.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
+              .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_UID.eq(artifact.uid))
+              .and(ENVIRONMENT_ARTIFACT_PIN.ARTIFACT_VERSION.eq(version))
+              .fetchOne { (pinnedBy, pinnedAt, comment) ->
+                ActionMetadata(at = pinnedAt.toInstant(UTC), by = pinnedBy, comment = comment)
+              }
+          }
 
           ArtifactSummaryInEnvironment(
             environment = environmentName,
@@ -970,7 +1005,9 @@ class SqlArtifactRepository(
             replacedAt = replacedAt?.toInstant(UTC),
             replacedBy = replacedBy,
             isPinned = pinned != null,
-            pinned = pinned
+            pinned = pinned,
+            isVetoed = vetoed != null,
+            vetoed = vetoed
           )
         }
     }

--- a/keel-sql/src/main/resources/db/changelog/20200528-add-veto-info.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200528-add-veto-info.yml
@@ -1,0 +1,53 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-veto-info-table
+      author: emjburns
+      changes:
+        - createTable:
+            tableName: environment_artifact_veto
+            columns:
+              - column:
+                  name: environment_uid
+                  type: char(26)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_uid
+                  type: char(26)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: artifact_version
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: vetoed_at
+                  type: timestamp(3)
+                  constraints:
+                    - nullable: false
+              - column:
+                  name: vetoed_by
+                  type: varchar(255)
+                  constraints:
+                    - nullable: false
+              - column:
+                  name: comment
+                  type: varchar(255)
+                  constraints:
+                    - nullable: true
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"
+      rollback:
+        - dropTable:
+            tableName: environment_artifact_veto
+  - changeSet:
+      id: create-environment-artifact-veto-pk
+      author: emjburns
+      changes:
+        - addPrimaryKey:
+            tableName: environment_artifact_veto
+            constraintName: env_art_veto_pk
+            columnNames: environment_uid, artifact_uid, artifact_version

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -152,3 +152,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200522-standardize-timestamps.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200528-add-veto-info.yml
+      relativeToChangelogFile: true

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.events.ApplicationEvent
+import com.netflix.spinnaker.keel.exceptions.InvalidVetoException
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.services.ApplicationService
@@ -198,8 +199,10 @@ class ApplicationController(
     @PathVariable("application") application: String,
     @RequestBody veto: EnvironmentArtifactVeto
   ) {
-
-    applicationService.markAsVetoedIn(application, veto, true)
+    val succeeded = applicationService.markAsVetoedIn(user, application, veto, true)
+    if (!succeeded) {
+      throw InvalidVetoException(application, veto.targetEnvironment, veto.reference, veto.version)
+    }
   }
 
   @DeleteMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.keel.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.events.ApplicationEvent
-import com.netflix.spinnaker.keel.exceptions.InvalidVetoException
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import com.netflix.spinnaker.keel.services.ApplicationService
@@ -199,10 +198,7 @@ class ApplicationController(
     @PathVariable("application") application: String,
     @RequestBody veto: EnvironmentArtifactVeto
   ) {
-    val succeeded = applicationService.markAsVetoedIn(user, application, veto, true)
-    if (!succeeded) {
-      throw InvalidVetoException(application, veto.targetEnvironment, veto.reference, veto.version)
-    }
+    applicationService.markAsVetoedIn(user, application, veto, true)
   }
 
   @DeleteMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExceptionHandler.kt
@@ -17,6 +17,7 @@ import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.exceptions.FailedNormalizationException
 import com.netflix.spinnaker.keel.exceptions.InvalidConstraintException
+import com.netflix.spinnaker.keel.exceptions.InvalidVetoException
 import com.netflix.spinnaker.keel.exceptions.NoSuchEnvironmentException
 import com.netflix.spinnaker.keel.exceptions.ValidationException
 import com.netflix.spinnaker.keel.persistence.ArtifactAlreadyRegistered
@@ -86,9 +87,9 @@ class ExceptionHandler(
     return ApiError(CONFLICT, e)
   }
 
-  @ExceptionHandler(ValidationException::class)
+  @ExceptionHandler(ValidationException::class, InvalidVetoException::class)
   @ResponseStatus(BAD_REQUEST)
-  fun onInvalidDeliveryConfig(e: ValidationException): ApiError {
+  fun onInvalidDeliveryConfig(e: Exception): ApiError {
     log.error(e.message)
     return ApiError(BAD_REQUEST, e)
   }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -278,8 +278,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/environment/prod/constraint").addData(jsonMapper,
-                UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
-              )
+              UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
+            )
               .accept(APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", user)
 
@@ -293,8 +293,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/environment/prod/constraint").addData(jsonMapper,
-                UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
-              )
+              UpdatedConstraintStatus("manual-judgement", "prod", OVERRIDE_PASS)
+            )
               .accept(APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", user)
 
@@ -353,8 +353,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/pin").addData(jsonMapper,
-                EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
-              )
+              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
+            )
               .accept(APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", user)
 
@@ -368,8 +368,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/pin").addData(jsonMapper,
-                EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
-              )
+              EnvironmentArtifactPin("test", "ref", "deb", "0.0.1", null)
+            )
               .accept(APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", user)
 
@@ -414,8 +414,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/veto").addData(jsonMapper,
-                EnvironmentArtifactVeto("test", "ref", "0.0.1")
-              )
+              EnvironmentArtifactVeto("test", "ref", "0.0.1", "me", "oopsie")
+            )
               .accept(APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", user)
 
@@ -429,8 +429,8 @@ internal class ApplicationControllerTests : JUnit5Minutests {
           }
           test("request is forbidden") {
             val request = post("/application/fnord/veto").addData(jsonMapper,
-                EnvironmentArtifactVeto("test", "ref", "0.0.1")
-              )
+              EnvironmentArtifactVeto("test", "ref", "0.0.1", "me", "oopsie")
+            )
               .accept(APPLICATION_JSON_VALUE)
               .header("X-SPINNAKER-USER", user)
 


### PR DESCRIPTION
Closes https://github.com/spinnaker/keel/issues/1233.

Adds a table to store 'mark as bad' comments + user + timestamp. 

`POST /applications/{application}/veto`
with body:

```kotlin
data class EnvironmentArtifactVeto(
  val targetEnvironment: String,
  val reference: String,
  val version: String,
  val comment: String?
)
```
Marks an artifact as bad and saves the user who vetoed.

Unmark as bad is `DELETE /{application}/veto/{targetEnvironment}/{reference}/{version}`

(will make the corresponding updates in `gate` shortly) 
