### PR TITLE
fix(artifacts): Allow long increasing versions

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
@@ -43,7 +43,7 @@ class TagComparator(
     val i2 = parseWithRegex(o2, strategy, customRegex)
     return when (strategy.sortType) {
       SEMVER -> semverComparator.compare(parseSemver(i1), parseSemver(i2))
-      INCREASING -> increasingComparator.compare(i1?.toIntOrNull(), i2?.toIntOrNull())
+      INCREASING -> increasingComparator.compare(i1?.toLongOrNull(), i2?.toLongOrNull())
     }
   }
 
@@ -83,8 +83,8 @@ val SEMVER_COMPARATOR: Comparator<SemVer> = Comparator { a, b ->
   b.compareTo(a)
 }
 
-val INCREASING_COMPARATOR: Comparator<Int> = Comparator { a, b ->
-  b - a
+val INCREASING_COMPARATOR: Comparator<Long> = Comparator { a, b ->
+  b.compareTo(a)
 }
 
 // descending by default

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/VersioningStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/VersioningStrategyTests.kt
@@ -35,7 +35,7 @@ import strikt.assertions.isNull
 
 class VersioningStrategyTests : JUnit5Minutests {
 
-  private val incrTags = listOf("1", "2", "3", "0")
+  private val incrTags = listOf("1", "2", "3", "0", "1597277806575", "1597276129386")
   private val semVerTags = listOf("0.0.3", "0.1.3", "0.10.3", "0.4.1")
   private val semVerTagsWithV = listOf("v0.0.3", "v0.1.3", "v0.10.3", "v0.4.1")
   private val branchJobCommitTags = listOf("master-h1.blah", "master-h2.blah", "master-h3.blah", "master-h0.blah")
@@ -46,7 +46,7 @@ class VersioningStrategyTests : JUnit5Minutests {
     context("increasing tags") {
       test("comparing gets highest") {
         val sorted = incrTags.sortedWith(TagComparator(INCREASING_TAG))
-        expectThat(sorted.first()).isEqualTo("3")
+        expectThat(sorted.first()).isEqualTo("1597277806575")
       }
     }
 


### PR DESCRIPTION
We noticed versions such as `1597277806575` were not being sorted correctly as they are bigger than `Int.MAX_VALUE`.