### PR TITLE
fix(artifacts): More fixes for NPM version parsing

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -69,6 +69,7 @@ class DebianArtifactSupplier(
   }
 
   override fun getVersionDisplayName(artifact: PublishedArtifact): String {
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val appversion = AppVersion.parseName(artifact.version)
     return if (appversion?.version != null) {
       appversion.version
@@ -79,6 +80,7 @@ class DebianArtifactSupplier(
 
   override fun parseDefaultBuildMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): BuildMetadata? {
     // attempt to parse helpful info from the appversion.
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val appversion = AppVersion.parseName(artifact.version)
     if (appversion?.buildNumber != null) {
       return BuildMetadata(id = appversion.buildNumber.toInt())
@@ -87,8 +89,8 @@ class DebianArtifactSupplier(
   }
 
   override fun parseDefaultGitMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): GitMetadata? {
-
     // attempt to parse helpful info from the appversion.
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val appversion = AppVersion.parseName(artifact.version)
     if (appversion?.commit != null) {
       return GitMetadata(commit = appversion.commit)

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
@@ -18,12 +18,12 @@ import com.netflix.spinnaker.keel.services.ArtifactMetadataService
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.coEvery as every
-import io.mockk.coVerify as verify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import io.mockk.coEvery as every
+import io.mockk.coVerify as verify
 
 internal class NpmArtifactSupplierTests : JUnit5Minutests {
   object Fixture {
@@ -36,14 +36,14 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
       deliveryConfigName = deliveryConfig.name,
       statuses = setOf(CANDIDATE)
     )
-    val versions = listOf("1.0.0-rc", "1.0.0", "1.0.1-5", "1.0.2-h6", "1.0.3-h7-gc0c60369")
+    val versions = listOf("1.0.0-rc", "1.0.0-rc.1", "1.0.0", "1.0.1-5", "1.0.2-h6", "1.0.3-rc-h7.gc0c60369")
     val latestArtifact = PublishedArtifact(
       name = npmArtifact.name,
       type = npmArtifact.type,
       reference = npmArtifact.reference,
-      version = "${npmArtifact.name}-${versions.last()}",
-      metadata = mapOf("releaseStatus" to CANDIDATE, "buildNumber" to "1", "commitId" to "a15p0")
-      )
+      version = versions.last(),
+      metadata = mapOf("releaseStatus" to CANDIDATE, "buildNumber" to "7", "commitId" to "gc0c60369")
+    )
     val npmArtifactSupplier = NpmArtifactSupplier(eventBridge, artifactService, artifactMetadataService)
 
     val artifactMetadata = ArtifactMetadata(
@@ -56,10 +56,10 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
           name = "job bla bla",
           link = "enkins.com"
         ),
-        number = "1"
+        number = "7"
       ),
       GitMetadata(
-        commit = "a15p0",
+        commit = "gc0c60369",
         author = "keel-user",
         repo = Repo(
           name = "keel",
@@ -70,7 +70,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
           url = "www.github.com/pr/111"
         ),
         commitInfo = Commit(
-          sha = "a15p0",
+          sha = "gc0c60369",
           message = "this is a commit message",
           link = ""
         ),
@@ -91,7 +91,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
           artifactService.getArtifact(npmArtifact.name, versions.last(), NPM)
         } returns latestArtifact
         every {
-          artifactMetadataService.getArtifactMetadata("1", "a15p0")
+          artifactMetadataService.getArtifactMetadata("7", "gc0c60369")
         } returns artifactMetadata
       }
 

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
@@ -36,13 +36,13 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
       deliveryConfigName = deliveryConfig.name,
       statuses = setOf(CANDIDATE)
     )
-    val versions = listOf("1.0.0-rc", "1.0.0-rc.1", "1.0.0", "1.0.1-5", "1.0.2-h6", "1.0.3-rc-h7.gc0c60369")
+    val versions = listOf("1.0.0-rc", "1.0.0-rc.1", "1.0.0", "1.0.1-5", "1.0.2-h6", "1.0.3-rc-h7.gc0c603")
     val latestArtifact = PublishedArtifact(
       name = npmArtifact.name,
       type = npmArtifact.type,
       reference = npmArtifact.reference,
       version = versions.last(),
-      metadata = mapOf("releaseStatus" to CANDIDATE, "buildNumber" to "7", "commitId" to "gc0c60369")
+      metadata = mapOf("releaseStatus" to CANDIDATE, "buildNumber" to "7", "commitId" to "gc0c603")
     )
     val npmArtifactSupplier = NpmArtifactSupplier(eventBridge, artifactService, artifactMetadataService)
 
@@ -59,7 +59,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
         number = "7"
       ),
       GitMetadata(
-        commit = "gc0c60369",
+        commit = "gc0c603",
         author = "keel-user",
         repo = Repo(
           name = "keel",
@@ -70,7 +70,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
           url = "www.github.com/pr/111"
         ),
         commitInfo = Commit(
-          sha = "gc0c60369",
+          sha = "gc0c603",
           message = "this is a commit message",
           link = ""
         ),
@@ -91,7 +91,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
           artifactService.getArtifact(npmArtifact.name, versions.last(), NPM)
         } returns latestArtifact
         every {
-          artifactMetadataService.getArtifactMetadata("7", "gc0c60369")
+          artifactMetadataService.getArtifactMetadata("7", "gc0c603")
         } returns artifactMetadata
       }
 

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -121,6 +121,7 @@ class ImageHandler(
     desiredVersion: String,
     diff: DefaultResourceDiff<Image>
   ): List<Task> {
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val appVersion = AppVersion.parseName(desiredVersion)
     val packageName = appVersion.packageName
     val version = desiredVersion.substringAfter("$packageName-")

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -53,6 +53,7 @@ class ImageExistsConstraintEvaluator(
     log.debug("Searching for baked image for {} in {}", version, vmOptions.regions.joinToString())
     return runBlocking {
       imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
         AppVersion.parseName(version),
         defaultImageAccount,
         vmOptions.regions

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -74,6 +74,7 @@ class ImageService(
       .filter { it.hasAppVersion }
       .sortedWith(NamedImageComparator)
       .firstOrNull {
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
         AppVersion.parseName(it.appVersion).packageName == packageName
       }
 
@@ -93,6 +94,7 @@ class ImageService(
       .filter { it.hasAppVersion }
       .sortedWith(NamedImageComparator)
       .firstOrNull {
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
         AppVersion.parseName(it.appVersion).run {
           packageName == appVersion.packageName && version == appVersion.version && commit == appVersion.commit
         }
@@ -111,6 +113,7 @@ class ImageService(
       .filter { it.hasAppVersion }
       .sortedWith(NamedImageComparator)
       .find { namedImage ->
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
         val curAppVersion = AppVersion.parseName(namedImage.appVersion)
         curAppVersion.packageName == appVersion.packageName &&
           curAppVersion.version == appVersion.version &&
@@ -139,6 +142,7 @@ class ImageService(
     val image = filteredImages
       .find {
         val errors = mutableListOf<String>()
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
         val curAppVersion = AppVersion.parseName(it.appVersion)
         if (curAppVersion.packageName != packageName) {
           errors.add("[package name ${curAppVersion.packageName} does not match required package]")
@@ -173,6 +177,7 @@ class ImageService(
       .filter { it.hasAppVersion }
       .sortedWith(NamedImageComparator)
       .filter {
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
         AppVersion.parseName(it.appVersion).packageName == packageName
       }
       .firstOrNull { namedImage ->

--- a/keel-core/src/main/java/com/netflix/rocket/semver/shaded/DebianVersionComparator.java
+++ b/keel-core/src/main/java/com/netflix/rocket/semver/shaded/DebianVersionComparator.java
@@ -4,7 +4,7 @@ import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class NetflixVersionComparator implements Comparator<String> {
+public class DebianVersionComparator implements Comparator<String> {
   private static final String PRERELEASE_SPLIT = "~";
   private static final String DOT_SEPARATOR = "\\.";
   private static final String PRERELEASE_SEPARATOR = "[.+]";
@@ -93,9 +93,17 @@ public class NetflixVersionComparator implements Comparator<String> {
       if (i >= mainParts1.length) {
         return 1;
       }
-      int diff = Integer.parseInt(mainParts0[i]) - Integer.parseInt(mainParts1[i]);
-      if (diff != 0) {
-        return diff;
+      boolean isNumeric0 = isNumeric(mainParts0[i]);
+      boolean isNumeric1 = isNumeric(mainParts1[i]);
+      if (isNumeric0 && isNumeric1) {
+        int diff = Integer.parseInt(mainParts0[i]) - Integer.parseInt(mainParts1[i]);
+        if (diff != 0) {
+          return diff;
+        }
+      } else if (isNumeric0) {
+        return 1;
+      } else {
+        return -1;
       }
     }
     return mainParts0.length - mainParts1.length;

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemVerVersioningStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemVerVersioningStrategy.kt
@@ -15,13 +15,13 @@ object NetflixSemVerVersioningStrategy : VersioningStrategy {
 
   private val NETFLIX_VERSION_REGEX = Regex(
     // version digits (capturing group 1)
-    "(\\d+\\.\\d+\\.\\d+)" +
+  "(\\d+\\.\\d+\\.\\d+)" +
     // release qualifier (capturing group 3)
-    "([-~](dev|snapshot|rc|rel|final))?" +
-    // build number (capturing group 5)
-    "([-\\.][h]?(\\d+\\b))?" +
-    // commit hash (capturing group 7)
-    "(-(\\w{7,}))?"
+    "([-~](dev|snapshot|rc)(\\.\\d+)?)?" +
+    // build number (capturing group 6)
+    "(-[h]?(\\d+\\b))?" +
+    // commit hash (capturing group 8)
+    "(\\.(\\w{7,}))?"
   )
 
   /**
@@ -37,7 +37,7 @@ object NetflixSemVerVersioningStrategy : VersioningStrategy {
    */
   fun getBuildNumber(artifact: PublishedArtifact): Int? {
     return try {
-      NETFLIX_VERSION_REGEX.find(artifact.version)?.groups?.get(5)?.value?.toInt()
+      NETFLIX_VERSION_REGEX.find(artifact.version)?.groups?.get(6)?.value?.toInt()
     } catch (e: NumberFormatException) {
       null
     }
@@ -47,7 +47,7 @@ object NetflixSemVerVersioningStrategy : VersioningStrategy {
    * Extracts the commit hash from the version string, if available.
    */
   fun getCommitHash(artifact: PublishedArtifact): String? {
-    return NETFLIX_VERSION_REGEX.find(artifact.version)?.groups?.get(7)?.value
+    return NETFLIX_VERSION_REGEX.find(artifact.version)?.groups?.get(8)?.value
   }
 
   override fun toString(): String =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
@@ -18,7 +18,7 @@
 package com.netflix.spinnaker.keel.core
 
 import com.netflix.frigga.ami.AppVersion
-import com.netflix.rocket.semver.shaded.NetflixVersionComparator
+import com.netflix.rocket.semver.shaded.DebianVersionComparator
 import com.netflix.spinnaker.keel.api.artifacts.SortType.INCREASING
 import com.netflix.spinnaker.keel.api.artifacts.SortType.SEMVER
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
@@ -92,7 +92,7 @@ val NETFLIX_SEMVER_COMPARATOR: Comparator<String> = object : Comparator<String> 
   override fun compare(s1: String, s2: String) =
     debComparator.compare(s2.toVersion(), s1.toVersion())
 
-  private val debComparator = NullSafeComparator(NetflixVersionComparator(), true)
+  private val debComparator = NullSafeComparator(DebianVersionComparator(), true)
 
   private fun String.toVersion(): String? = run {
     val appVersion = AppVersion.parseName(this)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
@@ -95,6 +95,7 @@ val NETFLIX_SEMVER_COMPARATOR: Comparator<String> = object : Comparator<String> 
   private val debComparator = NullSafeComparator(DebianVersionComparator(), true)
 
   private fun String.toVersion(): String? = run {
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val appVersion = AppVersion.parseName(this)
     if (appVersion == null) {
       log.warn("Unparseable artifact version \"{}\" encountered", this)

--- a/keel-core/src/test/java/com/netflix/rocket/semver/shaded/DebianVersionComparatorTest.java
+++ b/keel-core/src/test/java/com/netflix/rocket/semver/shaded/DebianVersionComparatorTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class DebianVersionComparatorTest {
-  private static NetflixVersionComparator comparator = new NetflixVersionComparator();
+  private static DebianVersionComparator comparator = new DebianVersionComparator();
 
   @ParameterizedTest(name = "[{index}]: {0} < {1}")
   @MethodSource("compareVersionsLessThan")
@@ -39,7 +39,8 @@ class DebianVersionComparatorTest {
         of("1.0.0~dev.1+abcdef", "1.0.0~dev.1+bcdef0"),
         of("1.0.0~rc.1.dev.2+abcdef", "1.0.0~rc.1"),
         of("1.0.0-h2.abcdef", "1.0.0-h11.123456"),
-        of("1.0.0-LOCAL", "1.0.0-h1.abcdef"));
+        of("1.0.0-LOCAL", "1.0.0-h1.abcdef"),
+        of("1.0.0-m001-h123", "1.0.0-h1.abcdef"));
   }
 
   @ParameterizedTest(name = "[{index}]: {0} == {1}")
@@ -83,7 +84,8 @@ class DebianVersionComparatorTest {
         of("1.0.0~dev.2+bcdefa", "1.0.0~dev.2+abcdef"),
         of("1.0.0~rc.1", "1.0.0~rc.1.dev.1+abcdef"),
         of("1.0.0-h23.123abc", "1.0.0-h12.34ad35"),
-        of("1.0.0-h2.123456", "1.0.0-LOCAL"));
+        of("1.0.0-h2.123456", "1.0.0-LOCAL"),
+        of("1.0.0-h.123", "1.0.1-m001-h762"));
   }
 
   @Test

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemverVersioningStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemverVersioningStrategyTests.kt
@@ -15,29 +15,24 @@ class NetflixSemverVersioningStrategyTests : JUnit5Minutests {
 
     context("valid version strings") {
       mapOf(
+        // simple versions
         "1.0.0" to Pair(null, null),
+        // pre-release versions
+        "1.0.0-dev.3" to Pair(null, null),
+        "1.0.0-snapshot.3" to Pair(null, null),
+        "1.0.0-rc.3" to Pair(null, null),
+        // versions with build number
         "1.0.0-3" to Pair(3, null),
         "1.0.0-h3" to Pair(3, null),
-        "1.0.0-dev.3" to Pair(3, null),
-        "1.0.0-snapshot.3" to Pair(3, null),
-        "1.0.0-rc.3" to Pair(3, null),
-        "1.0.0-rel.3" to Pair(3, null),
-        "1.0.0-final.3" to Pair(3, null),
-        "1.0.0~dev.3" to Pair(3, null),
-        "1.0.0~snapshot.3" to Pair(3, null),
-        "1.0.0~rc.3" to Pair(3, null),
-        "1.0.0~rel.3" to Pair(3, null),
-        "1.0.0~final.3" to Pair(3, null),
-        "1.0.0-6fbf05f078e2fd0ca75341bdaf3206a16beeb328" to Pair(null, "6fbf05f078e2fd0ca75341bdaf3206a16beeb328"),
-        "1.0.0-3-6fbf05f078e2fd0ca75341bdaf3206a16beeb328" to Pair(3, "6fbf05f078e2fd0ca75341bdaf3206a16beeb328"),
-        "1.0.0-h3-6fbf05f078e2fd0ca75341bdaf3206a16beeb328" to Pair(3, "6fbf05f078e2fd0ca75341bdaf3206a16beeb328"),
-        "1.0.0-dev.12-f89a05bfb44d54227f3cebaec59230a6077c0505" to Pair(12, "f89a05bfb44d54227f3cebaec59230a6077c0505"),
-        "1.0.0-dev-12-f89a05bfb44d54227f3cebaec59230a6077c0505" to Pair(12, "f89a05bfb44d54227f3cebaec59230a6077c0505"),
-        "1.0.0~dev.15-4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
-        "1.0.0~snapshot.15-4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
-        "1.0.0~rc.15-4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
-        "1.0.0~rel.15-4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
-        "1.0.0~final.15-4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a")
+        // versions with build number and commit hash
+        "1.0.0-3.6fbf05f078e2fd0ca75341bdaf3206a16beeb328" to Pair(3, "6fbf05f078e2fd0ca75341bdaf3206a16beeb328"),
+        "1.0.0-h3.6fbf05f078e2fd0ca75341bdaf3206a16beeb328" to Pair(3, "6fbf05f078e2fd0ca75341bdaf3206a16beeb328"),
+        // pre-release versions with build number and commit hash
+        "1.0.0-dev.3-12.f89a05bfb44d54227f3cebaec59230a6077c0505" to Pair(12, "f89a05bfb44d54227f3cebaec59230a6077c0505"),
+        "1.0.0-dev.3-h12.f89a05bfb44d54227f3cebaec59230a6077c0505" to Pair(12, "f89a05bfb44d54227f3cebaec59230a6077c0505"),
+        "1.0.0~dev-h15.4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
+        "1.0.0~snapshot.1-15.4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
+        "1.0.0~rc.2-h15.4cbd040533a2f43fc6691d773d510cda70f4126a" to Pair(15, "4cbd040533a2f43fc6691d773d510cda70f4126a")
       ).forEach { version, (build, commit) ->
         val artifact = PublishedArtifact("test", "DEB", "test", version)
 
@@ -54,10 +49,11 @@ class NetflixSemverVersioningStrategyTests : JUnit5Minutests {
     context("invalid version strings") {
       listOf(
         "1.0.0-i3",
-        "1.0.0-foo.12-f89a05bfb44d54227f3cebaec59230a6077c0505",
-        "1.0.0-bar-12-f89a05bfb44d54227f3cebaec59230a6077c0505",
-        "1.0.0-foo-12-banana",
-        "1.0.0-bar-12-123456",
+        "1.0.0-foo-12.f89a05bfb44d54227f3cebaec59230a6077c0505",
+        "1.0.0-foo.1-12.f89a05bfb44d54227f3cebaec59230a6077c0505",
+        "1.0.0-foo-12.banana",
+        "1.0.0-foo-h12.banana",
+        "1.0.0-foo-h12.123456",
         "1.0.0beta"
       ).forEach { version ->
         val artifact = PublishedArtifact("test", "DEB", "test", version)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -54,6 +54,7 @@ class Ec2CanaryConstraintDeployHandler(
     val judge = "canary:${deliveryConfig.application}:${targetEnvironment.name}:${constraint.canaryConfigId}"
 
     val image = imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+      // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
       appVersion = AppVersion.parseName(version.replace("~", "_")),
       account = imageResolver.defaultImageAccount,
       regions = constraint.regions.toList()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -88,6 +88,7 @@ class ImageResolver(
       environment.name
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
     val image = imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+      // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
       appVersion = AppVersion.parseName(artifactVersion),
       account = account,
       regions = regions

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -393,6 +393,7 @@ class ClusterHandler(
       serverGroupName = base.name
     ) ?: RedBlack()
 
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val appversion = AppVersion.parseName(base.image?.appVersion).packageName
 
     val spec = ClusterSpec(
@@ -441,6 +442,7 @@ class ClusterHandler(
       throw ExportError("Server group ${base.name} doesn't have image information - unable to correctly export artifact.")
     }
 
+    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
     val artifactName = AppVersion.parseName(base.launchConfiguration.appVersion).packageName
 
     val status = debianArtifactParser.parseStatus(base.launchConfiguration.appVersion?.substringAfter("$artifactName-"))


### PR DESCRIPTION
In this PR:
- Update for shaded Rocket's `DebianVersionComparator` which fixes the `NumberFormatException`
- Additional updates to the regular expression used in `NpmArtifactSupplier` such that it matches the format used for Debian packages at Netflix and allows us to continue to use the same comparator.

As noted in the `TODOs` added in this PR, in my opinion we should consolidate/simplify our parsing of semantic version strings, ideally by using an off-the-shelf library like we're already using for Docker tags, but at the very least consolidating between our usage of the `frigga` library's `AppVersion` class and the Rocket code when comparing versions for Debian and NPM.