### PR TITLE
fix(orca): support BUFFERED execution status

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaExecutionStatus.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaExecutionStatus.kt
@@ -27,6 +27,7 @@ enum class OrcaExecutionStatus {
   CANCELED,
   REDIRECT,
   STOPPED,
+  BUFFERED,
   SKIPPED;
 
   fun isFailure() = listOf(TERMINAL, FAILED_CONTINUE, STOPPED, CANCELED).contains(this)

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaExecutionStatus.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaExecutionStatus.kt
@@ -32,6 +32,6 @@ enum class OrcaExecutionStatus {
 
   fun isFailure() = listOf(TERMINAL, FAILED_CONTINUE, STOPPED, CANCELED).contains(this)
   fun isSuccess() = listOf(SUCCEEDED).contains(this)
-  fun isIncomplete() = listOf(NOT_STARTED, RUNNING, PAUSED, SUSPENDED).contains(this)
+  fun isIncomplete() = listOf(NOT_STARTED, RUNNING, PAUSED, SUSPENDED, BUFFERED).contains(this)
   fun isComplete() = isFailure() || isSuccess()
 }


### PR DESCRIPTION
We got the following error because keel was not aware of the "buffered" orca execution status.

```
com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `com.netflix.spinnaker.keel.orca.OrcaExecutionStatus` from String "BUFFERED": not one of the values accepted for Enum class: [SKIPPED, SUCCEEDED, NOT_STARTED, FAILED_CONTINUE, SUSPENDED, TERMINAL, STOPPED, PAUSED, RUNNING, CANCELED, REDIRECT]
```

Add support for this status.