### PR TITLE
feat(notifications): Improve manual judgement notifications

### DIFF
--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -21,6 +21,7 @@ import strikt.assertions.isA
   classes = [KeelApplication::class],
   webEnvironment = MOCK,
   properties = [
+    "spinnaker.baseUrl=http://spinnaker",
     "sql.enabled=true",
     "sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
     "sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -42,6 +42,7 @@ import strikt.assertions.isFalse
   classes = [KeelApplication::class, TestConfiguration::class],
   webEnvironment = MOCK,
   properties = [
+    "spinnaker.baseUrl=http://spinnaker",
     "sql.enabled=true",
     "sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
     "sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",

--- a/keel-web/src/test/resources/application.properties
+++ b/keel-web/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+spinnaker.baseUrl=https://spinnaker
 eureka.defaultToUp=false
 clouddriver.enabled=true
 clouddriver.baseUrl=http://localhost:8080


### PR DESCRIPTION
Improves the manual judgement (Slack) notification by adding a link to the corresponding artifact version in the Environments view and restructuring the format to make it more easily readable.

Sample:
![image](https://user-images.githubusercontent.com/1323478/93809642-5d14cd80-fc02-11ea-98bf-557ac931fd46.png)

Closes #1266 
