### PR TITLE
feat(core): Generalize resource/artifact linkage in actuation

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/actuation/TaskLauncher.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/actuation/TaskLauncher.kt
@@ -5,31 +5,36 @@ import com.netflix.spinnaker.keel.api.Resource
 import java.util.concurrent.CompletableFuture
 
 interface TaskLauncher {
+
   suspend fun submitJob(
     resource: Resource<*>,
     description: String,
     correlationId: String,
-    job: Map<String, Any?>
+    job: Map<String, Any?>,
+    artifactVersionUnderDeployment: String? = null
   ): Task =
     submitJob(
       resource = resource,
       description = description,
       correlationId = correlationId,
-      stages = listOf(job)
+      stages = listOf(job),
+      artifactVersionUnderDeployment
     )
 
   suspend fun submitJob(
     resource: Resource<*>,
     description: String,
     correlationId: String,
-    stages: List<Map<String, Any?>>
+    stages: List<Map<String, Any?>>,
+    artifactVersionUnderDeployment: String? = null
   ): Task
 
   fun submitJobAsync(
     resource: Resource<*>,
     description: String,
     correlationId: String,
-    stages: List<Map<String, Any?>>
+    stages: List<Map<String, Any?>>,
+    artifactVersionUnderDeployment: String? = null
   ): CompletableFuture<Task>
 
   suspend fun submitJob(
@@ -41,7 +46,8 @@ interface TaskLauncher {
     correlationId: String,
     stages: List<Map<String, Any?>>,
     artifacts: List<Map<String, Any?>> = emptyList(),
-    parameters: Map<String, Any> = emptyMap()
+    parameters: Map<String, Any> = emptyMap(),
+    artifactVersionUnderDeployment: String? = null
   ): Task =
     submitJob(
       user = user,
@@ -53,7 +59,8 @@ interface TaskLauncher {
       stages = stages,
       type = SubjectType.CONSTRAINT,
       artifacts = artifacts,
-      parameters = parameters
+      parameters = parameters,
+      artifactVersionUnderDeployment = artifactVersionUnderDeployment
     )
 
   suspend fun submitJob(
@@ -66,7 +73,8 @@ interface TaskLauncher {
     stages: List<Map<String, Any?>>,
     type: SubjectType,
     artifacts: List<Map<String, Any?>> = emptyList(),
-    parameters: Map<String, Any> = emptyMap()
+    parameters: Map<String, Any> = emptyMap(),
+    artifactVersionUnderDeployment: String? = null
   ): Task
 
   suspend fun correlatedTasksRunning(correlationId: String): Boolean

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactDeployedListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactDeployedListener.kt
@@ -39,7 +39,7 @@ class ArtifactDeployedListener(
           targetEnvironment = env.name
         )
         if (!markedCurrentlyDeployed) {
-          log.info("Marking {} as deployed in {} for config {} because it is already deployed", event.artifactVersion, env.name, deliveryConfig.name)
+          log.info("Marking {} as deployed in {} for config {}", event.artifactVersion, env.name, deliveryConfig.name)
           repository.markAsSuccessfullyDeployedTo(
             deliveryConfig = deliveryConfig,
             artifact = artifact,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
@@ -78,7 +78,7 @@ class EnvironmentConstraintRunner(
     envContext: EnvironmentContext,
     pendingVersionsToCheck: MutableSet<String>
   ) {
-    var version: String? = null
+    var version: String?
     var versionIsPending = false
     val vetoedVersions: Set<String> = envContext.vetoedVersions
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
+import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
 import com.netflix.spinnaker.keel.events.ResourceCheckError
@@ -189,7 +190,7 @@ class ResourceActuator(
             log.info("Resource {} is valid", id)
             val lastEvent = resourceRepository.lastEvent(id)
             when (lastEvent) {
-              is ResourceActuationLaunched -> log.debug("waiting for actuating task to be completed") // do nothing and wait
+              is ResourceActuationLaunched -> log.debug("Still waiting for actuating task to complete.") // do nothing and wait
               is ResourceDeltaDetected, is ResourceTaskSucceeded, is ResourceTaskFailed -> {
                 // if a delta was detected and a task wasn't launched, the delta is resolved
                 // if a task was launched and it completed, either successfully or not, the delta is resolved

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -12,7 +12,6 @@ import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
-import com.netflix.spinnaker.keel.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
 import com.netflix.spinnaker.keel.events.ResourceCheckError

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/TaskTrackingRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/TaskTrackingRepository.kt
@@ -10,5 +10,6 @@ interface TaskTrackingRepository {
 data class TaskRecord(
   val id: String,
   val name: String,
-  val subject: String
+  val subject: String,
+  val artifactVersionUnderDeployment: String? = null
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -233,9 +233,9 @@ class ApplicationService(
             }
           }
         }
-        return@map versionToSummary(artifact, version, artifactSummariesInEnvironments.toSet())
+        versionToSummary(artifact, version, artifactSummariesInEnvironments.toSet())
       }
-      return@map ArtifactSummary(
+      ArtifactSummary(
         name = artifact.name,
         type = artifact.type,
         reference = artifact.reference,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -354,10 +354,6 @@ internal class ClusterHandlerTests : JUnit5Minutests {
               activeServerGroupResponseWest.name
             )
         }
-
-        test("an event is fired if all server groups have the same artifact version") {
-          verify { publisher.publishEvent(ofType<ArtifactVersionDeployed>()) }
-        }
       }
     }
 

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
@@ -86,7 +86,7 @@ class OrcaTaskMonitorAgent(
                   handleTaskFailure(resourceId, executionDetails)
                 }
               } catch (e: NoSuchResourceId) {
-                log.warn("No resource found for id $taskRecord")
+                log.warn("No resource found for id $resourceId")
               }
             }
             taskTrackingRepository.delete(executionDetails.id)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepository.kt
@@ -18,6 +18,7 @@ class SqlTaskTrackingRepository(
         .set(TASK_TRACKING.SUBJECT, task.subject)
         .set(TASK_TRACKING.TASK_ID, task.id)
         .set(TASK_TRACKING.TASK_NAME, task.name)
+        .set(TASK_TRACKING.ARTIFACT_VERSION_UNDER_DEPLOYMENT, task.artifactVersionUnderDeployment)
         .set(TASK_TRACKING.TIMESTAMP, clock.timestamp())
         .onDuplicateKeyIgnore()
         .execute()
@@ -27,11 +28,11 @@ class SqlTaskTrackingRepository(
   override fun getTasks(): Set<TaskRecord> {
     return sqlRetry.withRetry(RetryCategory.READ) {
       jooq
-        .select(TASK_TRACKING.SUBJECT, TASK_TRACKING.TASK_ID, TASK_TRACKING.TASK_NAME)
+        .select(TASK_TRACKING.TASK_ID, TASK_TRACKING.TASK_NAME, TASK_TRACKING.SUBJECT, TASK_TRACKING.ARTIFACT_VERSION_UNDER_DEPLOYMENT)
         .from(TASK_TRACKING)
         .fetch()
-        .map { (resource_id, task_id, task_name) ->
-          TaskRecord(task_id, task_name, resource_id)
+        .map { (task_id, task_name, subject, artifactVersionUnderDeployment) ->
+          TaskRecord(task_id, task_name, subject, artifactVersionUnderDeployment)
         }
         .toSet()
     }

--- a/keel-sql/src/main/resources/db/changelog/20200827-add-artifact-under-deployment-to-tasks.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200827-add-artifact-under-deployment-to-tasks.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-artifact-under-deployment-to-tasks
+      author: lpollo
+      changes:
+        - addColumn:
+            tableName: task_tracking
+            columns:
+              - name: artifact_version_under_deployment
+                type: varchar(255)
+                afterColumn: subject
+                constraints:
+                  nullable: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -170,3 +170,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200731-add-artifact-reference-column.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200827-add-artifact-under-deployment-to-tasks.yml
+      relativeToChangelogFile: true

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -67,9 +67,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import java.time.Clock
-import java.time.Duration
-import java.util.UUID
 import kotlinx.coroutines.runBlocking
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.ResponseBody.Companion.toResponseBody
@@ -87,6 +84,9 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
 import strikt.assertions.map
+import java.time.Clock
+import java.time.Duration
+import java.util.UUID
 
 // todo eb: we could probably have generic cluster tests
 // where you provide the correct info for the spec and active server groups
@@ -285,10 +285,6 @@ class TitusClusterHandlerTests : JUnit5Minutests {
               activeServerGroupResponseWest.name
             )
         }
-
-        test("a deployed event fired") {
-          verify { publisher.publishEvent(any<ArtifactVersionDeployed>()) }
-        }
       }
     }
 
@@ -444,16 +440,6 @@ class TitusClusterHandlerTests : JUnit5Minutests {
           serverGroups.byRegion(),
           modified.byRegion()
         )
-
-        test("events are fired for the artifact deploying") {
-          runBlocking {
-            upsert(resource, diff)
-          }
-          val slot = slot<OrchestrationRequest>()
-          coVerify { orcaService.orchestrate(resource.serviceAccount, capture(slot)) }
-          verify { publisher.publishEvent(ArtifactVersionDeploying(resource.id, "master-h2.blah")) }
-          verify { publisher.publishEvent(ArtifactVersionDeploying(resource.id, "im-master-now")) }
-        }
 
         test("resolving diff clones the current server group by digest") {
           runBlocking {


### PR DESCRIPTION
Currently, the way we track artifact deployments and update the corresponding artifact status in the database is to trigger `ArtifactVersionDeploying` and `ArtifactVersionDeployed` events from resource-specific handlers, namely `ClusterHandler` and `TitusClusterHandler`. Now that we have resource handler plugins outside of `keel`, we need to generalize this mechanism such that other types of resources which also have a linkage with artifacts can be supported.

This PR introduces the following changes to achieve that goal:
- Removes logic previously in `ClusterHandler` and `TitusClusterHandler` to emit those events
- Adds logic to `OrcaTaskLauncher` to emit the `ArtifactVersionDeploying` event when an artifact version is passed in by the resource handlers as an indication that the job is to deploy a new artifact version
- Adds logic to `OrcaTaskMonitorAgent` to emit the `ArtifactVersionDeployed` event when a task launched to deploy an artifact (as tracked by the new `TASK_TRACKING.ARTIFACT_VERSION_UNDER_DEPLOYMENT` column) completes successfully.

There's a chance that, if we fail to process the task results for any reason, or the task fails but the resource still converges to desired state, the artifact will not be marked as `CURRENT` as with the previous approach (which looked at the current state of clusters every time we queried `clouddriver`), but I feel like this might be acceptable. Would appreciate specific feedback on this trade-off.

