### PR TITLE
chore(defaulting): set reasonable defaults for services

### DIFF
--- a/keel-web/config/keel.yml
+++ b/keel-web/config/keel.yml
@@ -1,0 +1,93 @@
+eureka:
+  enabled: false
+
+keel:
+  resourceCheck:
+    minAgeDuration: 10s
+  artifact-refresh:
+    frequency: PT1M
+  plugins:
+    bakery:
+      enabled: false
+      baseImages:
+        bionic:
+          candidate: bionicbase-x86_64-201904232145-ebs
+          unstable: bionicbase-unstable-x86_64-201904252133-ebs
+          release: bionicbase-x86_64-201904041959-ebs
+        xenial:
+          candidate: xenialbase-x86_64-201904232145-ebs
+          unstable: xenialbase-unstable-x86_64-201904252133-ebs
+          release: xenialbase-x86_64-201904041959-ebs
+          previous: xenialbase-x86_64-201902202219-ebs
+    ec2:
+      enabled: true
+    deliveryConfig:
+      enabled: true
+    titus:
+      enabled: false
+  constraints:
+    manual-judgement:
+      interactive-notifications:
+        enabled: true
+
+front50:
+  enabled: ${services.front50.enabled}
+  baseUrl: ${services.front50.baseUrl:http://localhost:8080}
+clouddriver:
+  enabled: ${services.clouddriver.enabled}
+  baseUrl: ${services.clouddriver.baseUrl:http://localhost:7002}
+echo:
+  enabled: ${services.echo.enabled}
+  baseUrl: ${services.echo.baseUrl:http://localhost:8089}
+igor:
+  enabled: ${services.igor.enabled}
+  baseUrl: ${services.igor.baseUrl:http://localhost:8088}
+orca:
+  enabled: ${services.orca.enabled}
+  baseUrl: ${services.orca.baseUrl:http://localhost:8083}
+
+services:
+  fiat:
+    enabled: false
+    legacyFallback: true
+    refreshable: false
+    baseUrl: ${services.fiat.baseUrl:http://localhost:7003}
+
+sql:
+  enabled: true
+  connectionPools:
+    default:
+      jdbcUrl: jdbc:mysql://127.0.0.1:3306/keel?useSSL=false&serverTimezone=UTC
+      user: root
+      password:
+  migration:
+    jdbcUrl: jdbc:mysql://127.0.0.1:3306/keel?useSSL=false&serverTimezone=UTC
+    user: root
+    password:
+
+okHttpClient:
+  # moved to spinnaker-common
+  #keyStore: /apps/keel/config/all-services-client.p12
+  #trustStore: /apps/keel/config/services-truststore.p12
+  propagateSpinnakerHeaders: true
+  connectTimeoutMs: 30000
+  readTimeoutMs: 59000
+  interceptor.skipHeaderCheck: true
+
+server:
+  port: 7002
+  legacyServerPort: 7101
+  ssl:
+    enabled: false
+    keyStore: ${user.home}/.spinnaker/keystores/localhost.p12
+    keyStorePassword: changeit
+    trustStore: ${user.home}/.spinnaker/truststores/services-truststore.p12
+    trustStorePassword: changeit
+
+EC2_REGION: us-east-2
+NETFLIX_ENVIRONMENT: ${netflix.environment}
+retrofit2:
+  logLevel: BASIC
+
+# logging:
+#   config: ${user.home}/.spinnaker/logback-defaults.xml

--- a/keel-web/config/keel.yml
+++ b/keel-web/config/keel.yml
@@ -28,7 +28,7 @@ keel:
   constraints:
     manual-judgement:
       interactive-notifications:
-        enabled: true
+        enabled: false
 
 front50:
   enabled: ${services.front50.enabled}
@@ -60,10 +60,6 @@ sql:
       jdbcUrl: jdbc:mysql://127.0.0.1:3306/keel?useSSL=false&serverTimezone=UTC
       user: root
       password:
-  migration:
-    jdbcUrl: jdbc:mysql://127.0.0.1:3306/keel?useSSL=false&serverTimezone=UTC
-    user: root
-    password:
 
 okHttpClient:
   # moved to spinnaker-common
@@ -75,7 +71,7 @@ okHttpClient:
   interceptor.skipHeaderCheck: true
 
 server:
-  port: 7002
+  port: 7010
   legacyServerPort: 7101
   ssl:
     enabled: false

--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -4,6 +4,8 @@ plugins {
   application
 }
 
+apply(plugin = "io.spinnaker.package")
+
 dependencies {
   api(project(":keel-core"))
   api(project(":keel-clouddriver"))

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/Main.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/Main.kt
@@ -27,7 +27,7 @@ private val DEFAULT_PROPS = mapOf(
   "netflix.environment" to "test",
   "netflix.account" to "\${netflix.environment}",
   "netflix.stack" to "test",
-  "spring.config.location" to "\${user.home}/.spinnaker/",
+  "spring.config.additional-location" to "\${user.home}/.spinnaker/",
   "spring.application.name" to "keel",
   "spring.config.name" to "spinnaker,\${spring.application.name}",
   "spring.profiles.active" to "\${netflix.environment},local",

--- a/keel-web/src/main/resources/application.properties
+++ b/keel-web/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
- add reasonable keel configuration defaults under `keel-web/config/keel.yml`
- apply `io.spinnaker.package` to keel-web
- use `additional-location` for additive properties

This work depends on fixing https://github.com/spinnaker/keel/issues/1409 , so let's address that first.

/cc @ezimanyi 
/cc @emjburns 
