### PR TITLE
refactor(artifacts): Allow single versioning strategy per ArtifactSupplier

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
@@ -24,10 +24,10 @@ import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint
  * version of an artifact. This is so that we don't miss any versions in case of missed or failure
  * to handle events in case of downtime, etc.
  */
-interface ArtifactSupplier<T : DeliveryArtifact> : SpinnakerExtensionPoint {
+interface ArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy> : SpinnakerExtensionPoint {
   val eventPublisher: EventPublisher
-  val supportedArtifact: SupportedArtifact<T>
-  val supportedVersioningStrategies: List<SupportedVersioningStrategy<*>>
+  val supportedArtifact: SupportedArtifact<A>
+  val supportedVersioningStrategy: SupportedVersioningStrategy<V>
 
   /**
    * Publishes an [ArtifactPublishedEvent] to core Keel so that the corresponding artifact version can be
@@ -87,6 +87,6 @@ interface ArtifactSupplier<T : DeliveryArtifact> : SpinnakerExtensionPoint {
 /**
  * Return the [ArtifactSupplier] supporting the specified artifact type.
  */
-fun List<ArtifactSupplier<*>>.supporting(type: ArtifactType) =
+fun List<ArtifactSupplier<*, *>>.supporting(type: ArtifactType) =
   find { it.supportedArtifact.name.toLowerCase() == type.toLowerCase() }
     ?: error("Artifact type '$type' is not supported.")

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/ArtifactListener.kt
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component
 class ArtifactListener(
   private val repository: KeelRepository,
   private val publisher: ApplicationEventPublisher,
-  private val artifactSuppliers: List<ArtifactSupplier<*>>
+  private val artifactSuppliers: List<ArtifactSupplier<*, *>>
 ) {
   private val enabled = AtomicBoolean(false)
 

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/DebianArtifactSupplier.kt
@@ -26,11 +26,11 @@ import org.springframework.stereotype.Component
 class DebianArtifactSupplier(
   override val eventPublisher: EventPublisher,
   private val artifactService: ArtifactService
-) : ArtifactSupplier<DebianArtifact> {
+) : ArtifactSupplier<DebianArtifact, DebianSemVerVersioningStrategy> {
   override val supportedArtifact = SupportedArtifact("deb", DebianArtifact::class.java)
 
-  override val supportedVersioningStrategies: List<SupportedVersioningStrategy<*>> =
-    listOf(SupportedVersioningStrategy("deb", DebianSemVerVersioningStrategy::class.java))
+  override val supportedVersioningStrategy =
+    SupportedVersioningStrategy("deb", DebianSemVerVersioningStrategy::class.java)
 
   override suspend fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact? =
     artifactService

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/DockerArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/DockerArtifactSupplier.kt
@@ -27,11 +27,11 @@ import org.springframework.stereotype.Component
 class DockerArtifactSupplier(
   override val eventPublisher: EventPublisher,
   private val cloudDriverService: CloudDriverService
-) : ArtifactSupplier<DockerArtifact> {
+) : ArtifactSupplier<DockerArtifact, DockerVersioningStrategy> {
   override val supportedArtifact = SupportedArtifact("docker", DockerArtifact::class.java)
 
-  override val supportedVersioningStrategies: List<SupportedVersioningStrategy<*>> =
-    listOf(SupportedVersioningStrategy("docker", DockerVersioningStrategy::class.java))
+  override val supportedVersioningStrategy =
+    SupportedVersioningStrategy("docker", DockerVersioningStrategy::class.java)
 
   override suspend fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact? {
     if (artifact !is DockerArtifact) {

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DebianArtifactSupplierTests.kt
@@ -22,7 +22,6 @@ import io.mockk.coVerify as verify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
-import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 
 internal class DebianArtifactSupplierTests : JUnit5Minutests {
@@ -69,8 +68,7 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
 
       test("supports Debian semver versioning strategy") {
         expectThat(debianArtifactPublisher.supportedVersioningStrategy)
-          .hasSize(1)
-          .containsExactly(
+          .isEqualTo(
             SupportedVersioningStrategy(DEBIAN, DebianSemVerVersioningStrategy::class.java)
           )
       }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DebianArtifactSupplierTests.kt
@@ -22,7 +22,6 @@ import io.mockk.coVerify as verify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
-import strikt.assertions.containsExactly
 import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 
@@ -69,7 +68,7 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
       }
 
       test("supports Debian semver versioning strategy") {
-        expectThat(debianArtifactPublisher.supportedVersioningStrategies)
+        expectThat(debianArtifactPublisher.supportedVersioningStrategy)
           .hasSize(1)
           .containsExactly(
             SupportedVersioningStrategy(DEBIAN, DebianSemVerVersioningStrategy::class.java)

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DockerArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DockerArtifactSupplierTests.kt
@@ -22,7 +22,6 @@ import io.mockk.coVerify as verify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
-import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNull
 
@@ -74,8 +73,7 @@ internal class DockerArtifactSupplierTests : JUnit5Minutests {
 
       test("supports Docker versioning strategy") {
         expectThat(dockerArtifactPublisher.supportedVersioningStrategy)
-          .hasSize(1)
-          .containsExactly(
+          .isEqualTo(
             SupportedVersioningStrategy(DOCKER, DockerVersioningStrategy::class.java)
           )
       }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DockerArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifact/DockerArtifactSupplierTests.kt
@@ -22,7 +22,6 @@ import io.mockk.coVerify as verify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
-import strikt.assertions.containsExactly
 import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNull
@@ -74,7 +73,7 @@ internal class DockerArtifactSupplierTests : JUnit5Minutests {
       }
 
       test("supports Docker versioning strategy") {
-        expectThat(dockerArtifactPublisher.supportedVersioningStrategies)
+        expectThat(dockerArtifactPublisher.supportedVersioningStrategy)
           .hasSize(1)
           .containsExactly(
             SupportedVersioningStrategy(DOCKER, DockerVersioningStrategy::class.java)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -54,7 +54,7 @@ class ApplicationService(
   private val repository: KeelRepository,
   private val resourceStatusService: ResourceStatusService,
   private val constraintEvaluators: List<ConstraintEvaluator<*>>,
-  private val artifactSuppliers: List<ArtifactSupplier<*>>,
+  private val artifactSuppliers: List<ArtifactSupplier<*, *>>,
   private val objectMapper: ObjectMapper
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.VETOED
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.test.DummyArtifact
+import com.netflix.spinnaker.keel.test.DummyVersioningStrategy
 import com.netflix.spinnaker.keel.test.artifactReferenceResource
 import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
 import com.netflix.spinnaker.keel.test.versionedArtifactResource
@@ -109,7 +110,7 @@ class ApplicationServiceTests : JUnit5Minutests {
     }
 
     private val publishedArtifact = slot<PublishedArtifact>()
-    private val artifactSupplier = mockk<ArtifactSupplier<DummyArtifact>>(relaxUnitFun = true) {
+    private val artifactSupplier = mockk<ArtifactSupplier<DummyArtifact, DummyVersioningStrategy>>(relaxUnitFun = true) {
       every { supportedArtifact } returns SupportedArtifact("dummy", DummyArtifact::class.java)
       every {
         getVersionDisplayName(capture(publishedArtifact))

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -59,7 +59,7 @@ class SqlConfiguration {
     SqlResourceRepository(jooq, clock, resourceSpecIdentifier, specMigrators, objectMapper, SqlRetry(sqlRetryProperties))
 
   @Bean
-  fun artifactRepository(jooq: DSLContext, clock: Clock, objectMapper: ObjectMapper, artifactSuppliers: List<ArtifactSupplier<*>>) =
+  fun artifactRepository(jooq: DSLContext, clock: Clock, objectMapper: ObjectMapper, artifactSuppliers: List<ArtifactSupplier<*, *>>) =
     SqlArtifactRepository(jooq, clock, objectMapper, SqlRetry(sqlRetryProperties), artifactSuppliers)
 
   @Bean
@@ -68,7 +68,7 @@ class SqlConfiguration {
     clock: Clock,
     resourceSpecIdentifier: ResourceSpecIdentifier,
     objectMapper: ObjectMapper,
-    artifactSuppliers: List<ArtifactSupplier<*>>
+    artifactSuppliers: List<ArtifactSupplier<*, *>>
   ) =
     SqlDeliveryConfigRepository(jooq, clock, resourceSpecIdentifier, objectMapper, SqlRetry(sqlRetryProperties), artifactSuppliers)
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
@@ -32,7 +32,7 @@ private val objectMapper: ObjectMapper = configuredObjectMapper()
  * A helper function to construct the proper artifact type from the serialized JSON.
  */
 fun mapToArtifact(
-  artifactSupplier: ArtifactSupplier<*>,
+  artifactSupplier: ArtifactSupplier<*, *>,
   name: String,
   type: ArtifactType,
   json: String,

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -64,7 +64,7 @@ class SqlArtifactRepository(
   private val clock: Clock,
   private val objectMapper: ObjectMapper,
   private val sqlRetry: SqlRetry,
-  private val artifactSuppliers: List<ArtifactSupplier<*>> = emptyList()
+  private val artifactSuppliers: List<ArtifactSupplier<*, *>> = emptyList()
 ) : ArtifactRepository {
   override fun register(artifact: DeliveryArtifact) {
     val id: String = (sqlRetry.withRetry(READ) {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -58,7 +58,7 @@ class SqlDeliveryConfigRepository(
   private val resourceSpecIdentifier: ResourceSpecIdentifier,
   private val mapper: ObjectMapper,
   private val sqlRetry: SqlRetry,
-  private val artifactSuppliers: List<ArtifactSupplier<*>> = emptyList()
+  private val artifactSuppliers: List<ArtifactSupplier<*, *>> = emptyList()
 ) : DeliveryConfigRepository {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
@@ -23,7 +23,7 @@ class DummyArtifact(
   }
 }
 
-fun defaultArtifactPublishers(): List<ArtifactSupplier<*>> {
+fun defaultArtifactPublishers(): List<ArtifactSupplier<*, *>> {
   val artifactService: ArtifactService = mockk(relaxUnitFun = true)
   val clouddriverService: CloudDriverService = mockk(relaxUnitFun = true)
   val eventBridge: SpringEventPublisherBridge = mockk(relaxUnitFun = true)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
@@ -17,10 +17,12 @@ class DummyArtifact(
   override val reference: String = "fnord"
 ) : DeliveryArtifact() {
   override val type: ArtifactType = "dummy"
-  override val versioningStrategy = object : VersioningStrategy() {
-    override val comparator: Comparator<String> = Comparator.naturalOrder()
-    override val type = "dummy"
-  }
+  override val versioningStrategy = DummyVersioningStrategy
+}
+
+object DummyVersioningStrategy : VersioningStrategy() {
+  override val comparator: Comparator<String> = Comparator.naturalOrder()
+  override val type = "dummy"
 }
 
 fun defaultArtifactPublishers(): List<ArtifactSupplier<*, *>> {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
@@ -25,7 +25,7 @@ class KeelConfigurationFinalizer(
   private val resourceHandlers: List<ResourceHandler<*, *>> = emptyList(),
   private val constraintEvaluators: List<ConstraintEvaluator<*>> = emptyList(),
   private val artifactHandlers: List<ArtifactHandler> = emptyList(),
-  private val artifactSuppliers: List<ArtifactSupplier<*>> = emptyList(),
+  private val artifactSuppliers: List<ArtifactSupplier<*, *>> = emptyList(),
   private val objectMappers: List<ObjectMapper>
 ) {
 
@@ -76,7 +76,7 @@ class KeelConfigurationFinalizer(
       }
 
     artifactSuppliers
-      .flatMap { it.supportedVersioningStrategies }
+      .map { it.supportedVersioningStrategy }
       .forEach { (name, strategyClass) ->
         log.info("Registering VersioningStrategy sub-type {}: {}", name, strategyClass.simpleName)
         val namedType = NamedType(strategyClass, name)

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/apidocs/DeliveryArtifactModelConverter.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/apidocs/DeliveryArtifactModelConverter.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 
 @Component
 class DeliveryArtifactModelConverter(
-  artifactSuppliers: List<ArtifactSupplier<*>>
+  artifactSuppliers: List<ArtifactSupplier<*, *>>
 ) : SubtypesModelConverter<DeliveryArtifact>(DeliveryArtifact::class.java) {
 
   override val discriminator: String? = DeliveryArtifact::type.name


### PR DESCRIPTION
In #1321, I defined `supportedVersioningStrategies` (plural) in `ArtifactSupplier`. But we currently only have a single versioning strategy per existing artifact type (Docker and Debian), with additional options configured within those as necessary (e.g. `DockerVersioningStrategy` uses the `tagVersionStrategy` to build the right comparator). So, on second thought, it seemed like unnecessary complexity to allow multiple strategies per artifact type.

This PR makes it so that each `ArtifactSupplier` can only support a single versioning strategy sub-type, which is also reflected in a new generic parameter to the interface, making it even more clear what each supplier supports.