### PR TITLE
fix(artifacts): Fix Netflix semver version comparisons

### DIFF
--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
@@ -14,6 +14,7 @@ import com.netflix.spinnaker.keel.api.artifacts.Repo
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedVersioningStrategy
 import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
+import com.netflix.spinnaker.keel.core.NETFLIX_SEMVER_COMPARATOR
 import com.netflix.spinnaker.keel.services.ArtifactMetadataService
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import dev.minutest.junit.JUnit5Minutests
@@ -88,7 +89,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
           artifactService.getVersions(npmArtifact.name, listOf(CANDIDATE.name), artifactType = NPM)
         } returns versions
         every {
-          artifactService.getArtifact(npmArtifact.name, versions.last(), NPM)
+          artifactService.getArtifact(npmArtifact.name, versions.sortedWith(NETFLIX_SEMVER_COMPARATOR).first(), NPM)
         } returns latestArtifact
         every {
           artifactMetadataService.getArtifactMetadata("7", "gc0c603")
@@ -115,7 +116,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
         expectThat(result).isEqualTo(latestArtifact)
         verify(exactly = 1) {
           artifactService.getVersions(npmArtifact.name, listOf(CANDIDATE.name), artifactType = NPM)
-          artifactService.getArtifact(npmArtifact.name, versions.last(), NPM)
+          artifactService.getArtifact(npmArtifact.name, versions.sortedWith(NETFLIX_SEMVER_COMPARATOR).first(), NPM)
         }
       }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemVerVersioningStrategy.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemVerVersioningStrategy.kt
@@ -25,6 +25,12 @@ object NetflixSemVerVersioningStrategy : VersioningStrategy {
   )
 
   /**
+   * Extracts the full version string matching the accepted pattern, or null if the input doesn't match.
+   */
+  fun extractVersion(input: String): String? =
+    NETFLIX_VERSION_REGEX.find(input)?.groups?.get(0)?.value
+
+  /**
    * Extracts a version display name from the longer version string, leaving out build and git details if present.
    */
   fun getVersionDisplayName(artifact: PublishedArtifact): String {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparators.kt
@@ -17,11 +17,11 @@
  */
 package com.netflix.spinnaker.keel.core
 
-import com.netflix.frigga.ami.AppVersion
 import com.netflix.rocket.semver.shaded.DebianVersionComparator
 import com.netflix.spinnaker.keel.api.artifacts.SortType.INCREASING
 import com.netflix.spinnaker.keel.api.artifacts.SortType.SEMVER
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
+import com.netflix.spinnaker.keel.artifacts.NetflixSemVerVersioningStrategy
 import com.netflix.spinnaker.keel.exceptions.InvalidRegexException
 import net.swiftzer.semver.SemVer
 import org.slf4j.LoggerFactory
@@ -95,13 +95,12 @@ val NETFLIX_SEMVER_COMPARATOR: Comparator<String> = object : Comparator<String> 
   private val debComparator = NullSafeComparator(DebianVersionComparator(), true)
 
   private fun String.toVersion(): String? = run {
-    // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val appVersion = AppVersion.parseName(this)
+    val appVersion = NetflixSemVerVersioningStrategy.extractVersion(this)
     if (appVersion == null) {
-      log.warn("Unparseable artifact version \"{}\" encountered", this)
+      log.warn("Unparseable artifact version \"{}\" encountered. Sorting results will be unpredictable.", this)
       null
     } else {
-      removePrefix(appVersion.packageName).removePrefix("-")
+      appVersion
     }
   }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemverVersioningStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixSemverVersioningStrategyTests.kt
@@ -36,12 +36,15 @@ class NetflixSemverVersioningStrategyTests : JUnit5Minutests {
       ).forEach { version, (build, commit) ->
         val artifact = PublishedArtifact("test", "DEB", "test", version)
 
-        test("returns expected build number for version $version") {
-          expectThat(getBuildNumber(artifact)).isEqualTo(build)
-        }
+        // check with and without debian package name prefix
+        listOf("", "mydebian-").forEach { prefix ->
+          test("returns expected build number for version $prefix$version") {
+            expectThat(getBuildNumber(artifact)).isEqualTo(build)
+          }
 
-        test("returns expected commit hash for version $version") {
-          expectThat(getCommitHash(artifact)).isEqualTo(commit)
+          test("returns expected commit hash for version $prefix$version") {
+            expectThat(getCommitHash(artifact)).isEqualTo(commit)
+          }
         }
       }
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparatorsTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/core/VersioningStrategyComparatorsTests.kt
@@ -1,0 +1,58 @@
+package com.netflix.spinnaker.keel.core
+
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isGreaterThan
+import strikt.assertions.isLessThan
+
+class VersioningStrategyComparatorsTests : JUnit5Minutests {
+  fun tests() = rootContext<Comparator<String>> {
+    context("NETFLIX_SEMVER_COMPARATOR") {
+
+      fixture {
+        NETFLIX_SEMVER_COMPARATOR
+      }
+
+      test("compares semver versions correctly") {
+        // note: comparator is descending by default, hence the backward less/greater than
+        expectThat(compare("0.368.0-h473.dfc46fb", "0.367.0-h468.0493add"))
+          .isLessThan(0)
+        expectThat(compare("0.367.0-h468.0493add", "0.368.0-h473.dfc46fb"))
+          .isGreaterThan(0)
+        expectThat(compare("0.368.0-h473.dfc46fb", "0.368.0-h473.dfc46fb"))
+          .isEqualTo(0)
+
+        // pre-release versions
+        expectThat(compare("1.0.0-dev-h18.d5230a7", "1.0.0-dev-h17.7d1e1c3"))
+          .isLessThan(0)
+        expectThat(compare("1.0.0-rc-h18.d5230a7", "1.0.0-dev-h18.d5230a7"))
+          .isLessThan(0)
+        expectThat(compare("1.0.0-h18.d5230a7", "1.0.0-rc-h18.d5230a7"))
+          .isLessThan(0)
+        expectThat(compare("1.0.0", "1.0.0-rc-h18.d5230a7"))
+          .isLessThan(0)
+      }
+
+      test("compares versions prefixed by debian package names correctly") {
+        expectThat(compare("mypkg-0.368.0-h473.dfc46fb", "mypkg-0.367.0-h468.0493add"))
+          .isLessThan(0)
+        expectThat(compare("mypkg-0.367.0-h468.0493add", "mypkg-0.368.0-h473.dfc46fb"))
+          .isGreaterThan(0)
+        expectThat(compare("mypkg-0.368.0-h473.dfc46fb", "mypkg-0.368.0-h473.dfc46fb"))
+          .isEqualTo(0)
+
+        // pre-release versions
+        expectThat(compare("mypkg-1.0.0-dev-h18.d5230a7", "mypkg-1.0.0-dev-h17.7d1e1c3"))
+          .isLessThan(0)
+        expectThat(compare("mypkg-1.0.0-rc-h18.d5230a7", "mypkg-1.0.0-dev-h18.d5230a7"))
+          .isLessThan(0)
+        expectThat(compare("mypkg-1.0.0-h18.d5230a7", "mypkg-1.0.0-rc-h18.d5230a7"))
+          .isLessThan(0)
+        expectThat(compare("mypkg-1.0.0", "mypkg-1.0.0-rc-h18.d5230a7"))
+          .isLessThan(0)
+      }
+    }
+  }
+}


### PR DESCRIPTION
We were still failing to parse valid versions of NPM artifacts with Frigga in `NETFLIX_SEMVER_COMPARATOR`. This PR fixes that by replacing the use of Frigga in this case with our internal parser, using a regular expression we know matches Rocket and accommodates for version strings with and without the package name as a prefix.