### PR TITLE
fix(artifacts): Attempt to fix retrieval of artifact metadata from igor

### DIFF
--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/BuildService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/BuildService.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.igor
 import com.netflix.spinnaker.model.Build
 import retrofit2.http.GET
+import retrofit2.http.Headers
 import retrofit2.http.Query
 
 interface BuildService {
@@ -15,6 +16,7 @@ interface BuildService {
    * @param buildNumber the build number .
    */
   @GET("/ci/builds")
+  @Headers("Accept: application/json")
   suspend fun getArtifactMetadata(
     @Query("commitId") commitId: String,
     @Query("buildNumber") buildNumber: String,

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/model/Build.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/model/Build.kt
@@ -14,9 +14,9 @@ data class Build(
   val fullDisplayName: String? = null,
   val name: String? = null,
   val number: Int = 0,
-  val duration: Int? = null,
+  val duration: Long? = null,
   /** String representation of time in nanoseconds since Unix epoch  */
-   val timestamp: String? = null,
+  val timestamp: String? = null,
 
   val result: Result? = null,
   val url: String? = null,


### PR DESCRIPTION
Going off on a hunch here that maybe the reason we're getting `null` from the retrofit call is that we're failing to parse the response as JSON (even though I'd have expected that to log an exception, which it doesn't).