### PR TITLE
test(github): java 11 only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Show version info
+        run: ./gradlew --version
       - name: Build
         run: ./gradlew build jacocoAggregateReport --stacktrace
       - name: Codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,12 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Show version info
         run: ./gradlew --version
+      - name: List of generated files before
+        run: ls keel-sql/src/generated/java
       - name: Build
         run: ./gradlew build jacocoAggregateReport --stacktrace
+      - name: List of generated files after
+        run: ls keel-sql/src/generated/java
       - name: Codecov
         uses: codecov/codecov-action@v1.0.6
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,6 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v1
-        with:
-          path: ~/.gradle
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Build
         run: ./gradlew build jacocoAggregateReport --stacktrace
       - name: Codecov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,11 @@ jobs:
       run: ./gradlew --version
     - name: List of generated files before
       run: ls keel-sql/src/generated/java || true
+    - name: current directory location
+      run: echo $PWD
     - name: Build
       run: ./gradlew build
     - name: List of generated files after
       run: ls keel-sql/src/generated/java
+    - name: List gradle files
+      run: ls ~/.gradle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,5 +18,9 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: Show version info
       run: ./gradlew --version
+    - name: List of generated files before
+      run: ls keel-sql/src/generated/java
     - name: Build
       run: ./gradlew build
+    - name: List of generated files after
+      run: ls keel-sql/src/generated/java

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Show version info
       run: ./gradlew --version
     - name: List of generated files before
-      run: ls keel-sql/src/generated/java
+      run: ls keel-sql/src/generated/java || true
     - name: Build
       run: ./gradlew build
     - name: List of generated files after

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,12 +19,12 @@ jobs:
     - name: Show version info
       run: ./gradlew --version
     - name: List of generated files before
-      run: ls keel-sql/src/generated/java || true
+      run: find keel-sql/src/generated || true
     - name: current directory location
       run: echo $PWD
-    - name: Build
-      run: ./gradlew build
+    - name: Generate source
+      run: ./gradlew generateJooqMetamodel
     - name: List of generated files after
-      run: ls keel-sql/src/generated/java
+      run: find keel-sql/src/generated
     - name: List gradle files
       run: ls ~/.gradle

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,5 +16,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
+    - name: Show version info
+      run: ./gradlew --version
     - name: Build
       run: ./gradlew build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,11 +16,5 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: ${{ matrix.java }}
-    - uses: actions/cache@v1
-      with:
-        path: ~/.gradle
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
     - name: Build
       run: ./gradlew build

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,6 @@ pull_request_rules:
   - name: Automatically merge on CI success and review
     conditions:
       - base=master
-      - status-success=build (8)
       - status-success=build (11)
       - "label=ready to merge"
       - "approved-reviews-by=@oss-approvers"
@@ -15,7 +14,6 @@ pull_request_rules:
   - name: Automatically merge release branch changes on CI success and release manager review
     conditions:
       - base~=^release-
-      - status-success=build (8)
       - status-success=build (11)
       - "label=ready to merge"
       - "approved-reviews-by=@release-managers"
@@ -42,7 +40,6 @@ pull_request_rules:
   - name: Automatically merge PRs from maintainers on CI success and review
     conditions:
       - base=master
-      - status-success=build (8)
       - status-success=build (11)
       - "label=ready to merge"
       - "author=@oss-approvers"
@@ -55,7 +52,6 @@ pull_request_rules:
   - name: Automatically merge autobump PRs on CI success
     conditions:
       - base=master
-      - status-success=build (8)
       - status-success=build (11)
       - "label~=autobump-*"
       - "author:spinnakerbot"
@@ -68,7 +64,6 @@ pull_request_rules:
   - name: Request reviews for autobump PRs on CI failure
     conditions:
       - base=master
-      - status-failure=build (8)
       - status-failure=build (11)
       - "label~=autobump-*"
       - base=master


### PR DESCRIPTION
Switch to java 11 only builds to verify we can reduce a problem where jooq generated code is written to the wrong directory.

This is happening on local development machines, even though the build is passing on master

