### PR TITLE
fix(deploy): we don't need to rollback on failure

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ClusterDeployStrategy.kt
@@ -38,7 +38,8 @@ sealed class ClusterDeployStrategy {
 
 @JsonTypeName("red-black")
 data class RedBlack(
-  val rollbackOnFailure: Boolean? = true,
+  // defaulting to false because this rollback behavior doesn't seem to play nice with managed delivery
+  val rollbackOnFailure: Boolean? = false,
   val resizePreviousToZero: Boolean? = false,
   val maxServerGroups: Int? = 2,
   val delayBeforeDisable: Duration? = ZERO,
@@ -76,9 +77,9 @@ data class RedBlack(
     "rollback" to mapOf("onFailure" to rollbackOnFailure),
     "stageTimeoutMs" to (
       (waitForInstancesUp ?: DEFAULT_WAIT_FOR_INSTANCES_UP) +
-      (delayBeforeDisable ?: ZERO) +
-      (delayBeforeScaleDown ?: ZERO)
-    ).toMillis()
+        (delayBeforeDisable ?: ZERO) +
+        (delayBeforeScaleDown ?: ZERO)
+      ).toMillis()
   )
 
   override val isStaggered: Boolean

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -13,7 +13,6 @@ import java.time.Duration
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
-import strikt.assertions.isTrue
 import strikt.jackson.at
 import strikt.jackson.booleanValue
 import strikt.jackson.hasSize
@@ -49,7 +48,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "red-black"
           path("resizePreviousToZero").booleanValue().isFalse()
-          path("rollbackOnFailure").booleanValue().isTrue()
+          path("rollbackOnFailure").booleanValue().isFalse()
           path("maxServerGroups").numberValue().isEqualTo(2)
           path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
           path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
@@ -75,7 +74,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
           expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
             path("strategy").textValue() isEqualTo "red-black"
             path("resizePreviousToZero").booleanValue().isFalse()
-            path("rollbackOnFailure").booleanValue().isTrue()
+            path("rollbackOnFailure").booleanValue().isFalse()
             path("maxServerGroups").numberValue().isEqualTo(2)
             path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
             path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
@@ -127,9 +126,9 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
                 "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
                 "stageTimeoutMs" to (
                   strategy.delayBeforeDisable!! +
-                  strategy.delayBeforeScaleDown!! +
-                  strategy.waitForInstancesUp!!
-                ).toMillis()
+                    strategy.delayBeforeScaleDown!! +
+                    strategy.waitForInstancesUp!!
+                  ).toMillis()
               )
             )
           }


### PR DESCRIPTION
The automatic rollback feature of deploys doesn't play nicely with keel's management. I'm switching this to default to off because keel will take care of rolling back if the deploy fails