### PR TITLE
Fix serialization of pinned and vetoed fields

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -566,8 +566,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
           )
           expectThat(envArtifactSummary)
             .isNotNull()
-            .get { isPinned }
-            .isFalse()
+            .get { pinned }
+            .isNull()
         }
 
         context("once pinned") {
@@ -610,7 +610,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             )
             expect {
               that(envArtifactSummary).isNotNull()
-              that(envArtifactSummary?.isPinned).isTrue()
               that(envArtifactSummary?.pinned).isEqualTo(ActionMetadata(by = pin1.pinnedBy, at = clock.instant(), comment = pin1.comment))
             }
           }
@@ -695,7 +694,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         )
         expect {
           that(envArtifactSummary).isNotNull()
-          that(envArtifactSummary?.isVetoed).isTrue()
           that(envArtifactSummary?.vetoed).isEqualTo(ActionMetadata(by = "tester", at = clock.instant(), comment = "you bad"))
         }
       }
@@ -718,7 +716,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         }
         expect {
           that(envArtifactSummary).isNotNull()
-          that(envArtifactSummary?.isVetoed).isFalse()
           that(envArtifactSummary?.vetoed).isNull()
         }
       }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -44,9 +44,7 @@ data class ArtifactSummaryInEnvironment(
   val replacedAt: Instant? = null,
   val replacedBy: String? = null,
   val pinned: ActionMetadata? = null,
-  val isPinned: Boolean = pinned != null,
   val vetoed: ActionMetadata? = null,
-  val isVetoed: Boolean = vetoed != null,
   val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
   val statelessConstraints: List<StatelessConstraintSummary> = emptyList()
 )

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/ArtifactSummarySerializationTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/ArtifactSummarySerializationTests.kt
@@ -1,0 +1,33 @@
+package com.netflix.spinnaker.keel.serialization
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.netflix.spinnaker.keel.core.api.ActionMetadata
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import java.time.Instant.now
+import strikt.api.expectThat
+import strikt.jackson.has
+import strikt.jackson.isObject
+import strikt.jackson.path
+
+class ArtifactSummarySerializationTests : JUnit5Minutests {
+
+  fun tests() = rootContext {
+    test("a boolean property is rendered with an is* prefix") {
+      val obj = ArtifactSummaryInEnvironment(
+        environment = "test",
+        version = "12345",
+        state = "PENDING",
+        pinned = ActionMetadata(at = now(), by = "HULK", comment = "HULK PIN ARTIFACT")
+      )
+
+      val tree = configuredObjectMapper()
+        .valueToTree<ObjectNode>(obj)
+
+      expectThat(tree)
+        .has("pinned")
+        .path("pinned").isObject()
+    }
+  }
+}


### PR DESCRIPTION
Fixes serialization of fields in artifact/environment summary. Instead of boolean fields and objects now there are just the objects.