### PR TITLE
fix(plugins): Fix discovery of supported resource kinds

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
@@ -14,22 +14,16 @@ import org.springframework.stereotype.Component
  * things like reading resources from the database, or parsing JSON.
  */
 @Component
-class ResourceSpecIdentifier @Autowired constructor (
-  private val extensionRegistry: ExtensionRegistry?
-) {
-  private var _kinds: List<SupportedKind<*>>? = null
-
+class ResourceSpecIdentifier(
   private val kinds: List<SupportedKind<*>>
-    get() {
-      return when {
-        _kinds != null -> _kinds!!
-        extensionRegistry != null -> extensionRegistry
-          .extensionsOf<ResourceSpec>()
-          .entries
-          .map { SupportedKind(ResourceKind.parseKind(it.key), it.value) }
-        else -> error("Keel is misconfigured. No resource kinds registered.")
-      }
-    }
+) {
+  @Autowired
+  constructor(extensionRegistry: ExtensionRegistry) :
+    this(extensionRegistry
+      .extensionsOf<ResourceSpec>()
+      .entries
+      .map { SupportedKind(ResourceKind.parseKind(it.key), it.value) }
+    )
 
   fun identify(kind: ResourceKind): Class<out ResourceSpec> =
     kinds.find { it.kind == kind }?.specClass ?: throw UnsupportedKind(kind)
@@ -37,7 +31,5 @@ class ResourceSpecIdentifier @Autowired constructor (
   /**
    * Constructor useful for tests so they can just wire in using varargs.
    */
-  constructor(vararg kinds: SupportedKind<*>) : this(null) {
-    _kinds = kinds.toList()
-  }
+  constructor(vararg kinds: SupportedKind<*>) : this(kinds.toList())
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
@@ -4,6 +4,8 @@ import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
+import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
+import com.netflix.spinnaker.keel.api.support.extensionsOf
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -12,14 +14,30 @@ import org.springframework.stereotype.Component
  * things like reading resources from the database, or parsing JSON.
  */
 @Component
-class ResourceSpecIdentifier @Autowired constructor(
-  private val kinds: List<SupportedKind<*>>
+class ResourceSpecIdentifier @Autowired constructor (
+  private val extensionRegistry: ExtensionRegistry?
 ) {
+  private var _kinds: List<SupportedKind<*>>? = null
+
+  private val kinds: List<SupportedKind<*>>
+    get() {
+      return when {
+        _kinds != null -> _kinds!!
+        extensionRegistry != null -> extensionRegistry
+          .extensionsOf<ResourceSpec>()
+          .entries
+          .map { SupportedKind(ResourceKind.parseKind(it.key), it.value) }
+        else -> error("Keel is misconfigured. No resource kinds registered.")
+      }
+    }
+
   fun identify(kind: ResourceKind): Class<out ResourceSpec> =
     kinds.find { it.kind == kind }?.specClass ?: throw UnsupportedKind(kind)
 
   /**
    * Constructor useful for tests so they can just wire in using varargs.
    */
-  constructor(vararg kinds: SupportedKind<*>) : this(kinds.toList())
+  constructor(vararg kinds: SupportedKind<*>) : this(null) {
+    _kinds = kinds.toList()
+  }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -17,11 +17,6 @@
 package com.netflix.spinnaker.config
 
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
-import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
-import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1
-import com.netflix.spinnaker.keel.api.ec2.EC2_SECURITY_GROUP_V1
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -47,22 +42,6 @@ import org.springframework.context.annotation.Configuration
 @EnableConfigurationProperties(CanaryConstraintConfigurationProperties::class)
 @ConditionalOnProperty("keel.plugins.ec2.enabled")
 class EC2Config {
-
-  @Bean
-  fun clusterV1() = EC2_CLUSTER_V1
-
-  @Bean
-  fun securityGroupV1() = EC2_SECURITY_GROUP_V1
-
-  @Bean
-  fun classicLoadBalancerV1() = EC2_CLASSIC_LOAD_BALANCER_V1
-
-  @Bean
-  fun applicationLoadBalancerV1() = EC2_APPLICATION_LOAD_BALANCER_V1
-
-  @Bean
-  fun applicationLoadBalancerV1dot1() = EC2_APPLICATION_LOAD_BALANCER_V1_1
-
   @Bean
   fun clusterHandler(
     cloudDriverService: CloudDriverService,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/config/TitusConfig.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.config
 
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -34,9 +33,6 @@ import org.springframework.context.annotation.Configuration
 @Configuration
 @ConditionalOnProperty("keel.plugins.titus.enabled")
 class TitusConfig {
-  @Bean
-  fun titusClusterV1() = TITUS_CLUSTER_V1
-
   @Bean
   fun titusClusterHandler(
     cloudDriverService: CloudDriverService,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
@@ -22,7 +22,6 @@ import org.springframework.stereotype.Component
 @Component
 class KeelConfigurationFinalizer(
   private val baseImageCache: BaseImageCache? = null,
-  private val kinds: List<SupportedKind<*>> = emptyList(),
   private val resourceHandlers: List<ResourceHandler<*, *>> = emptyList(),
   private val specMigrators: List<SpecMigrator<*, *>> = emptyList(),
   private val constraintEvaluators: List<ConstraintEvaluator<*>> = emptyList(),
@@ -33,6 +32,8 @@ class KeelConfigurationFinalizer(
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val kinds: List<SupportedKind<*>> by lazy { resourceHandlers.map { it.supportedKind } }
 
   // TODO: not sure if we can do this more dynamically
   @PostConstruct

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/KindController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/KindController.kt
@@ -1,6 +1,8 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.netflix.spinnaker.keel.api.plugins.SupportedKind
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
+import com.netflix.spinnaker.keel.api.support.extensionsOf
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.web.bind.annotation.GetMapping
@@ -10,9 +12,13 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping(path = ["/kinds"])
 class KindController(
-  val kinds: List<SupportedKind<*>>
+  val extensionRegistry: ExtensionRegistry
 ) {
   @GetMapping(produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE])
   fun get(): Set<String> =
-    kinds.map { it.kind.toString() }.toSet()
+    extensionRegistry
+      .extensionsOf<ResourceSpec>()
+      .entries
+      .map { it.key }
+      .toSortedSet()
 }


### PR DESCRIPTION
Replaces previous reliance on a Spring-injected list of `SupportedKind<*>` with querying the `ExtensionRegistry`, such that external plugin-provided resource kinds are included.