### PR TITLE
fix(jackson): Fix jackson-module-kotlin binary compatibility issue

### DIFF
--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -28,8 +28,8 @@ dependencies {
   implementation("com.netflix.spinnaker.fiat:fiat-api:${property("fiatVersion")}")
   implementation("com.netflix.spinnaker.fiat:fiat-core:${property("fiatVersion")}")
   implementation("net.logstash.logback:logstash-logback-encoder")
-  implementation("org.springdoc:springdoc-openapi-webmvc-core:1.4.1")
-  implementation("org.springdoc:springdoc-openapi-kotlin:1.4.1")
+  implementation("org.springdoc:springdoc-openapi-webmvc-core:1.2.34")
+  implementation("org.springdoc:springdoc-openapi-kotlin:1.2.34")
   implementation("org.apache.maven:maven-artifact:3.6.3")
 
   testImplementation("io.strikt:strikt-jackson")


### PR DESCRIPTION
The `springdoc` libs were recently updated and bring in a binary-incompatible version of `jackson-module-kotlin`. This rolls back the version to fix it.