### PR TITLE
fix(resources): Register ALB v1.1 resource kind

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.constraints.CanaryConstraintConfigurationProperties
 import com.netflix.spinnaker.keel.constraints.CanaryConstraintDeployHandler
 import com.netflix.spinnaker.keel.ec2.EC2_APPLICATION_LOAD_BALANCER_V1
+import com.netflix.spinnaker.keel.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
 import com.netflix.spinnaker.keel.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.ec2.EC2_CLUSTER_V1
 import com.netflix.spinnaker.keel.ec2.EC2_SECURITY_GROUP_V1
@@ -58,6 +59,9 @@ class EC2Config {
 
   @Bean
   fun applicationLoadBalancerV1() = EC2_APPLICATION_LOAD_BALANCER_V1
+
+  @Bean
+  fun applicationLoadBalancerV1dot1() = EC2_APPLICATION_LOAD_BALANCER_V1_1
 
   @Bean
   fun clusterHandler(


### PR DESCRIPTION
We were missing the registration of this resource kind as a Spring bean such that it gets picked up by `ResourceSpecIdentifier.identify()`.