### PR TITLE
feat(ec2): don't allow multiple enabled ASGs

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -45,6 +45,7 @@ data class ServerGroup(
   val health: Health = Health(),
   val scaling: Scaling = Scaling(),
   val tags: Map<String, String> = emptyMap(),
+  val onlyEnabledServerGroup: Boolean = true,
   @get:ExcludedFromDiff
   val image: ActiveServerGroupImage? = null,
   @get:ExcludedFromDiff

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.Tag
 import com.netflix.spinnaker.keel.clouddriver.model.TargetTrackingConfiguration
 import com.netflix.spinnaker.keel.core.parseMoniker
 import org.apache.commons.lang3.RandomStringUtils
+import com.netflix.spinnaker.keel.clouddriver.model.ServerGroup as ClouddriverServerGroup
 
 fun ServerGroup.toCloudDriverResponse(
   vpc: Network,
@@ -115,3 +116,211 @@ fun ServerGroup.toCloudDriverResponse(
       createdTime = 1544656134371
     )
   }
+
+
+fun ServerGroup.toMultiServerGroupResponse(
+  vpc: Network,
+  subnets: List<Subnet>,
+  securityGroups: List<SecurityGroupSummary>,
+  image: ServerGroup.ActiveServerGroupImage? = null,
+  instanceCounts: ServerGroup.InstanceCounts = ServerGroup.InstanceCounts(1, 1, 0, 0, 0, 0),
+  allEnabled: Boolean = false
+): Set<ClouddriverServerGroup> {
+  RandomStringUtils.randomNumeric(3).let { sequence ->
+    val sequence1 = sequence.padStart(3, '0')
+    val sequence2 = (sequence.toInt() + 1).toString().padStart(3, '0')
+    val serverGroups = mutableSetOf<ClouddriverServerGroup>()
+
+    val first = ClouddriverServerGroup(
+      name = "$name-v$sequence1",
+      region = location.region,
+      zones = location.availabilityZones,
+      image = ActiveServerGroupImage(
+        imageId = launchConfiguration.imageId,
+        appVersion = launchConfiguration.appVersion,
+        baseImageVersion = launchConfiguration.baseImageVersion,
+        name = "name",
+        imageLocation = "location",
+        description = image?.description
+      ),
+      launchConfig = LaunchConfig(
+        launchConfiguration.ramdiskId,
+        launchConfiguration.ebsOptimized,
+        launchConfiguration.imageId,
+        launchConfiguration.instanceType,
+        launchConfiguration.keyPair,
+        launchConfiguration.iamRole,
+        InstanceMonitoring(launchConfiguration.instanceMonitoring)
+      ),
+      asg = AutoScalingGroup(
+        "$name-v$sequence1",
+        health.cooldown.seconds,
+        health.healthCheckType.let(HealthCheckType::toString),
+        health.warmup.seconds,
+        scaling.suspendedProcesses.map { SuspendedProcess(it.name) }.toSet(),
+        health.enabledMetrics.map(Metric::toString).toSet(),
+        tags.map { Tag(it.key, it.value) }.toSet(),
+        health.terminationPolicies.map(TerminationPolicy::toString).toSet(),
+        subnets.map(Subnet::id).joinToString(",")
+      ),
+      scalingPolicies = listOf(
+        ScalingPolicy(
+          autoScalingGroupName = "$name-v$sequence1",
+          policyName = "$name-target-tracking-policy",
+          policyType = "TargetTrackingScaling",
+          estimatedInstanceWarmup = 300,
+          adjustmentType = null,
+          minAdjustmentStep = null,
+          minAdjustmentMagnitude = null,
+          stepAdjustments = null,
+          metricAggregationType = null,
+          targetTrackingConfiguration = TargetTrackingConfiguration(
+            560.0,
+            true,
+            CustomizedMetricSpecificationModel(
+              "RPS per instance",
+              "SPIN/ACH",
+              "Average",
+              null,
+              listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence1"))
+            ),
+            null
+          ),
+          alarms = listOf(
+            ScalingPolicyAlarm(
+              true,
+              "GreaterThanThreshold",
+              listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence1")),
+              3,
+              60,
+              560,
+              "RPS per instance",
+              "SPIN/ACH",
+              "Average"
+            )
+          )
+        )
+      ),
+      vpcId = vpc.id,
+      targetGroups = dependencies.targetGroups,
+      loadBalancers = dependencies.loadBalancerNames,
+      capacity = capacity.let { Capacity(it.min, it.max, it.desired) },
+      cloudProvider = CLOUD_PROVIDER,
+      securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
+      moniker = parseMoniker("$name-v$sequence1"),
+      instanceCounts = instanceCounts.run { InstanceCounts(total, up, down, unknown, outOfService, starting) },
+      createdTime = 1544656134371,
+      disabled = !allEnabled
+    )
+    serverGroups.add(first)
+
+    val second = ClouddriverServerGroup(
+      name = "$name-v$sequence2",
+      region = location.region,
+      zones = location.availabilityZones,
+      image = ActiveServerGroupImage(
+        imageId = launchConfiguration.imageId,
+        appVersion = launchConfiguration.appVersion,
+        baseImageVersion = launchConfiguration.baseImageVersion,
+        name = "name",
+        imageLocation = "location",
+        description = image?.description
+      ),
+      launchConfig = LaunchConfig(
+        launchConfiguration.ramdiskId,
+        launchConfiguration.ebsOptimized,
+        launchConfiguration.imageId,
+        launchConfiguration.instanceType,
+        launchConfiguration.keyPair,
+        launchConfiguration.iamRole,
+        InstanceMonitoring(launchConfiguration.instanceMonitoring)
+      ),
+      asg = AutoScalingGroup(
+        "$name-v$sequence2",
+        health.cooldown.seconds,
+        health.healthCheckType.let(HealthCheckType::toString),
+        health.warmup.seconds,
+        scaling.suspendedProcesses.map { SuspendedProcess(it.name) }.toSet(),
+        health.enabledMetrics.map(Metric::toString).toSet(),
+        tags.map { Tag(it.key, it.value) }.toSet(),
+        health.terminationPolicies.map(TerminationPolicy::toString).toSet(),
+        subnets.map(Subnet::id).joinToString(",")
+      ),
+      scalingPolicies = listOf(
+        ScalingPolicy(
+          autoScalingGroupName = "$name-v$sequence2",
+          policyName = "$name-target-tracking-policy",
+          policyType = "TargetTrackingScaling",
+          estimatedInstanceWarmup = 300,
+          adjustmentType = null,
+          minAdjustmentStep = null,
+          minAdjustmentMagnitude = null,
+          stepAdjustments = null,
+          metricAggregationType = null,
+          targetTrackingConfiguration = TargetTrackingConfiguration(
+            560.0,
+            true,
+            CustomizedMetricSpecificationModel(
+              "RPS per instance",
+              "SPIN/ACH",
+              "Average",
+              null,
+              listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence2"))
+            ),
+            null
+          ),
+          alarms = listOf(
+            ScalingPolicyAlarm(
+              true,
+              "GreaterThanThreshold",
+              listOf(MetricDimensionModel("AutoScalingGroupName", "$name-v$sequence2")),
+              3,
+              60,
+              560,
+              "RPS per instance",
+              "SPIN/ACH",
+              "Average"
+            )
+          )
+        )
+      ),
+      vpcId = vpc.id,
+      targetGroups = dependencies.targetGroups,
+      loadBalancers = dependencies.loadBalancerNames,
+      capacity = capacity.let { Capacity(it.min, it.max, it.desired) },
+      cloudProvider = CLOUD_PROVIDER,
+      securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
+      moniker = parseMoniker("$name-v$sequence1"),
+      instanceCounts = instanceCounts.run { InstanceCounts(total, up, down, unknown, outOfService, starting) },
+      createdTime = 1544656134371,
+      disabled = false
+    )
+
+    serverGroups.add(second)
+    return serverGroups
+  }
+}
+
+fun ActiveServerGroup.toAllServerGroupsResponse(
+  disabled: Boolean = false
+): ClouddriverServerGroup =
+  ClouddriverServerGroup(
+    name = name,
+    region = region,
+    zones = zones,
+    image = image,
+    launchConfig = launchConfig,
+    asg = asg,
+    scalingPolicies = scalingPolicies,
+    vpcId = vpcId,
+    targetGroups = targetGroups,
+    loadBalancers = loadBalancers,
+    capacity = capacity,
+    cloudProvider = cloudProvider,
+    securityGroups = securityGroups,
+    moniker = moniker,
+    buildInfo = buildInfo,
+    instanceCounts = instanceCounts,
+    createdTime = createdTime,
+    disabled = disabled
+  )

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterHandler.kt
@@ -536,13 +536,10 @@ class TitusClusterHandler(
           existingServerGroups[sg.region] = existing
         }
     } catch (e: HttpException) {
-      if (e.isNotFound) {
-        return emptyMap()
-      } else {
+      if (!e.isNotFound) {
         throw e
       }
     }
-
     return existingServerGroups
   }
 

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -229,7 +229,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } throws RETROFIT_NOT_FOUND
         coEvery { cloudDriverService.findDockerImages("testregistry", "spinnaker/keel", any(), any()) } returns
           listOf(DockerImage("testregistry", "spinnaker/keel", "master-h2.blah", "sha:1111"))
-        coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any()) } returns ServerGroupCollection(titusAccount, emptySet())
+        coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any()) } throws RETROFIT_NOT_FOUND
       }
 
       test("the current model is null") {


### PR DESCRIPTION
Follow up to https://github.com/spinnaker/keel/pull/1448: same functionality, but for EC2!

Also, fixing the titus tests to correctly throw a not found when there are no server groups, instead of returning the wrapper object with an empty list like I incorrectly expected it to.

Closes https://github.com/spinnaker/keel/issues/1084