### PR TITLE
feat(plugins): Expose ResourceHandler as a SpinnakerExtensionPoint

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -9,10 +9,25 @@ import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.kork.exceptions.SystemException
+import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 /**
+ * A [ResourceHandler] is a keel plugin that provides resource state monitoring and actuation capabilities
+ * for a specific type of [Resource]. The primary tasks of a [ResourceHandler] are to:
+ *
+ * 1. Translate the declarative definition of a [Resource], as represented by the matching [ResourceSpec]
+ *    (which can be arbitrarily abstract), into a concrete representation of the *desired state* of the resource
+ *    that the plugin itself can interpret and act upon. This is implemented in the [desired] method.
+ *
+ * 2. Provide the *current state* of a [Resource] as it exists in the real world, using the same concrete
+ *    representation as that used to represent desired state, so that keel can compare the two and look for
+ *    a drift (a.k.a. diff) between desired and current state. This is implemented in the [current] method.
+ *
+ * 3. Act to resolve the drift when requested by keel. This is done via the [create], [update] and [delete]
+ *    methods, which receive a [ResourceDiff] as a parameter.
+ *
  * @param S the spec type.
  * @param R the resolved model type.
  *
@@ -20,7 +35,7 @@ import org.slf4j.LoggerFactory
  */
 abstract class ResourceHandler<S : ResourceSpec, R : Any>(
   private val resolvers: List<Resolver<*>>
-) {
+) : SpinnakerExtensionPoint {
   val name: String
     get() = javaClass.simpleName
 
@@ -141,7 +156,7 @@ abstract class ResourceHandler<S : ResourceSpec, R : Any>(
 
   /**
    * Generates an artifact from a currently existing resource.
-   * Note: this only applies to clusters.
+   * Note: this only applies to resources that use artifacts, like clusters.
    */
   open suspend fun exportArtifact(exportable: Exportable): DeliveryArtifact {
     TODO("Not implemented or not supported with this handler")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -45,6 +45,15 @@ import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 
+/**
+ * The core component in keel responsible for resource state monitoring and actuation.
+ *
+ * The [checkResource] method of this class is called periodically by [CheckScheduler]
+ * to check on the current state of a specific [Resource] via the [ResourceHandler.current] method
+ * of the corresponding [ResourceHandler] plugin, compare that with the desired state obtained
+ * from [ResourceHandler.desired], and finally call the appropriate resource CRUD method on
+ * the [ResourceHandler] if differences are detected.
+ */
 @Component
 class ResourceActuator(
   private val resourceRepository: ResourceRepository,
@@ -91,8 +100,8 @@ class ResourceActuator(
           /**
            * [VersionedArtifactProvider] is a special [resource] sub-type. When a veto response sets
            * [VetoResponse.vetoArtifact] and the resource under evaluation is of type
-           * [VersionedArtifactProvider], denylist the desired artifact version from the environment
-           * containing [resource]. This ensures that the environment will be fully restored to
+           * [VersionedArtifactProvider], disallow the desired artifact version from being deployed to
+           * the environment containing [resource]. This ensures that the environment will be fully restored to
            * a prior good-state.
            */
           if (response.vetoArtifact && resource.spec is VersionedArtifactProvider) {


### PR DESCRIPTION
This simply marks `ResourceHandler` as a `SpinnakerExtensionPoint` to make it explicit that it supports implementations via the Spinnaker plugin framework.

As far as I can see at this point, there's nothing in `ResourceActuator` that would prevent an external plugin from working in keel, so my goal with this PR is to release a version that we can implement an external plugin against to verify that assumption.