### PR TITLE
fix(build): Remove unnecessary task to copy generated jooq files

### DIFF
--- a/keel-sql/keel-sql.gradle.kts
+++ b/keel-sql/keel-sql.gradle.kts
@@ -8,27 +8,9 @@ plugins {
   id("org.liquibase.gradle") version "2.0.4"
 }
 
-/**
- *  Workaround to enable composite build -- jOOQ uses the output path in its config XML file relative to current
- * working directory, which in the composite build is not keel-sql. This causes the generated files to be placed
- * in the root of the parent project. This task copies them over to the right place, and will only execute in the
- * context of a composite build.
- */
-tasks.register<Copy>("copyGeneratedJooqFiles") {
-  doFirst {
-    logger.lifecycle("Running from composite build. Copying jOOQ generated files from parent project.")
-    logger.lifecycle("From: ${project.gradle.parent?.rootProject?.projectDir}/keel-sql/src/generated/java")
-    logger.lifecycle("  To: $projectDir/src/generated/java")
-  }
-  from("${project.gradle.parent?.rootProject?.projectDir}/keel-sql/src/generated/java")
-  into("$projectDir/src/generated/java")
-  dependsOn("generateJooqMetamodel")
-  onlyIf { project.gradle.parent != null }
-}
-
 afterEvaluate {
   tasks.getByName("compileKotlin") {
-    dependsOn("copyGeneratedJooqFiles")
+    dependsOn("generateJooqMetamodel")
   }
 }
 


### PR DESCRIPTION
I had previously added this task to work around the fact that, when building the Netflix wrapper project, the joog-generated files ended up in the wrong place. After @robfletcher's changes in #1426, though, not only was this unnecessary, but it was causing the composite build to fail on my machine as I had left-over files from previous builds that were being copied and overwriting the correct, newly generated ones in `keel`.