### PR TITLE
feat(artifacts): Introduce ArtifactPublisher plugin interface (1 of 3)

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/SpinnakerArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/SpinnakerArtifact.kt
@@ -1,0 +1,20 @@
+package com.netflix.spinnaker.keel.api.artifacts
+
+/**
+ * An immutable data class that mirrors com.netflix.spinnaker.kork.artifacts.model.Artifact, but without
+ * all the Jackson baggage. One notable difference from the kork counterpart is that this class enforces
+ * non-nullability of a few key fields without which it doesn't make sense for an artifact to exist in
+ * Managed Delivery terms.
+ */
+data class SpinnakerArtifact(
+  val name: String,
+  val type: String,
+  val reference: String,
+  val version: String,
+  val customKind: Boolean? = null,
+  val location: String? = null,
+  val artifactAccount: String? = null,
+  val provenance: String? = null,
+  val uuid: String? = null,
+  val metadata: Map<String, Any?> = emptyMap()
+)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/events/artifacts.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/events/artifacts.kt
@@ -1,0 +1,27 @@
+package com.netflix.spinnaker.keel.api.events
+
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.SpinnakerArtifact
+
+/**
+ * An event that conveys information about one or more software artifacts that are
+ * potentially relevant to keel.
+ */
+data class ArtifactEvent(
+  val artifacts: List<SpinnakerArtifact>,
+  val details: Map<String, Any>?
+)
+
+/**
+ * Event emitted with a new [DeliveryArtifact] is registered.
+ */
+data class ArtifactRegisteredEvent(
+  val artifact: DeliveryArtifact
+)
+
+/**
+ * Event emitted to trigger synchronization of artifact information.
+ */
+data class ArtifactSyncEvent(
+  val controllerTriggered: Boolean = false
+)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactPublisher.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactPublisher.kt
@@ -1,0 +1,44 @@
+package com.netflix.spinnaker.keel.api.plugins
+
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.SpinnakerArtifact
+import com.netflix.spinnaker.keel.api.events.ArtifactEvent
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint
+
+/**
+ * Keel plugin interface to be implemented by publishers of artifact information.
+ *
+ * The primary responsibility of an [ArtifactPublisher] is to detect new versions of artifacts, using
+ * whatever mechanism they choose (e.g. they could receive events from another system,
+ * or poll an artifact repository for artifact versions), and notify keel via the [publishArtifact]
+ * method, so that the artifact versions can be persisted and evaluated for promotion.
+ */
+interface ArtifactPublisher<T : DeliveryArtifact> : SpinnakerExtensionPoint {
+  val eventPublisher: EventPublisher
+  val supportedArtifact: SupportedArtifact<T>
+  val supportedVersioningStrategies: List<SupportedVersioningStrategy<*>>
+
+  /**
+   * Publishes an [ArtifactEvent] to core Keel so that the corresponding artifact version can be
+   * persisted and evaluated for promotion into deployment environments.
+   *
+   * The default implementation of [publishArtifact] simply publishes the event via the [EventPublisher],
+   * and should *not* be overridden by implementors.
+   */
+  fun publishArtifact(artifactEvent: ArtifactEvent) =
+    eventPublisher.publishEvent(artifactEvent)
+
+  /**
+   * Returns the latest available version for the given [DeliveryArtifact], represented
+   * as a [SpinnakerArtifact].
+   *
+   * This function may interact with external systems to retrieve artifact information as needed.
+   */
+  suspend fun getLatestArtifact(artifact: DeliveryArtifact): SpinnakerArtifact?
+}
+
+fun List<ArtifactPublisher<*>>.supporting(type: ArtifactType) =
+  find { it.supportedArtifact.name == type.name }
+    ?: error("Artifact type '$type' is not supported.")

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/SupportedArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/SupportedArtifact.kt
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.keel.api.plugins
+
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+
+/**
+ * Tuple of [DeliveryArtifact] type name (e.g. "deb", "docker", etc.) and the
+ * corresponding [DeliveryArtifact] sub-class, used to facilitate registration
+ * and discovery of supported artifact types from [ArtifactPublisher] plugins.
+ */
+data class SupportedArtifact<T : DeliveryArtifact>(
+  val name: String,
+  val artifactClass: Class<T>
+)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/SupportedVersioningStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/SupportedVersioningStrategy.kt
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.keel.api.plugins
+
+import com.netflix.spinnaker.keel.api.artifacts.VersioningStrategy
+
+/**
+ * Tuple of [VersioningStrategy] type name (e.g. "deb", "docker", etc.) and the
+ * corresponding [VersioningStrategy] sub-class, used to facilitate registration
+ * and discovery of supported versioning strategies from [ArtifactPublisher] plugins.
+ */
+data class SupportedVersioningStrategy<T : VersioningStrategy>(
+  val name: String,
+  val strategyClass: Class<T>
+)


### PR DESCRIPTION
First part of breaking up #1286 into more manageable reviews.

This PR introduces only new code, which will be latent until part 3 of this series when I plan to refactor keel's existing artifact detection implementation to use the new plugin interface.