### PR TITLE
fix(retry): fixing retry for artifact metadata service

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BaseArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BaseArtifactSupplier.kt
@@ -8,19 +8,23 @@ import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.services.ArtifactMetadataService
 import org.slf4j.LoggerFactory
 
-abstract class BaseArtifactSupplier <A : DeliveryArtifact, V : VersioningStrategy> (
+abstract class BaseArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy>(
   open val artifactMetadataService: ArtifactMetadataService
-) : ArtifactSupplier<A, V>
-{
-   override suspend fun getArtifactMetadata(artifact: PublishedArtifact): ArtifactMetadata? {
+) : ArtifactSupplier<A, V> {
+  override suspend fun getArtifactMetadata(artifact: PublishedArtifact): ArtifactMetadata? {
     val buildNumber = artifact.metadata["buildNumber"]?.toString()
     val commitId = artifact.metadata["commitId"]?.toString()
     if (commitId == null || buildNumber == null) {
       return null
     }
-     log.debug("calling to artifact metadata service to get information for artifact: ${artifact.reference}, version: ${artifact.version}, type: ${artifact.type} " +
-       "with build number: $buildNumber and commit id: $commitId")
-    return artifactMetadataService.getArtifactMetadata(buildNumber, commitId)
+    log.debug("calling to artifact metadata service to get information for artifact: ${artifact.reference}, version: ${artifact.version}, type: ${artifact.type} " +
+      "with build number: $buildNumber and commit id: $commitId")
+    return try {
+      artifactMetadataService.getArtifactMetadata(buildNumber, commitId)
+    } catch (ex: Exception) {
+      log.error("failed to get artifact metadata for build $buildNumber and commit $commitId", ex)
+      null
+    }
   }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -70,6 +70,7 @@ class ArtifactController(
   ): List<String> =
     repository.artifactVersions(name, type)
 
+  // This endpoint is calling Igor (and then the CI provider) under the covers.
   @GetMapping(
     path = ["/build/{buildNumber}/commit/{commitId}"],
     produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.rest
 
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.events.ArtifactPublishedEvent
 import com.netflix.spinnaker.keel.api.events.ArtifactSyncEvent
@@ -7,7 +8,9 @@ import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedArtifactException
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.services.ArtifactMetadataService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus.ACCEPTED
@@ -25,7 +28,8 @@ import org.springframework.web.bind.annotation.RestController
 class ArtifactController(
   private val eventPublisher: ApplicationEventPublisher,
   private val repository: KeelRepository,
-  private val artifactSuppliers: List<ArtifactSupplier<*, *>>
+  private val artifactSuppliers: List<ArtifactSupplier<*, *>>,
+  private val artifactMetadataService: ArtifactMetadataService
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -65,6 +69,24 @@ class ArtifactController(
     @PathVariable type: ArtifactType
   ): List<String> =
     repository.artifactVersions(name, type)
+
+  @GetMapping(
+    path = ["/build/{buildNumber}/commit/{commitId}"],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  fun getArtifactMetadata(
+    @PathVariable buildNumber: String,
+    @PathVariable commitId: String
+  ): ArtifactMetadata? =
+
+     try {
+       runBlocking {
+         artifactMetadataService.getArtifactMetadata(buildNumber, commitId)
+       }
+    } catch (ex: Exception) {
+      log.error("failed to get artifact metadata for build $buildNumber and commit $commitId", ex)
+      null
+    }
 }
 
 data class EchoArtifactEvent(


### PR DESCRIPTION
- changed `retry` logic to support kotlin coroutines
- added an external endpoint for calling the artifact service, currently for debugging purposes. 