### PR TITLE
feat(resources): Add standardized display name for resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ out/
 *.rdb
 /.shelf/
 **/*/out/*
+/plugins/

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Monikered.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Monikered.kt
@@ -28,4 +28,7 @@ interface Monikered : ResourceSpec {
    */
   override val application: String
     get() = moniker.app
+
+  override val displayName: String
+    get() = moniker.toString()
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSpec.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSpec.kt
@@ -23,4 +23,9 @@ interface ResourceSpec {
    * [com.fasterxml.jackson.annotation.JsonIgnore].
    */
   val application: String
+
+  /**
+   * A more descriptive name than the [id], intended for displaying in the UI.
+   */
+  val displayName: String
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSpec.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ResourceSpec.kt
@@ -25,7 +25,9 @@ interface ResourceSpec {
   val application: String
 
   /**
-   * A more descriptive name than the [id], intended for displaying in the UI.
+   * A more descriptive name than the [id], intended for displaying in the UI. This property is
+   * not persisted, as it's expected to be calculated by the [ResourceSpec] implementation from
+   * other fields.
    */
   val displayName: String
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ResourceSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ResourceSummary.kt
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import com.netflix.spinnaker.keel.api.Locations
 import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
@@ -32,17 +33,23 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus
  * This powers the UI view of resource status.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
-@JsonPropertyOrder(value = ["id", "kind", "status", "moniker", "locations", "artifact"])
+@JsonPropertyOrder(value = ["id", "kind", "status", "moniker", "displayName", "locations", "artifact"])
 data class ResourceSummary(
   @JsonIgnore
   val resource: Resource<*>,
   val status: ResourceStatus,
-  val moniker: Moniker?,
   val locations: Locations<*>?,
   val artifact: ResourceArtifactSummary? = null
 ) {
   val id: String = resource.id
   val kind: ResourceKind = resource.kind
+  val displayName: String = resource.spec.displayName
+  val moniker: Moniker?
+    get() = if (resource.spec is Monikered) {
+      (resource.spec as Monikered).moniker
+    } else {
+      null
+    }
 }
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
@@ -39,6 +40,7 @@ import com.netflix.spinnaker.keel.jackson.mixins.LocatableMixin
 import com.netflix.spinnaker.keel.jackson.mixins.MonikeredMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ResourceKindMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ResourceMixin
+import com.netflix.spinnaker.keel.jackson.mixins.ResourceSpecMixin
 import com.netflix.spinnaker.keel.jackson.mixins.StaggeredRegionMixin
 import com.netflix.spinnaker.keel.jackson.mixins.SubnetAwareRegionSpecMixin
 
@@ -60,6 +62,7 @@ object KeelApiModule : SimpleModule("Keel API") {
       setMixInAnnotations<StaggeredRegion, StaggeredRegionMixin>()
       setMixInAnnotations<SubnetAwareRegionSpec, SubnetAwareRegionSpecMixin>()
       setMixInAnnotations<Resource<*>, ResourceMixin>()
+      setMixInAnnotations<ResourceSpec, ResourceSpecMixin>()
     }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceSpecMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceSpecMixin.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.jackson.mixins
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+
+interface ResourceSpecMixin {
+  @get:JsonIgnore
+  val displayName: String
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -148,11 +148,6 @@ class ApplicationService(
     ResourceSummary(
       resource = this,
       status = resourceStatusService.getStatus(id),
-      moniker = if (spec is Monikered) {
-        (spec as Monikered).moniker
-      } else {
-        null
-      },
       locations = if (spec is Locatable<*>) {
         (spec as Locatable<*>).locations
       } else {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedEnvironmentDeserializerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedEnvironmentDeserializerTests.kt
@@ -208,10 +208,14 @@ private data class TestSubnetAwareLocatableResource(
   override val id: String,
   override val application: String,
   override val locations: SubnetAwareLocations
-) : Locatable<SubnetAwareLocations>
+) : Locatable<SubnetAwareLocations> {
+  override val displayName: String = "$application-$id"
+}
 
 private data class TestSimpleLocatableResource(
   override val id: String,
   override val application: String,
   override val locations: SimpleLocations
-) : Locatable<SimpleLocations>
+) : Locatable<SimpleLocations> {
+  override val displayName: String = "$application-$id"
+}

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
@@ -71,6 +71,9 @@ data class SampleSpecWithContainer(
 
   @JsonIgnore
   override val application: String = "myapp"
+
+  @JsonIgnore
+  override val displayName: String = "myapp-sample-resource"
 }
 
 val SAMPLE_API_VERSION = ApiVersion("sample.resource")

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/LegacySpecUpgradeTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/LegacySpecUpgradeTests.kt
@@ -28,6 +28,7 @@ internal class LegacySpecUpgradeTests : JUnit5Minutests {
   ) : ResourceSpec {
     override val id = name
     override val application = "fnord"
+    override val displayName: String = "$application-$name"
   }
 
   data class SpecV2(
@@ -36,6 +37,7 @@ internal class LegacySpecUpgradeTests : JUnit5Minutests {
   ) : ResourceSpec {
     override val id = name
     override val application = "fnord"
+    override val displayName: String = "$application-$name"
   }
 
   data class SpecV3(
@@ -45,6 +47,7 @@ internal class LegacySpecUpgradeTests : JUnit5Minutests {
   ) : ResourceSpec {
     override val id = name
     override val application = "fnord"
+    override val displayName: String = "$application-$name"
   }
 
   object Fixture {

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -151,7 +151,8 @@ enum class DummyEnum { VALUE }
 data class DummyResourceSpec(
   override val id: String = randomString(),
   val data: String = randomString(),
-  override val application: String = "fnord"
+  override val application: String = "fnord",
+  override val displayName: String = "fnord-dummy"
 ) : ResourceSpec {
   val intData: Int = 1234
   val boolData: Boolean = true
@@ -163,6 +164,7 @@ data class DummyLocatableResourceSpec(
   override val id: String = randomString(),
   val data: String = randomString(),
   override val application: String = "fnord",
+  override val displayName: String = "fnord-locatable-dummy",
   override val locations: SimpleLocations = SimpleLocations(
     account = "test",
     vpc = "vpc0",
@@ -177,7 +179,8 @@ data class DummyArtifactVersionedResourceSpec(
   override val application: String = "fnord",
   override val artifactVersion: String? = "fnord-42.0",
   override val artifactName: String? = "fnord",
-  override val artifactType: ArtifactType? = DEBIAN
+  override val artifactType: ArtifactType? = DEBIAN,
+  override val displayName: String = "fnord-artifact-versioned-dummy",
 ) : ResourceSpec, VersionedArtifactProvider
 
 data class DummyArtifactReferenceResourceSpec(
@@ -186,7 +189,8 @@ data class DummyArtifactReferenceResourceSpec(
   val data: String = randomString(),
   override val application: String = "fnord",
   override val artifactType: ArtifactType? = DEBIAN,
-  override val artifactReference: String? = "fnord"
+  override val artifactReference: String? = "fnord",
+  override val displayName: String = "fnord-artifact-reference-dummy",
 ) : ResourceSpec, ArtifactReferenceProvider
 
 data class DummyResource(


### PR DESCRIPTION
Adds a `displayName` property to `ResourceSpec` and `ResourceSummary` such that we have a consistent way of figuring out what to display in the UI for all resource types.