### PR TITLE
fix(deps): revert fiat version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-fiatVersion=1.22.0
+fiatVersion=1.21.0
 kapt.use.worker.api=true
 korkVersion=7.50.0
 liquibaseTaskPrefix=liquibase


### PR DESCRIPTION
Revert fiat version to prevent fiat from bringing in a newer version of kork.

We want kork 7.50.0, but fiat-api 1.22.0 brings in kork 7.51.2, and that leads keel to throw the following error on startup:

```
Could not find class [com.netflix.spinnaker.kork.eureka.EurekaComponents]
```