### PR TITLE
fix(orcaError): catch errors from orca when failing to get info on tasks

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
@@ -58,7 +58,7 @@ class OrcaTaskMonitorAgent(
                 when (e.isNotFound) {
                   true -> {
                     log.warn("Exception ${e.message} has caught while calling orca to fetch status for execution id: ${it.id}" +
-                      " Possible reason: orca is saving info for 2000 tasks/app and this task is older.")
+                      " Possible reason: orca is saving info for 2000 tasks/app and this task is older. $e")
                     // when we get not found exception from orca, we shouldn't try to get the status anymore
                     taskTrackingRepository.delete(it.id)
                   }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
@@ -58,7 +58,7 @@ class OrcaTaskMonitorAgent(
                 when (e.isNotFound) {
                   true -> {
                     log.warn("Exception ${e.message} has caught while calling orca to fetch status for execution id: ${it.id}" +
-                      " Possible reason: orca is saving info for 2000 tasks/app and this task is older. $e")
+                      " Possible reason: orca is saving info for 2000 tasks/app and this task is older.", e)
                     // when we get not found exception from orca, we shouldn't try to get the status anymore
                     taskTrackingRepository.delete(it.id)
                   }

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
@@ -24,7 +24,14 @@ import io.mockk.mockk
 import io.mockk.verify
 import java.time.Clock
 import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.springframework.context.ApplicationEventPublisher
+import retrofit2.HttpException
+import retrofit2.Response
+import strikt.api.expectThat
+import strikt.api.expectThrows
+import strikt.assertions.isTrue
 
 internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
 
@@ -173,13 +180,13 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
       }
     }
 
-    context("cannot determinate task status since orca returned an exception for the task id") {
+    context("cannot determinate task status since orca returned a not found exception for the task id") {
       before {
         every { resourceRepository.get(resource.id) } returns resource
         every { taskTrackingRepository.getTasks() } returns setOf(event.taskRecord)
         every {
           orcaService.getOrchestrationExecution(event.taskRecord.id)
-        } throws Exception()
+        } throws RETROFIT_NOT_FOUND
       }
 
       test("task record was removed from the table") {
@@ -189,6 +196,27 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
 
         verify(exactly = 0) { publisher.publishEvent(any()) }
         verify { taskTrackingRepository.delete(event.taskRecord.id) }
+      }
+    }
+
+    context("cannot determinate task status since orca returned an exception for the task id") {
+      before {
+        every { resourceRepository.get(resource.id) } returns resource
+        every { taskTrackingRepository.getTasks() } returns setOf(event.taskRecord)
+        every {
+          orcaService.getOrchestrationExecution(event.taskRecord.id)
+        } throws Exception()
+      }
+
+      test("an exception is thrown and the task was not deleted") {
+        runBlocking {
+          expectThrows<Exception> {
+            subject.invokeAgent()
+          }
+        }
+
+        verify(exactly = 0) { publisher.publishEvent(any()) }
+        expectThat(taskTrackingRepository.getTasks().contains(event.taskRecord)).isTrue()
       }
     }
 
@@ -264,4 +292,8 @@ internal class OrcaTaskMonitorAgentTests : JUnit5Minutests {
       )
     ))
     )
+
+  val RETROFIT_NOT_FOUND = HttpException(
+    Response.error<Any>(404, "".toResponseBody("application/json".toMediaTypeOrNull()))
+  )
 }


### PR DESCRIPTION
If we are trying to query orca for information about some task and orca returns an error, log it, and remove that task from `task_tracking` table.

Question: should we publish an event for that unknown task, something like `ResourceTaskUnknown`?