### PR TITLE
fix(configName): check delivery config name uniqueness

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -52,6 +52,8 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
 
   val configName = "my-config"
   val secondConfigName = "my-config-2"
+  val application = "fnord"
+  val secondApplication = "fnord-2"
   val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName)
   val newArtifact = artifact.copy(reference = "myart")
   val firstResource = resource()
@@ -60,14 +62,30 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
   val secondEnv = Environment(name = "env2", resources = setOf(secondResource))
   val deliveryConfig = DeliveryConfig(
     name = configName,
-    application = "fnord",
+    application = application,
     serviceAccount = "keel@spinnaker",
     artifacts = setOf(artifact),
     environments = setOf(firstEnv)
   )
   val secondDeliveryConfig = DeliveryConfig(
     name = secondConfigName,
-    application = "fnord-2",
+    application = secondApplication,
+    serviceAccount = "keel@spinnaker",
+    artifacts = setOf(artifact),
+    environments = setOf(firstEnv)
+  )
+
+  val anotherDeliveryConfigWithSameName = DeliveryConfig(
+    name = configName,
+    application = secondApplication,
+    serviceAccount = "keel@spinnaker",
+    artifacts = setOf(),
+    environments = setOf()
+  )
+
+  val anotherDeliveryConfigWithSameApp = DeliveryConfig(
+    name = secondConfigName,
+    application = application,
     serviceAccount = "keel@spinnaker",
     artifacts = setOf(artifact),
     environments = setOf(firstEnv)
@@ -315,6 +333,34 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
         expectThrows<DuplicateManagedResourceException> { subject.upsertDeliveryConfig(secondDeliveryConfig) }
         expectThrows<NoSuchDeliveryConfigException> { deliveryConfigRepository.get(secondConfigName) }
         expectCatching { resourceRepository.get(firstResource.id) }.isSuccess()
+      }
+    }
+
+    context("don't allow storing delivery config with a non unique name") {
+      before {
+        subject.upsertDeliveryConfig(deliveryConfig)
+      }
+      test("trying to persist another config with the same name but different application") {
+        expectThrows<DuplicateDeliveryConfigsException> { subject.upsertDeliveryConfig(anotherDeliveryConfigWithSameName) }
+        expectThat(deliveryConfigRepository.get(configName))
+          .get { application }
+          .isEqualTo(deliveryConfig.application)
+
+        expectThrows<NoSuchDeliveryConfigException> { deliveryConfigRepository.getByApplication(anotherDeliveryConfigWithSameName.application) }
+      }
+    }
+
+    context("an application cannot have more than a single config") {
+      before {
+        subject.upsertDeliveryConfig(deliveryConfig)
+      }
+      test("trying to persist another config with the same application but different config names") {
+        expectThrows<TooManyDeliveryConfigsException> { subject.upsertDeliveryConfig(anotherDeliveryConfigWithSameApp) }
+        expectThat(deliveryConfigRepository.get(configName))
+          .get { application }
+          .isEqualTo(deliveryConfig.application)
+
+        expectThrows<NoSuchDeliveryConfigException> { deliveryConfigRepository.get(anotherDeliveryConfigWithSameApp.name) }
       }
     }
   }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -336,12 +336,12 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
       }
     }
 
-    context("don't allow storing delivery config with a non unique name") {
+    context("trying to persist two configs with the same name, but different application") {
       before {
         subject.upsertDeliveryConfig(deliveryConfig)
       }
-      test("trying to persist another config with the same name but different application") {
-        expectThrows<DuplicateDeliveryConfigsException> { subject.upsertDeliveryConfig(anotherDeliveryConfigWithSameName) }
+      test("second config fails with exception, first config didn't change") {
+        expectThrows<ConflictingDeliveryConfigsException> { subject.upsertDeliveryConfig(anotherDeliveryConfigWithSameName) }
         expectThat(deliveryConfigRepository.get(configName))
           .get { application }
           .isEqualTo(deliveryConfig.application)
@@ -350,11 +350,11 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
       }
     }
 
-    context("an application cannot have more than a single config") {
+    context("trying to persist another config with the same application, but different config names") {
       before {
         subject.upsertDeliveryConfig(deliveryConfig)
       }
-      test("trying to persist another config with the same application but different config names") {
+      test("second config fails with exception, first config didn't change") {
         expectThrows<TooManyDeliveryConfigsException> { subject.upsertDeliveryConfig(anotherDeliveryConfigWithSameApp) }
         expectThat(deliveryConfigRepository.get(configName))
           .get { application }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateManagedResourceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DuplicateManagedResourceException.kt
@@ -6,5 +6,5 @@ class DuplicateManagedResourceException(
   newConfig: String
 ) : ValidationException(
   "Resource with id $id exist in a delivery config named ($existingConfig). " +
-    "Please ensure to remove reousrce $id from config named $existingConfig, if you wish this resource to be managed in $newConfig."
+    "Please ensure to remove resource $id from config named $existingConfig, if you wish this resource to be managed in $newConfig."
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -81,26 +81,31 @@ class CombinedRepository(
 
   @Transactional(propagation = REQUIRED)
   override fun upsertDeliveryConfig(deliveryConfig: DeliveryConfig): DeliveryConfig {
-    val old = try {
+    val configWithSameName = try {
       getDeliveryConfig(deliveryConfig.name)
     } catch (e: NoSuchDeliveryConfigException) {
       null
     }
 
-    val existingConfig = try {
+    if (configWithSameName != null && configWithSameName.application != deliveryConfig.application) {
+      // we don't allow storing 2 configs with the same name, for different applications
+      throw DuplicateDeliveryConfigsException(configWithSameName.application)
+    }
+
+    val existingApplicationConfig = try {
       getDeliveryConfigForApplication(deliveryConfig.application)
     } catch (e: NoSuchDeliveryConfigException) {
       null
     }
 
-    if (old == null && existingConfig != null) {
+    if (configWithSameName == null && existingApplicationConfig != null) {
       // we only allow one delivery config, so throw an error if someone is trying to submit a new config
-      // instead of updating the existing config
-      throw TooManyDeliveryConfigsException(deliveryConfig.application, existingConfig.name)
+      // instead of updating the existing config for the same application
+      throw TooManyDeliveryConfigsException(deliveryConfig.application, existingApplicationConfig.name)
     }
 
+    // by this point, configWithSameName is the old delivery config for this application
     deliveryConfig.resources.forEach { resource ->
-
       upsertResource(resource, deliveryConfig.name)
     }
 
@@ -110,8 +115,8 @@ class CombinedRepository(
 
     storeDeliveryConfig(deliveryConfig)
 
-    if (old != null) {
-      removeDependents(old, deliveryConfig)
+    if (configWithSameName != null) {
+      removeDependents(configWithSameName, deliveryConfig)
     }
     return deliveryConfig
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -89,7 +89,7 @@ class CombinedRepository(
 
     if (configWithSameName != null && configWithSameName.application != deliveryConfig.application) {
       // we don't allow storing 2 configs with the same name, for different applications
-      throw DuplicateDeliveryConfigsException(configWithSameName.application)
+      throw ConflictingDeliveryConfigsException(configWithSameName.application)
     }
 
     val existingApplicationConfig = try {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -175,7 +175,7 @@ class NoMatchingArtifactException(deliveryConfigName: String, type: ArtifactType
 class TooManyDeliveryConfigsException(application: String, existing: String) :
   ConfigurationException("A delivery config already exists for application $application, and we only allow one per application - please delete existing config $existing before submitting a new config")
 
-class DuplicateDeliveryConfigsException(application: String) :
+class ConflictingDeliveryConfigsException(application: String) :
   ConfigurationException("A delivery config already exists for a different application $application, and we don't allow delivery config name duplication - please select a different config name before submitting a new config")
 
 class OrphanedResourceException(id: String) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -175,5 +175,8 @@ class NoMatchingArtifactException(deliveryConfigName: String, type: ArtifactType
 class TooManyDeliveryConfigsException(application: String, existing: String) :
   ConfigurationException("A delivery config already exists for application $application, and we only allow one per application - please delete existing config $existing before submitting a new config")
 
+class DuplicateDeliveryConfigsException(application: String) :
+  ConfigurationException("A delivery config already exists for a different application $application, and we don't allow delivery config name duplication - please select a different config name before submitting a new config")
+
 class OrphanedResourceException(id: String) :
   SystemException("Resource $id exists without being a part of a delivery config")


### PR DESCRIPTION
closes #1260 .

The delivery config name should be unique across all applications. 
This PR preventing the following:
- delivery config with name "config" and application "app1" is already persisted.
- someone is trying to submit a config with name "config", for application "app2".
- "app1" and "app2" have at least one same resource.

If app1 and app2 somehow have the same resources (like in the bug description), both apps are entering a weird state.

