### PR TITLE
fix(api): Fix delete delivery config API

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -64,7 +64,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
     }
 
     fun delete() {
-      repository.delete(deliveryConfig.application)
+      repository.deleteByApplication(deliveryConfig.application)
     }
 
     fun store() {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -127,7 +127,7 @@ class CombinedRepository(
    * Deletes a config and everything in it and about it
    */
   override fun deleteDeliveryConfigByApplication(application: String) =
-    deliveryConfigRepository.delete(application)
+    deliveryConfigRepository.deleteByApplication(application)
 
   /**
    * Deletes a config and everything in it and about it

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -40,17 +40,17 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun getByApplication(application: String): DeliveryConfig
 
   /**
-   * Deletes a delivery config and everything in it
+   * Deletes a delivery config and everything in it, based on the application name.
    */
-  fun delete(application: String)
+  fun deleteByApplication(application: String)
 
   /**
-   * Deletes a delivery config and everything in it
+   * Deletes a delivery config and everything in it.
    */
   fun deleteByName(name: String)
 
   /**
-   * Removes a resource from an environment
+   * Removes a resource from an environment.
    */
   fun deleteResourceFromEnv(deliveryConfigName: String, environmentName: String, resourceId: String)
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -173,15 +173,15 @@ class SqlDeliveryConfigRepository(
   override fun deleteByName(name: String) {
     val application = sqlRetry.withRetry(READ) {
       jooq
-        .select(DELIVERY_CONFIG.NAME)
+        .select(DELIVERY_CONFIG.APPLICATION)
         .from(DELIVERY_CONFIG)
         .where(DELIVERY_CONFIG.NAME.eq(name))
-        .fetchOne(DELIVERY_CONFIG.NAME)
+        .fetchOne(DELIVERY_CONFIG.APPLICATION)
     }
-    delete(application)
+    deleteByApplication(application)
   }
 
-  override fun delete(application: String) {
+  override fun deleteByApplication(application: String) {
     val configUid = getUIDByApplication(application)
     val envUids = getEnvironmentUIDs(listOf(configUid))
     val resourceUids = getResourceUIDs(envUids)


### PR DESCRIPTION
I tried deleting a delivery config locally during testing and it failed. We were mixing up delivery config names with application names. This fixes it.