### PR TITLE
feat(build): Replace jooqModelator with native jooq tooling + docker

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -23,6 +23,4 @@ RUN usermod -d /var/lib/mysql/ mysql && \
 
 CMD /etc/init.d/mysql restart && \
     ./gradlew --no-daemon -PenableCrossCompilerPlugin=true -PbuildingInDocker=true \
-        keel-sql:liquibaseUpdate \
-        keel-sql:jooqGenerate \
         keel-web:installDist -x test

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,11 +1,28 @@
 FROM ubuntu:bionic
 LABEL maintainer="sig-platform@spinnaker.io"
+RUN echo "mysql-server mysql-server/root_password password sa" | debconf-set-selections
+RUN echo "mysql-server mysql-server/root_password_again password sa" | debconf-set-selections
 RUN apt-get update && apt-get install -y \
     openjdk-8-jdk \
     openjdk-11-jdk \
+    mysql-server \
  && rm -rf /var/lib/apt/lists/*
 ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
 ENV GRADLE_OPTS -Xmx6g
-CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true keel-web:installDist -x test
+
+RUN usermod -d /var/lib/mysql/ mysql && \
+    sed -i "s/bind-address\s*=\s*127.0.0.1/bind-address = 0.0.0.0/" /etc/mysql/mysql.conf.d/mysqld.cnf && \
+    sed -i "s/port\s*=\s*3306/port = 6603/" /etc/mysql/mysql.conf.d/mysqld.cnf && \
+    /etc/init.d/mysql start && \
+    mysql -u root --password=sa -e "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'sa' WITH GRANT OPTION;" && \
+    mysql -u root --password=sa -e "GRANT PROXY ON ''@'' TO 'root'@'%' WITH GRANT OPTION;" && \
+    /etc/init.d/mysql restart && \
+    mysql -u root --password=sa -e 'CREATE DATABASE `keel` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
+
+CMD /etc/init.d/mysql restart && \
+    ./gradlew --no-daemon -PenableCrossCompilerPlugin=true -PbuildingInDocker=true \
+        keel-sql:liquibaseUpdate \
+        keel-sql:jooqGenerate \
+        keel-web:installDist -x test

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ korkVersion=7.60.1
 liquibaseTaskPrefix=liquibase
 org.gradle.parallel=true
 spinnakerGradleVersion=8.5.0
+buildingInDocker=false
 
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.

--- a/keel-sql/keel-sql.gradle.kts
+++ b/keel-sql/keel-sql.gradle.kts
@@ -1,12 +1,11 @@
-import ch.ayedo.jooqmodelator.gradle.JooqModelatorTask
 import com.diffplug.gradle.spotless.SpotlessExtension
+import java.lang.Thread.sleep
 
 val buildingInDocker = project.properties["buildingInDocker"]?.toString().let { it == "true" }
 
 plugins {
   `java-library`
   id("kotlin-spring")
-  id("ch.ayedo.jooqmodelator") version "3.9.0"
   id("nu.studer.jooq") version "5.0.1"
   id("org.liquibase.gradle") version "2.0.4"
 }
@@ -15,7 +14,7 @@ afterEvaluate {
   // When not running in Docker, we can use jooqModelator (which itself uses Docker) to generate the jOOQ meta-model
   if (!buildingInDocker) {
     tasks.getByName("compileKotlin") {
-      dependsOn("generateJooqMetamodel")
+      dependsOn("jooqGenerate")
     }
   }
 }
@@ -57,9 +56,6 @@ dependencies {
   testImplementation("org.testcontainers:mysql")
   testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
 
-  jooqModelatorRuntime(platform("com.netflix.spinnaker.kork:kork-bom:${property("korkVersion")}"))
-  jooqModelatorRuntime("mysql:mysql-connector-java")
-
   jooqGenerator(platform("com.netflix.spinnaker.kork:kork-bom:${property("korkVersion")}"))
   jooqGenerator("mysql:mysql-connector-java")
   jooqGenerator("org.jooq:jooq-meta-extensions")
@@ -72,17 +68,16 @@ dependencies {
   liquibaseRuntime("mysql:mysql-connector-java")
 }
 
-jooqModelator {
-  jooqVersion = "3.13.2"
-  jooqEdition = "OSS"
-  jooqConfigPath = "$buildDir/resources/main/jooqConfig.xml"
-  jooqOutputPath = "$projectDir/src/generated/java"
-  migrationEngine = "LIQUIBASE"
-  migrationsPaths = listOf("$projectDir/src/main/resources/db")
-  dockerTag = "mysql/mysql-server:5.7"
-  dockerEnv = listOf("MYSQL_ROOT_PASSWORD=sa", "MYSQL_ROOT_HOST=%", "MYSQL_DATABASE=keel")
-  dockerHostPort = 6603
-  dockerContainerPort = 3306
+tasks.register<Exec>("runMysql") {
+  commandLine("docker run --name mysqlJooq -d --rm -e MYSQL_ROOT_PASSWORD=sa -e MYSQL_DATABASE=keel -p 6603:3306 mysql:5.7".split(" "))
+  doLast {
+    // Wait for the DB server to come up...
+    sleep(15 * 1000)
+  }
+}
+
+tasks.register<Exec>("stopMysql") {
+  commandLine("docker stop mysqlJooq".split(" "))
 }
 
 // Task used when building in Docker in place of jooqModelator (see Dockerfile.compile)
@@ -93,6 +88,13 @@ tasks.register<JavaExec>("jooqGenerate") {
   main = "org.jooq.codegen.GenerationTool"
   args = listOf("$buildDir/resources/main/jooqConfig.xml")
   dependsOn("processResources")
+  if (!buildingInDocker) {
+    dependsOn("runMysql")
+    dependsOn("liquibaseUpdate").mustRunAfter("runMysql")
+    finalizedBy("stopMysql")
+  } else {
+    dependsOn("liquibaseUpdate")
+  }
 }
 
 // expand properties in jooqConfig.xml so it gets a fully-qualified directory to generate into
@@ -100,11 +102,6 @@ tasks.withType<ProcessResources> {
   filesMatching("jooqConfig.xml") {
     expand(project.properties)
   }
-}
-
-// process resources before generating JOOQ stuff so we tokenize the config XML
-tasks.withType<JooqModelatorTask> {
-  dependsOn("processResources")
 }
 
 // Don't enforce spotless for generated code
@@ -130,10 +127,10 @@ liquibase {
     arguments = mapOf(
       "logLevel" to "info",
       "changeLogFile" to "src/main/resources/db/databaseChangeLog.yml",
-      "url" to "jdbc:mysql://localhost:6603/keel?useSSL=false&serverTimezone=UTC",
+      "url" to "jdbc:mysql://127.0.0.1:6603/keel?useSSL=false&serverTimezone=UTC",
       "username" to "root",
       "password" to "sa"
     )
   }
-  runList = if (buildingInDocker) "docker" else "local"
+  runList = "docker"
 }

--- a/keel-sql/keel-sql.gradle.kts
+++ b/keel-sql/keel-sql.gradle.kts
@@ -11,11 +11,8 @@ plugins {
 }
 
 afterEvaluate {
-  // When not running in Docker, we can use jooqModelator (which itself uses Docker) to generate the jOOQ meta-model
-  if (!buildingInDocker) {
-    tasks.getByName("compileKotlin") {
-      dependsOn("jooqGenerate")
-    }
+  tasks.getByName("compileKotlin") {
+    dependsOn("jooqGenerate")
   }
 }
 

--- a/keel-sql/src/main/resources/jooqConfig.xml
+++ b/keel-sql/src/main/resources/jooqConfig.xml
@@ -2,7 +2,7 @@
 <configuration xmlns="http://www.jooq.org/xsd/jooq-codegen-3.13.0.xsd">
   <jdbc>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://localhost:6603/keel?useLegacyDatetimeCode=false&amp;serverTimezone=UTC</url>
+    <url>jdbc:mysql://127.0.0.1:6603/keel?useLegacyDatetimeCode=false&amp;serverTimezone=UTC</url>
     <user>root</user>
     <password>sa</password>
   </jdbc>

--- a/keel-sql/src/main/resources/jooqConfig.xml
+++ b/keel-sql/src/main/resources/jooqConfig.xml
@@ -2,7 +2,7 @@
 <configuration xmlns="http://www.jooq.org/xsd/jooq-codegen-3.13.0.xsd">
   <jdbc>
     <driver>com.mysql.cj.jdbc.Driver</driver>
-    <url>jdbc:mysql://127.0.0.1:6603/keel?useLegacyDatetimeCode=false&amp;serverTimezone=UTC</url>
+    <url>jdbc:mysql://localhost:6603/keel?useLegacyDatetimeCode=false&amp;serverTimezone=UTC</url>
     <user>root</user>
     <password>sa</password>
   </jdbc>


### PR DESCRIPTION
This PR introduces the ability to build keel inside a Docker container by installing MySQL in the container, then using liquibase and the standard jOOQ code generation tool in place of the jooqModelator plugin (which itself uses Docker).

Cc: @nimakaviani 