### PR TITLE
refactor(artifacts): Cleanup from ArtifactSupplier implementation PoC

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,6 +73,7 @@ subprojects {
         languageVersion = "1.3"
         jvmTarget = "1.8"
         freeCompilerArgs += "-progressive"
+        freeCompilerArgs += "-Xjvm-default=enable"
       }
     }
 

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/VersioningStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/VersioningStrategy.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.api.artifacts
 /**
  * Strategy for how to sort versions of artifacts.
  */
-abstract class VersioningStrategy {
-  abstract val type: String
-  abstract val comparator: Comparator<String>
+interface VersioningStrategy {
+  val type: String
+  val comparator: Comparator<String>
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
@@ -36,6 +36,7 @@ interface ArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy> : Spinn
    * The default implementation of [publishArtifact] simply publishes the event via the [EventPublisher],
    * and should *not* be overridden by implementors.
    */
+  @JvmDefault
   fun publishArtifact(artifactPublishedEvent: ArtifactPublishedEvent) =
     eventPublisher.publishEvent(artifactPublishedEvent)
 
@@ -45,7 +46,7 @@ interface ArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy> : Spinn
    *
    * This function may interact with external systems to retrieve artifact information as needed.
    */
-  suspend fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact?
+  fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact?
 
   /**
    * Given a [PublishedArtifact] supported by this [ArtifactSupplier], return the full representation of

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/coroutines.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifact/coroutines.kt
@@ -1,0 +1,13 @@
+package com.netflix.spinnaker.keel.artifact
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+
+internal fun <T> runWithIoContext(block: suspend () -> T): T {
+  return runBlocking {
+    withContext(Dispatchers.IO) {
+      block()
+    }
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianSemVerVersioningStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianSemVerVersioningStrategy.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.artifacts
 import com.netflix.spinnaker.keel.api.artifacts.VersioningStrategy
 import com.netflix.spinnaker.keel.core.DEBIAN_VERSION_COMPARATOR
 
-object DebianSemVerVersioningStrategy : VersioningStrategy() {
+object DebianSemVerVersioningStrategy : VersioningStrategy {
   override val type: String = "debian"
 
   override val comparator: Comparator<String> =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerVersioningStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerVersioningStrategy.kt
@@ -7,7 +7,7 @@ import com.netflix.spinnaker.keel.core.TagComparator
 data class DockerVersioningStrategy(
   val strategy: TagVersionStrategy,
   val captureGroupRegex: String? = null
-) : VersioningStrategy() {
+) : VersioningStrategy {
   override val type: String = "docker"
 
   override val comparator: Comparator<String> =

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
@@ -20,7 +20,7 @@ class DummyArtifact(
   override val versioningStrategy = DummyVersioningStrategy
 }
 
-object DummyVersioningStrategy : VersioningStrategy() {
+object DummyVersioningStrategy : VersioningStrategy {
   override val comparator: Comparator<String> = Comparator.naturalOrder()
   override val type = "dummy"
 }


### PR DESCRIPTION
Addresses a couple of issues found when attempting to implement the first plugin based on `ArtifactSupplier`:
- Removes `suspend` modifier from `getLatestArtifact()`
- Annotates `publishArtifact()` with `@JvmDefault` such that the default implementation carries over to Java
- Changes `VersioningStrategy` to an interface