### PR TITLE
fix(validation): disallow invalid artifact refs in delivery configs

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidArtifactReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidArtifactReferenceException.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.exceptions
 
-class NonexistentArtifactReferenceException(
+class InvalidArtifactReferenceException(
   invalidReference: String,
   validReferences: List<String>
 ) : ValidationException(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NonexistentArtifactReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NonexistentArtifactReferenceException.kt
@@ -5,4 +5,3 @@ class NonexistentArtifactReferenceException(
 ) : ValidationException(
   "Config uses an artifact reference that does not correspond to any artifacts: $reference."
 )
-

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NonexistentArtifactReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NonexistentArtifactReferenceException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.exceptions
+
+class NonexistentArtifactReferenceException(
+  reference: String
+) : ValidationException(
+  "Config uses an artifact reference that does not correspond to any artifacts: $reference."
+)
+

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NonexistentArtifactReferenceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/NonexistentArtifactReferenceException.kt
@@ -1,7 +1,8 @@
 package com.netflix.spinnaker.keel.exceptions
 
 class NonexistentArtifactReferenceException(
-  reference: String
+  invalidReference: String,
+  validReferences: List<String>
 ) : ValidationException(
-  "Config uses an artifact reference that does not correspond to any artifacts: $reference."
+  "Config uses an artifact reference ($invalidReference) that does not correspond to any artifacts. Valid references are: $validReferences."
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -1,11 +1,13 @@
 package com.netflix.spinnaker.keel.validators
 
+import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.id
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
+import com.netflix.spinnaker.keel.exceptions.NonexistentArtifactReferenceException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -23,6 +25,7 @@ class DeliveryConfigValidator {
    * - resources have unique ids
    * - artifacts have unique references
    * - depends on environments are unique
+   * - references to artifacts are valid
    *
    * Throws an exception if config fails any checks
    */
@@ -81,6 +84,21 @@ class DeliveryConfigValidator {
             it.name == constraint.environment
           } ?: throw MissingEnvironmentReferenceException(constraint.environment)
         }
+      }
+    }
+
+    /**
+     * check: all referenced artifacts exist
+     */
+    config.environments.forEach { environment ->
+      environment.resources.forEach { resource ->
+        (resource.spec as? ArtifactReferenceProvider)
+          ?.artifactReference
+          ?.also {
+            if(!refs.contains(it)) {
+              throw NonexistentArtifactReferenceException(it)
+            }
+          }
       }
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -6,8 +6,8 @@ import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.id
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
+import com.netflix.spinnaker.keel.exceptions.InvalidArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
-import com.netflix.spinnaker.keel.exceptions.NonexistentArtifactReferenceException
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -96,7 +96,7 @@ class DeliveryConfigValidator {
           ?.artifactReference
           ?.also {
             if (!refs.contains(it)) {
-              throw NonexistentArtifactReferenceException(it, refs)
+              throw InvalidArtifactReferenceException(it, refs)
             }
           }
       }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -95,7 +95,7 @@ class DeliveryConfigValidator {
         (resource.spec as? ArtifactReferenceProvider)
           ?.artifactReference
           ?.also {
-            if(!refs.contains(it)) {
+            if (!refs.contains(it)) {
               throw NonexistentArtifactReferenceException(it)
             }
           }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidator.kt
@@ -96,7 +96,7 @@ class DeliveryConfigValidator {
           ?.artifactReference
           ?.also {
             if (!refs.contains(it)) {
-              throw NonexistentArtifactReferenceException(it)
+              throw NonexistentArtifactReferenceException(it, refs)
             }
           }
       }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -143,7 +143,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
             resources = setOf(
               SubmittedResource(
                 kind = TEST_API_V1.qualify("whatever"),
-                spec = DummyArtifactReferenceResourceSpec(artifactReference="does-not-exist")
+                spec = DummyArtifactReferenceResourceSpec(artifactReference = "does-not-exist")
               )
 
             ),

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -8,6 +8,8 @@ import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
+import com.netflix.spinnaker.keel.exceptions.NonexistentArtifactReferenceException
+import com.netflix.spinnaker.keel.test.DummyArtifactReferenceResourceSpec
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.TEST_API_V1
 import dev.minutest.junit.JUnit5Minutests
@@ -125,6 +127,35 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
           subject.validate(submittedConfig)
         }.isFailure()
           .isA<MissingEnvironmentReferenceException>()
+      }
+    }
+
+    context("delivery config with reference to non-existent artifact") {
+
+      val submittedConfig = SubmittedDeliveryConfig(
+        name = configName,
+        application = "keel",
+        serviceAccount = "keel@spinnaker",
+        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+        environments = setOf(
+          SubmittedEnvironment(
+            name = "test",
+            resources = setOf(
+              SubmittedResource(
+                kind = TEST_API_V1.qualify("whatever"),
+                spec = DummyArtifactReferenceResourceSpec(artifactReference="does-not-exist")
+              )
+
+            ),
+            constraints = emptySet()
+          ))
+      )
+      test("an error is thrown") {
+
+        expectCatching {
+          subject.validate(submittedConfig)
+        }.isFailure()
+          .isA<NonexistentArtifactReferenceException>()
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -7,8 +7,8 @@ import com.netflix.spinnaker.keel.core.api.SubmittedEnvironment
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import com.netflix.spinnaker.keel.exceptions.DuplicateArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.DuplicateResourceIdException
+import com.netflix.spinnaker.keel.exceptions.InvalidArtifactReferenceException
 import com.netflix.spinnaker.keel.exceptions.MissingEnvironmentReferenceException
-import com.netflix.spinnaker.keel.exceptions.NonexistentArtifactReferenceException
 import com.netflix.spinnaker.keel.test.DummyArtifactReferenceResourceSpec
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.TEST_API_V1
@@ -155,7 +155,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
         expectCatching {
           subject.validate(submittedConfig)
         }.isFailure()
-          .isA<NonexistentArtifactReferenceException>()
+          .isA<InvalidArtifactReferenceException>()
       }
     }
   }


### PR DESCRIPTION
Add a validation check for artifact references that refefrences artifacts that aren't defined in the delivery config.

Fixes #1271