### PR TITLE
feat(plugins): Enablement for Java plugins

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -22,9 +22,6 @@ data class Resource<out T : ResourceSpec>(
   val application: String
     get() = metadata.getValue("application").toString()
 
-  val environment: String
-    get() = metadata.getValue("environmentName").toString()
-
   /**
    * Attempts to find an artifact in the delivery config based on information in this resource's spec.
    */

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -13,6 +13,18 @@ data class Resource<out T : ResourceSpec>(
     require(metadata["application"].isValidApplication()) { "application must be a valid application" }
   }
 
+  val id: String
+    get() = metadata.getValue("id").toString()
+
+  val serviceAccount: String
+    get() = metadata.getValue("serviceAccount").toString()
+
+  val application: String
+    get() = metadata.getValue("application").toString()
+
+  val environment: String
+    get() = metadata.getValue("environmentName").toString()
+
   /**
    * Attempts to find an artifact in the delivery config based on information in this resource's spec.
    */
@@ -57,15 +69,6 @@ data class Resource<out T : ResourceSpec>(
  */
 fun generateId(kind: ResourceKind, spec: ResourceSpec) =
   "${kind.group}:${kind.kind}:${spec.id}"
-
-val <T : ResourceSpec> Resource<T>.id: String
-  get() = metadata.getValue("id").toString()
-
-val <T : ResourceSpec> Resource<T>.serviceAccount: String
-  get() = metadata.getValue("serviceAccount").toString()
-
-val <T : ResourceSpec> Resource<T>.application: String
-  get() = metadata.getValue("application").toString()
 
 private fun Any?.isValidId() =
   when (this) {

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/actuation/TaskLauncher.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/actuation/TaskLauncher.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.api.actuation
 
 import com.netflix.spinnaker.keel.api.NotificationConfig
 import com.netflix.spinnaker.keel.api.Resource
+import java.util.concurrent.CompletableFuture
 
 interface TaskLauncher {
   suspend fun submitJob(
@@ -23,6 +24,13 @@ interface TaskLauncher {
     correlationId: String,
     stages: List<Map<String, Any?>>
   ): Task
+
+  fun submitJobAsync(
+    resource: Resource<*>,
+    description: String,
+    correlationId: String,
+    stages: List<Map<String, Any?>>
+  ): CompletableFuture<Task>
 
   suspend fun submitJob(
     user: String,

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactDeployedListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactDeployedListenerTests.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.test.DummyResourceSpec

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactDeployingListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactDeployingListenerTests.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.test.DummyResourceSpec

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -6,7 +6,6 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import com.netflix.spinnaker.keel.core.api.normalize

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -7,7 +7,6 @@ import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.kind
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
@@ -17,7 +17,6 @@
  */
 package com.netflix.spinnaker.keel.persistence
 
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.time.MutableClock

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -17,8 +17,6 @@ package com.netflix.spinnaker.keel.persistence
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -2,8 +2,6 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.activation.ApplicationDown
 import com.netflix.spinnaker.keel.activation.ApplicationUp
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.AgentLockRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactCheckTimedOut

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -7,7 +7,6 @@ import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.actuation.Task
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResolvableResourceHandler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResolvableResourceHandler.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.api.plugins
 
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.id
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -6,7 +6,6 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.APPROVED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ResourceSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ResourceSummary.kt
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 
 /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/diff/AdHocDiffer.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.keel.diff
 
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -26,8 +26,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.actuation.Task
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceState.Diff
 import com.netflix.spinnaker.keel.events.ResourceState.Error

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidResourceException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidResourceException.kt
@@ -19,7 +19,6 @@
 package com.netflix.spinnaker.keel.exceptions
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.kork.exceptions.UserException
 
 sealed class InvalidResourceException(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.api.Constraint
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
+import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
@@ -37,6 +38,7 @@ import com.netflix.spinnaker.keel.jackson.mixins.DeliveryArtifactMixin
 import com.netflix.spinnaker.keel.jackson.mixins.LocatableMixin
 import com.netflix.spinnaker.keel.jackson.mixins.MonikeredMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ResourceKindMixin
+import com.netflix.spinnaker.keel.jackson.mixins.ResourceMixin
 import com.netflix.spinnaker.keel.jackson.mixins.StaggeredRegionMixin
 import com.netflix.spinnaker.keel.jackson.mixins.SubnetAwareRegionSpecMixin
 
@@ -57,6 +59,7 @@ object KeelApiModule : SimpleModule("Keel API") {
       setMixInAnnotations<ResourceKind, ResourceKindMixin>()
       setMixInAnnotations<StaggeredRegion, StaggeredRegionMixin>()
       setMixInAnnotations<SubnetAwareRegionSpec, SubnetAwareRegionSpecMixin>()
+      setMixInAnnotations<Resource<*>, ResourceMixin>()
     }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceMixin.kt
@@ -1,0 +1,17 @@
+package com.netflix.spinnaker.keel.jackson.mixins
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+interface ResourceMixin {
+  @get:JsonIgnore
+  val id: String
+
+  @get:JsonIgnore
+  val serviceAccount: String
+
+  @get:JsonIgnore
+  val application: String
+
+  @get:JsonIgnore
+  val environment: String
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceMixin.kt
@@ -11,7 +11,4 @@ interface ResourceMixin {
 
   @get:JsonIgnore
   val application: String
-
-  @get:JsonIgnore
-  val environment: String
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.logging
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.id
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.slf4j.MDCContext
 import kotlinx.coroutines.withContext

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauser.kt
@@ -18,8 +18,6 @@
 package com.netflix.spinnaker.keel.pause
 
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -11,7 +11,6 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -7,7 +7,6 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.persistence.KeelReadOnlyRepository
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceHistoryEvent

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -14,7 +14,6 @@ import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
 import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
 import com.netflix.spinnaker.keel.api.constraints.UpdatedConstraintStatus
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.supporting

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -19,8 +19,6 @@ package com.netflix.spinnaker.keel.veto.unhappy
 
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.UnhappyControl
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
 import com.netflix.spinnaker.keel.veto.Veto

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -3,8 +3,6 @@ package com.netflix.spinnaker.keel.actuation
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.actuation.Task
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.api.randomUID

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -6,7 +6,6 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
@@ -2,12 +2,17 @@ package com.netflix.spinnaker.keel.api
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.TEST_API_V1
+import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import org.assertj.core.api.Assertions.assertThat
 import strikt.api.expectThat
 import strikt.assertions.get
 import strikt.assertions.hasEntry
 import strikt.assertions.isEqualTo
+
 
 internal class ResourceMetadataTests : JUnit5Minutests {
 
@@ -67,6 +72,27 @@ internal class ResourceMetadataTests : JUnit5Minutests {
       test("deserializes extra data") {
         expectThat(mapper.readValue<Map<String, Any?>>(this))
           .hasEntry("namespace", "default")
+      }
+    }
+
+    derivedContext<Resource<*>>("standard metadata fields") {
+      fixture {
+        Resource(
+          kind = TEST_API_V1.qualify("whatever"),
+          spec = DummyResourceSpec(id = "myResource", application = "fnord"),
+          metadata =  mapOf(
+          "id" to "myResource",
+          "serviceAccount" to "myAccount",
+          "application" to "fnord",
+          "environmentName" to "test"
+        ))
+      }
+
+      test("are exposed via field accessors") {
+        assertThat(this.id).isEqualTo("myResource")
+        assertThat(this.serviceAccount).isEqualTo("myAccount")
+        assertThat(this.application).isEqualTo("fnord")
+        assertThat(this.environment).isEqualTo("test")
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ResourceMetadataTests.kt
@@ -83,8 +83,7 @@ internal class ResourceMetadataTests : JUnit5Minutests {
           metadata =  mapOf(
           "id" to "myResource",
           "serviceAccount" to "myAccount",
-          "application" to "fnord",
-          "environmentName" to "test"
+          "application" to "fnord"
         ))
       }
 
@@ -92,7 +91,6 @@ internal class ResourceMetadataTests : JUnit5Minutests {
         assertThat(this.id).isEqualTo("myResource")
         assertThat(this.serviceAccount).isEqualTo("myAccount")
         assertThat(this.application).isEqualTo("fnord")
-        assertThat(this.environment).isEqualTo("test")
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/diff/AdHocDifferTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/diff/AdHocDifferTests.kt
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.keel.diff
 
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/logging/TracingSupportTests.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.logging
 
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Moniker
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.X_SPINNAKER_RESOURCE_ID
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.test.resource

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/pause/ActuationPauserTests.kt
@@ -17,8 +17,6 @@
  */
 package com.netflix.spinnaker.keel.pause
 
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusServiceTests.kt
@@ -1,7 +1,5 @@
 package com.netflix.spinnaker.keel.services
 
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/veto/UnhappyVetoTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/veto/UnhappyVetoTests.kt
@@ -17,8 +17,6 @@
  */
 package com.netflix.spinnaker.keel.veto
 
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository.UnhappyVetoStatus

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.TagComparator

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolverTests.kt
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.exceptions.NoDockerImageSatisfiesConstraints
 import com.netflix.spinnaker.keel.persistence.KeelRepository

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -12,7 +12,6 @@ import com.netflix.spinnaker.keel.api.ec2.JenkinsImageProvider
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
 import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
 import com.netflix.spinnaker.keel.api.ec2.VirtualMachineImage
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -15,10 +15,8 @@ import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.Location
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -17,10 +17,8 @@ import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.Location
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -42,10 +42,8 @@ import com.netflix.spinnaker.keel.api.ec2.TargetTrackingPolicy
 import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.api.ec2.byRegion
 import com.netflix.spinnaker.keel.api.ec2.resolve
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.withDefaultsOmitted
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -36,10 +36,8 @@ import com.netflix.spinnaker.keel.api.ec2.SecurityGroupOverride
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule.Protocol
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.api.ec2.VirtualMachineImage
 import com.netflix.spinnaker.keel.api.ec2.resolve
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -15,7 +15,6 @@ import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.ec2.ImageProvider
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -25,9 +25,7 @@ import com.netflix.spinnaker.keel.api.ec2.VirtualMachineImage
 import com.netflix.spinnaker.keel.api.ec2.byRegion
 import com.netflix.spinnaker.keel.api.ec2.resolve
 import com.netflix.spinnaker.keel.api.ec2.resolveCapacity
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/OrcaTaskLauncherTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/OrcaTaskLauncherTests.kt
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.keel.api.NotificationConfig
 import com.netflix.spinnaker.keel.api.NotificationFrequency.quiet
 import com.netflix.spinnaker.keel.api.NotificationType.slack
 import com.netflix.spinnaker.keel.api.Resource
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_FAILED
 import com.netflix.spinnaker.keel.model.OrchestrationRequest

--- a/keel-echo/src/main/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifier.kt
+++ b/keel-echo/src/main/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifier.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.echo
 
 import com.netflix.spinnaker.config.ManualJudgementNotificationConfig
 import com.netflix.spinnaker.keel.api.NotificationConfig
-import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.events.ConstraintStateChanged
 import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -5,7 +5,6 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.NotificationConfig
 import com.netflix.spinnaker.keel.api.NotificationFrequency
 import com.netflix.spinnaker.keel.api.NotificationType
-import com.netflix.spinnaker.keel.api.application
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.events.ConstraintStateChanged

--- a/keel-orca/keel-orca.gradle.kts
+++ b/keel-orca/keel-orca.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("com.fasterxml.jackson.core:jackson-annotations")
   implementation("org.jetbrains.kotlin:kotlin-reflect")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
 

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskLauncher.kt
@@ -22,9 +22,6 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.actuation.SubjectType
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.events.TaskCreatedEvent
 import com.netflix.spinnaker.keel.model.Job

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskLauncher.kt
@@ -30,9 +30,12 @@ import com.netflix.spinnaker.keel.model.OrchestrationTrigger
 import com.netflix.spinnaker.keel.model.toOrcaNotification
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.TaskRecord
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.future.future
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
 
 /**
  * Wraps [OrcaService] to make it easier to launch tasks in a standard way.
@@ -59,6 +62,15 @@ class OrcaTaskLauncher(
       stages = stages,
       type = SubjectType.RESOURCE
     )
+
+  override fun submitJobAsync(
+    resource: Resource<*>,
+    description: String,
+    correlationId: String,
+    stages: List<Map<String, Any?>>
+  ): CompletableFuture<Task> = GlobalScope.future {
+    submitJob(resource, description, correlationId, stages)
+  }
 
   override suspend fun submitJob(
     user: String,

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgentTests.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.orca
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.actuation.SubjectType
 import com.netflix.spinnaker.keel.api.actuation.Task
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.ResourceTaskFailed
 import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -9,7 +9,6 @@ import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.allPass
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.api.statefulCount

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.PersistentEvent

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/LegacySpecUpgradeTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/LegacySpecUpgradeTests.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.sql
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.resources.SpecMigrator

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -4,7 +4,6 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.core.api.SubmittedEnvironment

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -36,10 +36,8 @@ import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.InstanceCounts
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.exceptions.RegistryNotFoundException

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -11,7 +11,6 @@ import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_CO
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.cluster.ResourcesSpec

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -31,9 +31,7 @@ import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.InstanceCounts
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.api.plugins.Resolver
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.cluster.TitusClusterHandler

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupport.kt
@@ -20,8 +20,6 @@ package com.netflix.spinnaker.keel.rest
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.keel.api.AccountAwareLocations
 import com.netflix.spinnaker.keel.api.Locatable
-import com.netflix.spinnaker.keel.api.application
-import com.netflix.spinnaker.keel.api.serviceAccount
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchEntityException
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.APPLICATION

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupportTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AuthorizationSupportTests.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.rest
 import com.netflix.spinnaker.fiat.shared.FiatPermissionEvaluator
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.persistence.CombinedRepository
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.actuation.Task
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.events.PersistentEvent
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.KeelApplication
-import com.netflix.spinnaker.keel.api.id
 import com.netflix.spinnaker.keel.diff.AdHocDiffer
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceId


### PR DESCRIPTION
This PR addresses the following:
- Make `Resource` metadata accessor fields accessible from Java-based plugins
- Add a version of `TaskLauncher.submitJob()` that is asynchronous but not `suspend` so it can be called from Java
