### PR TITLE
Handle a cluster that does use discovery but is configued not to

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -97,7 +97,7 @@ data class ServerGroup(
   ) {
     // active asg is healthy if all instances are up
     fun isHealthy(noHealth: Boolean): Boolean =
-      if (noHealth) unknown == total
+      if (noHealth) (unknown + up) == total
       else up == total
   }
 


### PR DESCRIPTION
If a cluster's instances are registered in discovery we'll wait forever for them to be `unknown` which is just as dumb as waiting for ones that _do_ use discovery to be `up`.