### PR TITLE
feat(docker): don't allow a/a/a format

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
@@ -16,11 +16,20 @@ data class DockerArtifact(
   val captureGroupRegex: String? = null,
   override val versioningStrategy: VersioningStrategy = DockerVersioningStrategy(tagVersionStrategy, captureGroupRegex)
 ) : DeliveryArtifact() {
+  init {
+    require(name.count { it == '/' } <= 1) {
+      "Docker image name has more than one slash, which is not Docker convention. Please convert to `organization/image-name` format."
+    }
+  }
+
   override val type = DOCKER
+
   @JsonIgnore
   val organization: String = name.substringBefore('/')
+
   @JsonIgnore
   val image: String = name.substringAfter('/')
+
   @JsonIgnore
   override val statuses: Set<ArtifactStatus> = emptySet()
   override fun toString(): String = super.toString()


### PR DESCRIPTION
Docker convention is to have images of the form `organization/image-name:tag`. Adding some validation to enforce that because it's tricky when images have a slash in the `image-name` format.