### PR TITLE
fix(sql): handle veto when never previously deployed to target environment

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -302,7 +302,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
           }
         }
 
-        test("an artifact version can be vetoed") {
+        test("an artifact version can be vetoed even if it was not previously deployed") {
           val veto = EnvironmentArtifactVeto(
             targetEnvironment = environment1.name,
             reference = artifact1.reference,

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -28,7 +28,6 @@ import strikt.api.expect
 import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.api.expectThrows
-import strikt.assertions.contains
 import strikt.assertions.containsExactly
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.first
@@ -42,7 +41,6 @@ import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
 import strikt.assertions.isTrue
-import strikt.assertions.size
 
 abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests {
   abstract fun factory(clock: Clock): T

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -597,8 +597,7 @@ class SqlArtifactRepository(
      * another artifact version being vetoed. In that case, we don't veto unless [force] is enabled.
      */
     selectPromotionReference(envUid, artUid, veto.version)
-      .fetchOne() // null if [veto.version] never made it to the target environment
-      ?.value1() // null if the `promotion_reference` column is NULL
+      .fetchOne(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE)
       ?.let { reference ->
       if (!force) {
         log.warn(

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -546,9 +546,10 @@ class SqlArtifactRepository(
    * Preconditions for success:
    *
    *  1. [veto.version] is not currently pinned in the target environment
-   *  2. There exists a record R in the environment_artifacts_versions table such that:
-   *     a. R references the artifact version to veto and the target environment encoded in [veto]
-   *     b. R.promotion_reference is NULL, or [force] is true
+   *  2. One of the following is true:
+   *     a. There is no record in the environment_artifacts_version table for this version
+   *     b. The record in the environment_artifacts_versions table for this version has promotion_reference=NULL
+   *     c. [force] is true
    *
    *  Note: 2b is a precondition to avoid cascading veto-triggered deployments. If R contains a promotion reference, then
    *  [veto.version] was originally deployed as a result of another artifact version being vetoed (see postcondition 3a).
@@ -591,44 +592,45 @@ class SqlArtifactRepository(
       return false
     }
 
-    return selectPromotionReference(envUid, artUid, veto.version)
-      .fetchOne { (ref: String?) ->
-        ref?.let { reference ->
-          /**
-           * If there's a promotion reference, that means this artifact version was deployed as a result of
-           * another artifact version being vetoed. In that case, we don't veto unless [force] is enabled.
-           */
-          if (!force) {
-            log.warn(
-              "Not vetoing artifact version as it appears to have already been an automated rollback target: " +
-                "deliveryConfig=${deliveryConfig.name}, " +
-                "environment=${veto.targetEnvironment}, " +
-                "artifactVersion=${veto.version}, " +
-                "priorVersionReference=$reference")
-            return@fetchOne false
-          }
-        }
-
-        val prior = priorVersionDeployedIn(envUid, artUid, veto.version)
-
-        sqlRetry.withRetry(WRITE) {
-          jooq.transaction { config ->
-            val txn = DSL.using(config)
-            txn.updateAsVetoedInEnvironmentArtifactVersionsTable(prior, veto, envUid, artUid)
-            txn.addRecordToEnvironmentArtifactVetoTable(envUid, artUid, veto)
-
-            /**
-             * If there's a previously deployed version in [targetEnvironment], set `promotion_reference`
-             * to the version that's currently being vetoed. If that version also fails to fully deploy,
-             * this is used to short-circuit further automated vetoes. We want to avoid a cloud provider
-             * or other issue unrelated to an artifact version triggering continual automated rollbacks
-             * thru all previously deployed versions.
-             */
-            prior?.let { txn.setPromotionReference(veto.version, envUid, artUid, it) }
-          }
-        }
-        return@fetchOne true
+    /**
+     * If there's a promotion reference, that means this artifact version was deployed as a result of
+     * another artifact version being vetoed. In that case, we don't veto unless [force] is enabled.
+     */
+    selectPromotionReference(envUid, artUid, veto.version)
+      .fetchOne() // null if [veto.version] never made it to the target environment
+      ?.value1() // null if the `promotion_reference` column is NULL
+      ?.let { reference ->
+      if (!force) {
+        log.warn(
+          "Not vetoing artifact version as it appears to have already been an automated rollback target: " +
+            "deliveryConfig=${deliveryConfig.name}, " +
+            "environment=${veto.targetEnvironment}, " +
+            "artifactVersion=${veto.version}, " +
+            "priorVersionReference=$reference")
+        return false
       }
+    }
+
+    val prior = priorVersionDeployedIn(envUid, artUid, veto.version)
+
+    sqlRetry.withRetry(WRITE) {
+      jooq.transaction { config ->
+        val txn = DSL.using(config)
+        txn.upsertAsVetoedInEnvironmentArtifactVersionsTable(prior, veto, envUid, artUid)
+        txn.addRecordToEnvironmentArtifactVetoTable(envUid, artUid, veto)
+
+        /**
+         * If there's a previously deployed version in [targetEnvironment], set `promotion_reference`
+         * to the version that's currently being vetoed. If that version also fails to fully deploy,
+         * this is used to short-circuit further automated vetoes. We want to avoid a cloud provider
+         * or other issue unrelated to an artifact version triggering continual automated rollbacks
+         * thru all previously deployed versions.
+         */
+        prior?.let { txn.setPromotionReference(veto.version, envUid, artUid, it) }
+      }
+    }
+
+    return true
   }
 
   private fun DSLContext.setPromotionReference(version: String, envUid: String, artUid: String, prior: String) {
@@ -661,20 +663,21 @@ class SqlArtifactRepository(
       .execute()
   }
 
-  private fun DSLContext.updateAsVetoedInEnvironmentArtifactVersionsTable(
+  private fun DSLContext.upsertAsVetoedInEnvironmentArtifactVersionsTable(
     prior: String?,
     veto: EnvironmentArtifactVeto,
     envUid: String,
     artUid: String
   ) {
-    update(ENVIRONMENT_ARTIFACT_VERSIONS)
+    insertInto(ENVIRONMENT_ARTIFACT_VERSIONS)
+      .set(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID, envUid)
+      .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID, artUid)
+      .set(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION, veto.version)
       .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, VETOED.name)
       .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, prior ?: veto.version)
-      .where(
-        ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(envUid),
-        ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artUid),
-        ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(veto.version)
-      )
+      .onDuplicateKeyUpdate()
+      .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, VETOED.name)
+      .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_REFERENCE, prior ?: veto.version)
       .execute()
   }
 


### PR DESCRIPTION
Properly handle the case when vetoing (marking as bad) an artifact version in an environment that had never been deployed to that environment.

Fixes #1086


## Upsert instead of update

Previously, we did an UPDATE to the record in environment_artifact_versions to mark the version as vetoed. This change does an *upsert* instead of an *update*, to handle the case where the record doesn't exist yet.

`updateAsVetoedInEnvironmentArtifactVersionsTable` has been renamed to `upsertAsVetoedInEnvironmentArtifactVersionsTable` to reflect this.

## Don't assume fetchOne always returns a value

Previously, all of the logic in this method was in a lambda passed to the `fetchOne` method. But, because `fetchOne` can return null if there are no matching records, the code inside that lambda wasn't getting executed when the record in environment_artifact_versions didn't exist yet. 

This change moves code out of that lambda.

