### PR TITLE
Support all protocols / all ports ingress rules

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
@@ -18,15 +18,18 @@ package com.netflix.spinnaker.keel.api.ec2
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.JsonDeserializer.None
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.netflix.spinnaker.keel.ec2.jackson.IngressPortsDeserializer
+import com.netflix.spinnaker.keel.ec2.jackson.IngressPortsSerializer
 import com.netflix.spinnaker.keel.ec2.jackson.SecurityGroupRuleDeserializer
 
 @JsonDeserialize(using = SecurityGroupRuleDeserializer::class)
 sealed class SecurityGroupRule {
   abstract val protocol: Protocol
-  abstract val portRange: PortRange
+  abstract val portRange: IngressPorts
 
   enum class Protocol {
-    TCP, UDP, ICMP
+    ALL, TCP, UDP, ICMP
   }
 
   @JsonIgnore
@@ -37,7 +40,7 @@ sealed class SecurityGroupRule {
 data class ReferenceRule(
   override val protocol: Protocol,
   val name: String? = null,
-  override val portRange: PortRange
+  override val portRange: IngressPorts
 ) : SecurityGroupRule() {
   @get:JsonIgnore
   override val isSelfReference: Boolean
@@ -50,17 +53,23 @@ data class CrossAccountReferenceRule(
   val name: String,
   val account: String,
   val vpc: String,
-  override val portRange: PortRange
+  override val portRange: IngressPorts
 ) : SecurityGroupRule()
 
 @JsonDeserialize(using = None::class)
 data class CidrRule(
   override val protocol: Protocol,
-  override val portRange: PortRange,
+  override val portRange: IngressPorts,
   val blockRange: String
 ) : SecurityGroupRule()
+
+@JsonSerialize(using = IngressPortsSerializer::class)
+@JsonDeserialize(using = IngressPortsDeserializer::class)
+sealed class IngressPorts
+
+object AllPorts : IngressPorts()
 
 data class PortRange(
   val startPort: Int,
   val endPort: Int
-)
+) : IngressPorts()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/IngressPortsDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/IngressPortsDeserializer.kt
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.keel.ec2.jackson
+
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.databind.node.TextNode
+import com.netflix.spinnaker.keel.api.ec2.AllPorts
+import com.netflix.spinnaker.keel.api.ec2.IngressPorts
+import com.netflix.spinnaker.keel.api.ec2.PortRange
+
+class IngressPortsDeserializer : StdNodeBasedDeserializer<IngressPorts>(IngressPorts::class.java) {
+  override fun convert(root: JsonNode, context: DeserializationContext): IngressPorts =
+    when (root) {
+      is TextNode -> if (root.textValue() == "ALL") AllPorts else error("${root.textValue()} is not a valid value for port ranges")
+      is ObjectNode -> root.run {
+        PortRange(
+          get("startPort").intValue(),
+          get("endPort").intValue()
+        )
+      }
+      else -> error("port ranges must be either an object with startPort and endPort fields, or the value 'ALL'")
+    }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/IngressPortsSerializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/IngressPortsSerializer.kt
@@ -1,0 +1,22 @@
+package com.netflix.spinnaker.keel.ec2.jackson
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+import com.netflix.spinnaker.keel.api.ec2.AllPorts
+import com.netflix.spinnaker.keel.api.ec2.IngressPorts
+import com.netflix.spinnaker.keel.api.ec2.PortRange
+
+class IngressPortsSerializer : StdSerializer<IngressPorts>(IngressPorts::class.java) {
+  override fun serialize(value: IngressPorts, gen: JsonGenerator, provider: SerializerProvider) {
+    when (value) {
+      is PortRange -> gen.apply {
+        writeStartObject()
+        writeObjectField("startPort", value.startPort)
+        writeObjectField("endPort", value.endPort)
+        writeEndObject()
+      }
+      is AllPorts -> gen.writeString("ALL")
+    }
+  }
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRuleTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRuleTests.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol.ALL
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol.TCP
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
 import dev.minutest.TestContextBuilder
@@ -11,7 +12,7 @@ import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.propertiesAreEqualTo
 
-internal object SecurityGroupRuleTests : JUnit5Minutests {
+internal class SecurityGroupRuleTests : JUnit5Minutests {
 
   data class Fixture(
     val mapper: ObjectMapper = configuredYamlMapper(),
@@ -106,6 +107,26 @@ internal object SecurityGroupRuleTests : JUnit5Minutests {
             protocol = TCP,
             blockRange = "172.16.0.0/24",
             portRange = PortRange(8080, 8080)
+          )
+        )
+      }
+
+      canSerialize()
+      canDeserialize()
+    }
+    context("an open CIDR rule") {
+      fixture {
+        Fixture(
+          yaml = """
+            |---
+            |protocol: "ALL"
+            |portRange: "ALL"
+            |blockRange: "172.16.0.0/24"
+            |""".trimMargin(),
+          model = CidrRule(
+            protocol = ALL,
+            blockRange = "172.16.0.0/24",
+            portRange = AllPorts
           )
         )
       }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -23,12 +23,14 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.ec2.AllPorts
 import com.netflix.spinnaker.keel.api.ec2.CidrRule
 import com.netflix.spinnaker.keel.api.ec2.CrossAccountReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.PortRange
 import com.netflix.spinnaker.keel.api.ec2.ReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroup
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupOverride
+import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol.ALL
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol.TCP
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.plugins.Resolver
@@ -76,6 +78,7 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
+import strikt.assertions.isNull
 
 @Suppress("UNCHECKED_CAST")
 internal class SecurityGroupHandlerTests : JUnit5Minutests {
@@ -327,28 +330,41 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
             inboundRules = setOf(
               // cross account ingress rule from another app
               SecurityGroupRule(
-                "tcp",
-                listOf(SecurityGroupRulePortRange(443, 443)),
-                SecurityGroupRuleReference("otherapp", vpcOtherAccount.account, vpcOtherAccount.region, vpcOtherAccount.id),
-                null),
+                protocol = "tcp",
+                portRanges = listOf(SecurityGroupRulePortRange(443, 443)),
+                securityGroup = SecurityGroupRuleReference("otherapp", vpcOtherAccount.account, vpcOtherAccount.region, vpcOtherAccount.id),
+                range = null),
               // multi-port range self-referencing ingress
               SecurityGroupRule(
-                "tcp",
-                listOf(
+                protocol = "tcp",
+                portRanges = listOf(
                   SecurityGroupRulePortRange(7001, 7001),
-                  SecurityGroupRulePortRange(7102, 7102)),
-                SecurityGroupRuleReference(
+                  SecurityGroupRulePortRange(7102, 7102)
+                ),
+                securityGroup = SecurityGroupRuleReference(
                   cloudDriverResponse1.name,
                   cloudDriverResponse1.accountName,
                   cloudDriverResponse1.region,
-                  vpcRegion1.id),
-                null),
+                  vpcRegion1.id
+                ),
+                range = null
+              ),
               // CIDR ingress
-              SecurityGroupRule("tcp",
-                listOf(
-                  SecurityGroupRulePortRange(443, 443)),
-                null,
-                SecurityGroupRuleCidr("10.0.0.0", "/16"))
+              SecurityGroupRule(
+                protocol = "tcp",
+                portRanges = listOf(
+                  SecurityGroupRulePortRange(443, 443)
+                ),
+                securityGroup = null,
+                range = SecurityGroupRuleCidr("10.0.0.0", "/16")
+              ),
+              // CIDR ingress on all protocols and ports
+              SecurityGroupRule(
+                protocol = "-1",
+                portRanges = emptyList(),
+                securityGroup = null,
+                range = SecurityGroupRuleCidr("100.64.0.0", "/10")
+              )
             )
           )
         )
@@ -496,8 +512,8 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
                   .and {
                     securityGroupSpec.inboundRules.first().also { rule ->
                       get("type").isEqualTo(rule.protocol.name.toLowerCase())
-                      get("startPort").isEqualTo(rule.portRange.startPort)
-                      get("endPort").isEqualTo(rule.portRange.endPort)
+                      get("startPort").isEqualTo((rule.portRange as? PortRange)?.startPort)
+                      get("endPort").isEqualTo((rule.portRange as? PortRange)?.endPort)
                       get("name").isEqualTo((rule as CrossAccountReferenceRule).name)
                     }
                   }
@@ -558,10 +574,10 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
                   .first()
                   .and {
                     securityGroupSpec.inboundRules.first().also { rule ->
-                      get("type").isEqualTo(rule.protocol.name)
+                      get("type").isEqualTo(rule.protocol.name.toLowerCase())
                       get("cidr").isEqualTo((rule as CidrRule).blockRange)
-                      get("startPort").isEqualTo(rule.portRange.startPort)
-                      get("endPort").isEqualTo(rule.portRange.endPort)
+                      get("startPort").isEqualTo((rule.portRange as? PortRange)?.startPort)
+                      get("endPort").isEqualTo((rule.portRange as? PortRange)?.endPort)
                     }
                   }
               }
@@ -669,6 +685,70 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
             job.hasSize(1)
             job.first().type.isEqualTo("upsertSecurityGroup")
             job.first().securityGroupIngress.hasSize(1)
+          }
+        }
+      }
+    }
+
+    context("update a security group with an all protocols/ports ingress rule") {
+      deriveFixture {
+        copy(
+          securityGroupSpec = securityGroupSpec.copy(
+            inboundRules = setOf(
+              CidrRule(
+                protocol = ALL,
+                portRange = AllPorts,
+                blockRange = "100.64.0.0/10"
+              )
+            )
+          )
+        )
+      }
+
+      before {
+        clearMocks(orcaService)
+        every { orcaService.orchestrate("keel@spinnaker", any()) } answers {
+          TaskRefResponse("/tasks/${randomUUID()}")
+        }
+
+        runBlocking {
+          val withoutIngress = resource.copy(
+            spec = resource.spec.copy(
+              inboundRules = emptySet()
+            )
+          )
+
+          handler.update(resource,
+            DefaultResourceDiff(handler.desired(resource), handler.desired(withoutIngress)))
+        }
+      }
+
+      after {
+        confirmVerified(orcaService)
+      }
+
+      test("it includes all protocols/ports rule in the Orca task") {
+        val tasks = mutableListOf<OrchestrationRequest>()
+        verify { orcaService.orchestrate("keel@spinnaker", capture(tasks)) }
+        expectThat(tasks)
+          .hasSize(2)
+        expectThat(tasks.flatMap { it.job.first()["regions"] as List<String> })
+          .hasSize(2)
+          .containsExactly(regions)
+
+        tasks.forEach { task ->
+          expectThat(task) {
+            application.isEqualTo(securityGroupSpec.moniker.app)
+            job.hasSize(1)
+            with(job.first()) {
+              type.isEqualTo("upsertSecurityGroup")
+              ipIngress.hasSize(1)
+              with(ipIngress.first()) {
+                get("type").isEqualTo("-1")
+                get("startPort").isNull()
+                get("endPort").isNull()
+              }
+            }
           }
         }
       }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -361,7 +361,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
               // CIDR ingress on all protocols and ports
               SecurityGroupRule(
                 protocol = "-1",
-                portRanges = emptyList(),
+                portRanges = listOf(SecurityGroupRulePortRange(null, null)),
                 securityGroup = null,
                 range = SecurityGroupRuleCidr("100.64.0.0", "/10")
               )


### PR DESCRIPTION
Clouddriver can return a security group with ingress rules defined like this:  

```json
"inboundRules": [
    {
        "class": "com.netflix.spinnaker.clouddriver.model.securitygroups.IpRangeRule",
        "range": {
            "ip": "100.64.0.0",
            "cidr": "/10"
        },
        "protocol": "-1",
        "portRanges": [
            {}
        ],
        "description": "0AIr0"
    }
]
```

A protocol of `-1` means "all protocols" and an empty port range object means "all ports".

This change supports those in `ec2/security-group@v1` resources with the notation 

```yaml
protocol: ALL
portRange: ALL
```