### PR TITLE
fix(ec2): serialize TargetGroups as their name (for history deltas)

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
@@ -64,6 +64,7 @@ data class ApplicationLoadBalancerSpec(
         "targetGroup names have a 32 character limit"
       }
     }
+    override fun toString() = name
   }
 
   data class ApplicationLoadBalancerOverride(


### PR DESCRIPTION
Turns out this class gets `toString`'d when we serialize history event deltas, because the diffing lib sees the structure as a map where the `TargetGroup` is the key. Today that produces some gnarly diff output, seen here in the UI:

<img width="1527" alt="Screen Shot 2020-07-01 at 1 06 02 PM" src="https://user-images.githubusercontent.com/1850998/86412640-4a7aa000-bc74-11ea-8a40-269a9179b952.png">

This serializes the name instead, so you get something like `targetGroups[deck-test-targetgroup]`