### PR TITLE
fix(delete): delete without serialization

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -163,7 +163,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
 
       context("delivery config was deleted") {
         before {
-          subject.deleteDeliveryConfig(configName)
+          subject.deleteDeliveryConfigByApplication(deliveryConfig.application)
         }
         test("everything is deleted") {
           expectThrows<NoSuchDeliveryConfigException> { deliveryConfigRepository.get(configName) }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -64,7 +64,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
     }
 
     fun delete() {
-      repository.deleteByApplication(deliveryConfig.application)
+      repository.deleteWithoutSerialization(deliveryConfig.application)
     }
 
     fun store() {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -64,7 +64,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
     }
 
     fun delete() {
-      repository.deleteWithoutSerialization(deliveryConfig.application)
+      repository.delete(deliveryConfig.application)
     }
 
     fun store() {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -124,16 +124,16 @@ class CombinedRepository(
   }
 
   /**
-   * Deletes a config and everything in it and about it w/o serializing it
+   * Deletes a config and everything in it and about it
    */
   override fun deleteDeliveryConfigByApplication(application: String) =
-    deliveryConfigRepository.deleteWithoutSerialization(application)
+    deliveryConfigRepository.delete(application)
 
   /**
-   * Deletes a config and everything in it and about it w/o serializing it
+   * Deletes a config and everything in it and about it
    */
   override fun deleteDeliveryConfigByName(name: String) {
-    deliveryConfigRepository.deleteWithoutSerializationByName(name)
+    deliveryConfigRepository.deleteByName(name)
   }
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -61,7 +61,8 @@ class CombinedRepository(
     val new = DeliveryConfig(
       name = submittedDeliveryConfig.safeName,
       application = submittedDeliveryConfig.application,
-      serviceAccount = submittedDeliveryConfig.serviceAccount ?: error("No service account specified, and no default applied"),
+      serviceAccount = submittedDeliveryConfig.serviceAccount
+        ?: error("No service account specified, and no default applied"),
       artifacts = submittedDeliveryConfig.artifacts.transform(submittedDeliveryConfig.safeName),
       environments = submittedDeliveryConfig.environments.mapTo(mutableSetOf()) { env ->
         Environment(
@@ -123,40 +124,16 @@ class CombinedRepository(
   }
 
   /**
-   * Fetches delivery config by name, then deletes everything in it.
+   * Deletes a config and everything in it and about it w/o serializing it
    */
-  @Transactional(propagation = REQUIRED)
-  override fun deleteDeliveryConfig(deliveryConfigName: String): DeliveryConfig =
-    deleteDeliveryConfigFull(deliveryConfigRepository.get(deliveryConfigName))
+  override fun deleteDeliveryConfigByApplication(application: String) =
+    deliveryConfigRepository.deleteWithoutSerialization(application)
 
   /**
-   * Fetches delivery config by application, then deletes everything in it.
+   * Deletes a config and everything in it and about it w/o serializing it
    */
-  @Transactional(propagation = REQUIRED)
-  override fun deleteDeliveryConfigByApplication(application: String): DeliveryConfig =
-    deleteDeliveryConfigFull(deliveryConfigRepository.getByApplication(application))
-
-  /**
-   * Deletes a delivery config and everything in it.
-   */
-  @Transactional(propagation = REQUIRED)
-  internal fun deleteDeliveryConfigFull(deliveryConfig: DeliveryConfig): DeliveryConfig {
-    deliveryConfig.environments.forEach { environment ->
-      environment.resources.forEach { resource ->
-        // resources must be removed from the environment then deleted
-        deliveryConfigRepository.deleteResourceFromEnv(deliveryConfig.name, environment.name, resource.id)
-        deleteResource(resource.id)
-      }
-      deliveryConfigRepository.deleteEnvironment(deliveryConfig.name, environment.name)
-    }
-
-    deliveryConfig.artifacts.forEach { artifact ->
-      artifactRepository.delete(artifact)
-    }
-
-    deliveryConfigRepository.delete(deliveryConfig.name)
-
-    return deliveryConfig
+  override fun deleteDeliveryConfigByName(name: String) {
+    deliveryConfigRepository.deleteWithoutSerializationByName(name)
   }
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -40,20 +40,14 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun getByApplication(application: String): DeliveryConfig
 
   /**
-   * Deletes a delivery config, and the environments within in it.
-   * Does not delete any resources or artifacts.
+   * Deletes a delivery config and everything in it
    */
-  fun delete(name: String)
+  fun delete(application: String)
 
   /**
-   * Deletes a delivery config and everything in it without serializing the resources, in case of a database problem.
+   * Deletes a delivery config and everything in it
    */
-  fun deleteWithoutSerialization(application: String)
-
-  /**
-   * Deletes a delivery config and everything in it without serializing the resources, in case of a database problem.
-   */
-  fun deleteWithoutSerializationByName(name: String)
+  fun deleteByName(name: String)
 
   /**
    * Removes a resource from an environment

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -40,18 +40,20 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun getByApplication(application: String): DeliveryConfig
 
   /**
-   * Delete the [DeliveryConfig] persisted for an application. This does not delete the underlying
-   * resources.
-   *
-   * @return The number of deleted [DeliveryConfig]s.
-   */
-  fun deleteByApplication(application: String): Int
-
-  /**
    * Deletes a delivery config, and the environments within in it.
    * Does not delete any resources or artifacts.
    */
   fun delete(name: String)
+
+  /**
+   * Deletes a delivery config and everything in it without serializing the resources, in case of a database problem.
+   */
+  fun deleteWithoutSerialization(application: String)
+
+  /**
+   * Deletes a delivery config and everything in it without serializing the resources, in case of a database problem.
+   */
+  fun deleteWithoutSerializationByName(name: String)
 
   /**
    * Removes a resource from an environment

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -78,14 +78,12 @@ interface KeelRepository {
   /**
    * Deletes a delivery config and everything in it.
    */
-  @Transactional(propagation = Propagation.REQUIRED)
-  fun deleteDeliveryConfig(deliveryConfigName: String): DeliveryConfig
+  fun deleteDeliveryConfigByApplication(application: String)
 
   /**
    * Deletes a delivery config and everything in it.
    */
-  @Transactional(propagation = Propagation.REQUIRED)
-  fun deleteDeliveryConfigByApplication(application: String): DeliveryConfig
+  fun deleteDeliveryConfigByName(name: String)
 
   /**
    * Removes artifacts, environments, and resources that were present in the [old]

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -20,8 +20,7 @@ class AdminService(
 
   fun deleteApplicationData(application: String) {
     log.debug("Deleting all data for application: $application")
-    val config = repository.getDeliveryConfigForApplication(application)
-    repository.deleteDeliveryConfig(config.name)
+    repository.deleteDeliveryConfigByApplication(application)
   }
 
   fun getPausedApplications() = actuationPauser.pausedApplications()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -29,11 +29,14 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG_A
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG_LAST_CHECKED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_CONSTRAINT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_PIN
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VERSIONS
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VETO
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_LAST_CHECKED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_WITH_METADATA
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
@@ -78,66 +81,6 @@ class SqlDeliveryConfigRepository(
             .attachDependents(uid)
         }
     } ?: throw NoDeliveryConfigForApplication(application)
-
-  override fun deleteByApplication(application: String): Int {
-
-    val deliveryConfigUIDs = getUIDsByApplication(application)
-    val environmentUIDs = getEnvironmentUIDs(deliveryConfigUIDs)
-
-    deliveryConfigUIDs.forEach { uid ->
-      sqlRetry.withRetry(WRITE) {
-        jooq.deleteFrom(DELIVERY_CONFIG)
-          .where(DELIVERY_CONFIG.UID.eq(uid))
-          .execute()
-      }
-      sqlRetry.withRetry(WRITE) {
-        jooq.deleteFrom(DELIVERY_CONFIG_ARTIFACT)
-          .where(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(uid))
-          .execute()
-      }
-      sqlRetry.withRetry(WRITE) {
-        jooq.deleteFrom(DELIVERY_CONFIG_LAST_CHECKED)
-          .where(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID.eq(uid))
-          .execute()
-      }
-    }
-    environmentUIDs.forEach { uid ->
-      sqlRetry.withRetry(WRITE) {
-        jooq.deleteFrom(ENVIRONMENT)
-          .where(ENVIRONMENT.UID.eq(uid))
-          .execute()
-      }
-      sqlRetry.withRetry(WRITE) {
-        jooq.deleteFrom(ENVIRONMENT_ARTIFACT_VERSIONS)
-          .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(uid))
-          .execute()
-      }
-      sqlRetry.withRetry(WRITE) {
-        jooq.deleteFrom(ENVIRONMENT_RESOURCE)
-          .where(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
-          .execute()
-      }
-      sqlRetry.withRetry(WRITE) {
-        jooq
-          .select(CURRENT_CONSTRAINT.APPLICATION, CURRENT_CONSTRAINT.TYPE)
-          .from(CURRENT_CONSTRAINT)
-          .where(CURRENT_CONSTRAINT.ENVIRONMENT_UID.eq(uid))
-          .fetch { (application, type) ->
-            jooq.deleteFrom(CURRENT_CONSTRAINT)
-              .where(
-                CURRENT_CONSTRAINT.APPLICATION.eq(application),
-                CURRENT_CONSTRAINT.ENVIRONMENT_UID.eq(uid),
-                CURRENT_CONSTRAINT.TYPE.eq(type))
-              .execute()
-          }
-        jooq
-          .deleteFrom(ENVIRONMENT_ARTIFACT_CONSTRAINT)
-          .where(ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(uid))
-          .execute()
-      }
-    }
-    return deliveryConfigUIDs.size
-  }
 
   override fun delete(name: String) {
     sqlRetry.withRetry(WRITE) {
@@ -248,13 +191,97 @@ class SqlDeliveryConfigRepository(
       }
   }
 
-  private fun getUIDsByApplication(application: String): List<String> =
+  override fun deleteWithoutSerializationByName(name: String) {
+    val application = sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_CONFIG.NAME)
+        .from(DELIVERY_CONFIG)
+        .where(DELIVERY_CONFIG.NAME.eq(name))
+        .fetchOne(DELIVERY_CONFIG.NAME)
+    }
+    deleteWithoutSerialization(application)
+  }
+
+  override fun deleteWithoutSerialization(application: String) {
+    val configUid = getUIDByApplication(application)
+    val envUids = getEnvironmentUIDs(listOf(configUid))
+    val resourceUids = getResourceUIDs(envUids)
+    val artifactUids = getArtifactUIDs(configUid)
+
+    sqlRetry.withRetry(WRITE) {
+      jooq.transaction { config ->
+        val txn = DSL.using(config)
+        // remove resources from environment
+        txn.deleteFrom(ENVIRONMENT_RESOURCE)
+          .where(
+            ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.`in`(envUids),
+            ENVIRONMENT_RESOURCE.RESOURCE_UID.`in`(resourceUids))
+          .execute()
+        // delete resources
+        txn.deleteFrom(RESOURCE)
+          .where(RESOURCE.UID.`in`(resourceUids))
+          .execute()
+        // delete from resource last checked
+        txn.deleteFrom(RESOURCE_LAST_CHECKED)
+          .where(RESOURCE_LAST_CHECKED.RESOURCE_UID.`in`(resourceUids))
+          .execute()
+        // delete environment
+        txn.deleteFrom(ENVIRONMENT)
+          .where(ENVIRONMENT.UID.`in`(envUids))
+          .execute()
+        // remove from env artifact versions
+        txn.deleteFrom(ENVIRONMENT_ARTIFACT_VERSIONS)
+          .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.`in`(envUids))
+          .execute()
+        // delete constraints
+        txn.deleteFrom(ENVIRONMENT_ARTIFACT_CONSTRAINT)
+          .where(ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.`in`(envUids))
+          .execute()
+        // delete current constraints
+        txn.deleteFrom(CURRENT_CONSTRAINT)
+          .where(CURRENT_CONSTRAINT.ENVIRONMENT_UID.`in`(envUids))
+          .execute()
+        // delete from pin
+        txn.deleteFrom(ENVIRONMENT_ARTIFACT_PIN)
+          .where(ENVIRONMENT_ARTIFACT_PIN.ENVIRONMENT_UID.`in`(envUids))
+          .execute()
+        // delete from veto
+        txn.deleteFrom(ENVIRONMENT_ARTIFACT_VETO)
+          .where(ENVIRONMENT_ARTIFACT_VETO.ENVIRONMENT_UID.`in`(envUids))
+          .execute()
+        // delete from queued approval
+        txn.deleteFrom(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL)
+          .where(ENVIRONMENT_ARTIFACT_QUEUED_APPROVAL.ENVIRONMENT_UID.`in`(envUids))
+          .execute()
+        // remove artifact from delivery config
+        txn.deleteFrom(DELIVERY_CONFIG_ARTIFACT)
+          .where(
+            DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(configUid),
+            DELIVERY_CONFIG_ARTIFACT.ARTIFACT_UID.`in`(artifactUids))
+          .execute()
+        // delete artifact
+        txn.deleteFrom(DELIVERY_ARTIFACT)
+          .where(DELIVERY_ARTIFACT.UID.`in`(artifactUids))
+          .execute()
+        // delete delivery config
+        txn.deleteFrom(DELIVERY_CONFIG)
+          .where(DELIVERY_CONFIG.UID.eq(configUid))
+          .execute()
+        // delete from delivery config last checked
+        txn.deleteFrom(DELIVERY_CONFIG_LAST_CHECKED)
+          .where(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID.eq(configUid))
+          .execute()
+      }
+    }
+  }
+
+  private fun getUIDByApplication(application: String): String =
     sqlRetry.withRetry(READ) {
       jooq
         .select(DELIVERY_CONFIG.UID)
         .from(DELIVERY_CONFIG)
         .where(DELIVERY_CONFIG.APPLICATION.eq(application))
-        .fetch(DELIVERY_CONFIG.UID)
+        .fetchOne(DELIVERY_CONFIG.UID)
     }
 
   private fun getEnvironmentUIDs(deliveryConfigUIDs: List<String>): List<String> =
@@ -264,6 +291,24 @@ class SqlDeliveryConfigRepository(
         .from(ENVIRONMENT)
         .where(ENVIRONMENT.DELIVERY_CONFIG_UID.`in`(deliveryConfigUIDs))
         .fetch(ENVIRONMENT.UID)
+    }
+
+  private fun getResourceUIDs(environmentUids: List<String>): List<String> =
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(ENVIRONMENT_RESOURCE.RESOURCE_UID)
+        .from(ENVIRONMENT_RESOURCE)
+        .where(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.`in`(environmentUids))
+        .fetch(ENVIRONMENT_RESOURCE.RESOURCE_UID)
+    }
+
+  private fun getArtifactUIDs(deliveryConfigUid: String): List<String> =
+    sqlRetry.withRetry(READ) {
+      jooq
+        .select(DELIVERY_CONFIG_ARTIFACT.ARTIFACT_UID)
+        .from(DELIVERY_CONFIG_ARTIFACT)
+        .where(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(deliveryConfigUid))
+        .fetch(DELIVERY_CONFIG_ARTIFACT.ARTIFACT_UID)
     }
 
   // todo: queries in this function aren't inherently retryable because of the cross-repository interactions

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -83,8 +83,10 @@ class DeliveryConfigController(
   @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #name)
     and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #name)"""
   )
-  fun delete(@PathVariable("name") name: String) =
+  fun delete(@PathVariable("name") name: String) {
+    log.debug("Deleting delivery config $name")
     repository.deleteDeliveryConfigByName(name)
+  }
 
   // todo eb: make this work with artifact references
   @PostMapping(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -83,12 +83,8 @@ class DeliveryConfigController(
   @PreAuthorize("""@authorizationSupport.hasApplicationPermission('WRITE', 'DELIVERY_CONFIG', #name)
     and @authorizationSupport.hasServiceAccountAccess('DELIVERY_CONFIG', #name)"""
   )
-  fun delete(@PathVariable("name") name: String): DeliveryConfig {
-    val deliveryConfig = repository.getDeliveryConfig(name)
-    log.info("Deleting delivery config $name: $deliveryConfig")
-    repository.deleteDeliveryConfig(name)
-    return deliveryConfig
-  }
+  fun delete(@PathVariable("name") name: String) =
+    repository.deleteDeliveryConfigByName(name)
 
   // todo eb: make this work with artifact references
   @PostMapping(


### PR DESCRIPTION
Recently we had an incident where a rogue delivery config caused resource checks to drop off. To remediate the issue we wanted to delete the delivery config, but we couldn't because our current delete relies on serialization of resources.

This PR changes delete to delete without serialization so that it is more bester and able to be used when we have serialization problems