### PR TITLE
feat(api): Enable resources with just regions for locations

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -11,6 +11,14 @@ interface Locatable<T : Locations<*>> : ResourceSpec {
   val locations: T
 }
 
+/** A [Locations] type for resources where the regions alone are sufficient information */
+data class SimpleRegions(override val regions: Set<SimpleRegionSpec>) : Locations<SimpleRegionSpec>
+
+abstract class AccountAwareLocations<T : RegionSpec> : Locations<T> {
+  abstract val account: String
+}
+
+/** A [Locations] type for resources where the VPC and subnet matter. */
 data class SubnetAwareLocations(
   override val account: String,
   /**
@@ -18,9 +26,9 @@ data class SubnetAwareLocations(
    */
   val subnet: String?,
   // TODO: this is not ideal as we'd like this default to be configurable
-  override val vpc: String? = defaultVPC(subnet),
+  val vpc: String? = defaultVPC(subnet),
   override val regions: Set<SubnetAwareRegionSpec>
-) : Locations<SubnetAwareRegionSpec> {
+) : AccountAwareLocations<SubnetAwareRegionSpec>() {
   // TODO: probably should be an extension at use-site
   fun withDefaultsOmitted() =
     copy(
@@ -37,12 +45,13 @@ data class SubnetAwareLocations(
     )
 }
 
+/** A [Locations] type for resources where the VPC matters. */
 data class SimpleLocations(
   override val account: String,
   // TODO: this is not ideal as we'd like this default to be configurable
-  override val vpc: String? = DEFAULT_VPC_NAME,
+  val vpc: String? = DEFAULT_VPC_NAME,
   override val regions: Set<SimpleRegionSpec>
-) : Locations<SimpleRegionSpec>
+) : AccountAwareLocations<SimpleRegionSpec>()
 
 object LocationConstants {
   const val DEFAULT_VPC_NAME = "vpc0"

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -28,7 +28,7 @@ data class SubnetAwareLocations(
   // TODO: this is not ideal as we'd like this default to be configurable
   val vpc: String? = defaultVPC(subnet),
   override val regions: Set<SubnetAwareRegionSpec>
-) : AccountAwareLocations<SubnetAwareRegionSpec>() {
+) : AccountAwareLocations<SubnetAwareRegionSpec> {
   // TODO: probably should be an extension at use-site
   fun withDefaultsOmitted() =
     copy(

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -14,8 +14,8 @@ interface Locatable<T : Locations<*>> : ResourceSpec {
 /** A [Locations] type for resources where the regions alone are sufficient information */
 data class SimpleRegions(override val regions: Set<SimpleRegionSpec>) : Locations<SimpleRegionSpec>
 
-abstract class AccountAwareLocations<T : RegionSpec> : Locations<T> {
-  abstract val account: String
+interface AccountAwareLocations<T : RegionSpec> : Locations<T> {
+  val account: String
 }
 
 /** A [Locations] type for resources where the VPC and subnet matter. */

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locatable.kt
@@ -51,7 +51,7 @@ data class SimpleLocations(
   // TODO: this is not ideal as we'd like this default to be configurable
   val vpc: String? = DEFAULT_VPC_NAME,
   override val regions: Set<SimpleRegionSpec>
-) : AccountAwareLocations<SimpleRegionSpec>()
+) : AccountAwareLocations<SimpleRegionSpec>
 
 object LocationConstants {
   const val DEFAULT_VPC_NAME = "vpc0"

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locations.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Locations.kt
@@ -1,11 +1,5 @@
 package com.netflix.spinnaker.keel.api
 
 interface Locations<T : RegionSpec> {
-  val account: String
-  /**
-   * If not specified here, this should be derived from the [SubnetAwareLocations.subnet] (if
-   * present) or use a default VPC name.
-   */
-  val vpc: String?
   val regions: Set<T>
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -6,8 +6,6 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.SimpleLocations
-import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.StatefulConstraint
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
@@ -157,11 +155,7 @@ class ApplicationService(
         null
       },
       locations = if (spec is Locatable<*>) {
-        SimpleLocations(
-          account = (spec as Locatable<*>).locations.account,
-          vpc = (spec as Locatable<*>).locations.vpc,
-          regions = (spec as Locatable<*>).locations.regions.map { SimpleRegionSpec(it.name) }.toSet()
-        )
+        (spec as Locatable<*>).locations
       } else {
         null
       },


### PR DESCRIPTION
As discussed, certain resources won't concern themselves with VPCs and subnets. This PR introduces an even simpler `Locations` implementation that contains the regions alone.