### PR TITLE
Document enums in schema as lower case

### DIFF
--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Generator.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Generator.kt
@@ -44,7 +44,13 @@ class Generator(
      * type is. If `false` nullable properties are treated as optional (because omitting them in the
      * JSON maps to `null` when Jackson parses it).
      */
-    val nullableAsOneOf: Boolean = false
+    val nullableAsOneOf: Boolean = false,
+
+    /**
+     * If `true`, enum names are lower-cased in the schema. If `false` they are rendered as-is in
+     * the enum declaration.
+     */
+    val lowerCaseEnums: Boolean = false
   )
 
   /**
@@ -425,7 +431,9 @@ class Generator(
       require(isEnum) {
         "enumNames is only valid on enum types"
       }
-      return (jvmErasure.java as Class<Enum<*>>).enumConstants.map { it.name }
+      return (jvmErasure.java as Class<Enum<*>>)
+        .enumConstants
+        .map { if (options.lowerCaseEnums) it.name.toLowerCase() else it.name }
     }
 
   /**

--- a/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
+++ b/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
@@ -115,18 +115,37 @@ internal class GeneratorTests {
     )
 
     enum class Size {
-      tall, grande, venti
+      TALL, GRANDE, VENTI
     }
 
-    val schema by lazy { generateSchema<Foo>() }
+    @Nested
+    @DisplayName("with lower-case-enums set to true")
+    class LowerCaseEnumsOn : GeneratorTestBase(Generator.Options(lowerCaseEnums = true)) {
+      val schema by lazy { generateSchema<Foo>() }
 
-    @Test
-    fun `applies correct property types`() {
-      expectThat(schema.properties)
-        .get(Foo::size.name)
-        .isA<EnumSchema>()
-        .get { enum }
-        .containsExactly(Size.values().map { it.name })
+      @Test
+      fun `schema is an enum with all enum names lower-cased`() {
+        expectThat(schema.properties)
+          .get(Foo::size.name)
+          .isA<EnumSchema>()
+          .get { enum }
+          .containsExactly(Size.values().map { it.name.toLowerCase() })
+      }
+    }
+
+    @Nested
+    @DisplayName("with lower-case-enums set to false")
+    class LowerCaseEnumsFalse : GeneratorTestBase(Generator.Options(lowerCaseEnums = false)) {
+      val schema by lazy { generateSchema<Foo>() }
+
+      @Test
+      fun `schema is an enum with all enum names`() {
+        expectThat(schema.properties)
+          .get(Foo::size.name)
+          .isA<EnumSchema>()
+          .get { enum }
+          .containsExactly(Size.values().map { it.name })
+      }
     }
   }
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/DefaultConfiguration.kt
@@ -113,6 +113,9 @@ class DefaultConfiguration(
       ResourceKindSchemaCustomizer(
         resourceHandlers.map { it.supportedKind.kind } + migrators.map { it.input.kind }
       )
+    ),
+    options = Generator.Options(
+      lowerCaseEnums = true
     )
   )
 }


### PR DESCRIPTION
Since Keel accepts enums case-insensitively and we typically document them as lower case this PR makes the schema generator emit them as lower-case as well.