### PR TITLE
Fix deserialization of Titus cluster resources

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/jackson/TitusClusterSpecDeserializer.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/jackson/TitusClusterSpecDeserializer.kt
@@ -27,7 +27,15 @@ class TitusClusterSpecDeserializer : StdNodeBasedDeserializer<TitusClusterSpec>(
           ?: root.missingFieldError("locations"),
         _defaults = TitusServerGroupSpec(
           capacity = treeToValue(root.get("capacity")),
+          constraints = treeToValue(root.get("constraints")),
           dependencies = treeToValue(root.get("dependencies")),
+          env = treeToValue(root.get("env")),
+          containerAttributes = treeToValue(root.get("containerAttributes")),
+          resources = treeToValue(root.get("resources")),
+          iamProfile = treeToValue(root.get("iamProfile")),
+          entryPoint = treeToValue(root.get("entryPoint")),
+          capacityGroup = treeToValue(root.get("capacityGroup")),
+          migrationPolicy = treeToValue(root.get("migrationPolicy")),
           tags = treeToValue(root.get("tags"))
         ),
         // this is pretty hairy but we can't just use treeToValue because the map's value type is erased


### PR DESCRIPTION
This was an error caused when moving from a `@JsonCreator` factory method see https://github.com/spinnaker/keel/blob/v0.173.0/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/cluster/TitusClusterSpec.kt#L95-L112 to a custom deserializer (in order to remove Jackson annotations from the API types).