### PR TITLE
feat(cluster): allow no health and healthy percentage

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ArtifactInterfaces.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ArtifactInterfaces.kt
@@ -52,7 +52,27 @@ interface ArtifactReferenceProvider {
     }
 }
 
-interface ComputeResourceSpec : ResourceSpec, VersionedArtifactProvider, ArtifactReferenceProvider
+interface ComputeResourceSpec : ResourceSpec, VersionedArtifactProvider, ArtifactReferenceProvider {
+  val clusterHealth: ClusterHealth?
+}
+
+/**
+ * Contains user-configured health information about a server group
+ * [ignoreHealthForDeployments] if true, considers deployments healthy when instances are not in a
+ *  [InstanceCounts] down, out of service, or starting status. This is the setting for apps which
+ *  "only consider provider health"
+ * [healthyPercentage] the percentage of instances that need to be in the "up" status before
+ *  we consider a cluster fully deployed
+ */
+data class ClusterHealth(
+  val ignoreHealthForDeployments: Boolean = false,
+  val healthyPercentage: Double = 100.0
+) {
+  init {
+    require(healthyPercentage > 0.0) { "healthyPercentage must be > 0" }
+    require(healthyPercentage <= 100.0) { "healthyPercentage must be <= 100" }
+  }
+}
 
 /**
  * Simple container of the information defined in [ArtifactProvider] that ensures non-nullability of the fields.

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/HealthyHelper.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/HealthyHelper.kt
@@ -1,0 +1,29 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+import com.netflix.spinnaker.keel.api.ClusterHealth
+
+/**
+ * Considers user defined health information to determine if a cluster is healthy or not
+ */
+fun isHealthy(clusterHealth: ClusterHealth?, instanceCounts: InstanceCounts?): Boolean {
+  // if we have no information about cluster health, default to not healthy
+  clusterHealth ?: return false
+  // if we have no information about the instance health, default to not healthy
+  instanceCounts ?: return false
+
+  val healthyCount: Double = if (clusterHealth.ignoreHealthForDeployments) {
+    // a deploy may not come up healthy, so use the total of up and and unknown
+    // this happens when someone has checked "use cloud provider health"
+    instanceCounts.unknown.toDouble() + instanceCounts.up.toDouble()
+  } else {
+    instanceCounts.up.toDouble()
+  }
+
+  return meetsHealthyThreshold(healthyCount, instanceCounts.total.toDouble(), clusterHealth.healthyPercentage)
+}
+
+/**
+ * [percentageRequired] is a number between (0 and 100]
+ */
+fun meetsHealthyThreshold(healthyCount: Double, total: Double, percentageRequired: Double): Boolean =
+  healthyCount >= total * (percentageRequired / 100.0)

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/HealthyHelperTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/HealthyHelperTests.kt
@@ -1,0 +1,79 @@
+package com.netflix.spinnaker.keel.clouddriver
+
+import com.netflix.spinnaker.keel.api.ClusterHealth
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts
+import com.netflix.spinnaker.keel.clouddriver.model.isHealthy
+import com.netflix.spinnaker.keel.clouddriver.model.meetsHealthyThreshold
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.isFalse
+import strikt.assertions.isTrue
+
+class HealthyHelperTests : JUnit5Minutests {
+  class Fixture {
+    val ignoreHealth = ClusterHealth(ignoreHealthForDeployments = true)
+    val ignoreHealthAndSpecifyPercentage = ClusterHealth(ignoreHealthForDeployments = true, healthyPercentage = 88.0)
+    val specifyPercentage = ClusterHealth(healthyPercentage = 88.0)
+    val default = ClusterHealth()
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    context("no info provided") {
+      test("returns false") {
+        expectThat(isHealthy(null, null)).isFalse()
+      }
+    }
+
+    context("info provided") {
+      test("100% and ignoring health, healthy case") {
+        expectThat(
+          isHealthy(ignoreHealth, InstanceCounts(100, 0, 0, 100, 0, 0))
+        ).isTrue()
+      }
+      test("100% and ignoring health, unhealthy case") {
+        expectThat(
+          isHealthy(ignoreHealth, InstanceCounts(100, 0, 0, 99, 1, 0))
+        ).isFalse()
+      }
+      test("88% and ignoring health, healthy case") {
+        expectThat(
+          isHealthy(ignoreHealthAndSpecifyPercentage, InstanceCounts(100, 0, 0, 90, 10, 0))
+        ).isTrue()
+      }
+      test("88% and ignoring health, unhealthy case") {
+        expectThat(
+          isHealthy(ignoreHealthAndSpecifyPercentage, InstanceCounts(100, 0, 0, 87, 13, 0))
+        ).isFalse()
+      }
+      test("100% and consider health, healthy case") {
+        expectThat(
+          isHealthy(default, InstanceCounts(2, 2, 0, 0, 0, 0))
+        ).isTrue()
+      }
+      test("100% and consider health, healthy case") {
+        expectThat(
+          isHealthy(default, InstanceCounts(2, 1, 0, 1, 0, 0))
+        ).isFalse()
+      }
+      test("88% and consider health, healthy case") {
+        expectThat(
+          isHealthy(specifyPercentage, InstanceCounts(10, 9, 1, 0, 0, 0))
+        ).isTrue()
+      }
+      test("88% and consider health, unhealthy case") {
+        expectThat(
+          isHealthy(specifyPercentage, InstanceCounts(10, 8, 1, 1, 0, 0))
+        ).isFalse()
+      }
+    }
+
+    context("percentage tests") {
+      test("88 needed 87 healthy") {
+        expectThat(meetsHealthyThreshold(87.0, 100.0, 88.0)).isFalse()
+      }
+    }
+  }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.netflix.spinnaker.keel.api.ClusterHealth
 import com.netflix.spinnaker.keel.api.ComputeResourceSpec
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Locations
@@ -127,7 +128,8 @@ data class ClusterSpec(
   override val maxDiffCount: Int? = 2,
   @JsonIgnore
   // Once clusters go unhappy, only retry when the diff changes, or if manually unvetoed
-  override val unhappyWaitTime: Duration? = null
+  override val unhappyWaitTime: Duration? = null,
+  override val clusterHealth: ClusterHealth? = null
 ) : ComputeResourceSpec, Monikered, Locatable<SubnetAwareLocations>, OverrideableClusterDependencyContainer<ServerGroupSpec>, UnhappyControl {
   @JsonIgnore
   override val id = "${locations.account}:$moniker"
@@ -172,7 +174,8 @@ data class ClusterSpec(
     scaling: Scaling?,
     tags: Map<String, String>?,
     @JsonInclude(NON_EMPTY)
-    overrides: Map<String, ServerGroupSpec> = emptyMap()
+    overrides: Map<String, ServerGroupSpec> = emptyMap(),
+    clusterHealth: ClusterHealth = ClusterHealth()
   ) : this(
     moniker,
     imageProvider,
@@ -184,7 +187,8 @@ data class ClusterSpec(
       dependencies,
       health,
       scaling,
-      tags
+      tags,
+      clusterHealth
     ),
     overrides
   )
@@ -196,7 +200,8 @@ data class ClusterSpec(
     val health: HealthSpec? = null,
     val scaling: Scaling? = null,
     @JsonInclude(NON_EMPTY)
-    val tags: Map<String, String>? = null
+    val tags: Map<String, String>? = null,
+    val clusterHealth: ClusterHealth? = null
   ) : ClusterDependencyContainer {
     init {
       // Require capacity.desired or scaling policies, or let them both be blank for constructing overrides

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -52,6 +52,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.PredefinedMetricSpecificatio
 import com.netflix.spinnaker.keel.clouddriver.model.ScalingPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.StepAdjustmentModel
 import com.netflix.spinnaker.keel.clouddriver.model.Tag
+import com.netflix.spinnaker.keel.clouddriver.model.isHealthy
 import com.netflix.spinnaker.keel.clouddriver.model.subnet
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
@@ -784,7 +785,7 @@ class ClusterHandler(
     )
       .also { them ->
         val allSame: Boolean = them.distinctBy { it.launchConfiguration.appVersion }.size == 1
-        val healthy: Boolean = them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = them.all { isHealthy(resource.spec.clusterHealth, it.instanceCounts) }
         if (allSame && healthy) {
           // // only publish a successfully deployed event if the server group is healthy
           val appVersion = them.first().launchConfiguration.appVersion

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.ClusterHealth
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
@@ -153,7 +154,8 @@ object Fixture {
       ),
       health = HealthSpec(
         warmup = Duration.ofSeconds(120)
-      )
+      ),
+      clusterHealth = ClusterHealth()
     ),
     overrides = mapOf(
       "us-east-1" to ServerGroupSpec(
@@ -185,7 +187,8 @@ object Fixture {
           keyPair = "fnord-keypair-325719997469-us-west-2"
         )
       )
-    )
+    ),
+    clusterHealth = null
   )
 
   fun resolve(): Set<ServerGroup> = spec.resolve()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
+import com.netflix.spinnaker.keel.api.ClusterHealth
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Moniker
@@ -127,6 +128,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         StaggeredRegion(region = vpcEast.region, hours = "16-02")
       )
     ),
+    clusterHealth = ClusterHealth(),
     _defaults = ServerGroupSpec(
       launchConfiguration = LaunchConfigurationSpec(
         image = VirtualMachineImage(
@@ -156,7 +158,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
       dependencies = ClusterDependencies(
         loadBalancerNames = setOf("keel-test-frontend"),
         securityGroupNames = setOf(sg1West.name, sg2West.name)
-      )
+      ),
+      clusterHealth = ClusterHealth()
     )
   )
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -49,6 +49,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.isHealthy
 import com.netflix.spinnaker.keel.core.api.Capacity
 import com.netflix.spinnaker.keel.core.api.ClusterDependencies
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
@@ -414,7 +415,7 @@ class TitusClusterHandler(
     )
       .also { them ->
         val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
-        val healthy: Boolean = them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = them.all { isHealthy(resource.spec.clusterHealth, it.instanceCounts) }
         if (sameContainer && healthy) {
           // only publish a successfully deployed event if the server group is healthy
           val container = them.first().container

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonUnwrapped
+import com.netflix.spinnaker.keel.api.ClusterHealth
 import com.netflix.spinnaker.keel.api.ComputeResourceSpec
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Moniker
@@ -66,7 +67,8 @@ data class TitusClusterSpec(
   override val maxDiffCount: Int? = 2,
   @JsonIgnore
   // Once clusters go unhappy, only retry when the diff changes, or if manually unvetoed
-  override val unhappyWaitTime: Duration? = null
+  override val unhappyWaitTime: Duration? = null,
+  override val clusterHealth: ClusterHealth? = ClusterHealth()
 ) : ComputeResourceSpec, Monikered, Locatable<SimpleLocations>, UnhappyControl {
 
   @JsonIgnore
@@ -109,7 +111,8 @@ data class TitusClusterSpec(
     migrationPolicy: MigrationPolicy?,
     dependencies: ClusterDependencies?,
     tags: Map<String, String>?,
-    overrides: Map<String, TitusServerGroupSpec> = emptyMap()
+    overrides: Map<String, TitusServerGroupSpec> = emptyMap(),
+    clusterHealth: ClusterHealth?
   ) : this(
     moniker,
     deployWith,
@@ -126,7 +129,8 @@ data class TitusClusterSpec(
       iamProfile = iamProfile,
       migrationPolicy = migrationPolicy,
       resources = resources,
-      tags = tags
+      tags = tags,
+      clusterHealth = clusterHealth
     ),
     overrides,
     containerProvider = container
@@ -145,7 +149,8 @@ data class TitusServerGroupSpec(
   val iamProfile: String? = null,
   val migrationPolicy: MigrationPolicy? = null,
   val resources: ResourcesSpec? = null,
-  val tags: Map<String, String>? = null
+  val tags: Map<String, String>? = null,
+  val clusterHealth: ClusterHealth? = null
 )
 
 data class ResourcesSpec(


### PR DESCRIPTION
closes https://github.com/spinnaker/keel/issues/1311 and https://github.com/spinnaker/keel/issues/1324.

Recently we had an adopter that didn't use cloud provider health, and that meant that his environments view never showed "deployed". That is a v bad experience. 

This is a first stab at including some health information in the resources. I know that @robfletcher wants to pull this style info out of the resource entirely, but I think it's more important to support this now than it is to move these things out.

Thoughts on the implementation here?