### PR TITLE
Derive resource metadata instead of storing it

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -10,7 +10,6 @@ data class Resource<out T : ResourceSpec>(
 ) {
   init {
     require(metadata["id"].isValidId()) { "resource id must be a valid id" }
-    require(metadata["serviceAccount"].isValidServiceAccount()) { "serviceAccount must be a valid service account" }
     require(metadata["application"].isValidApplication()) { "application must be a valid application" }
   }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -33,6 +33,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIF
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_WITH_METADATA
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
@@ -928,12 +929,12 @@ class SqlDeliveryConfigRepository(
     sqlRetry.withRetry(READ) {
       jooq
         .select(
-          RESOURCE.KIND,
-          RESOURCE.METADATA,
-          RESOURCE.SPEC
+          RESOURCE_WITH_METADATA.KIND,
+          RESOURCE_WITH_METADATA.METADATA,
+          RESOURCE_WITH_METADATA.SPEC
         )
-        .from(RESOURCE, ENVIRONMENT_RESOURCE)
-        .where(RESOURCE.UID.eq(ENVIRONMENT_RESOURCE.RESOURCE_UID))
+        .from(RESOURCE_WITH_METADATA, ENVIRONMENT_RESOURCE)
+        .where(RESOURCE_WITH_METADATA.UID.eq(ENVIRONMENT_RESOURCE.RESOURCE_UID))
         .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
         .fetch { (kind, metadata, spec) ->
           Resource(

--- a/keel-sql/src/main/resources/db/changelog/20200611-create-resource-metadata-view.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200611-create-resource-metadata-view.yml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+- changeSet:
+    id: create-resource-metadata-view
+    author: fletch
+    changes:
+    - createView:
+        viewName: resource_with_metadata
+        selectQuery: |
+          select
+            resource.uid,
+            resource.id,
+            resource.application,
+            resource.kind,
+            json_object(
+              'uid', resource.uid,
+              'id', resource.id,
+              'application', resource.application,
+              'environment', environment.uid,
+              'environmentName', environment.name,
+              'deliveryConfig', delivery_config.uid,
+              'serviceAccount', delivery_config.service_account
+            ) as metadata,
+            resource.spec
+          from resource
+          left outer join environment_resource on resource.uid = environment_resource.resource_uid
+          left outer join environment on environment.uid = environment_resource.environment_uid
+          left outer join delivery_config on delivery_config.uid = environment.delivery_config_uid
+    - dropColumn:
+        tableName: resource
+        columnName: metadata

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -161,3 +161,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200611-fix-event-timestamps.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200611-create-resource-metadata-view.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -1,12 +1,10 @@
 package com.netflix.spinnaker.keel.sql
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
 import com.netflix.spinnaker.keel.persistence.DummyResourceSpecIdentifier
 import com.netflix.spinnaker.keel.persistence.ResourceRepositoryPeriodicallyCheckedTests
-import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.keel.test.TEST_API_V1
 import com.netflix.spinnaker.keel.test.resource
@@ -23,10 +21,8 @@ import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import strikt.api.expectCatching
 import strikt.api.expectThat
-import strikt.assertions.containsKey
 import strikt.assertions.hasSize
 import strikt.assertions.isA
-import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isSuccess
 
@@ -78,40 +74,6 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
         }
 
         expectThat(results).describedAs("number of unique resources processed").hasSize(1000)
-      }
-    }
-
-    context("database schema consistency") {
-      before {
-        val resource = resource()
-        subject.store(resource)
-      }
-
-      test("metadata is persisted") {
-        jooq
-          .select(RESOURCE.METADATA)
-          .from(RESOURCE)
-          .fetchOne()
-          .let { (metadata) ->
-            configuredObjectMapper().readValue<Map<String, Any?>>(metadata)
-          }
-          .also { metadata ->
-            expectThat(metadata)
-              .containsKey("uid")
-              .containsKey("id")
-          }
-      }
-
-      test("uid is stored consistently") {
-        jooq
-          .select(RESOURCE.UID, RESOURCE.METADATA)
-          .from(RESOURCE)
-          .fetchOne()
-          .also { (uid, metadata) ->
-            val metadataMap = configuredObjectMapper().readValue<Map<String, Any?>>(metadata)
-            expectThat(uid)
-              .isEqualTo(metadataMap["uid"].toString())
-          }
       }
     }
   }


### PR DESCRIPTION
Original intent here was a way to keep service account consistent between a delivery config and its resources. However, I think it makes sense to have all metadata be derived.

Fixes #1097.