### PR TITLE
fix(allowed-times): use correct zoneId, switch default to PST

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
@@ -242,6 +242,6 @@ class AllowedTimesConstraintEvaluator(
 
   private fun defaultTimeZone(): ZoneId =
     ZoneId.of(
-      dynamicConfigService.getConfig(String::class.java, "default.time-zone", "UTC")
+      dynamicConfigService.getConfig(String::class.java, "default.time-zone", "America/Los_Angeles")
     )
 }


### PR DESCRIPTION
Addresses the keel side of https://github.com/spinnaker/keel/issues/1263

`UTC` (the short code) wasn't valid. You have to use the long code. Switched to PST while i was at it because... most of us are in California.