### PR TITLE
Use an enum rather than a boolean to represent deploy health behavior

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategyTests.kt
@@ -32,7 +32,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
       test("serializes to JSON") {
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "highlander"
-          path("noHealth").isBoolean().booleanValue().isFalse()
+          path("health").textValue() isEqualTo DeployHealth.AUTO.name
         }
       }
     }
@@ -43,7 +43,7 @@ internal class ClusterDeployStrategyTests : JUnit5Minutests {
       test("serializes to JSON") {
         expectThat<ObjectNode>(mapper.valueToTree(strategy)) {
           path("strategy").textValue() isEqualTo "red-black"
-          path("noHealth").isBoolean().booleanValue().isFalse()
+          path("health").textValue() isEqualTo DeployHealth.AUTO.name
           path("resizePreviousToZero").isBoolean().booleanValue().isFalse()
           path("rollbackOnFailure").isBoolean().booleanValue().isFalse()
           path("maxServerGroups").numberValue().isEqualTo(2)

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -17,6 +17,9 @@
  */
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.netflix.spinnaker.keel.api.DeployHealth
+import com.netflix.spinnaker.keel.api.DeployHealth.AUTO
+import com.netflix.spinnaker.keel.api.DeployHealth.NONE
 import com.netflix.spinnaker.keel.api.ExcludedFromDiff
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
@@ -96,9 +99,11 @@ data class ServerGroup(
     val starting: Int
   ) {
     // active asg is healthy if all instances are up
-    fun isHealthy(noHealth: Boolean): Boolean =
-      if (noHealth) (unknown + up) == total
-      else up == total
+    fun isHealthy(health: DeployHealth): Boolean =
+      when (health) {
+        AUTO -> up == total
+        NONE -> (up + unknown) == total
+      }
   }
 
   data class LaunchConfiguration(
@@ -115,6 +120,7 @@ data class ServerGroup(
     companion object {
       const val DEFAULT_EBS_OPTIMIZED = false
       const val DEFAULT_INSTANCE_MONITORING = false
+
       // TODO (lpollo): make configurable, or resolve via LaunchConfigurationResolver
       fun defaultIamRoleFor(application: String) = "${application}InstanceProfile"
     }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -806,7 +806,7 @@ class ClusterHandler(
       .also { them ->
         val allSame: Boolean = them.distinctBy { it.launchConfiguration.appVersion }.size == 1
         val healthy: Boolean = them.all {
-          it.instanceCounts?.isHealthy(resource.spec.deployWith.noHealth) == true
+          it.instanceCounts?.isHealthy(resource.spec.deployWith.health) == true
         }
         if (allSame && healthy) {
           // // only publish a successfully deployed event if the server group is healthy

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -1,5 +1,8 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
+import com.netflix.spinnaker.keel.api.DeployHealth
+import com.netflix.spinnaker.keel.api.DeployHealth.AUTO
+import com.netflix.spinnaker.keel.api.DeployHealth.NONE
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Highlander
@@ -731,7 +734,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
 
         test("the cluster does not use discovery-based health during deployment") {
-          val deployWith = RedBlack(noHealth = true)
+          val deployWith = RedBlack(health = NONE)
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
           }
@@ -746,7 +749,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
 
         test("the cluster uses discovery-based health during deployment") {
-          val deployWith = RedBlack(noHealth = false)
+          val deployWith = RedBlack(health = AUTO)
           runBlocking {
             upsert(resource.copy(spec = resource.spec.copy(deployWith = deployWith)), diff)
           }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
@@ -2,6 +2,9 @@ package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
+import com.netflix.spinnaker.keel.api.DeployHealth
+import com.netflix.spinnaker.keel.api.DeployHealth.AUTO
+import com.netflix.spinnaker.keel.api.DeployHealth.NONE
 import com.netflix.spinnaker.keel.api.Highlander
 import com.netflix.spinnaker.keel.api.RedBlack
 import java.time.Duration.ZERO
@@ -26,19 +29,17 @@ fun ClusterDeployStrategy.toOrcaJobProperties(vararg instanceOnlyHealthProviders
           (delayBeforeDisable ?: ZERO) +
           (delayBeforeScaleDown ?: ZERO)
         ).toMillis(),
-      "interestingHealthProviderNames" to if (noHealth) {
-        instanceOnlyHealthProviders.toList()
-      } else {
-        null
+      "interestingHealthProviderNames" to when (health) {
+        NONE -> instanceOnlyHealthProviders.toList()
+        AUTO -> null
       }
     )
     is Highlander -> mapOf(
       "strategy" to "highlander",
       "stageTimeoutMs" to DEFAULT_WAIT_FOR_INSTANCES_UP.toMillis(),
-      "interestingHealthProviderNames" to if (noHealth) {
-        instanceOnlyHealthProviders.toList()
-      } else {
-        null
+      "interestingHealthProviderNames" to when (health) {
+        NONE -> instanceOnlyHealthProviders.toList()
+        AUTO -> null
       }
     )
   }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -423,7 +423,7 @@ class TitusClusterHandler(
       .also { them ->
         val sameContainer: Boolean = them.distinctBy { it.container.digest }.size == 1
         val healthy: Boolean = them.all {
-          it.instanceCounts?.isHealthy(resource.spec.deployWith.noHealth) == true
+          it.instanceCounts?.isHealthy(resource.spec.deployWith.health) == true
         }
         if (sameContainer && healthy) {
           // only publish a successfully deployed event if the server group is healthy


### PR DESCRIPTION
Booleans suck generally and especially when their name is a negative.
