### PR TITLE
fix(deploys): active server groups are not always healthy

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -127,6 +127,9 @@ interface CloudDriverService {
     @Query("region") region: String
   ): ServerGroupCollection<TitusServerGroup>
 
+  /**
+   * Note: This endpoint does not get the latest healthy cluster, only the latest enabled cluster
+   */
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{region}/serverGroups/target/current_asg_dynamic?onlyEnabled=true")
   suspend fun activeServerGroup(
     @Header("X-SPINNAKER-USER") user: String,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
@@ -67,7 +67,8 @@ data class TitusServerGroup(
   override val tags: Map<String, String>,
   override val resources: Resources,
   override val capacityGroup: String,
-  override val disabled: Boolean
+  override val disabled: Boolean,
+  override val instanceCounts: InstanceCounts
 ) : BaseTitusServerGroup
 
 fun TitusServerGroup.toActive() =
@@ -92,7 +93,9 @@ fun TitusServerGroup.toActive() =
     constraints = constraints,
     tags = tags,
     resources = resources,
-    capacityGroup = capacityGroup)
+    capacityGroup = capacityGroup,
+    instanceCounts = instanceCounts
+  )
 
 /**
  * Object returned when querying for the active titus server groups associated with a cluster.
@@ -121,7 +124,8 @@ data class TitusActiveServerGroup(
   override val constraints: Constraints,
   override val tags: Map<String, String>,
   override val resources: Resources,
-  override val capacityGroup: String
+  override val capacityGroup: String,
+  override val instanceCounts: InstanceCounts
 ) : BaseTitusServerGroup
 
 data class Placement(

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
@@ -474,6 +474,7 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
       app = app,
       sequence = 0
     ),
-    buildInfo = BuildInfo(packageName = "fnord")
+    buildInfo = BuildInfo(packageName = "fnord"),
+    instanceCounts = InstanceCounts(1, 0, 0, 1, 0, 0)
   )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
 import com.netflix.spinnaker.keel.clouddriver.model.BuildInfo
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
 import com.netflix.spinnaker.keel.core.parseMoniker
@@ -61,7 +62,10 @@ data class ServerGroup(
   override val artifactType: ArtifactType? = ArtifactType.deb,
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = EXCLUDED)
-  override val artifactVersion: String? = null
+  override val artifactVersion: String? = null,
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = EXCLUDED)
+  val instanceCounts: InstanceCounts? = null
 ) : VersionedArtifactProvider {
   init {
     require(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
 import com.netflix.spinnaker.keel.clouddriver.model.AutoScalingGroup
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts
 import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
 import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
@@ -236,6 +237,7 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
     cloudProvider = "aws",
     securityGroups = setOf("fnord"),
     accountName = "test",
-    moniker = parseMoniker("fnord-prod")
+    moniker = parseMoniker("fnord-prod"),
+    instanceCounts = InstanceCounts(10, 10, 0, 0, 0, 0)
   )
 }

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
 import com.netflix.spinnaker.keel.clouddriver.model.AutoScalingGroup
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts
 import com.netflix.spinnaker.keel.clouddriver.model.InstanceMonitoring
 import com.netflix.spinnaker.keel.clouddriver.model.LaunchConfig
 import com.netflix.spinnaker.keel.core.api.Capacity
@@ -62,7 +63,8 @@ class ClusterExportHelperTests : JUnit5Minutests {
       cloudProvider = "aws",
       securityGroups = emptySet(),
       accountName = "test",
-      moniker = parseMoniker("keek-test-v001")
+      moniker = parseMoniker("keek-test-v001"),
+      instanceCounts = InstanceCounts(1, 1, 0, 0, 0, 0)
     )
 
     val taskEntityTags = EntityTags(

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -396,7 +396,10 @@ class TitusClusterHandler(
       resource.serviceAccount
     )
       .also { them ->
-        if (them.distinctBy { it.container.digest }.size == 1) {
+        val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
+        val healthy: Boolean = them.all { it.instanceCounts?.isHealthy() == true }
+        if (sameContainer && healthy) {
+          // only publish a successfully deployed event if the server group is healthy
           val container = them.first().container
           getTagsForDigest(container, resource.spec.locations.account)
             .forEach { tag ->
@@ -480,7 +483,8 @@ class TitusClusterHandler(
         loadBalancers,
         securityGroupNames = securityGroupNames,
         targetGroups = targetGroups
-      )
+      ),
+      instanceCounts = instanceCounts
     )
 
   private suspend fun getAwsAccountNameForTitusAccount(titusAccount: String): String =

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
 import com.netflix.spinnaker.keel.core.api.Capacity
@@ -66,7 +67,10 @@ data class TitusServerGroup(
   override val artifactType: ArtifactType? = ArtifactType.docker,
   @JsonIgnore
   @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
-  override val artifactVersion: String? = null
+  override val artifactVersion: String? = null,
+  @JsonIgnore
+  @get:ObjectDiffProperty(inclusion = Inclusion.EXCLUDED)
+  val instanceCounts: InstanceCounts? = null
 ) : VersionedArtifactProvider
 
 val TitusServerGroup.moniker: Moniker

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.keel.titus.resource
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.cluster.TitusServerGroup
 import com.netflix.spinnaker.keel.api.titus.cluster.moniker
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts
 import com.netflix.spinnaker.keel.clouddriver.model.Placement
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.ServiceJobProcesses
@@ -13,7 +14,8 @@ import org.apache.commons.lang3.RandomStringUtils
 
 fun TitusServerGroup.toClouddriverResponse(
   securityGroups: List<SecurityGroupSummary>,
-  awsAccount: String
+  awsAccount: String,
+  instanceCounts: InstanceCounts = InstanceCounts(1, 1, 0, 0, 0, 0)
 ): TitusActiveServerGroup =
   RandomStringUtils.randomNumeric(3).padStart(3, '0').let { sequence ->
     TitusActiveServerGroup(
@@ -36,6 +38,7 @@ fun TitusServerGroup.toClouddriverResponse(
       serviceJobProcesses = ServiceJobProcesses(),
       tags = emptyMap(),
       resources = resources,
-      capacityGroup = moniker.app
+      capacityGroup = moniker.app,
+      instanceCounts = instanceCounts
     )
   }


### PR DESCRIPTION
We had a longstanding incorrect assumption that an active asg was healthy. this is not true. 

This pr takes advantage of the `instanceCounts` object on all server group responses:
```
instanceCounts": {
        "total": 1,
        "up": 1,
        "down": 0,
        "unknown": 0,
        "outOfService": 0,
        "starting": 0
      }
```

Now, we will only publish a "successfully deployed" event if the server groups are all healthy (`total == up`).