### PR TITLE
fix(core): Delay usage of extension registry when identifying resource types

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/ResourceSpecIdentifier.kt
@@ -6,7 +6,6 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedKind
 import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
 import com.netflix.spinnaker.keel.api.support.extensionsOf
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
@@ -16,22 +15,21 @@ import org.springframework.stereotype.Component
  */
 @Component
 class ResourceSpecIdentifier(
-  private val kinds: List<SupportedKind<*>>
+  private val kinds: List<SupportedKind<*>>,
+  private val extensionRegistry: ExtensionRegistry? = null
 ) {
-  private val log by lazy { LoggerFactory.getLogger(javaClass) }
-
   @Autowired
-  constructor(extensionRegistry: ExtensionRegistry) :
-    this(extensionRegistry
-      .extensionsOf<ResourceSpec>()
+  constructor(extensionRegistry: ExtensionRegistry) : this(emptyList(), extensionRegistry)
+
+  private val ExtensionRegistry.supportedKinds: List<SupportedKind<*>>
+    get() = extensionsOf<ResourceSpec>()
       .entries
       .map { SupportedKind(ResourceKind.parseKind(it.key), it.value) }
-    ) {
-    log.debug("Registered the following kinds from extension registry: ${kinds.map { it.kind }.joinToString()}")
-  }
 
   fun identify(kind: ResourceKind): Class<out ResourceSpec> =
-    kinds.find { it.kind == kind }?.specClass ?: throw UnsupportedKind(kind)
+    // This gives priority to the extension registry which is auto-wired by default, and falls back on the list of
+    // explicit supported kinds which is only used in tests.
+    (extensionRegistry?.supportedKinds ?: kinds).find { it.kind == kind }?.specClass ?: throw UnsupportedKind(kind)
 
   /**
    * Constructor useful for tests so they can just wire in using varargs.


### PR DESCRIPTION
We were reading the supported resource kinds too early in the constructor. This PR delays that until the list is actually used to give a chance for the configuration finalizer to register the types.