### PR TITLE
chore(constraints): refactor the environment promotion checker

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.persistence
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.netflix.spinnaker.keel.actuation.EnvironmentConstraintRunner
 import com.netflix.spinnaker.keel.actuation.EnvironmentPromotionChecker
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
@@ -77,9 +78,15 @@ abstract class ApproveOldVersionTests<T : KeelRepository> : JUnit5Minutests {
       every { isImplicit() } returns true
       every { canPromote(any(), any(), any(), any()) } returns true
     }
-    val subject = EnvironmentPromotionChecker(
+    val environmentConstraintRunner = EnvironmentConstraintRunner(
       repository,
       listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator),
+      publisher
+    )
+
+    val subject = EnvironmentPromotionChecker(
+      repository,
+      environmentConstraintRunner,
       publisher
     )
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
@@ -80,8 +80,7 @@ abstract class ApproveOldVersionTests<T : KeelRepository> : JUnit5Minutests {
     }
     val environmentConstraintRunner = EnvironmentConstraintRunner(
       repository,
-      listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator),
-      publisher
+      listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator)
     )
 
     val subject = EnvironmentPromotionChecker(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
@@ -1,0 +1,259 @@
+package com.netflix.spinnaker.keel.actuation
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.anyStateful
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.constraints.ConstraintEvaluator
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
+import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
+import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
+import com.netflix.spinnaker.keel.core.comparator
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+/**
+ * This class is responsible for running constraints and queueing them for approval.
+ * Approval into an environment is the responsibility of the [EnvironmentPromotionChecker].
+ */
+@Component
+class EnvironmentConstraintRunner(
+  private val repository: KeelRepository,
+  private val constraints: List<ConstraintEvaluator<*>>,
+  private val publisher: ApplicationEventPublisher
+) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val implicitConstraints: List<ConstraintEvaluator<*>> = constraints.filter { it.isImplicit() }
+  private val explicitConstraints: List<ConstraintEvaluator<*>> = constraints - implicitConstraints
+
+  // constraints that are only run if they are defined in a delivery config
+  private val statefulEvaluators: List<ConstraintEvaluator<*>> = explicitConstraints
+    .filterIsInstance<StatefulConstraintEvaluator<*, *>>()
+  private val statelessEvaluators = explicitConstraints - statefulEvaluators
+
+  // constraints that run for every environment in a delivery config but aren't shown to the user.
+  private val implicitStatefulEvaluators: List<ConstraintEvaluator<*>> = implicitConstraints
+    .filterIsInstance<StatefulConstraintEvaluator<*, *>>()
+  private val implicitStatelessEvaluators: List<ConstraintEvaluator<*>> = implicitConstraints - implicitStatefulEvaluators
+
+  /**
+   * Checks the environment and determines the version that should be approved,
+   * or null if there is no version that passes the constraints for an env + artifact combo.
+   * Queues that version for approval if it exists.
+   */
+  fun checkEnvironment(
+    envInfo: EnvironmentInfo
+  ) {
+    val pendingVersionsToCheck: MutableSet<String> =
+      when (envInfo.environment.constraints.anyStateful) {
+        true -> repository
+          .pendingConstraintVersionsFor(envInfo.deliveryConfig.name, envInfo.environment.name)
+          .filter { envInfo.versions.contains(it) }
+          .toMutableSet()
+        false -> mutableSetOf()
+      }
+
+    checkConstraints(
+      envInfo,
+      pendingVersionsToCheck
+    )
+
+    /*
+     * If there are pending constraints for prior versions, that we didn't recheck in the process of
+     * finding the latest version above, recheck in ascending version order
+     * so they can be timed out, failed, or approved.
+     */
+    dealWithOldVersions(envInfo, pendingVersionsToCheck)
+  }
+
+  /**
+   * Looks at all versions for an environment, and determines the latest version that passes constraints,
+   * or null if none pass.
+   *
+   * In the process we check and evaluate constraints for each version.
+   *
+   * If a version passes all constraints it is queued for approval.
+   */
+  private fun checkConstraints(
+    envInfo: EnvironmentInfo,
+    pendingVersionsToCheck: MutableSet<String>
+  ) {
+    var version: String? = null
+    var versionIsPending = false
+    val vetoedVersions: Set<String> =
+      (envInfo.vetoedArtifacts[envPinKey(envInfo.environment.name, envInfo.artifact)]?.versions)
+        ?: emptySet()
+
+    if (envInfo.environment.constraints.isEmpty() && implicitConstraints.isEmpty()) {
+      version = envInfo.versions.firstOrNull { v ->
+        !vetoedVersions.contains(v)
+      }
+    } else {
+      version = envInfo.versions
+        .firstOrNull { v ->
+          pendingVersionsToCheck.remove(v) // remove to indicate we are rechecking this version
+          if (vetoedVersions.contains(v)) {
+            false
+          } else {
+            /**
+             * Only check stateful evaluators if all stateless evaluators pass. We don't
+             * want to request judgement or deploy a canary for artifacts that aren't
+             * deployed to a required environment or outside of an allowed time.
+             */
+            val passesConstraints =
+              checkStatelessConstraints(envInfo.artifact, envInfo.deliveryConfig, v, envInfo.environment) &&
+                checkStatefulConstraints(envInfo.artifact, envInfo.deliveryConfig, v, envInfo.environment)
+
+            if (envInfo.environment.constraints.anyStateful) {
+              versionIsPending = repository
+                .constraintStateFor(envInfo.deliveryConfig.name, envInfo.environment.name, v)
+                .any { it.status == PENDING }
+            }
+
+            // select either the first version that passes all constraints,
+            // or the first version where stateful constraints are pending.
+            passesConstraints || versionIsPending
+          }
+        }
+    }
+    if (version != null && !versionIsPending) {
+      // we've selected a version that passes all constraints, queue it for approval
+      queueApproval(envInfo.deliveryConfig, envInfo.artifact, version, envInfo.environment.name)
+    }
+  }
+
+  /**
+   * Re-checks older versions with pending stateful constraints to see if they can be approved,
+   * queues them for approval if they pass
+   */
+  private fun dealWithOldVersions(
+    envInfo: EnvironmentInfo,
+    pendingVersionsToCheck: MutableSet<String>
+  ) {
+    log.debug("pendingVersionsToCheck: [$pendingVersionsToCheck] of artifact ${envInfo.artifact.name} for environment ${envInfo.environment.name} ")
+    pendingVersionsToCheck
+      .sortedWith(envInfo.artifact.versioningStrategy.comparator.reversed()) // oldest first
+      .forEach { version ->
+        val passesConstraints =
+          checkStatelessConstraints(envInfo.artifact, envInfo.deliveryConfig, version, envInfo.environment) &&
+            checkStatefulConstraints(envInfo.artifact, envInfo.deliveryConfig, version, envInfo.environment)
+
+        if (passesConstraints) {
+          repository.queueAllConstraintsApproved(envInfo.deliveryConfig.name, envInfo.environment.name, version)
+        }
+      }
+  }
+
+  /**
+   * A container to hold all info needed for these functions
+   * so that we can actually break this shit up into functions
+   */
+  data class EnvironmentInfo(
+    val deliveryConfig: DeliveryConfig,
+    val environment: Environment,
+    val artifact: DeliveryArtifact,
+    val versions: List<String>,
+    val vetoedArtifacts: Map<String, EnvironmentArtifactVetoes>
+  )
+
+  /**
+   * Queues a version for approval if it's not already approved in the environment.
+   * [EnvironmentPromotionChecker] handles actually approving a version for an environment.
+   */
+  private fun queueApproval(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    targetEnvironment: String
+  ) {
+    val latestVersion = repository
+      .latestVersionApprovedIn(deliveryConfig, artifact, targetEnvironment)
+    if (latestVersion != version) {
+      log.debug("Queueing version $version of ${artifact.type} artifact ${artifact.name} in environment $targetEnvironment for approval")
+      repository.queueAllConstraintsApproved(deliveryConfig.name, targetEnvironment, version)
+    }
+  }
+
+  fun checkStatelessConstraints(
+    artifact: DeliveryArtifact,
+    deliveryConfig: DeliveryConfig,
+    version: String,
+    environment: Environment
+  ): Boolean =
+    checkImplicitConstraints(implicitStatelessEvaluators, artifact, deliveryConfig, version, environment) &&
+      checkConstraints(statelessEvaluators, artifact, deliveryConfig, version, environment)
+
+  fun checkStatefulConstraints(
+    artifact: DeliveryArtifact,
+    deliveryConfig: DeliveryConfig,
+    version: String,
+    environment: Environment
+  ): Boolean =
+    checkImplicitConstraints(implicitStatefulEvaluators, artifact, deliveryConfig, version, environment) &&
+      checkConstraints(statefulEvaluators, artifact, deliveryConfig, version, environment)
+
+  /**
+   * Checks constraints for a list of evaluators.
+   * Evaluates the constraint for every environment passed in.
+   * @return true if all constraints pass
+   */
+  private fun checkImplicitConstraints(
+    evaluators: List<ConstraintEvaluator<*>>,
+    artifact: DeliveryArtifact,
+    deliveryConfig: DeliveryConfig,
+    version: String,
+    environment: Environment
+  ): Boolean {
+    return if (evaluators.isEmpty()) {
+      true
+    } else {
+      evaluators.all { evaluator ->
+        evaluator.canPromote(artifact, version, deliveryConfig, environment)
+      }
+    }
+  }
+
+  /**
+   * Checks constraints for a list of evaluators.
+   * Evaluates the constraint only if it's defined on the environment.
+   * @return true if all constraints pass
+   */
+  private fun checkConstraints(
+    evaluators: List<ConstraintEvaluator<*>>,
+    artifact: DeliveryArtifact,
+    deliveryConfig: DeliveryConfig,
+    version: String,
+    environment: Environment
+  ): Boolean {
+    return if (evaluators.isEmpty()) {
+      true
+    } else {
+      evaluators.all { evaluator ->
+        !environment.hasSupportedConstraint(evaluator) ||
+          evaluator.canPromote(artifact, version, deliveryConfig, environment)
+      }
+    }
+  }
+
+  private fun Environment.hasSupportedConstraint(constraintEvaluator: ConstraintEvaluator<*>) =
+    constraints.any { it.javaClass.isAssignableFrom(constraintEvaluator.supportedType.type) }
+
+  private fun Map<String, PinnedEnvironment>.hasPinFor(
+    environmentName: String,
+    artifact: DeliveryArtifact
+  ): Boolean {
+    if (isEmpty()) {
+      return false
+    }
+
+    val key = envPinKey(environmentName, artifact)
+    return containsKey(key) && checkNotNull(get(key)).artifact == artifact
+  }
+
+  private fun envPinKey(environmentName: String, artifact: DeliveryArtifact): String =
+    "$environmentName:${artifact.name}:${artifact.type.name.toLowerCase()}"
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -78,7 +78,9 @@ class EnvironmentPromotionChecker(
               }
             }
 
-          val versionSelected = queuedForApproval.lastOrNull()
+          val versionSelected = queuedForApproval
+            .sortedWith(artifact.versioningStrategy.comparator.reversed())
+            .lastOrNull()
           if (versionSelected == null) {
             log.warn("No version of {} passes constraints for environment {}", artifact.name, environment.name)
           }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.actuation
 
-import com.netflix.spinnaker.keel.actuation.EnvironmentConstraintRunner.EnvironmentInfo
+import com.netflix.spinnaker.keel.actuation.EnvironmentConstraintRunner.EnvironmentContext
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
@@ -50,9 +50,8 @@ class EnvironmentPromotionChecker(
             return@forEach
           }
 
-          // todo eb: should this be in another loop?
           constraintRunner.checkEnvironment(
-            EnvironmentInfo(deliveryConfig, environment, artifact, versions, vetoedArtifacts)
+            EnvironmentContext(deliveryConfig, environment, artifact, versions, vetoedArtifacts)
           )
 
           // everything the constraint runner has already approved
@@ -63,7 +62,6 @@ class EnvironmentPromotionChecker(
           /**
            * Approve all constraints starting with oldest first so that the ordering is
            * maintained.
-           * todo eb: understand ^ comment and figure out if it's needed
            */
           queuedForApproval
             .sortedWith(artifact.versioningStrategy.comparator.reversed())
@@ -72,7 +70,7 @@ class EnvironmentPromotionChecker(
                * We don't need to re-invoke stateful constraint evaluators for these, but we still
                * check stateless constraints to avoid approval outside of allowed-times.
                */
-              log.debug("Version $v of artifact ${artifact.name} is in queued for approval, " +
+              log.debug("Version $v of artifact ${artifact.name} is queued for approval, " +
                 "and being evaluated for stateless constraints in environment ${environment.name}")
               if (constraintRunner.checkStatelessConstraints(artifact, deliveryConfig, v, environment)) {
                 approveVersion(deliveryConfig, artifact, v, environment.name)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -1,12 +1,8 @@
 package com.netflix.spinnaker.keel.actuation
 
+import com.netflix.spinnaker.keel.actuation.EnvironmentConstraintRunner.EnvironmentInfo
 import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.api.Environment
-import com.netflix.spinnaker.keel.api.anyStateful
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.constraints.ConstraintEvaluator
-import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
-import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.comparator
@@ -16,24 +12,16 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
+/**
+ * This class is responsible for approving artifacts in environments
+ */
 @Component
 class EnvironmentPromotionChecker(
   private val repository: KeelRepository,
-  private val constraints: List<ConstraintEvaluator<*>>,
+  private val constraintRunner: EnvironmentConstraintRunner,
   private val publisher: ApplicationEventPublisher
 ) {
-  private val implicitConstraints: List<ConstraintEvaluator<*>> = constraints.filter { it.isImplicit() }
-  private val explicitConstraints: List<ConstraintEvaluator<*>> = constraints - implicitConstraints
-
-  // constraints that are only run if they are defined in a delivery config
-  private val statefulEvaluators: List<ConstraintEvaluator<*>> = explicitConstraints
-    .filterIsInstance<StatefulConstraintEvaluator<*, *>>()
-  private val statelessEvaluators = explicitConstraints - statefulEvaluators
-
-  // constraints that run for every environment in a delivery config but aren't shown to the user.
-  private val implicitStatefulEvaluators: List<ConstraintEvaluator<*>> = implicitConstraints
-    .filterIsInstance<StatefulConstraintEvaluator<*, *>>()
-  private val implicitStatelessEvaluators: List<ConstraintEvaluator<*>> = implicitConstraints - implicitStatefulEvaluators
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   suspend fun checkEnvironments(deliveryConfig: DeliveryConfig) {
     val pinnedEnvs: Map<String, PinnedEnvironment> = repository
@@ -49,120 +37,52 @@ class EnvironmentPromotionChecker(
       .forEach { (artifact, versions) ->
         if (versions.isEmpty()) {
           log.warn("No versions for ${artifact.type} artifact ${artifact.name} are known")
-        } else {
-          deliveryConfig.environments.forEach { environment ->
-            var hasPin = false
-            var versionIsPending = false
-            val pendingVersionsToCheck: MutableSet<String> =
-              when (environment.constraints.anyStateful) {
-                true -> repository
-                  .pendingConstraintVersionsFor(deliveryConfig.name, environment.name)
-                  .filter { versions.contains(it) }
-                  .toMutableSet()
-                false -> mutableSetOf()
-              }
+          return@forEach
+        }
+        deliveryConfig.environments.forEach { environment ->
+          // if pinned, we approve that version right away without doing anything else
+          // to fast track that deployment
+          if (pinnedEnvs.hasPinFor(environment.name, artifact)) {
+            // todo: https://github.com/spinnaker/keel/issues/1254
+            val pinnedVersion: String = pinnedEnvs.versionFor(environment.name, artifact) ?: return@forEach
+            // todo eb: this shouldn't be null, we just checked if a pin exists in the map above.
+            approveVersion(deliveryConfig, artifact, pinnedVersion, environment.name)
+            return@forEach
+          }
 
-            val queuedForApproval: MutableSet<String> =
-              when (environment.constraints.anyStateful) {
-                true -> repository
-                  .getQueuedConstraintApprovals(deliveryConfig.name, environment.name)
-                  .toMutableSet()
-                false -> mutableSetOf()
-              }
+          // todo eb: should this be in another loop?
+          constraintRunner.checkEnvironment(
+            EnvironmentInfo(deliveryConfig, environment, artifact, versions, vetoedArtifacts)
+          )
 
-            val vetoedVersions: Set<String> =
-              (vetoedArtifacts[envPinKey(environment.name, artifact)]?.versions)
-                ?: emptySet()
+          // everything the constraint runner has already approved
+          val queuedForApproval: MutableSet<String> = repository
+            .getQueuedConstraintApprovals(deliveryConfig.name, environment.name)
+            .toMutableSet()
 
-            val version = when {
-              pinnedEnvs.hasPinFor(environment.name, artifact) -> {
-                hasPin = true
-                pinnedEnvs.versionFor(environment.name, artifact)
-              }
-              environment.constraints.isEmpty() && implicitConstraints.isEmpty() -> {
-                versions.firstOrNull { v ->
-                  !vetoedVersions.contains(v)
-                }
-              }
-              else -> {
-                versions
-                  .firstOrNull { v ->
-                    pendingVersionsToCheck.remove(v)
-                    queuedForApproval.remove(v)
-                    if (vetoedVersions.contains(v)) {
-                      false
-                    } else {
-                      /**
-                       * Only check stateful evaluators if all stateless evaluators pass. We don't
-                       * want to request judgement or deploy a canary for artifacts that aren't
-                       * deployed to a required environment or outside of an allowed time.
-                       */
-                      val passesConstraints =
-                        checkStatelessConstraints(artifact, deliveryConfig, v, environment) &&
-                          checkStatefulConstraints(artifact, deliveryConfig, v, environment)
-                      versionIsPending = when (environment.constraints.anyStateful) {
-                        true -> repository
-                          .constraintStateFor(deliveryConfig.name, environment.name, v)
-                          .any { it.status == PENDING }
-                        else -> false
-                      }
-                      passesConstraints || versionIsPending
-                    }
-                  }
+          /**
+           * Approve all constraints starting with oldest first so that the ordering is
+           * maintained.
+           * todo eb: understand ^ comment and figure out if it's needed
+           */
+          queuedForApproval
+            .sortedWith(artifact.versioningStrategy.comparator.reversed())
+            .forEach { v ->
+              /**
+               * We don't need to re-invoke stateful constraint evaluators for these, but we still
+               * check stateless constraints to avoid approval outside of allowed-times.
+               */
+              log.debug("Version $v of artifact ${artifact.name} is in queued for approval, " +
+                "and being evaluated for stateless constraints in environment ${environment.name}")
+              if (constraintRunner.checkStatelessConstraints(artifact, deliveryConfig, v, environment)) {
+                approveVersion(deliveryConfig, artifact, v, environment.name)
+                repository.deleteQueuedConstraintApproval(deliveryConfig.name, environment.name, v)
               }
             }
 
-            /**
-             * If there are pending constraints for prior versions, recheck in ascending version order
-             * so they can be timed out, failed, or approved. If a newer version was selected above,
-             * it is approved last in an attempt to retain ENVIRONMENT_ARTIFACT_VERSIONS.APPROVED_AT
-             * ordering.
-             */
-            var approvedPending = false
-            if (!hasPin) {
-              log.debug("pendingVersionsToCheck: [$pendingVersionsToCheck] of artifact ${artifact.name} for environment ${environment.name} ")
-              pendingVersionsToCheck
-                .sortedWith(artifact.versioningStrategy.comparator.reversed()) // oldest first
-                .forEach {
-                  val passesConstraints =
-                    checkStatelessConstraints(artifact, deliveryConfig, it, environment) &&
-                      checkStatefulConstraints(artifact, deliveryConfig, it, environment)
-
-                  if (passesConstraints) {
-                    approveVersion(deliveryConfig, artifact, it, environment.name)
-                    approvedPending = true
-                  }
-                }
-
-              queuedForApproval
-                .sortedWith(artifact.versioningStrategy.comparator.reversed())
-                .forEach { v ->
-                  /**
-                   * We don't need to re-invoke stateful constraint evaluators for these, but we still
-                   * check stateless constraints to avoid approval outside of allowed-times.
-                   */
-                  log.debug("Version $v of artifact ${artifact.name} is in queued for approval, " +
-                    "and being evaluated for stateless constraints in environment ${environment.name}")
-                  if (checkStatelessConstraints(artifact, deliveryConfig, v, environment)) {
-                    approveVersion(deliveryConfig, artifact, v, environment.name)
-                    repository.deleteQueuedConstraintApproval(deliveryConfig.name, environment.name, v)
-                  }
-                }
-            }
-            if (!approvedPending && versionIsPending || version == null) {
-              if (version != null) {
-                val approvedVersion = repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)
-                if (approvedVersion != null) {
-                  log.debug("Version: $approvedVersion of artifact ${artifact.name} is currently approved in environment ${environment.name}")
-                }
-              } else {
-                log.warn("No version of {} passes constraints for environment {}", artifact.name, environment.name)
-              }
-            } else {
-              if (!versionIsPending) {
-                approveVersion(deliveryConfig, artifact, version, environment.name)
-              }
-            }
+          val versionSelected = queuedForApproval.lastOrNull()
+          if (versionSelected == null) {
+            log.warn("No version of {} passes constraints for environment {}", artifact.name, environment.name)
           }
         }
       }
@@ -198,70 +118,6 @@ class EnvironmentPromotionChecker(
     }
   }
 
-  private fun checkStatelessConstraints(
-    artifact: DeliveryArtifact,
-    deliveryConfig: DeliveryConfig,
-    version: String,
-    environment: Environment
-  ): Boolean =
-    checkImplicitConstraints(implicitStatelessEvaluators, artifact, deliveryConfig, version, environment) &&
-      checkConstraints(statelessEvaluators, artifact, deliveryConfig, version, environment)
-
-  private fun checkStatefulConstraints(
-    artifact: DeliveryArtifact,
-    deliveryConfig: DeliveryConfig,
-    version: String,
-    environment: Environment
-  ): Boolean =
-    checkImplicitConstraints(implicitStatefulEvaluators, artifact, deliveryConfig, version, environment) &&
-      checkConstraints(statefulEvaluators, artifact, deliveryConfig, version, environment)
-
-  /**
-   * Checks constraints for a list of evaluators.
-   * Evaluates the constraint for every environment passed in.
-   * @return true if all constraints pass
-   */
-  private fun checkImplicitConstraints(
-    evaluators: List<ConstraintEvaluator<*>>,
-    artifact: DeliveryArtifact,
-    deliveryConfig: DeliveryConfig,
-    version: String,
-    environment: Environment
-  ): Boolean {
-    return if (evaluators.isEmpty()) {
-      true
-    } else {
-      evaluators.all { evaluator ->
-        evaluator.canPromote(artifact, version, deliveryConfig, environment)
-      }
-    }
-  }
-
-  /**
-   * Checks constraints for a list of evaluators.
-   * Evaluates the constraint only if it's defined on the environment.
-   * @return true if all constraints pass
-   */
-  private fun checkConstraints(
-    evaluators: List<ConstraintEvaluator<*>>,
-    artifact: DeliveryArtifact,
-    deliveryConfig: DeliveryConfig,
-    version: String,
-    environment: Environment
-  ): Boolean {
-    return if (evaluators.isEmpty()) {
-      true
-    } else {
-      evaluators.all { evaluator ->
-        !environment.hasSupportedConstraint(evaluator) ||
-          evaluator.canPromote(artifact, version, deliveryConfig, environment)
-      }
-    }
-  }
-
-  private fun Environment.hasSupportedConstraint(constraintEvaluator: ConstraintEvaluator<*>) =
-    constraints.any { it.javaClass.isAssignableFrom(constraintEvaluator.supportedType.type) }
-
   private fun Map<String, PinnedEnvironment>.hasPinFor(
     environmentName: String,
     artifact: DeliveryArtifact
@@ -282,6 +138,4 @@ class EnvironmentPromotionChecker(
 
   private fun envPinKey(environmentName: String, artifact: DeliveryArtifact): String =
     "$environmentName:${artifact.name}:${artifact.type.name.toLowerCase()}"
-
-  private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -137,10 +137,24 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
     artifactVersion: String
   ): List<ConstraintState>
 
+  /**
+   * Fetches all versions have a pending stateful constraint in an environment
+   */
   fun pendingConstraintVersionsFor(deliveryConfigName: String, environmentName: String): List<String>
 
+  /**
+   * Gets all versions queued for approval for the environment
+   */
   fun getQueuedConstraintApprovals(deliveryConfigName: String, environmentName: String): Set<String>
+
+  /**
+   * Adds an artifact version to the queued table to indicate all constraints pass for that version
+   */
   fun queueAllConstraintsApproved(deliveryConfigName: String, environmentName: String, artifactVersion: String)
+
+  /**
+   * Removes a queued version from the queued table
+   */
   fun deleteQueuedConstraintApproval(deliveryConfigName: String, environmentName: String, artifactVersion: String)
 
   fun getApplicationSummaries(): Collection<ApplicationSummary>

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunnerTests.kt
@@ -1,0 +1,454 @@
+package com.netflix.spinnaker.keel.actuation
+
+import com.netflix.spinnaker.keel.actuation.EnvironmentConstraintRunner.EnvironmentContext
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
+import com.netflix.spinnaker.keel.api.constraints.ConstraintEvaluator
+import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
+import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
+import com.netflix.spinnaker.keel.constraints.ArtifactUsedConstraintEvaluator
+import com.netflix.spinnaker.keel.core.api.ArtifactUsedConstraint
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import strikt.api.expectCatching
+import strikt.assertions.isSuccess
+
+internal class EnvironmentConstraintRunnerTests : JUnit5Minutests {
+  data class Fixture(
+    val environment: Environment = Environment(
+      name = "test"
+    )
+  ) {
+    val repository: KeelRepository = mockk(relaxUnitFun = true)
+
+    val statelessEvaluator = mockk<ConstraintEvaluator<*>>() {
+      every { supportedType } returns SupportedConstraintType<DependsOnConstraint>("depends-on")
+      every { isImplicit() } returns false
+    }
+    val statefulEvaluator = mockk<StatefulConstraintEvaluator<*, *>>() {
+      every { supportedType } returns SupportedConstraintType<ManualJudgementConstraint>("manual-judegment")
+      every { isImplicit() } returns false
+    }
+    val implicitStatelessEvaluator = mockk<ArtifactUsedConstraintEvaluator>() {
+      every { supportedType } returns SupportedConstraintType<ArtifactUsedConstraint>("artifact-type")
+      every { isImplicit() } returns true
+      every { canPromote(any(), any(), any(), any()) } returns true
+    }
+    val subject = EnvironmentConstraintRunner(
+      repository,
+      listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator)
+    )
+
+    val artifact = DockerArtifact(
+      name = "fnord",
+      deliveryConfigName = "my-manifest",
+      tagVersionStrategy = SEMVER_TAG
+    )
+
+    val deliveryConfig = DeliveryConfig(
+      name = "my-manifest",
+      application = "fnord",
+      serviceAccount = "keel@spinnaker",
+      environments = setOf(environment),
+      artifacts = setOf(artifact)
+    )
+
+    val pendingManualJudgement = ConstraintState(
+      deliveryConfig.name,
+      environment.name,
+      "2.0",
+      "manual-judgement",
+      ConstraintStatus.PENDING
+    )
+
+    val passedManualJudgement = ConstraintState(
+      deliveryConfig.name,
+      environment.name,
+      "1.2",
+      "manual-judgement",
+      ConstraintStatus.OVERRIDE_PASS
+    )
+
+    fun generateContext(
+      versions: List<String>,
+      vetoedVersions: Set<String> = emptySet()
+    ) =
+      EnvironmentContext(deliveryConfig, environment, artifact, versions, vetoedVersions)
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    context("no versions of an artifact exist") {
+      test("the check does not throw an exception") {
+        expectCatching {
+          subject.checkEnvironment(generateContext(versions = emptyList()))
+        }
+          .isSuccess()
+      }
+    }
+
+    context("versions exist") {
+      before {
+        every {
+          repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)
+        } returns "1.2"
+
+        every {
+          repository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
+        } returns true
+
+        every {
+          repository.pendingConstraintVersionsFor(any(), any())
+        } returns emptyList()
+      }
+
+      context("there are no constraints on the environment") {
+        before {
+          runBlocking {
+            subject.checkEnvironment(generateContext(versions = listOf("2.0", "1.2", "1.1", "1.0")))
+          }
+        }
+
+        test("the implicit constraint is checked") {
+          verify {
+            implicitStatelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+          }
+        }
+
+        test("the latest version is queued for approval") {
+          verify {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "2.0")
+          }
+        }
+      }
+
+      context("a version is vetoed") {
+        before {
+          runBlocking {
+            subject.checkEnvironment(generateContext(
+              versions = listOf("2.0", "1.2", "1.1", "1.0"),
+              vetoedVersions = mutableSetOf("2.0")
+            ))
+          }
+        }
+
+        test("the version doesn't get checked") {
+          verify(exactly = 0) {
+            implicitStatelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+          }
+        }
+      }
+
+      context("the latest version of the artifact was already approved for this environment") {
+        before {
+
+          every {
+            repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)
+          } returns "2.0"
+
+          runBlocking {
+            subject.checkEnvironment(generateContext(versions = listOf("2.0", "1.2", "1.1", "1.0")))
+          }
+        }
+
+        test("we don't re-queue the version") {
+          verify(exactly = 0) {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, any())
+          }
+        }
+      }
+
+      context("the environment has a simple constraint and a version can be found") {
+        deriveFixture {
+          copy(environment = Environment(
+            name = "staging",
+            constraints = setOf(DependsOnConstraint("test"))
+          ))
+        }
+        before {
+          // TODO: sucks that this is necessary but when using deriveFixture you get a different mockk
+          every {
+            repository.pendingConstraintVersionsFor(any(), any())
+          } returns emptyList()
+
+          every { statelessEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment) } returns true
+          every { statefulEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment) } returns true
+          every { statelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment) } returns true
+          every { statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment) } returns true
+
+          every {
+            repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)
+          } returns "1.1"
+        }
+
+        context("a version is vetoed") {
+          before {
+            runBlocking {
+              subject.checkEnvironment(generateContext(
+                versions = listOf("2.0", "1.2", "1.1", "1.0"),
+                vetoedVersions = mutableSetOf("2.0")
+              ))
+            }
+          }
+
+          test("the vetoed version doesn't get checked") {
+            verify(exactly = 0) {
+              implicitStatelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+            }
+          }
+          test("the other version is checked and queued for approval") {
+            verify(exactly = 1) {
+              implicitStatelessEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
+              statelessEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
+            }
+          }
+
+          test("the correct version is the only one queued for approval") {
+            verify(exactly = 0) {
+              repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "2.0")
+            }
+            verify(exactly = 1) {
+              repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "1.2")
+            }
+          }
+        }
+
+        context("no versions are vetoed") {
+          before {
+            runBlocking {
+              subject.checkEnvironment(generateContext(
+                versions = listOf("2.0", "1.2", "1.1", "1.0")
+              ))
+            }
+          }
+
+          test("we only check the latest version") {
+            verify(exactly = 1) {
+              implicitStatelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+              statelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+            }
+            verify(exactly = 0) {
+              implicitStatelessEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
+              statelessEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
+            }
+          }
+
+          test("the latest version is queued for approval") {
+            verify(exactly = 1) {
+              repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "2.0")
+            }
+          }
+        }
+      }
+
+      context("the environment has constraints and a version can be found") {
+        deriveFixture {
+          copy(environment = Environment(
+            name = "staging",
+            constraints = setOf(DependsOnConstraint("test"), ManualJudgementConstraint())
+          ))
+        }
+        before {
+          // TODO: sucks that this is necessary but when using deriveFixture you get a different mockk
+          every {
+            repository.getConstraintState(any(), any(), "2.0", "manual-judgement")
+          } returns pendingManualJudgement
+
+          every {
+            repository.getConstraintState(any(), any(), "1.2", "manual-judgement")
+          } returns passedManualJudgement
+
+          every {
+            repository.pendingConstraintVersionsFor(any(), any())
+          } returns listOf("2.0", "1.2")
+
+          every {
+            repository.constraintStateFor("my-manifest", "staging", "1.2")
+          } returns listOf(passedManualJudgement)
+
+          every {
+            repository.constraintStateFor("my-manifest", "staging", "2.0")
+          } returns listOf(pendingManualJudgement)
+
+          every { statelessEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment) } returns true
+          every { statefulEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment) } returns true
+          every { statelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment) } returns false
+          every { statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment) } returns false
+
+          every {
+            repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name)
+          } returns "1.1"
+        }
+
+        context("no versions are vetoed") {
+          before {
+            runBlocking {
+              subject.checkEnvironment(generateContext(versions = listOf("2.0", "1.2", "1.1", "1.0")))
+            }
+          }
+
+          test("the implicit constraint is checked") {
+            verify {
+              implicitStatelessEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+            }
+          }
+
+          test("the latest version that passes constraints is queued for approval") {
+            verify {
+              repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "1.2")
+            }
+
+            /**
+             * Verify that stateful constraints are not checked if a stateless constraint blocks promotion
+             */
+            verify(exactly = 0) {
+              statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+            }
+          }
+        }
+      }
+
+      context("the environment has constraints and a version cannot be found") {
+        deriveFixture {
+          copy(environment = Environment(
+            name = "staging",
+            constraints = setOf(DependsOnConstraint("test"))
+          ))
+        }
+
+        before {
+          // TODO: sucks that this is necessary but when using deriveFixture you get a different mockk
+          every { statelessEvaluator.canPromote(artifact, "1.0", deliveryConfig, environment) } returns false
+        }
+
+        test("no exception is thrown") {
+          expectCatching {
+            subject.checkEnvironment(generateContext(versions = listOf("1.0")))
+          }
+            .isSuccess()
+        }
+
+        test("no artifact is registered") {
+          runBlocking {
+            subject.checkEnvironment(generateContext(versions = listOf("1.0")))
+          }
+
+          verify(exactly = 0) {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, any())
+          }
+        }
+      }
+
+      context("the environment has a stateful constraint and a version cannot be found") {
+        deriveFixture {
+          copy(environment = Environment(
+            name = "staging",
+            constraints = setOf(ManualJudgementConstraint())
+          ))
+        }
+
+        before {
+          // TODO: sucks that this is necessary but when using deriveFixture you get a different mockk
+          every { repository.pendingConstraintVersionsFor(any(), any()) } returns emptyList()
+
+          every { statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment) } returns false
+
+          every {
+            repository.constraintStateFor("my-manifest", "staging", "2.0")
+          } returns listOf(pendingManualJudgement)
+
+          every { repository.latestVersionApprovedIn(any(), any(), any()) } returns null
+
+          runBlocking { subject.checkEnvironment(generateContext(versions = listOf("2.0", "1.2", "1.1"))) }
+        }
+
+        test("stateful constraints are only evaluated for the most recent version") {
+          verify(exactly = 1) {
+            statefulEvaluator.canPromote(artifact, "2.0", deliveryConfig, environment)
+          }
+          verify(exactly = 0) {
+            statefulEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
+            statefulEvaluator.canPromote(artifact, "1.1", deliveryConfig, environment)
+          }
+        }
+
+        test("no artifact is approved") {
+          verify(exactly = 0) {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, any())
+          }
+        }
+
+        test("no exception is thrown") {
+          expectCatching {
+            subject.checkEnvironment(generateContext(versions = listOf("2.0", "1.2", "1.1")))
+          }
+            .isSuccess()
+        }
+      }
+
+      context("a new artifact passes stateful constraints while older versions are pending") {
+        deriveFixture {
+          copy(environment = Environment(
+            name = "staging",
+            constraints = setOf(DependsOnConstraint("test"), ManualJudgementConstraint())
+          ))
+        }
+
+        before {
+          // TODO: sucks that this is necessary but when using deriveFixture you get a different mockk
+          every { repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name) } returns "1.1"
+
+          every { repository.pendingConstraintVersionsFor(any(), any()) } returns listOf("1.2", "1.1")
+
+          every { repository.getQueuedConstraintApprovals(any(), any()) } returns setOf("1.2", "1.0")
+
+          every { statefulEvaluator.canPromote(any(), "2.0", any(), any()) } returns false
+          every { statefulEvaluator.canPromote(any(), "1.2", any(), any()) } returns true
+          every { statefulEvaluator.canPromote(any(), "1.1", any(), any()) } returns false
+          every { statelessEvaluator.canPromote(any(), "2.0", any(), any()) } returns true
+          every { statelessEvaluator.canPromote(any(), "1.2", any(), any()) } returns true
+          every { statelessEvaluator.canPromote(any(), "1.1", any(), any()) } returns true
+          every { statelessEvaluator.canPromote(any(), "1.0", any(), any()) } returns true
+
+          every { repository.approveVersionFor(deliveryConfig, artifact, "1.2", environment.name) } returns true
+          every { repository.approveVersionFor(deliveryConfig, artifact, "1.0", environment.name) } returns true
+
+          every {
+            repository.constraintStateFor("my-manifest", "staging", "2.0")
+          } returns listOf(pendingManualJudgement)
+
+          runBlocking { subject.checkEnvironment(generateContext(versions = listOf("2.0", "1.2", "1.1", "1.0", "0.9"))) }
+        }
+
+        test("pending versions are checked and approved if passed") {
+          verify(exactly = 1) {
+            statefulEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
+            statefulEvaluator.canPromote(artifact, "1.1", deliveryConfig, environment)
+          }
+
+          verify(exactly = 1) {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "1.2")
+          }
+
+          verify(exactly = 0) {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "2.0")
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -54,8 +54,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
     }
     val environmentConstraintRunner = EnvironmentConstraintRunner(
       repository,
-      listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator),
-      publisher
+      listOf(statelessEvaluator, statefulEvaluator, implicitStatelessEvaluator)
     )
     val subject = EnvironmentPromotionChecker(
       repository,
@@ -93,6 +92,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
     )
   }
 
+  // todo eb: remove these tests (in favor of EnvironmentConstraintRunnerTests and NewEnvironmentPromotionCheckerTests)
   fun tests() = rootContext<Fixture> {
     fixture {
       Fixture()

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -489,6 +489,7 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           every { repository.pinnedEnvironments(any()) } returns emptyList()
 
           every { repository.vetoedEnvironmentVersions(any()) } returns emptyList()
+          every { repository.latestVersionApprovedIn(deliveryConfig, artifact, environment.name) } returns "1.1"
 
           every { repository.pendingConstraintVersionsFor(any(), any()) } returns listOf("1.2", "1.1")
 
@@ -516,6 +517,10 @@ internal class EnvironmentPromotionCheckerTests : JUnit5Minutests {
           verify(exactly = 1) {
             statefulEvaluator.canPromote(artifact, "1.2", deliveryConfig, environment)
             statefulEvaluator.canPromote(artifact, "1.1", deliveryConfig, environment)
+          }
+
+          verify(exactly = 1) {
+            repository.queueAllConstraintsApproved(deliveryConfig.name, environment.name, "1.2")
           }
 
           verify(exactly = 1) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/NewEnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/NewEnvironmentPromotionCheckerTests.kt
@@ -1,0 +1,321 @@
+package com.netflix.spinnaker.keel.actuation
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.telemetry.ArtifactVersionApproved
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectCatching
+import strikt.assertions.isSuccess
+
+internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
+  class Fixture {
+    val repository: KeelRepository = mockk(relaxUnitFun = true)
+
+    val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
+
+    val environmentConstraintRunner: EnvironmentConstraintRunner = mockk(relaxed = true)
+    val subject = EnvironmentPromotionChecker(
+      repository,
+      environmentConstraintRunner,
+      publisher
+    )
+
+    val artifact = DockerArtifact(
+      name = "fnord",
+      deliveryConfigName = "my-manifest",
+      tagVersionStrategy = SEMVER_TAG
+    )
+    val environment: Environment = Environment(
+      name = "test"
+    )
+    val deliveryConfig = DeliveryConfig(
+      name = "my-manifest",
+      application = "fnord",
+      serviceAccount = "keel@spinnaker",
+      environments = setOf(environment),
+      artifacts = setOf(artifact)
+    )
+
+    val env1 = environment
+    val env2 = env1.copy(name = "staging", constraints = setOf(DependsOnConstraint("test")))
+    val multiEnvConfig = deliveryConfig.copy(environments = setOf(env1, env2))
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    context("no versions of an artifact exist") {
+      before {
+        every {
+          repository.artifactVersions(artifact)
+        } returns emptyList()
+
+        every {
+          repository.pinnedEnvironments(any())
+        } returns emptyList()
+
+        every {
+          repository.vetoedEnvironmentVersions(any())
+        } returns emptyList()
+      }
+
+      test("the check does not throw an exception") {
+        expectCatching {
+          subject.checkEnvironments(deliveryConfig)
+        }
+          .isSuccess()
+      }
+    }
+
+    context("multiple versions of an artifact exist") {
+      before {
+        every {
+          repository.artifactVersions(artifact)
+        } returns listOf("2.0", "1.2", "1.1", "1.0")
+
+        every {
+          repository.pinnedEnvironments(any())
+        } returns emptyList()
+
+        every {
+          repository.vetoedEnvironmentVersions(any())
+        } returns emptyList()
+      }
+
+      context("a single new version is queued for approval") {
+        before {
+          every {
+            repository.getQueuedConstraintApprovals(deliveryConfig.name, environment.name)
+          } returns setOf("2.0")
+        }
+
+        context("the version is not already approved for the environment") {
+          before {
+            every {
+              environmentConstraintRunner.checkStatelessConstraints(artifact, deliveryConfig, "2.0", environment)
+            } returns true
+
+            every {
+              repository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
+            } returns true
+
+            runBlocking {
+              subject.checkEnvironments(deliveryConfig)
+            }
+          }
+
+          test("the environment is assigned the latest version of an artifact") {
+            verify {
+              repository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
+            }
+          }
+
+          test("a telemetry event is fired") {
+            verify {
+              publisher.publishEvent(ArtifactVersionApproved(
+                deliveryConfig.application,
+                deliveryConfig.name,
+                environment.name,
+                artifact.name,
+                artifact.type,
+                "2.0"
+              ))
+            }
+          }
+        }
+
+        context("the version is already approved for the environment") {
+          before {
+            every {
+              environmentConstraintRunner.checkStatelessConstraints(artifact, deliveryConfig, "2.0", environment)
+            } returns true
+
+            every {
+              repository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
+            } returns false
+
+            runBlocking {
+              subject.checkEnvironments(deliveryConfig)
+            }
+          }
+
+          test("an event is not sent") {
+            verify(exactly = 0) {
+              publisher.publishEvent(any<ArtifactVersionApproved>())
+            }
+          }
+        }
+
+        context("the stateless constraints no longer pass") {
+          before {
+            every {
+              environmentConstraintRunner.checkStatelessConstraints(artifact, deliveryConfig, "2.0", environment)
+            } returns false
+
+            runBlocking {
+              subject.checkEnvironments(deliveryConfig)
+            }
+          }
+
+          test("nothing is approved") {
+            verify(exactly = 0) {
+              repository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
+              publisher.publishEvent(any<ArtifactVersionApproved>())
+            }
+          }
+        }
+
+        context("the environment is pinned") {
+          before {
+            every {
+              repository.pinnedEnvironments(any())
+            } returns listOf(PinnedEnvironment(
+              deliveryConfigName = deliveryConfig.name,
+              targetEnvironment = environment.name,
+              artifact = artifact,
+              version = "1.0",
+              pinnedBy = null,
+              pinnedAt = null,
+              comment = null
+            ))
+
+            every {
+              repository.approveVersionFor(deliveryConfig, artifact, any(), environment.name)
+            } returns true
+
+            runBlocking {
+              subject.checkEnvironments(deliveryConfig)
+            }
+          }
+
+          test("no constraint evaluation happens") {
+            verify(exactly = 0) {
+              environmentConstraintRunner.checkEnvironment(any())
+              environmentConstraintRunner.checkStatelessConstraints(any(), any(), any(), any())
+              repository.getQueuedConstraintApprovals(any(), any())
+            }
+          }
+
+          test("the artifact is approved") {
+            verify(exactly = 1) {
+              repository.approveVersionFor(deliveryConfig, artifact, "1.0", environment.name)
+            }
+          }
+        }
+      }
+
+      context("there are several versions queued for approval") {
+        before {
+          every {
+            repository.getQueuedConstraintApprovals(deliveryConfig.name, environment.name)
+          } returns setOf("2.0", "1.2", "1.1")
+        }
+
+        context("all versions still pass stateless constraints") {
+          before {
+            every {
+              environmentConstraintRunner.checkStatelessConstraints(artifact, deliveryConfig, any(), environment)
+            } returns true
+
+            every {
+              repository.approveVersionFor(deliveryConfig, artifact, any(), environment.name)
+            } returns true
+
+            runBlocking {
+              subject.checkEnvironments(deliveryConfig)
+            }
+          }
+
+          test("all versions get approved") {
+            verify {
+              repository.approveVersionFor(deliveryConfig, artifact, "2.0", environment.name)
+              repository.approveVersionFor(deliveryConfig, artifact, "1.2", environment.name)
+              repository.approveVersionFor(deliveryConfig, artifact, "1.1", environment.name)
+            }
+          }
+        }
+      }
+    }
+
+    context("multiple environments exist") {
+      before {
+        every {
+          repository.vetoedEnvironmentVersions(any())
+        } returns emptyList()
+
+        every {
+          repository.artifactVersions(artifact)
+        } returns listOf("2.0", "1.2", "1.1", "1.0")
+
+        every {
+          environmentConstraintRunner.checkStatelessConstraints(artifact, multiEnvConfig, "2.0", any())
+        } returns true
+
+        every {
+          repository.approveVersionFor(multiEnvConfig, artifact, "2.0", any())
+        } returns true
+
+        every {
+          repository.getQueuedConstraintApprovals(any(), any())
+        } returns setOf("2.0")
+      }
+
+      context("there are no pins") {
+        before {
+          every {
+            repository.pinnedEnvironments(any())
+          } returns emptyList()
+
+          runBlocking {
+            subject.checkEnvironments(multiEnvConfig)
+          }
+        }
+
+        test("all environments have the version approved") {
+          verify(exactly = 2) {
+            repository.approveVersionFor(multiEnvConfig, artifact, "2.0", any())
+          }
+        }
+      }
+
+      context("one environment is pinned") {
+        before {
+          every {
+            repository.pinnedEnvironments(any())
+          } returns listOf(PinnedEnvironment(
+            deliveryConfigName = multiEnvConfig.name,
+            targetEnvironment = env1.name,
+            artifact = artifact,
+            version = "2.0",
+            pinnedBy = null,
+            pinnedAt = null,
+            comment = null
+          ))
+
+          runBlocking {
+            subject.checkEnvironments(multiEnvConfig)
+          }
+        }
+
+        test("all environments have the version approved") {
+          verify(exactly = 2) {
+            repository.approveVersionFor(multiEnvConfig, artifact, "2.0", any())
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -429,6 +429,12 @@ class SqlDeliveryConfigRepository(
         }
     } ?: throw OrphanedResourceException(resourceId)
 
+  /**
+   * gets or creates constraint id
+   * saves constraint
+   * calls [constraintStateForWithTransaction]
+   * if all constraints pass, puts in queue for approval table
+   */
   override fun storeConstraintState(state: ConstraintState) {
     environmentUidByName(state.deliveryConfigName, state.environmentName)
       ?.also { envUid ->
@@ -491,6 +497,7 @@ class SqlDeliveryConfigRepository(
              */
             val allStates = constraintStateForWithTransaction(state.deliveryConfigName, state.environmentName, state.artifactVersion, txn)
             if (allStates.allPass && allStates.size >= environment.constraints.statefulCount) {
+              // todo eb: add link to artifact https://github.com/spinnaker/keel/issues/1270
               txn.insertInto(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ENVIRONMENT_UID, envUid)
                 .set(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ARTIFACT_VERSION, state.artifactVersion)
@@ -846,6 +853,7 @@ class SqlDeliveryConfigRepository(
     }
   }
 
+  // todo eb: add link to artifact https://github.com/spinnaker/keel/issues/1270
   override fun pendingConstraintVersionsFor(deliveryConfigName: String, environmentName: String): List<String> {
     val environmentUID = environmentUidByName(deliveryConfigName, environmentName)
       ?: return emptyList()
@@ -861,6 +869,7 @@ class SqlDeliveryConfigRepository(
     }
   }
 
+  // todo eb: add link to artifact https://github.com/spinnaker/keel/issues/1270
   override fun getQueuedConstraintApprovals(deliveryConfigName: String, environmentName: String): Set<String> {
     val environmentUID = environmentUidByName(deliveryConfigName, environmentName)
       ?: return emptySet()
@@ -874,6 +883,12 @@ class SqlDeliveryConfigRepository(
     }
   }
 
+  /**
+   * Not actually used because this is done in [storeConstraintState], except
+   * in that place the envId does not have to be queried for.
+   * It's also done as part of the existing transaction
+   */
+  // todo eb: add link to artifact https://github.com/spinnaker/keel/issues/1270
   override fun queueAllConstraintsApproved(
     deliveryConfigName: String,
     environmentName: String,


### PR DESCRIPTION
In preparation for solving https://github.com/spinnaker/keel/issues/1254, I needed to split up the `EnvironmentPromotionChecker` class to make it a lot easier to build on. I did that by splitting the checking constraints into a new class, `EnvironmentConstraintRunner`.

In  `EnvironmentConstraintRunner`, constraints get evaluated and then queued for approval. `EnvironmentPromotionChecker` looks at that list to figure out what should be approved for each environment. Most notably, if the environment is pinned, we never evaluate the constraints (right now). Changing that is now an easy change!

There are still some todos in here for me, but I wanted to open a PR because this took me like 3 full days and I'm thrilled that the tests pass with only some small additions to reflect the queue then approve behavior.

Still to come, maybe in this PR maybe in a follow up PR: tests for the constraint runner and some live testing