### PR TITLE
refactor(plugins): Make ResourceHandler an interface for Spinnaker plugin compatibility

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResolvableResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResolvableResourceHandler.kt
@@ -1,0 +1,45 @@
+package com.netflix.spinnaker.keel.api.plugins
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.id
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+/**
+ * A base class for native resource handlers which leverage [Resolver]s to apply defaults/opinions to
+ * [Resource] specs when determining desired state.
+ */
+abstract class ResolvableResourceHandler<S : ResourceSpec, R : Any>(
+  private val resolvers: List<Resolver<*>>
+) : ResourceHandler<S, R> {
+  protected val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
+
+  /**
+   * Applies any defaults / opinions to the resource as it is resolved into its [desired] state.
+   *
+   * @return [resource] or a copy of [resource] that may have been changed in order to set default
+   * values or apply opinions.
+   */
+  private fun applyResolvers(resource: Resource<S>): Resource<S> =
+    resolvers
+      .supporting(resource)
+      .fold(resource) { r, resolver ->
+        log.debug("Applying ${resolver.javaClass.simpleName} to ${r.id}")
+        resolver(r)
+      }
+
+  /**
+   * Convert the resource spec into the type that represents the diff-able desired state. This may
+   * involve looking up referenced resources, splitting a multi-region resource into discrete
+   * objects for each region, etc.
+   *
+   * Implementations of this method should not actuate any changes.
+   *
+   * @param resource a fully-resolved version of the persisted resource spec. You can assume that
+   * [applyResolvers] has already been called on this object.
+   */
+  protected abstract suspend fun toResolvedType(resource: Resource<S>): R
+
+  override suspend fun desired(resource: Resource<S>): R = toResolvedType(applyResolvers(resource))
+}

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/SimpleResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/SimpleResourceHandler.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 
 abstract class SimpleResourceHandler<T : ResourceSpec>(
   resolvers: List<Resolver<*>>
-) : ResourceHandler<T, T>(resolvers) {
+) : ResolvableResourceHandler<T, T>(resolvers) {
 
   /**
    * If you need to do any resolution of the desired value into a different type you should

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -16,8 +16,8 @@ import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.Location
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -39,7 +39,7 @@ class ApplicationLoadBalancerHandler(
   private val orcaService: OrcaService,
   private val taskLauncher: TaskLauncher,
   resolvers: List<Resolver<*>>
-) : ResourceHandler<ApplicationLoadBalancerSpec, Map<String, ApplicationLoadBalancer>>(resolvers) {
+) : ResolvableResourceHandler<ApplicationLoadBalancerSpec, Map<String, ApplicationLoadBalancer>>(resolvers) {
 
   override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_1
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -18,8 +18,8 @@ import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.Location
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -41,7 +41,7 @@ class ClassicLoadBalancerHandler(
   private val orcaService: OrcaService,
   private val taskLauncher: TaskLauncher,
   resolvers: List<Resolver<*>>
-) : ResourceHandler<ClassicLoadBalancerSpec, Map<String, ClassicLoadBalancer>>(resolvers) {
+) : ResolvableResourceHandler<ClassicLoadBalancerSpec, Map<String, ClassicLoadBalancer>>(resolvers) {
 
   override val supportedKind = EC2_CLASSIC_LOAD_BALANCER_V1
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -43,8 +43,8 @@ import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.api.ec2.byRegion
 import com.netflix.spinnaker.keel.api.ec2.resolve
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
@@ -95,7 +95,7 @@ class ClusterHandler(
   private val publisher: ApplicationEventPublisher,
   resolvers: List<Resolver<*>>,
   private val clusterExportHelper: ClusterExportHelper
-) : ResourceHandler<ClusterSpec, Map<String, ServerGroup>>(resolvers) {
+) : ResolvableResourceHandler<ClusterSpec, Map<String, ServerGroup>>(resolvers) {
 
   private val debianArtifactParser = DebianArtifactParser()
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -37,8 +37,8 @@ import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -59,7 +59,7 @@ class SecurityGroupHandler(
   private val orcaService: OrcaService,
   private val taskLauncher: TaskLauncher,
   resolvers: List<Resolver<*>>
-) : ResourceHandler<SecurityGroupSpec, Map<String, SecurityGroup>>(resolvers) {
+) : ResolvableResourceHandler<SecurityGroupSpec, Map<String, SecurityGroup>>(resolvers) {
 
   override val supportedKind = EC2_SECURITY_GROUP_V1
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -37,8 +37,8 @@ import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.InstanceCounts
 import com.netflix.spinnaker.keel.api.id
+import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
@@ -88,7 +88,7 @@ class TitusClusterHandler(
   private val publisher: ApplicationEventPublisher,
   resolvers: List<Resolver<*>>,
   private val clusterExportHelper: ClusterExportHelper
-) : ResourceHandler<TitusClusterSpec, Map<String, TitusServerGroup>>(resolvers) {
+) : ResolvableResourceHandler<TitusClusterSpec, Map<String, TitusServerGroup>>(resolvers) {
 
   private val mapper = configuredObjectMapper()
 


### PR DESCRIPTION
It turns out that abstract classes don't work with the current implementation of the Spinnaker plugin framework because it uses proxy classes which can implement interfaces marked as `SpinnakerExtensionPoint`, but cannot extend an abstract class. This PR refactors `ResourceHandler` into an interface and pulls the common behavior around using resolvers into an abstract `ResolvableResourceHandler` base-class that the native plugin implementations now extend.