### PR TITLE
fix(orcaException): fix deserialization issue while parsing errors from orca

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaService.kt
@@ -97,14 +97,14 @@ data class GeneralErrorsDetails(
   val stackTrace: String?,
   val responseBody: String?,
   val kind: String?,
-  val error: String,
-  val errors: List<String>
+  val error: String?,
+  val errors: List<String>?
 )
 
 data class OrcaException(
-  val exceptionType: String,
-  val shouldRetry: Boolean,
-  val details: GeneralErrorsDetails
+  val exceptionType: String?,
+  val shouldRetry: Boolean?,
+  val details: GeneralErrorsDetails?
 )
 
 data class ClouddriverException(

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskMonitorAgent.kt
@@ -65,7 +65,10 @@ class OrcaTaskMonitorAgent(
                     // when we get not found exception from orca, we shouldn't try to get the status anymore
                     taskTrackingRepository.delete(it.id)
                   }
-                  else -> throw e
+                  else -> log.warn(
+                    "Exception ${e.message} has caught while calling orca to fetch status for execution id: ${it.id}" ,
+                    e
+                  )
                 }
                 null
               }
@@ -111,7 +114,7 @@ class OrcaTaskMonitorAgent(
 
       // find the first exception and return
       if (context?.exception != null) {
-        return context.exception.details.errors.joinToString(",")
+        return context.exception.details?.errors?.joinToString(",")
       }
 
       if (context?.clouddriverException != null) {


### PR DESCRIPTION
keel assumed that failed orca tasks always had certain fields present in the context about the exception. This turned out not to be true. This change makes all exception fields optional so keel doesn't throw a deserialization exception.

In addition, if keel encountered an error when deserializing a task, that would prevent it from processing other tasks that are valid. This PR adds a warning log instead of throwing an exception.