### PR TITLE
feat(titus): only allow one active server group

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -113,8 +113,7 @@ interface CloudDriverService {
     @Path("app") app: String,
     @Path("account") account: String,
     @Path("cluster") cluster: String,
-    @Path("cloudProvider") cloudProvider: String,
-    @Query("region") region: String
+    @Path("cloudProvider") cloudProvider: String = "aws"
   ): ServerGroupCollection<ServerGroup>
 
   @GET("/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}")
@@ -123,8 +122,7 @@ interface CloudDriverService {
     @Path("app") app: String,
     @Path("account") account: String,
     @Path("cluster") cluster: String,
-    @Path("cloudProvider") cloudProvider: String,
-    @Query("region") region: String
+    @Path("cloudProvider") cloudProvider: String = "titus"
   ): ServerGroupCollection<TitusServerGroup>
 
   /**

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -26,6 +26,7 @@ interface BaseServerGroup {
   val disabled: Boolean
     get() = false
   val instanceCounts: InstanceCounts
+  val createdTime: Long
 }
 
 data class InstanceCounts(
@@ -74,7 +75,8 @@ data class ServerGroup(
   override val moniker: Moniker,
   override val buildInfo: BuildInfo? = null,
   override val disabled: Boolean,
-  override val instanceCounts: InstanceCounts
+  override val instanceCounts: InstanceCounts,
+  override val createdTime: Long
 ) : BaseEc2ServerGroup
 
 fun ServerGroup.toActive(accountName: String) =
@@ -95,7 +97,8 @@ fun ServerGroup.toActive(accountName: String) =
     accountName = accountName,
     moniker = moniker,
     buildInfo = buildInfo,
-    instanceCounts = instanceCounts
+    instanceCounts = instanceCounts,
+    createdTime = createdTime
   )
 
 // todo eb: this should be more general so that it works for all server groups, not just ec2
@@ -116,7 +119,8 @@ data class ActiveServerGroup(
   val accountName: String,
   override val moniker: Moniker,
   override val buildInfo: BuildInfo? = null,
-  override val instanceCounts: InstanceCounts
+  override val instanceCounts: InstanceCounts,
+  override val createdTime: Long
 ) : BaseEc2ServerGroup
 
 fun ActiveServerGroup.subnet(cloudDriverCache: CloudDriverCache): String =

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/TitusActiveServerGroup.kt
@@ -67,7 +67,8 @@ data class TitusServerGroup(
   override val resources: Resources,
   override val capacityGroup: String,
   override val disabled: Boolean,
-  override val instanceCounts: InstanceCounts
+  override val instanceCounts: InstanceCounts,
+  override val createdTime: Long
 ) : BaseTitusServerGroup
 
 fun TitusServerGroup.toActive() =
@@ -93,7 +94,8 @@ fun TitusServerGroup.toActive() =
     tags = tags,
     resources = resources,
     capacityGroup = capacityGroup,
-    instanceCounts = instanceCounts
+    instanceCounts = instanceCounts,
+    createdTime = createdTime
   )
 
 /**
@@ -124,7 +126,8 @@ data class TitusActiveServerGroup(
   override val tags: Map<String, String>,
   override val resources: Resources,
   override val capacityGroup: String,
-  override val instanceCounts: InstanceCounts
+  override val instanceCounts: InstanceCounts,
+  override val createdTime: Long
 ) : BaseTitusServerGroup
 
 data class Placement(

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
@@ -478,6 +478,7 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
       sequence = 0
     ),
     buildInfo = BuildInfo(packageName = "fnord"),
-    instanceCounts = InstanceCounts(1, 0, 0, 1, 0, 0)
+    instanceCounts = InstanceCounts(1, 0, 0, 1, 0, 0),
+    createdTime = 1544656135184
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/ActiveServerGroupsException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/ActiveServerGroupsException.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.SystemException
+
+class ActiveServerGroupsException(
+  val resourceId: String,
+  val error: String
+) : SystemException("There were too many active server groups, " +
+  "and an error occurred when trying to identify which server group to disable, for resource $resourceId: $error")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -243,6 +243,7 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
     securityGroups = setOf("fnord"),
     accountName = "test",
     moniker = parseMoniker("fnord-prod"),
-    instanceCounts = InstanceCounts(10, 10, 0, 0, 0, 0)
+    instanceCounts = InstanceCounts(10, 10, 0, 0, 0, 0),
+    createdTime = 1544656134371
   )
 }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
@@ -111,6 +111,7 @@ fun ServerGroup.toCloudDriverResponse(
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       accountName = location.account,
       moniker = parseMoniker("$name-v$sequence"),
-      instanceCounts = instanceCounts.run { InstanceCounts(total, up, down, unknown, outOfService, starting) }
+      instanceCounts = instanceCounts.run { InstanceCounts(total, up, down, unknown, outOfService, starting) },
+      createdTime = 1544656134371
     )
   }

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
@@ -64,7 +64,8 @@ class ClusterExportHelperTests : JUnit5Minutests {
       securityGroups = emptySet(),
       accountName = "test",
       moniker = parseMoniker("keek-test-v001"),
-      instanceCounts = InstanceCounts(1, 1, 0, 0, 0, 0)
+      instanceCounts = InstanceCounts(1, 1, 0, 0, 0, 0),
+      createdTime = 1544656135184
     )
 
     val taskEntityTags = EntityTags(

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -75,7 +75,6 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
@@ -460,12 +459,12 @@ class TitusClusterHandler(
     current != null && affectedRootPropertyTypes.all { it == Capacity::class.java }
 
   /**
-   * @return true if the only difference is in the onlyActiveServerGroup property
+   * @return true if the only difference is in the onlyEnabledServerGroup property
    */
   private fun ResourceDiff<TitusServerGroup>.isEnabledOnly(): Boolean =
     current != null &&
-      affectedRootPropertyNames.all { it == "onlyActiveServerGroup" } &&
-      current!!.onlyActiveServerGroup != desired.onlyActiveServerGroup
+      affectedRootPropertyNames.all { it == "onlyEnabledServerGroup" } &&
+      current!!.onlyEnabledServerGroup != desired.onlyEnabledServerGroup
 
   private fun TitusClusterSpec.generateOverrides(serverGroups: Map<String, TitusServerGroup>) =
     serverGroups.forEach { (region, serverGroup) ->
@@ -490,8 +489,8 @@ class TitusClusterHandler(
         .size
 
       when (numEnabled) {
-        1 -> activeServerGroup.copy(onlyActiveServerGroup = true)
-        else -> activeServerGroup.copy(onlyActiveServerGroup = false)
+        1 -> activeServerGroup.copy(onlyEnabledServerGroup = true)
+        else -> activeServerGroup.copy(onlyEnabledServerGroup = false)
       }
     }
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
+import com.netflix.spinnaker.keel.api.titus.exceptions.ActiveServerGroupsException
 import com.netflix.spinnaker.keel.api.titus.exceptions.RegistryNotFoundException
 import com.netflix.spinnaker.keel.api.titus.exceptions.TitusAccountConfigurationException
 import com.netflix.spinnaker.keel.api.withDefaultsOmitted
@@ -51,7 +52,9 @@ import com.netflix.spinnaker.keel.clouddriver.model.Constraints
 import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
 import com.netflix.spinnaker.keel.clouddriver.model.MigrationPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.Resources
+import com.netflix.spinnaker.keel.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
+import com.netflix.spinnaker.keel.clouddriver.model.TitusServerGroup as ClouddriverTitusServerGroup
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.core.orcaClusterMoniker
 import com.netflix.spinnaker.keel.core.serverGroup
@@ -72,6 +75,7 @@ import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
@@ -101,7 +105,7 @@ class TitusClusterHandler(
 
   override suspend fun current(resource: Resource<TitusClusterSpec>): Map<String, TitusServerGroup> =
     cloudDriverService
-      .getServerGroups(resource)
+      .getActiveServerGroups(resource)
       .byRegion()
 
   override suspend fun actuationInProgress(resource: Resource<TitusClusterSpec>): Boolean =
@@ -147,11 +151,13 @@ class TitusClusterHandler(
 
           val job = when {
             diff.isCapacityOnly() -> diff.resizeServerGroupJob()
+            diff.isEnabledOnly() -> diff.disableOtherServerGroupJob(resource, version.toString())
             else -> diff.upsertServerGroupJob(tagToUse) + resource.spec.deployWith.toOrcaJobProperties("Amazon")
           }
 
-          val description = when (version) {
-            null -> "Resize server group ${desired.moniker} in ${desired.location.account}/${desired.location.region}"
+          val description = when {
+            diff.isCapacityOnly() -> "Resize server group ${desired.moniker} in ${desired.location.account}/${desired.location.region}"
+            diff.isEnabledOnly() -> "Disable extra active server group ${job["asgName"]} in ${desired.location.account}/${desired.location.region}"
             else -> "Deploy $version to server group ${desired.moniker} in ${desired.location.account}/${desired.location.region}"
           }
           log.info("Upserting server group using task: {}", job)
@@ -165,13 +171,14 @@ class TitusClusterHandler(
             )
           }
 
-          tags.forEach { tag ->
-            publisher.publishEvent(
-              ArtifactVersionDeploying(
+          if (!diff.isEnabledOnly() && !diff.isCapacityOnly()) {
+            // only publish deploying if we're deploying a new version
+            tags.forEach { tag ->
+              publisher.publishEvent(ArtifactVersionDeploying(
                 resourceId = resource.id,
                 artifactVersion = tag
-              )
-            )
+              ))
+            }
           }
           return@map result
         }
@@ -179,7 +186,7 @@ class TitusClusterHandler(
     }
 
   override suspend fun export(exportable: Exportable): TitusClusterSpec {
-    val serverGroups = cloudDriverService.getServerGroups(
+    val serverGroups = cloudDriverService.getActiveServerGroups(
       exportable.account,
       exportable.moniker,
       exportable.regions,
@@ -229,7 +236,7 @@ class TitusClusterHandler(
   }
 
   override suspend fun exportArtifact(exportable: Exportable): DeliveryArtifact {
-    val serverGroups = cloudDriverService.getServerGroups(
+    val serverGroups = cloudDriverService.getActiveServerGroups(
       exportable.account,
       exportable.moniker,
       exportable.regions,
@@ -312,6 +319,52 @@ class TitusClusterHandler(
     } catch (e: IllegalArgumentException) {
       false
     }
+
+  // todo eb: capture this heuristic and document it for users
+  private fun ResourceDiff<TitusServerGroup>.disableOtherServerGroupJob(resource: Resource<TitusClusterSpec>, desiredVersion: String): Map<String, Any?> {
+    val current = requireNotNull(current) {
+      "Current server group must not be null when generating a disable job"
+    }
+    // todo eb: figure out what server group to disable
+    val existingServerGroups: Map<String, List<ClouddriverTitusServerGroup>> = runBlocking { getExistingServerGroupsByRegion(resource) }
+    val sgInRegion = existingServerGroups.getOrDefault(current.location.region, emptyList()).filterNot { it.disabled }
+
+    if (sgInRegion.size < 2) {
+      log.error("Diff says this is not the only active server group, but now we say otherwise. " +
+        "What is going on? Existing server groups: {}", existingServerGroups)
+      throw ActiveServerGroupsException(resource.id, "No other active server group found to disable.")
+    }
+
+    val wrongImageSGs = sgInRegion.filterNot { it.image.dockerImageVersion == desiredVersion }.sortedBy { it.createdTime }
+    val rightImageSGs = sgInRegion.filter { it.image.dockerImageVersion == desiredVersion }.sortedBy { it.createdTime }
+
+    val sgToDisable = when {
+      wrongImageSGs.isNotEmpty() -> {
+        log.debug("Disabling oldest server group with incorrect docker image version for {}", resource.id)
+        wrongImageSGs.first()
+      }
+      rightImageSGs.size > 1 -> {
+        log.debug("Disabling oldest server group with correct docker image version " +
+          "(because there is more than one active server group with the correct image) for {}", resource.id)
+        rightImageSGs.first()
+      }
+      else -> {
+        log.error("Could not find a server group to disable, looking at: {}", wrongImageSGs + rightImageSGs)
+        throw ActiveServerGroupsException(resource.id, "No other active server group found to disable.")
+      }
+    }
+    log.debug("Disabling server group {} for {}: {}", sgToDisable.name, resource.id, sgToDisable)
+
+    return mapOf(
+      "type" to "disableServerGroup",
+      "cloudProvider" to CLOUD_PROVIDER,
+      "credentials" to desired.location.account,
+      "moniker" to sgToDisable.moniker.orcaClusterMoniker,
+      "region" to sgToDisable.region,
+      "serverGroupName" to sgToDisable.name,
+      "asgName" to sgToDisable.name
+    )
+  }
 
   private fun ResourceDiff<TitusServerGroup>.resizeServerGroupJob(): Map<String, Any?> {
     val current = requireNotNull(current) {
@@ -404,6 +457,14 @@ class TitusClusterHandler(
   private fun ResourceDiff<TitusServerGroup>.isCapacityOnly(): Boolean =
     current != null && affectedRootPropertyTypes.all { it == Capacity::class.java }
 
+  /**
+   * @return true if the only difference is in the onlyActiveServerGroup property
+   */
+  private fun ResourceDiff<TitusServerGroup>.isEnabledOnly(): Boolean =
+    current != null &&
+      affectedRootPropertyNames.all { it == "onlyActiveServerGroup" } &&
+      current!!.onlyActiveServerGroup != desired.onlyActiveServerGroup
+
   private fun TitusClusterSpec.generateOverrides(serverGroups: Map<String, TitusServerGroup>) =
     serverGroups.forEach { (region, serverGroup) ->
       val workingSpec = serverGroup.exportSpec(moniker.app)
@@ -413,35 +474,72 @@ class TitusClusterHandler(
       }
     }
 
-  private suspend fun CloudDriverService.getServerGroups(resource: Resource<TitusClusterSpec>): Iterable<TitusServerGroup> =
-    getServerGroups(
+  private suspend fun CloudDriverService.getActiveServerGroups(resource: Resource<TitusClusterSpec>): Iterable<TitusServerGroup> {
+    val activeServerGroups = getActiveServerGroups(
       resource.spec.locations.account,
       resource.spec.moniker,
       resource.spec.locations.regions.map { it.name }.toSet(),
       resource.serviceAccount
-    )
-      .also { them ->
-        val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
-        val healthy: Boolean = them.all {
-          it.instanceCounts?.isHealthy(resource.spec.deployWith.health) == true
+    ).map { activeServerGroup ->
+      // get all server groups in the cluster, split by region,
+      val existingServerGroups: Map<String, List<ClouddriverTitusServerGroup>> = getExistingServerGroupsByRegion(resource)
+      val numEnabled = AtomicInteger()
+      existingServerGroups
+        .getOrDefault(activeServerGroup.location.region, emptyList<ServerGroup>())
+        .forEach { serverGroup ->
+          log.info(">> serverGroup is disabled: {}", serverGroup.disabled)
+          if (!serverGroup.disabled) {
+            numEnabled.incrementAndGet()
+          }
         }
-        if (sameContainer && healthy) {
-          // only publish a successfully deployed event if the server group is healthy
-          val container = them.first().container
-          getTagsForDigest(container, resource.spec.locations.account)
-            .forEach { tag ->
-              // We publish an event for each tag that matches the digest
-              // so that we handle the tags like `latest` where more than one tags have the same digest
-              // and we don't care about some of them.
-              publisher.publishEvent(
-                ArtifactVersionDeployed(
-                  resourceId = resource.id,
-                  artifactVersion = tag
-                )
-              )
-            }
-        }
+      when (numEnabled.get()) {
+        1 -> activeServerGroup.copy(onlyActiveServerGroup = true)
+        else -> activeServerGroup.copy(onlyActiveServerGroup = false)
       }
+    }
+
+    // publish health events
+    val sameContainer: Boolean = activeServerGroups.distinctBy { it.container.digest }.size == 1
+    val healthy: Boolean = activeServerGroups.all {
+      it.instanceCounts?.isHealthy(resource.spec.deployWith.health) == true
+    }
+    if (sameContainer && healthy) {
+      // only publish a successfully deployed event if the server group is healthy
+      val container = activeServerGroups.first().container
+      getTagsForDigest(container, resource.spec.locations.account)
+        .forEach { tag ->
+          // We publish an event for each tag that matches the digest
+          // so that we handle the tags like `latest` where more than one tags have the same digest
+          // and we don't care about some of them.
+          publisher.publishEvent(
+            ArtifactVersionDeployed(
+              resourceId = resource.id,
+              artifactVersion = tag
+            )
+          )
+        }
+    }
+    return activeServerGroups
+  }
+
+  private suspend fun getExistingServerGroupsByRegion(resource: Resource<TitusClusterSpec>): Map<String, List<ClouddriverTitusServerGroup>> {
+    val existingServerGroups: MutableMap<String, MutableList<ClouddriverTitusServerGroup>> = mutableMapOf()
+
+    cloudDriverService
+      .listTitusServerGroups(
+        user = resource.serviceAccount,
+        app = resource.spec.application,
+        account = resource.spec.locations.account,
+        cluster = resource.spec.moniker.toString()
+      )
+      .serverGroups
+      .forEach { sg ->
+        val existing = existingServerGroups.getOrPut(sg.region, { mutableListOf() })
+        existing.add(sg)
+        existingServerGroups[sg.region] = existing
+      }
+    return existingServerGroups
+  }
 
   /**
    * Get all tags that match a digest, filtering out the "latest" tag.
@@ -457,7 +555,7 @@ class TitusClusterHandler(
       .map { it.tag }
       .toSet()
 
-  private suspend fun CloudDriverService.getServerGroups(
+  private suspend fun CloudDriverService.getActiveServerGroups(
     account: String,
     moniker: Moniker,
     regions: Set<String>,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -239,7 +239,8 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       resources = resolveResources(it.name),
       tags = defaults.tags + overrides[it.name]?.tags,
       artifactName = artifactName,
-      artifactVersion = artifactVersion
+      artifactVersion = artifactVersion,
+      onlyActiveServerGroup = true
     )
   }
     .toSet()

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt
@@ -240,7 +240,7 @@ fun TitusClusterSpec.resolve(): Set<TitusServerGroup> =
       tags = defaults.tags + overrides[it.name]?.tags,
       artifactName = artifactName,
       artifactVersion = artifactVersion,
-      onlyActiveServerGroup = true
+      onlyEnabledServerGroup = true
     )
   }
     .toSet()

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -59,7 +59,7 @@ data class TitusServerGroup(
   val deferredInitialization: Boolean = true,
   val delayBeforeDisableSec: Int = 0,
   val delayBeforeScaleDownSec: Int = 0,
-  val onlyActiveServerGroup: Boolean = true,
+  val onlyEnabledServerGroup: Boolean = true,
   @JsonIgnore
   @get:ExcludedFromDiff
   override val artifactName: String? = null,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusServerGroup.kt
@@ -59,6 +59,7 @@ data class TitusServerGroup(
   val deferredInitialization: Boolean = true,
   val delayBeforeDisableSec: Int = 0,
   val delayBeforeScaleDownSec: Int = 0,
+  val onlyActiveServerGroup: Boolean = true,
   @JsonIgnore
   @get:ExcludedFromDiff
   override val artifactName: String? = null,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ActiveServerGroupsException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ActiveServerGroupsException.kt
@@ -1,8 +1,0 @@
-package com.netflix.spinnaker.keel.api.titus.exceptions
-
-import com.netflix.spinnaker.kork.exceptions.SystemException
-
-class ActiveServerGroupsException(
-  val resourceId: String,
-  val error: String
-) : SystemException("There was an error finding an extra active server group to disable for resource $resourceId: $error")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ActiveServerGroupsException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/exceptions/ActiveServerGroupsException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.api.titus.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.SystemException
+
+class ActiveServerGroupsException(
+  val resourceId: String,
+  val error: String
+) : SystemException("There was an error finding an extra active server group to disable for resource $resourceId: $error")

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
@@ -40,6 +40,7 @@ fun TitusServerGroup.toClouddriverResponse(
       tags = emptyMap(),
       resources = resources,
       capacityGroup = moniker.app,
-      instanceCounts = instanceCounts.run { com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts(total, up, down, unknown, outOfService, starting) }
+      instanceCounts = instanceCounts.run { com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts(total, up, down, unknown, outOfService, starting) },
+      createdTime = 1544656134371
     )
   }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
@@ -12,6 +12,8 @@ import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroupImage
 import com.netflix.spinnaker.keel.core.parseMoniker
 import org.apache.commons.lang3.RandomStringUtils
+import com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts as ClouddriverInstanceCounts
+import com.netflix.spinnaker.keel.clouddriver.model.TitusServerGroup as ClouddriverTitusServerGroup
 
 fun TitusServerGroup.toClouddriverResponse(
   securityGroups: List<SecurityGroupSummary>,
@@ -40,7 +42,105 @@ fun TitusServerGroup.toClouddriverResponse(
       tags = emptyMap(),
       resources = resources,
       capacityGroup = moniker.app,
-      instanceCounts = instanceCounts.run { com.netflix.spinnaker.keel.clouddriver.model.InstanceCounts(total, up, down, unknown, outOfService, starting) },
+      instanceCounts = instanceCounts.run { ClouddriverInstanceCounts(total, up, down, unknown, outOfService, starting) },
       createdTime = 1544656134371
     )
   }
+
+fun TitusServerGroup.toMultiServerGroupResponse(
+  securityGroups: List<SecurityGroupSummary>,
+  awsAccount: String,
+  instanceCounts: InstanceCounts = InstanceCounts(1, 1, 0, 0, 0, 0),
+  allEnabled: Boolean = false
+): Set<ClouddriverTitusServerGroup> =
+  RandomStringUtils.randomNumeric(3).let { sequence ->
+    val sequence1 = sequence.padStart(3, '0')
+    val sequence2 = (sequence.toInt() + 1).toString().padStart(3, '0')
+    val serverGroups = mutableSetOf<ClouddriverTitusServerGroup>()
+
+    val first = ClouddriverTitusServerGroup(
+      name = "$name-v$sequence1",
+      awsAccount = awsAccount,
+      placement = Placement(location.account, location.region, emptyList()),
+      region = location.region,
+      image = TitusActiveServerGroupImage("${container.organization}/${container.image}", "", container.digest),
+      iamProfile = moniker.app + "InstanceProfile",
+      entryPoint = entryPoint,
+      targetGroups = dependencies.targetGroups,
+      loadBalancers = dependencies.loadBalancerNames,
+      securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
+      capacity = capacity.run { Capacity(min, max, desired) },
+      cloudProvider = CLOUD_PROVIDER,
+      moniker = parseMoniker("$name-v$sequence1"),
+      env = env,
+      constraints = constraints,
+      migrationPolicy = migrationPolicy,
+      serviceJobProcesses = ServiceJobProcesses(),
+      tags = emptyMap(),
+      resources = resources,
+      capacityGroup = moniker.app,
+      instanceCounts = instanceCounts.run { ClouddriverInstanceCounts(total, up, down, unknown, outOfService, starting) },
+      createdTime = 1544656134371,
+      disabled = !allEnabled
+    )
+    serverGroups.add(first)
+
+    val second = ClouddriverTitusServerGroup(
+      name = "$name-v$sequence2",
+      awsAccount = awsAccount,
+      placement = Placement(location.account, location.region, emptyList()),
+      region = location.region,
+      image = TitusActiveServerGroupImage("${container.organization}/${container.image}", "", container.digest),
+      iamProfile = moniker.app + "InstanceProfile",
+      entryPoint = entryPoint,
+      targetGroups = dependencies.targetGroups,
+      loadBalancers = dependencies.loadBalancerNames,
+      securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
+      capacity = capacity.run { Capacity(min, max, desired) },
+      cloudProvider = CLOUD_PROVIDER,
+      moniker = parseMoniker("$name-v$sequence2"),
+      env = env,
+      constraints = constraints,
+      migrationPolicy = migrationPolicy,
+      serviceJobProcesses = ServiceJobProcesses(),
+      tags = emptyMap(),
+      resources = resources,
+      capacityGroup = moniker.app,
+      instanceCounts = instanceCounts.run { ClouddriverInstanceCounts(total, up, down, unknown, outOfService, starting) },
+      createdTime = 1544656134371,
+      disabled = false
+    )
+
+    serverGroups.add(second)
+    return serverGroups
+  }
+
+fun TitusActiveServerGroup.toAllServerGroupsResponse(
+  disabled: Boolean = false
+): ClouddriverTitusServerGroup =
+  ClouddriverTitusServerGroup(
+    name = name,
+    awsAccount = awsAccount,
+    placement = placement,
+    region = region,
+    image = image,
+    iamProfile = iamProfile,
+    entryPoint = entryPoint,
+    targetGroups = targetGroups,
+    loadBalancers = loadBalancers,
+    securityGroups = securityGroups,
+    capacity = capacity,
+    cloudProvider = cloudProvider,
+    moniker = moniker,
+    env = env,
+    containerAttributes = containerAttributes,
+    migrationPolicy = migrationPolicy,
+    serviceJobProcesses = serviceJobProcesses,
+    constraints = constraints,
+    tags = tags,
+    resources = resources,
+    capacityGroup = capacityGroup,
+    instanceCounts = instanceCounts,
+    createdTime = createdTime,
+    disabled = disabled
+  )

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -45,6 +45,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
+import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCollection
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.docker.DigestProvider
 import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
@@ -142,6 +143,14 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   val activeServerGroupResponseEast = serverGroupEast.toClouddriverResponse(listOf(sg1East, sg2East), awsAccount)
   val activeServerGroupResponseWest = serverGroupWest.toClouddriverResponse(listOf(sg1West, sg2West), awsAccount)
 
+  val allServerGroups = ServerGroupCollection(
+    titusAccount,
+    setOf(
+      activeServerGroupResponseEast.toAllServerGroupsResponse(),
+      activeServerGroupResponseWest.toAllServerGroupsResponse()
+    )
+  )
+
   val resource = resource(
     kind = TITUS_CLUSTER_V1.kind,
     spec = spec
@@ -220,6 +229,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } throws RETROFIT_NOT_FOUND
         coEvery { cloudDriverService.findDockerImages("testregistry", "spinnaker/keel", any(), any()) } returns
           listOf(DockerImage("testregistry", "spinnaker/keel", "master-h2.blah", "sha:1111"))
+        coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any()) } returns ServerGroupCollection(titusAccount, emptySet())
       }
 
       test("the current model is null") {
@@ -252,6 +262,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
         coEvery { cloudDriverService.findDockerImages("testregistry", "spinnaker/keel", any(), any()) } returns
           listOf(DockerImage("testregistry", "spinnaker/keel", "master-h2.blah", "sha:1111"))
+        coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any())} returns allServerGroups
       }
 
       // TODO: test for multiple server group response
@@ -284,10 +295,14 @@ class TitusClusterHandlerTests : JUnit5Minutests {
     context("the cluster has unhealthy active server groups") {
       before {
         val instanceCounts = InstanceCounts(1, 0, 0, 1, 0, 0)
-        coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-east-1") } returns serverGroupEast.toClouddriverResponse(listOf(sg1East, sg2East), awsAccount, instanceCounts)
-        coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } returns serverGroupWest.toClouddriverResponse(listOf(sg1West, sg2West), awsAccount, instanceCounts)
+        val east = serverGroupEast.toClouddriverResponse(listOf(sg1East, sg2East), awsAccount, instanceCounts)
+        val west = serverGroupWest.toClouddriverResponse(listOf(sg1West, sg2West), awsAccount, instanceCounts)
+        coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-east-1") } returns east
+        coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } returns west
         coEvery { cloudDriverService.findDockerImages("testregistry", "spinnaker/keel", any(), any()) } returns
           listOf(DockerImage("testregistry", "spinnaker/keel", "master-h2.blah", "sha:1111"))
+        coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any())} returns
+          ServerGroupCollection(titusAccount, setOf(east.toAllServerGroupsResponse(), west.toAllServerGroupsResponse()))
       }
 
       // TODO: test for multiple server group response
@@ -336,6 +351,46 @@ class TitusClusterHandlerTests : JUnit5Minutests {
               }
             )
             get("serverGroupName").isEqualTo(activeServerGroupResponseWest.name)
+          }
+        }
+      }
+
+      context("the diff is only in enabled/disabled status") {
+        val east = serverGroupEast.toMultiServerGroupResponse(listOf(sg1East, sg2East), awsAccount, allEnabled = true)
+        val west = serverGroupWest.toMultiServerGroupResponse(listOf(sg1West, sg2West), awsAccount)
+
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyActiveServerGroup = false),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+        )
+        val diff = DefaultResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+
+        before {
+          coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any())} returns
+            ServerGroupCollection(
+              titusAccount,
+              east + west
+            )
+          coEvery { cloudDriverService.findDockerImages("testregistry", "spinnaker/keel", any(), any(), any()) } returns
+            listOf(
+              DockerImage("testregistry", "spinnaker/keel", "master-h2.blah", "sha:1111")
+            )
+        }
+
+        test("resolving diff disables the oldest enabled server group") {
+          runBlocking {
+            upsert(resource, diff)
+          }
+
+          val slot = slot<OrchestrationRequest>()
+          coVerify { orcaService.orchestrate(resource.serviceAccount, capture(slot)) }
+
+          expectThat(slot.captured.job.first()) {
+            get("type").isEqualTo("disableServerGroup")
+            get("asgName").isEqualTo(east.sortedBy { it.createdTime }.first().name)
           }
         }
       }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -360,7 +360,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         val west = serverGroupWest.toMultiServerGroupResponse(listOf(sg1West, sg2West), awsAccount)
 
         val modified = setOf(
-          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyActiveServerGroup = false),
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyEnabledServerGroup = false),
           serverGroupWest.copy(name = activeServerGroupResponseWest.name)
         )
         val diff = DefaultResourceDiff(

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/PassThruController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/PassThruController.kt
@@ -25,35 +25,34 @@ class PassThruController(
 ) {
 
   @GetMapping(
-    path = ["/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/{region}/serverGroups"]
+    path = ["/applications/{app}/clusters/{account}/{cluster}/{cloudProvider}/serverGroups"]
   )
   fun getActiveServerGroups(
     @PathVariable("app") app: String,
     @PathVariable("account") account: String,
     @PathVariable("cluster") cluster: String,
-    @PathVariable("cloudProvider") cloudProvider: String,
-    @PathVariable("region") region: String
+    @PathVariable("cloudProvider") cloudProvider: String
   ): List<BaseServerGroup> =
     runBlocking {
       when (cloudProvider) {
-        "aws" -> getActiveAwsServerGroups(app, account, cluster, region)
-        "titus" -> getActiveTitusServerGroups(app, account, cluster, region)
+        "aws" -> getActiveAwsServerGroups(app, account, cluster)
+        "titus" -> getActiveTitusServerGroups(app, account, cluster)
         else -> throw UserException("Unknown cloud provider: $cloudProvider")
       }
     }
 
-  suspend fun getActiveAwsServerGroups(app: String, account: String, cluster: String, region: String) =
+  suspend fun getActiveAwsServerGroups(app: String, account: String, cluster: String) =
     cloudDriverService
-      .listServerGroups(DEFAULT_SERVICE_ACCOUNT, app, account, cluster, "aws", region)
+      .listServerGroups(DEFAULT_SERVICE_ACCOUNT, app, account, cluster, "aws")
       .let { c ->
         c.serverGroups
           .filterNot { it.disabled }
           .map { it.toActive(c.accountName) }
       }
 
-  suspend fun getActiveTitusServerGroups(app: String, account: String, cluster: String, region: String) =
+  suspend fun getActiveTitusServerGroups(app: String, account: String, cluster: String) =
     cloudDriverService
-      .listTitusServerGroups(DEFAULT_SERVICE_ACCOUNT, app, account, cluster, "titus", region)
+      .listTitusServerGroups(DEFAULT_SERVICE_ACCOUNT, app, account, cluster, "titus")
       .let { c ->
         c.serverGroups
           .filterNot { it.disabled }


### PR DESCRIPTION
Fist stab at addressing https://github.com/spinnaker/keel/issues/1084 for titus only (titus is less complicated). Feedback desired.

This PR adds a new property to the server group response (`onlyEnabledServerGroup`) which defaults to true. When the desired state is resolved for a server group, it is also true. When we fetch the current state of clusters we calculate whether that property is true or false for each "active server group" (aka the one we're looking at to see if it's in the right state or not).

If `onlyEnabledServerGroup == false`, and that's the only diff, then we disable the oldest active server group (heuristic alert! feedback desired!). The heuristic is: disable the oldest active server group with the _wrong version_ until there are none left. Then, do the same with clusters with the right version until there is only one active server group left.