### PR TITLE
ensure event timestamps have subsecond precision

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20200611-fix-event-timestamps.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200611-fix-event-timestamps.yml
@@ -1,0 +1,8 @@
+databaseChangeLog:
+- changeSet:
+    id: fix-event-timestamps
+    author: fletch
+    changes:
+    - sql:
+        sql: |
+          update event set timestamp = timestamp(json_unquote(json->'$.timestamp'));

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -158,3 +158,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200603-add-delivery-config-metadata.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200611-fix-event-timestamps.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Because the `event.timestamp` column used to not store sub-second precision this change just ensures that the timestamps in the event JSON payload and the denormalized `timestamp` column are identical.

Fixes #1158