### PR TITLE
debug(core): Debug registration of supported resource kinds

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
 import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
 import com.netflix.spinnaker.keel.api.support.extensionsOf
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -17,13 +18,17 @@ import org.springframework.stereotype.Component
 class ResourceSpecIdentifier(
   private val kinds: List<SupportedKind<*>>
 ) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
   @Autowired
   constructor(extensionRegistry: ExtensionRegistry) :
     this(extensionRegistry
       .extensionsOf<ResourceSpec>()
       .entries
       .map { SupportedKind(ResourceKind.parseKind(it.key), it.value) }
-    )
+    ) {
+    log.debug("Registered the following kinds from extension registry: ${kinds.map { it.kind }.joinToString()}")
+  }
 
   fun identify(kind: ResourceKind): Class<out ResourceSpec> =
     kinds.find { it.kind == kind }?.specClass ?: throw UnsupportedKind(kind)


### PR DESCRIPTION
Adding some debug logs so we can see if the expected auto-wired constructor is being called.