### PR TITLE
support non discovery clusters

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
@@ -6,7 +6,7 @@ import java.time.Duration.ZERO
 sealed class ClusterDeployStrategy {
   open val isStaggered: Boolean = false
   open val stagger: List<StaggeredRegion> = emptyList()
-  abstract val considerOnlyInstanceHealth: Boolean
+  abstract val noHealth: Boolean
 
   companion object {
     val DEFAULT_WAIT_FOR_INSTANCES_UP: Duration = Duration.ofMinutes(30)
@@ -14,7 +14,7 @@ sealed class ClusterDeployStrategy {
 }
 
 data class RedBlack(
-  override val considerOnlyInstanceHealth: Boolean = false,
+  override val noHealth: Boolean = false,
   // defaulting to false because this rollback behavior doesn't seem to play nice with managed delivery
   val rollbackOnFailure: Boolean? = false,
   val resizePreviousToZero: Boolean? = false,
@@ -30,7 +30,7 @@ data class RedBlack(
 }
 
 data class Highlander(
-  override val considerOnlyInstanceHealth: Boolean = false
+  override val noHealth: Boolean = false
 ) : ClusterDeployStrategy()
 
 fun ClusterDeployStrategy.withDefaultsOmitted(): ClusterDeployStrategy =

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
@@ -6,6 +6,7 @@ import java.time.Duration.ZERO
 sealed class ClusterDeployStrategy {
   open val isStaggered: Boolean = false
   open val stagger: List<StaggeredRegion> = emptyList()
+  abstract val considerOnlyAmazonHealth: Boolean
   abstract fun toOrcaJobProperties(): Map<String, Any?>
   abstract fun withDefaultsOmitted(): ClusterDeployStrategy
 
@@ -15,6 +16,7 @@ sealed class ClusterDeployStrategy {
 }
 
 data class RedBlack(
+  override val considerOnlyAmazonHealth: Boolean = false,
   // defaulting to false because this rollback behavior doesn't seem to play nice with managed delivery
   val rollbackOnFailure: Boolean? = false,
   val resizePreviousToZero: Boolean? = false,
@@ -71,7 +73,9 @@ data class RedBlack(
     )
 }
 
-object Highlander : ClusterDeployStrategy() {
+data class Highlander(
+  override val considerOnlyAmazonHealth: Boolean = false
+) : ClusterDeployStrategy() {
   override fun toOrcaJobProperties() = mapOf(
     "strategy" to "highlander",
     "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis()

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
@@ -57,7 +57,8 @@ data class RedBlack(
       (waitForInstancesUp ?: DEFAULT_WAIT_FOR_INSTANCES_UP) +
         (delayBeforeDisable ?: ZERO) +
         (delayBeforeScaleDown ?: ZERO)
-      ).toMillis()
+      ).toMillis(),
+    "interestingHealthProviderNames" to if (considerOnlyAmazonHealth) listOf("Amazon") else null
   )
 
   override val isStaggered: Boolean

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
@@ -45,7 +45,7 @@ fun ClusterDeployStrategy.withDefaultsOmitted(): ClusterDeployStrategy =
         rollbackOnFailure = nullIfDefault(rollbackOnFailure, defaults.rollbackOnFailure)
       )
     }
-      else -> this
+    else -> this
   }
 
 /**

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
@@ -6,9 +6,7 @@ import java.time.Duration.ZERO
 sealed class ClusterDeployStrategy {
   open val isStaggered: Boolean = false
   open val stagger: List<StaggeredRegion> = emptyList()
-  abstract val considerOnlyAmazonHealth: Boolean
-  abstract fun toOrcaJobProperties(): Map<String, Any?>
-  abstract fun withDefaultsOmitted(): ClusterDeployStrategy
+  abstract val considerOnlyInstanceHealth: Boolean
 
   companion object {
     val DEFAULT_WAIT_FOR_INSTANCES_UP: Duration = Duration.ofMinutes(30)
@@ -16,7 +14,7 @@ sealed class ClusterDeployStrategy {
 }
 
 data class RedBlack(
-  override val considerOnlyAmazonHealth: Boolean = false,
+  override val considerOnlyInstanceHealth: Boolean = false,
   // defaulting to false because this rollback behavior doesn't seem to play nice with managed delivery
   val rollbackOnFailure: Boolean? = false,
   val resizePreviousToZero: Boolean? = false,
@@ -27,63 +25,28 @@ data class RedBlack(
   // The order of this list is important for pauseTime based staggers
   override val stagger: List<StaggeredRegion> = emptyList()
 ) : ClusterDeployStrategy() {
-
-  companion object {
-    fun fromOrcaStageContext(context: Map<String, Any?>) =
-      RedBlack(
-        rollbackOnFailure = context["rollback"]
-          ?.let {
-            @Suppress("UNCHECKED_CAST")
-            it as Map<String, Any>
-          }
-          ?.get("onFailure") as Boolean,
-        resizePreviousToZero = context["scaleDown"] as Boolean,
-        maxServerGroups = context["maxRemainingAsgs"].toString().toInt(),
-        delayBeforeDisable = Duration.ofSeconds((context["delayBeforeDisableSec"].toString().toInt()).toLong()),
-        delayBeforeScaleDown = Duration.ofSeconds((context["delayBeforeScaleDownSec"].toString().toInt()).toLong())
-      )
-
-    val DEFAULTS = RedBlack()
-  }
-
-  override fun toOrcaJobProperties() = mapOf(
-    "strategy" to "redblack",
-    "maxRemainingAsgs" to maxServerGroups,
-    "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
-    "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
-    "scaleDown" to resizePreviousToZero,
-    "rollback" to mapOf("onFailure" to rollbackOnFailure),
-    "stageTimeoutMs" to (
-      (waitForInstancesUp ?: DEFAULT_WAIT_FOR_INSTANCES_UP) +
-        (delayBeforeDisable ?: ZERO) +
-        (delayBeforeScaleDown ?: ZERO)
-      ).toMillis(),
-    "interestingHealthProviderNames" to if (considerOnlyAmazonHealth) listOf("Amazon") else null
-  )
-
   override val isStaggered: Boolean
     get() = stagger.isNotEmpty()
-
-  override fun withDefaultsOmitted() =
-    RedBlack(
-      maxServerGroups = nullIfDefault(maxServerGroups, DEFAULTS.maxServerGroups),
-      delayBeforeDisable = nullIfDefault(delayBeforeDisable, DEFAULTS.delayBeforeDisable),
-      delayBeforeScaleDown = nullIfDefault(delayBeforeScaleDown, DEFAULTS.delayBeforeScaleDown),
-      resizePreviousToZero = nullIfDefault(resizePreviousToZero, DEFAULTS.resizePreviousToZero),
-      rollbackOnFailure = nullIfDefault(rollbackOnFailure, DEFAULTS.rollbackOnFailure)
-    )
 }
 
 data class Highlander(
-  override val considerOnlyAmazonHealth: Boolean = false
-) : ClusterDeployStrategy() {
-  override fun toOrcaJobProperties() = mapOf(
-    "strategy" to "highlander",
-    "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis()
-  )
+  override val considerOnlyInstanceHealth: Boolean = false
+) : ClusterDeployStrategy()
 
-  override fun withDefaultsOmitted() = this
-}
+fun ClusterDeployStrategy.withDefaultsOmitted(): ClusterDeployStrategy =
+  when (this) {
+    is RedBlack -> {
+      val defaults = RedBlack()
+      RedBlack(
+        maxServerGroups = nullIfDefault(maxServerGroups, defaults.maxServerGroups),
+        delayBeforeDisable = nullIfDefault(delayBeforeDisable, defaults.delayBeforeDisable),
+        delayBeforeScaleDown = nullIfDefault(delayBeforeScaleDown, defaults.delayBeforeScaleDown),
+        resizePreviousToZero = nullIfDefault(resizePreviousToZero, defaults.resizePreviousToZero),
+        rollbackOnFailure = nullIfDefault(rollbackOnFailure, defaults.rollbackOnFailure)
+      )
+    }
+      else -> this
+  }
 
 /**
  * Allows the deployment of multi-region clusters to be staggered by region.

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -35,11 +35,7 @@ data class InstanceCounts(
   val unknown: Int,
   val outOfService: Int,
   val starting: Int
-) {
-  // active asg is healthy if all instances are up
-  fun isHealthy(): Boolean =
-    up == total
-}
+)
 
 /**
  * Fields common to classes that model EC2 server groups

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -1,11 +1,9 @@
 package com.netflix.spinnaker.keel.api
 
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.netflix.spinnaker.keel.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import java.time.Duration
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
@@ -13,6 +11,7 @@ import strikt.jackson.at
 import strikt.jackson.booleanValue
 import strikt.jackson.hasSize
 import strikt.jackson.isArray
+import strikt.jackson.isBoolean
 import strikt.jackson.isMissing
 import strikt.jackson.isTextual
 import strikt.jackson.numberValue
@@ -33,7 +32,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
       test("serializes to JSON") {
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "highlander"
-          path("considerOnlyAmazonHealth").booleanValue().isFalse()
+          path("considerOnlyInstanceHealth").isBoolean().booleanValue().isFalse()
         }
       }
     }
@@ -42,12 +41,11 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
       fixture { Fixture(RedBlack()) }
 
       test("serializes to JSON") {
-        println(mapper.writeValueAsString(strategy))
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "red-black"
-          path("considerOnlyAmazonHealth").booleanValue().isFalse()
-          path("resizePreviousToZero").booleanValue().isFalse()
-          path("rollbackOnFailure").booleanValue().isFalse()
+          path("considerOnlyInstanceHealth").isBoolean().booleanValue().isFalse()
+          path("resizePreviousToZero").isBoolean().booleanValue().isFalse()
+          path("rollbackOnFailure").isBoolean().booleanValue().isFalse()
           path("maxServerGroups").numberValue().isEqualTo(2)
           path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
           path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
@@ -73,8 +71,8 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
           println(mapper.writeValueAsString(strategy))
           expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
             path("strategy").textValue() isEqualTo "red-black"
-            path("resizePreviousToZero").booleanValue().isFalse()
-            path("rollbackOnFailure").booleanValue().isFalse()
+            path("resizePreviousToZero").isBoolean().booleanValue().isFalse()
+            path("rollbackOnFailure").isBoolean().booleanValue().isFalse()
             path("maxServerGroups").numberValue().isEqualTo(2)
             path("delayBeforeDisable").isTextual().textValue() isEqualTo "PT0S"
             path("delayBeforeScaleDown").isTextual().textValue() isEqualTo "PT0S"
@@ -83,56 +81,6 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
             at("/stagger/0/hours").isTextual().textValue() isEqualTo "12-18"
             at("/stagger/0/allowedHours").isMissing()
             at("/stagger/0/pauseTime").isMissing()
-          }
-        }
-      }
-
-      context("conversion to orca job properties") {
-        context("with defaults") {
-          test("includes job properties as expected, stage timeout is default wait + margin") {
-            expectThat((strategy as RedBlack).toOrcaJobProperties()).isEqualTo(
-              mapOf(
-                "strategy" to "redblack",
-                "maxRemainingAsgs" to strategy.maxServerGroups,
-                "delayBeforeDisableSec" to strategy.delayBeforeDisable?.seconds,
-                "delayBeforeScaleDownSec" to strategy.delayBeforeScaleDown?.seconds,
-                "scaleDown" to strategy.resizePreviousToZero,
-                "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
-                "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
-                "interestingHealthProviderNames" to null
-              )
-            )
-          }
-        }
-
-        context("with overrides") {
-          fixture {
-            Fixture(
-              RedBlack(
-                delayBeforeDisable = Duration.ofMinutes(30),
-                delayBeforeScaleDown = Duration.ofMinutes(30),
-                waitForInstancesUp = Duration.ofMinutes(10)
-              )
-            )
-          }
-
-          test("includes job properties as expected, stage timeout is specified delays combined + margin") {
-            expectThat((strategy as RedBlack).toOrcaJobProperties()).isEqualTo(
-              mapOf(
-                "strategy" to "redblack",
-                "maxRemainingAsgs" to strategy.maxServerGroups,
-                "delayBeforeDisableSec" to strategy.delayBeforeDisable?.seconds,
-                "delayBeforeScaleDownSec" to strategy.delayBeforeScaleDown?.seconds,
-                "scaleDown" to strategy.resizePreviousToZero,
-                "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
-                "stageTimeoutMs" to (
-                  strategy.delayBeforeDisable!! +
-                    strategy.delayBeforeScaleDown!! +
-                    strategy.waitForInstancesUp!!
-                  ).toMillis(),
-                "interestingHealthProviderNames" to null
-              )
-            )
           }
         }
       }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -98,7 +98,8 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
                 "delayBeforeScaleDownSec" to strategy.delayBeforeScaleDown?.seconds,
                 "scaleDown" to strategy.resizePreviousToZero,
                 "rollback" to mapOf("onFailure" to strategy.rollbackOnFailure),
-                "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis()
+                "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
+                "interestingHealthProviderNames" to null
               )
             )
           }
@@ -128,7 +129,8 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
                   strategy.delayBeforeDisable!! +
                     strategy.delayBeforeScaleDown!! +
                     strategy.waitForInstancesUp!!
-                  ).toMillis()
+                  ).toMillis(),
+                "interestingHealthProviderNames" to null
               )
             )
           }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -32,7 +32,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
       test("serializes to JSON") {
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "highlander"
-          path("considerOnlyInstanceHealth").isBoolean().booleanValue().isFalse()
+          path("noHealth").isBoolean().booleanValue().isFalse()
         }
       }
     }
@@ -43,7 +43,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
       test("serializes to JSON") {
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "red-black"
-          path("considerOnlyInstanceHealth").isBoolean().booleanValue().isFalse()
+          path("noHealth").isBoolean().booleanValue().isFalse()
           path("resizePreviousToZero").isBoolean().booleanValue().isFalse()
           path("rollbackOnFailure").isBoolean().booleanValue().isFalse()
           path("maxServerGroups").numberValue().isEqualTo(2)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -28,11 +28,13 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
 
   fun tests() = rootContext<Fixture> {
     context("highlander") {
-      fixture { Fixture(Highlander) }
+      fixture { Fixture(Highlander()) }
 
       test("serializes to JSON") {
-        expectThat(mapper.writeValueAsString(strategy))
-          .isEqualTo("""{"strategy":"highlander"}""")
+        expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
+          path("strategy").textValue() isEqualTo "highlander"
+          path("considerOnlyAmazonHealth").booleanValue().isFalse()
+        }
       }
     }
 
@@ -43,6 +45,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
         println(mapper.writeValueAsString(strategy))
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "red-black"
+          path("considerOnlyAmazonHealth").booleanValue().isFalse()
           path("resizePreviousToZero").booleanValue().isFalse()
           path("rollbackOnFailure").booleanValue().isFalse()
           path("maxServerGroups").numberValue().isEqualTo(2)

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -96,8 +96,8 @@ data class ServerGroup(
     val starting: Int
   ) {
     // active asg is healthy if all instances are up
-    fun isHealthy(considerOnlyInstanceHealth: Boolean): Boolean =
-      if (considerOnlyInstanceHealth) unknown == total
+    fun isHealthy(noHealth: Boolean): Boolean =
+      if (noHealth) unknown == total
       else up == total
   }
 

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -96,8 +96,9 @@ data class ServerGroup(
     val starting: Int
   ) {
     // active asg is healthy if all instances are up
-    fun isHealthy(): Boolean =
-      up == total
+    fun isHealthy(considerOnlyInstanceHealth: Boolean): Boolean =
+      if (considerOnlyInstanceHealth) unknown == total
+      else up == total
   }
 
   data class LaunchConfiguration(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -805,7 +805,7 @@ class ClusterHandler(
     )
       .also { them ->
         val allSame: Boolean = them.distinctBy { it.launchConfiguration.appVersion }.size == 1
-        val healthy: Boolean = them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = resource.spec.deployWith.considerOnlyAmazonHealth || them.all { it.instanceCounts?.isHealthy() == true }
         if (allSame && healthy) {
           // // only publish a successfully deployed event if the server group is healthy
           val appVersion = them.first().launchConfiguration.appVersion

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -808,7 +808,7 @@ class ClusterHandler(
       .also { them ->
         val allSame: Boolean = them.distinctBy { it.launchConfiguration.appVersion }.size == 1
         val healthy: Boolean = them.all {
-          it.instanceCounts?.isHealthy(resource.spec.deployWith.considerOnlyInstanceHealth) == true
+          it.instanceCounts?.isHealthy(resource.spec.deployWith.noHealth) == true
         }
         if (allSame && healthy) {
           // // only publish a successfully deployed event if the server group is healthy

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -205,11 +205,11 @@ class ClusterHandler(
         }
         when {
           diff.shouldDeployAndModifyScalingPolicies() -> {
-            stages.add(diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties())
+            stages.add(diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon"))
             refId++
             stages.addAll(diff.modifyScalingPolicyJob(refId))
           }
-          else -> stages.add(diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties())
+          else -> stages.add(diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon"))
         }
 
         if (stages.isEmpty()) {
@@ -266,7 +266,7 @@ class ClusterHandler(
           refId++
         }
 
-        val stage = (diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties())
+        val stage = (diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon"))
           .toMutableMap()
 
         refId++

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -807,7 +807,9 @@ class ClusterHandler(
     )
       .also { them ->
         val allSame: Boolean = them.distinctBy { it.launchConfiguration.appVersion }.size == 1
-        val healthy: Boolean = resource.spec.deployWith.considerOnlyInstanceHealth || them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = them.all {
+          it.instanceCounts?.isHealthy(resource.spec.deployWith.considerOnlyInstanceHealth) == true
+        }
         if (allSame && healthy) {
           // // only publish a successfully deployed event if the server group is healthy
           val appVersion = them.first().launchConfiguration.appVersion

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -46,6 +46,7 @@ import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.serviceAccount
+import com.netflix.spinnaker.keel.api.withDefaultsOmitted
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -71,6 +72,7 @@ import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.dependsOn
 import com.netflix.spinnaker.keel.orca.restrictedExecutionWindow
+import com.netflix.spinnaker.keel.orca.toOrcaJobProperties
 import com.netflix.spinnaker.keel.orca.waitStage
 import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
 import com.netflix.spinnaker.keel.retrofit.isNotFound
@@ -805,7 +807,7 @@ class ClusterHandler(
     )
       .also { them ->
         val allSame: Boolean = them.distinctBy { it.launchConfiguration.appVersion }.size == 1
-        val healthy: Boolean = resource.spec.deployWith.considerOnlyAmazonHealth || them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = resource.spec.deployWith.considerOnlyInstanceHealth || them.all { it.instanceCounts?.isHealthy() == true }
         if (allSame && healthy) {
           // // only publish a successfully deployed event if the server group is healthy
           val appVersion = them.first().launchConfiguration.appVersion

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -733,7 +733,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
         test("a different deploy strategy is used") {
           runBlocking {
-            upsert(resource.copy(spec = resource.spec.copy(deployWith = Highlander)), diff)
+            upsert(resource.copy(spec = resource.spec.copy(deployWith = Highlander())), diff)
           }
 
           val slot = slot<OrchestrationRequest>()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -733,7 +733,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
 
         test("the cluster does not use discovery-based health during deployment") {
-          val deployWith = RedBlack(considerOnlyInstanceHealth = true)
+          val deployWith = RedBlack(noHealth = true)
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
           }
@@ -748,7 +748,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
 
         test("the cluster uses discovery-based health during deployment") {
-          val deployWith = RedBlack(considerOnlyInstanceHealth = false)
+          val deployWith = RedBlack(noHealth = false)
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
           }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -733,7 +733,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
 
         test("the cluster does not use discovery-based health during deployment") {
-          val deployWith = RedBlack(considerOnlyAmazonHealth = true)
+          val deployWith = RedBlack(considerOnlyInstanceHealth = true)
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
           }
@@ -748,7 +748,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
 
         test("the cluster uses discovery-based health during deployment") {
-          val deployWith = RedBlack(considerOnlyAmazonHealth = false)
+          val deployWith = RedBlack(considerOnlyInstanceHealth = false)
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
           }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -102,7 +102,7 @@ class ClusterExportHelper(
             null
           }
         }
-        "highlander" -> Highlander
+        "highlander" -> Highlander()
         null -> null.also {
           log.error(
             "Deployment strategy information not found for server group $serverGroupName " +

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.api.Highlander
 import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import java.time.Duration
 import kotlinx.coroutines.async
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -96,7 +97,7 @@ class ClusterExportHelper(
       when (val strategy = context?.get("strategy")) {
         "redblack" -> {
           try {
-            RedBlack.fromOrcaStageContext(context)
+            context.contextToRedBlack()
           } catch (e: ClassCastException) {
             log.error("Could not convert strategy to redblack, context is {}", context)
             null
@@ -119,6 +120,20 @@ class ClusterExportHelper(
       }
     }
   }
+
+  private fun Map<String, Any?>.contextToRedBlack() =
+    RedBlack(
+      rollbackOnFailure = this["rollback"]
+        ?.let {
+          @Suppress("UNCHECKED_CAST")
+          it as Map<String, Any>
+        }
+        ?.get("onFailure") as Boolean,
+      resizePreviousToZero = this["scaleDown"] as Boolean,
+      maxServerGroups = this["maxRemainingAsgs"].toString().toInt(),
+      delayBeforeDisable = Duration.ofSeconds((this["delayBeforeDisableSec"].toString().toInt()).toLong()),
+      delayBeforeScaleDown = Duration.ofSeconds((this["delayBeforeScaleDownSec"].toString().toInt()).toLong())
+    )
 
   @Suppress("UNCHECKED_CAST")
   private fun ExecutionDetailResponse.getDeployStageContext() =

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
@@ -26,7 +26,7 @@ fun ClusterDeployStrategy.toOrcaJobProperties(vararg instanceOnlyHealthProviders
           (delayBeforeDisable ?: ZERO) +
           (delayBeforeScaleDown ?: ZERO)
         ).toMillis(),
-      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) {
+      "interestingHealthProviderNames" to if (noHealth) {
         instanceOnlyHealthProviders.toList()
       } else {
         null
@@ -35,7 +35,7 @@ fun ClusterDeployStrategy.toOrcaJobProperties(vararg instanceOnlyHealthProviders
     is Highlander -> mapOf(
       "strategy" to "highlander",
       "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
-      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) {
+      "interestingHealthProviderNames" to if (noHealth) {
         instanceOnlyHealthProviders.toList()
       } else {
         null

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.keel.orca
+
+import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
+import com.netflix.spinnaker.keel.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
+import com.netflix.spinnaker.keel.api.Highlander
+import com.netflix.spinnaker.keel.api.RedBlack
+import java.time.Duration.ZERO
+
+/**
+ * Transforms [ClusterDeployStrategy] into the properties required for an Orca deploy stage.
+ */
+fun ClusterDeployStrategy.toOrcaJobProperties(): Map<String, Any?> =
+  when (this) {
+    is RedBlack -> mapOf(
+      "strategy" to "redblack",
+      "maxRemainingAsgs" to maxServerGroups,
+      "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
+      "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
+      "scaleDown" to resizePreviousToZero,
+      "rollback" to mapOf("onFailure" to rollbackOnFailure),
+      "stageTimeoutMs" to (
+        (waitForInstancesUp
+          ?: DEFAULT_WAIT_FOR_INSTANCES_UP) +
+          (delayBeforeDisable ?: ZERO) +
+          (delayBeforeScaleDown ?: ZERO)
+        ).toMillis(),
+      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) listOf("Amazon") else null
+    )
+    is Highlander -> mapOf(
+      "strategy" to "highlander",
+      "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
+      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) listOf("Amazon") else null
+    )
+  }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
@@ -9,7 +9,7 @@ import java.time.Duration.ZERO
 /**
  * Transforms [ClusterDeployStrategy] into the properties required for an Orca deploy stage.
  */
-fun ClusterDeployStrategy.toOrcaJobProperties(): Map<String, Any?> =
+fun ClusterDeployStrategy.toOrcaJobProperties(vararg instanceOnlyHealthProviders: String): Map<String, Any?> =
   when (this) {
     is RedBlack -> mapOf(
       "strategy" to "redblack",
@@ -24,11 +24,19 @@ fun ClusterDeployStrategy.toOrcaJobProperties(): Map<String, Any?> =
           (delayBeforeDisable ?: ZERO) +
           (delayBeforeScaleDown ?: ZERO)
         ).toMillis(),
-      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) listOf("Amazon") else null
+      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) {
+        instanceOnlyHealthProviders.toList()
+      } else {
+        null
+      }
     )
     is Highlander -> mapOf(
       "strategy" to "highlander",
       "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
-      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) listOf("Amazon") else null
+      "interestingHealthProviderNames" to if (considerOnlyInstanceHealth) {
+        instanceOnlyHealthProviders.toList()
+      } else {
+        null
+      }
     )
   }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
@@ -19,8 +19,10 @@ fun ClusterDeployStrategy.toOrcaJobProperties(vararg instanceOnlyHealthProviders
       "scaleDown" to resizePreviousToZero,
       "rollback" to mapOf("onFailure" to rollbackOnFailure),
       "stageTimeoutMs" to (
-        (waitForInstancesUp
-          ?: DEFAULT_WAIT_FOR_INSTANCES_UP) +
+        (
+          waitForInstancesUp
+            ?: DEFAULT_WAIT_FOR_INSTANCES_UP
+          ) +
           (delayBeforeDisable ?: ZERO) +
           (delayBeforeScaleDown ?: ZERO)
         ).toMillis(),

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterDeployStrategyTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterDeployStrategyTests.kt
@@ -1,0 +1,66 @@
+package com.netflix.spinnaker.keel.orca
+
+import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
+import com.netflix.spinnaker.keel.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
+import com.netflix.spinnaker.keel.api.RedBlack
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import java.time.Duration
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class ClusterDeployStrategyTests : JUnit5Minutests {
+  fun tests() = rootContext<ClusterDeployStrategy> {
+    derivedContext<RedBlack>("red-black") {
+      fixture { RedBlack() }
+
+      context("conversion to orca job properties") {
+        context("with defaults") {
+          test("includes job properties as expected, stage timeout is default wait + margin") {
+            expectThat(toOrcaJobProperties()).isEqualTo(
+              mapOf(
+                "strategy" to "redblack",
+                "maxRemainingAsgs" to maxServerGroups,
+                "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
+                "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
+                "scaleDown" to resizePreviousToZero,
+                "rollback" to mapOf("onFailure" to rollbackOnFailure),
+                "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
+                "interestingHealthProviderNames" to null
+              )
+            )
+          }
+        }
+
+        context("with overrides") {
+          fixture {
+            RedBlack(
+              delayBeforeDisable = Duration.ofMinutes(30),
+              delayBeforeScaleDown = Duration.ofMinutes(30),
+              waitForInstancesUp = Duration.ofMinutes(10)
+            )
+          }
+
+          test("includes job properties as expected, stage timeout is specified delays combined + margin") {
+            expectThat(toOrcaJobProperties()).isEqualTo(
+              mapOf(
+                "strategy" to "redblack",
+                "maxRemainingAsgs" to maxServerGroups,
+                "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
+                "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
+                "scaleDown" to resizePreviousToZero,
+                "rollback" to mapOf("onFailure" to rollbackOnFailure),
+                "stageTimeoutMs" to (
+                  delayBeforeDisable!! +
+                    delayBeforeScaleDown!! +
+                    waitForInstancesUp!!
+                  ).toMillis(),
+                "interestingHealthProviderNames" to null
+              )
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterDeployStrategyTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterDeployStrategyTests.kt
@@ -17,18 +17,19 @@ class ClusterDeployStrategyTests : JUnit5Minutests {
       context("conversion to orca job properties") {
         context("with defaults") {
           test("includes job properties as expected, stage timeout is default wait + margin") {
-            expectThat(toOrcaJobProperties()).isEqualTo(
-              mapOf(
-                "strategy" to "redblack",
-                "maxRemainingAsgs" to maxServerGroups,
-                "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
-                "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
-                "scaleDown" to resizePreviousToZero,
-                "rollback" to mapOf("onFailure" to rollbackOnFailure),
-                "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
-                "interestingHealthProviderNames" to null
+            expectThat(toOrcaJobProperties("Amazon"))
+              .isEqualTo(
+                mapOf(
+                  "strategy" to "redblack",
+                  "maxRemainingAsgs" to maxServerGroups,
+                  "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
+                  "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
+                  "scaleDown" to resizePreviousToZero,
+                  "rollback" to mapOf("onFailure" to rollbackOnFailure),
+                  "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
+                  "interestingHealthProviderNames" to null
+                )
               )
-            )
           }
         }
 
@@ -42,22 +43,23 @@ class ClusterDeployStrategyTests : JUnit5Minutests {
           }
 
           test("includes job properties as expected, stage timeout is specified delays combined + margin") {
-            expectThat(toOrcaJobProperties()).isEqualTo(
-              mapOf(
-                "strategy" to "redblack",
-                "maxRemainingAsgs" to maxServerGroups,
-                "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
-                "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
-                "scaleDown" to resizePreviousToZero,
-                "rollback" to mapOf("onFailure" to rollbackOnFailure),
-                "stageTimeoutMs" to (
-                  delayBeforeDisable!! +
-                    delayBeforeScaleDown!! +
-                    waitForInstancesUp!!
-                  ).toMillis(),
-                "interestingHealthProviderNames" to null
+            expectThat(toOrcaJobProperties("Amazon"))
+              .isEqualTo(
+                mapOf(
+                  "strategy" to "redblack",
+                  "maxRemainingAsgs" to maxServerGroups,
+                  "delayBeforeDisableSec" to delayBeforeDisable?.seconds,
+                  "delayBeforeScaleDownSec" to delayBeforeScaleDown?.seconds,
+                  "scaleDown" to resizePreviousToZero,
+                  "rollback" to mapOf("onFailure" to rollbackOnFailure),
+                  "stageTimeoutMs" to (
+                    delayBeforeDisable!! +
+                      delayBeforeScaleDown!! +
+                      waitForInstancesUp!!
+                    ).toMillis(),
+                  "interestingHealthProviderNames" to null
+                )
               )
-            )
           }
         }
       }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -425,7 +425,7 @@ class TitusClusterHandler(
       .also { them ->
         val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
         val healthy: Boolean = them.all {
-          it.instanceCounts?.isHealthy(resource.spec.deployWith.considerOnlyInstanceHealth) == true
+          it.instanceCounts?.isHealthy(resource.spec.deployWith.noHealth) == true
         }
         if (sameContainer && healthy) {
           // only publish a successfully deployed event if the server group is healthy

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -424,7 +424,9 @@ class TitusClusterHandler(
     )
       .also { them ->
         val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
-        val healthy: Boolean = resource.spec.deployWith.considerOnlyInstanceHealth || them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = them.all {
+          it.instanceCounts?.isHealthy(resource.spec.deployWith.considerOnlyInstanceHealth) == true
+        }
         if (sameContainer && healthy) {
           // only publish a successfully deployed event if the server group is healthy
           val container = them.first().container

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -149,7 +149,7 @@ class TitusClusterHandler(
 
           val job = when {
             diff.isCapacityOnly() -> diff.resizeServerGroupJob()
-            else -> diff.upsertServerGroupJob(tagToUse) + resource.spec.deployWith.toOrcaJobProperties()
+            else -> diff.upsertServerGroupJob(tagToUse) + resource.spec.deployWith.toOrcaJobProperties("Amazon")
           }
 
           val description = when (version) {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -422,7 +422,7 @@ class TitusClusterHandler(
     )
       .also { them ->
         val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
-        val healthy: Boolean = them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = resource.spec.deployWith.considerOnlyAmazonHealth || them.all { it.instanceCounts?.isHealthy() == true }
         if (sameContainer && healthy) {
           // only publish a successfully deployed event if the server group is healthy
           val container = them.first().container

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -44,6 +44,7 @@ import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.exceptions.RegistryNotFoundException
 import com.netflix.spinnaker.keel.api.titus.exceptions.TitusAccountConfigurationException
+import com.netflix.spinnaker.keel.api.withDefaultsOmitted
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -65,6 +66,7 @@ import com.netflix.spinnaker.keel.exceptions.DockerArtifactExportError
 import com.netflix.spinnaker.keel.exceptions.ExportError
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.orca.toOrcaJobProperties
 import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
@@ -422,7 +424,7 @@ class TitusClusterHandler(
     )
       .also { them ->
         val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
-        val healthy: Boolean = resource.spec.deployWith.considerOnlyAmazonHealth || them.all { it.instanceCounts?.isHealthy() == true }
+        val healthy: Boolean = resource.spec.deployWith.considerOnlyInstanceHealth || them.all { it.instanceCounts?.isHealthy() == true }
         if (sameContainer && healthy) {
           // only publish a successfully deployed event if the server group is healthy
           val container = them.first().container

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -469,7 +469,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
         test("a different deploy strategy is used") {
           runBlocking {
-            upsert(resource.copy(spec = resource.spec.copy(deployWith = Highlander)), diff)
+            upsert(resource.copy(spec = resource.spec.copy(deployWith = Highlander())), diff)
           }
 
           val slot = slot<OrchestrationRequest>()


### PR DESCRIPTION
Clusters that don't use Discovery-based health need to send an additional parameter to Orca, and should be considered healthy regardless of Discovery health counts.