### PR TITLE
Fix overrides for Titus cluster map properties

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -170,10 +170,10 @@ internal fun TitusClusterSpec.resolveCapacity(region: String) =
   overrides[region]?.capacity ?: defaults.capacity ?: Capacity(1, 1, 1)
 
 internal fun TitusClusterSpec.resolveEnv(region: String) =
-  emptyMap<String, String>() + overrides[region]?.env + defaults.env
+  emptyMap<String, String>() + defaults.env + overrides[region]?.env
 
 internal fun TitusClusterSpec.resolveContainerAttributes(region: String) =
-  emptyMap<String, String>() + overrides[region]?.containerAttributes + defaults.containerAttributes
+  emptyMap<String, String>() + defaults.containerAttributes + overrides[region]?.containerAttributes
 
 internal fun TitusClusterSpec.resolveResources(region: String): Resources {
   val default by lazy { Resources() }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterDesiredStateResolutionTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterDesiredStateResolutionTests.kt
@@ -1,0 +1,132 @@
+package com.netflix.spinnaker.keel.titus.resource
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.ec2.Capacity
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterSpec
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusServerGroup
+import com.netflix.spinnaker.keel.api.titus.cluster.TitusServerGroupSpec
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.docker.DigestProvider
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
+import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.mockk
+import java.time.Clock
+import kotlinx.coroutines.runBlocking
+import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectThat
+import strikt.assertions.getValue
+import strikt.assertions.isEqualTo
+
+class TitusClusterDesiredStateResolutionTests : JUnit5Minutests {
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    mapOf(
+      TitusServerGroupSpec::capacity to TitusServerGroup::capacity,
+      TitusServerGroupSpec::containerAttributes to TitusServerGroup::containerAttributes,
+      TitusServerGroupSpec::env to TitusServerGroup::env,
+      TitusServerGroupSpec::tags to TitusServerGroup::tags
+    )
+      .forEach { (specProperty, desiredProperty) ->
+        context("the `$specProperty` property") {
+          test("default value applies in non-overridden region") {
+            expectThat(desired)
+              .getValue("ca-central-1")
+              .get(desiredProperty)
+              .isEqualTo(specProperty.get(spec.defaults))
+          }
+
+          test("override value applies in overridden region") {
+            expectThat(desired)
+              .getValue("af-south-1")
+              .get(desiredProperty)
+              .isEqualTo(specProperty.get(spec.overrides.getValue("af-south-1")))
+          }
+        }
+      }
+  }
+
+  class Fixture(
+    val spec: TitusClusterSpec = TitusClusterSpec(
+      moniker = Moniker(app = "fnord"),
+      locations = SimpleLocations(
+        "test",
+        regions = setOf(
+          SimpleRegionSpec("ca-central-1"),
+          SimpleRegionSpec("af-south-1")
+        )
+      ),
+      _defaults = TitusServerGroupSpec(
+        capacity = Capacity(1, 1, 1),
+        container = DigestProvider(
+          organization = "fnord",
+          image = "some-image",
+          digest = "4ef5d72110943e43fc029b63cf84939f64893401b0870eed34b66d5b72bead2c"
+        ),
+        containerAttributes = mapOf(
+          "key" to "default value"
+        ),
+        env = mapOf(
+          "key" to "default value"
+        ),
+        tags = mapOf(
+          "key" to "default value"
+        )
+      ),
+      containerProvider = DigestProvider(
+        organization = "fnord",
+        image = "some-image",
+        digest = "4ef5d72110943e43fc029b63cf84939f64893401b0870eed34b66d5b72bead2c"
+      ),
+      overrides = mapOf(
+        "af-south-1" to TitusServerGroupSpec(
+          capacity = Capacity(2, 2, 2),
+          containerAttributes = mapOf(
+            "key" to "override value"
+          ),
+          env = mapOf(
+            "key" to "override value"
+          ),
+          tags = mapOf(
+            "key" to "override value"
+          )
+        )
+      )
+    )
+  ) {
+    val resource = resource(
+      kind = TITUS_CLUSTER_V1.kind,
+      spec = spec
+    )
+
+    val cloudDriverService = mockk<CloudDriverService>()
+    val cloudDriverCache = mockk<CloudDriverCache>()
+    val orcaService = mockk<OrcaService>()
+    val taskLauncher = mockk<TaskLauncher>()
+    val publisher = mockk<ApplicationEventPublisher>()
+    val handler = TitusClusterHandler(
+      cloudDriverService,
+      cloudDriverCache,
+      orcaService,
+      Clock.systemDefaultZone(),
+      taskLauncher,
+      publisher,
+      emptyList(),
+      ClusterExportHelper(cloudDriverService, orcaService)
+    )
+
+    val desired: Map<String, TitusServerGroup> by lazy {
+      runBlocking { handler.desired(resource) }
+    }
+  }
+}


### PR DESCRIPTION
There was a subtle bug where the default took precedence over the override in map properties of Titus clusters. This fixes it.