### PR TITLE
fix(core): Don't make assumptions about which resources link to artifacts

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ArtifactInterfaces.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ArtifactInterfaces.kt
@@ -13,6 +13,7 @@ interface ArtifactProvider {
   val artifactName: String?
   val artifactType: ArtifactType?
 
+  @JvmDefault
   fun completeArtifactOrNull() =
     if (artifactName != null && artifactType != null) {
       CompleteArtifact(artifactName!!, artifactType!!)
@@ -28,6 +29,7 @@ interface ArtifactProvider {
 interface VersionedArtifactProvider : ArtifactProvider {
   val artifactVersion: String?
 
+  @JvmDefault
   fun completeVersionedArtifactOrNull() =
     if (artifactName != null && artifactType != null && artifactVersion != null) {
       CompleteVersionedArtifact(artifactName!!, artifactType!!, artifactVersion!!)
@@ -44,6 +46,7 @@ interface ArtifactReferenceProvider {
   val artifactReference: String?
   val artifactType: ArtifactType?
 
+  @JvmDefault
   fun completeArtifactReferenceOrNull() =
     if (artifactReference != null && artifactType != null) {
       CompleteArtifactReference(artifactReference!!, artifactType!!)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -26,19 +26,18 @@ data class Resource<out T : ResourceSpec>(
    * Attempts to find an artifact in the delivery config based on information in this resource's spec.
    */
   fun findAssociatedArtifact(deliveryConfig: DeliveryConfig) =
-    if (spec is ComputeResourceSpec) {
-      // prefer reference-based artifact info
-      spec.completeArtifactReferenceOrNull()
-        ?.let { ref ->
-          deliveryConfig.matchingArtifactByReference(ref.artifactReference)
-        }
-        // if not found, then try old-style image provider info
-        ?: spec.completeArtifactOrNull()
+    when (spec) {
+      is ArtifactReferenceProvider ->
+        spec.completeArtifactReferenceOrNull()
+          ?.let { ref ->
+            deliveryConfig.matchingArtifactByReference(ref.artifactReference)
+          }
+      is ArtifactProvider ->
+        spec.completeArtifactOrNull()
           ?.let { art ->
             deliveryConfig.matchingArtifactByName(art.artifactName, art.artifactType)
           }
-    } else {
-      null
+      else -> null
     }
 
   // TODO: this is kinda dirty, but because we add uid to the metadata when persisting we don't really want to consider it in equality checks


### PR DESCRIPTION
Instead of checking for `ComputeResourceSpec` to figure out which resources have links to artifacts, just check the artifact-provider interfaces it wraps, allowing for other types of resources to provide that information. This is required to enable our current work on internal resource plugins.

Also, annotates a few methods on those interfaces with `@JvmDefault` so they can be used in Java plugins.

Cc: @erikmunson 