### PR TITLE
Use a generated application column on event table

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -36,7 +36,6 @@ import java.time.Instant.EPOCH
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import org.jooq.DSLContext
-import org.jooq.Field
 import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
 
@@ -48,10 +47,6 @@ open class SqlResourceRepository(
   private val objectMapper: ObjectMapper,
   private val sqlRetry: SqlRetry
 ) : ResourceRepository {
-
-  companion object {
-    val EVENT_JSON_APPLICATION: Field<String> = field("json->'$.application'")
-  }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -209,7 +204,7 @@ open class SqlResourceRepository(
         )
         // ...or application events that match the application as they apply to all resources
         .or(EVENT.SCOPE.eq(Scope.APPLICATION.name)
-          .and(EVENT_JSON_APPLICATION.eq(resource.application))
+          .and(EVENT.APPLICATION.eq(resource.application))
         )
         .orderBy(EVENT.TIMESTAMP.desc())
         .limit(limit)
@@ -248,7 +243,7 @@ open class SqlResourceRepository(
           )
           // ...or application events that match the application as they apply to all resources
           .or(EVENT.SCOPE.eq(Scope.APPLICATION.name)
-            .and(EVENT_JSON_APPLICATION.eq(event.application))
+            .and(EVENT.APPLICATION.eq(event.application))
           )
           .orderBy(EVENT.TIMESTAMP.desc())
           .limit(1)

--- a/keel-sql/src/main/resources/db/changelog/20200714-add-event-application-column.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200714-add-event-application-column.yml
@@ -8,14 +8,23 @@ databaseChangeLog:
           alter table event add column application varchar(255) generated always as (json ->> '$.application');
     - createIndex:
         tableName: event
-        indexName: event_ref_scope_application_timestamp_idx
+        indexName: event_scope_application_timestamp_idx
         columns:
-        - column:
-            name: ref
         - column:
             name: scope
         - column:
             name: application
+        - column:
+            name: timestamp
+            descending: true
+    - createIndex:
+        tableName: event
+        indexName: event_scope_ref_timestamp_idx
+        columns:
+        - column:
+            name: scope
+        - column:
+            name: ref
         - column:
             name: timestamp
             descending: true

--- a/keel-sql/src/main/resources/db/changelog/20200714-add-event-application-column.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200714-add-event-application-column.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+- changeSet:
+    id: add-event-application-column
+    author: fletch
+    changes:
+    - sql:
+        sql: |
+          alter table event add column application varchar(255) generated always as (json ->> '$.application') stored;
+    - createIndex:
+        tableName: event
+        indexName: event_ref_scope_application_timestamp_idx
+        columns:
+        - column:
+            name: ref
+        - column:
+            name: scope
+        - column:
+            name: application
+        - column:
+            name: timestamp
+            descending: true
+    - dropIndex:
+        tableName: event
+        indexName: event_uid_scope_timestamp_idx
+    rollback:
+    - sql:
+        sql: |
+          alter table event drop column application;

--- a/keel-sql/src/main/resources/db/changelog/20200714-add-event-application-column.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200714-add-event-application-column.yml
@@ -5,7 +5,7 @@ databaseChangeLog:
     changes:
     - sql:
         sql: |
-          alter table event add column application varchar(255) generated always as (json ->> '$.application') stored;
+          alter table event add column application varchar(255) generated always as (json ->> '$.application');
     - createIndex:
         tableName: event
         indexName: event_ref_scope_application_timestamp_idx

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -164,3 +164,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200611-create-resource-metadata-view.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200714-add-event-application-column.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
@robzienert observed recently that we were doing some quite expensive queries selecting for `json -> '$.application'` on the event table. This PR introduces a generated column to avoid the need to do that.

See #1359