### PR TITLE
fix(titus): Revert ignoring serialization of container field in TitusClusterSpec

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/jackson/mixins/TitusClusterSpecMixin.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/jackson/mixins/TitusClusterSpecMixin.kt
@@ -29,9 +29,6 @@ interface TitusClusterSpecMixin {
   val artifactVersion: String?
 
   @get:JsonIgnore
-  val container: ContainerProvider
-
-  @get:JsonIgnore
   val maxDiffCount: Int?
 
   @get:JsonIgnore


### PR DESCRIPTION
We were ignoring the `container` field when serializing, but requiring it when deserializing:
https://github.com/spinnaker/keel/blob/9e944c253820818464d92e38a84be98c474671a3/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/jackson/TitusClusterSpecDeserializer.kt#L48-L49

This just removes the unnecessary annotated field from the mixin.