### PR TITLE
Better representation of resource kinds in schema

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt
@@ -1,10 +1,12 @@
 package com.netflix.spinnaker.keel.api
 
 import com.netflix.spinnaker.keel.api.DeployHealth.AUTO
+import com.netflix.spinnaker.keel.api.schema.Discriminator
 import java.time.Duration
 import java.time.Duration.ZERO
 
-sealed class ClusterDeployStrategy {
+abstract class ClusterDeployStrategy {
+  @Discriminator abstract val strategy: String
   open val isStaggered: Boolean = false
   open val stagger: List<StaggeredRegion> = emptyList()
   abstract val health: DeployHealth
@@ -26,13 +28,17 @@ data class RedBlack(
   // The order of this list is important for pauseTime based staggers
   override val stagger: List<StaggeredRegion> = emptyList()
 ) : ClusterDeployStrategy() {
+  override val strategy = "red-black"
+
   override val isStaggered: Boolean
     get() = stagger.isNotEmpty()
 }
 
 data class Highlander(
   override val health: DeployHealth = AUTO
-) : ClusterDeployStrategy()
+) : ClusterDeployStrategy() {
+  override val strategy = "highlander"
+}
 
 enum class DeployHealth {
   /** Use Orca's default (Discovery and ELB/Target group if attached). */

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ClusterDeployStrategyMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ClusterDeployStrategyMixin.kt
@@ -14,7 +14,7 @@ import com.netflix.spinnaker.keel.api.StaggeredRegion
 
 @JsonTypeInfo(
   use = Id.NAME,
-  include = As.PROPERTY,
+  include = As.EXISTING_PROPERTY,
   property = "strategy"
 )
 @JsonSubTypes(

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
@@ -7,11 +7,12 @@ import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Listener
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
+import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
 
 data class ApplicationLoadBalancerSpec(
   override val moniker: Moniker,
-  override val locations: SubnetAwareLocations,
+  @Optional override val locations: SubnetAwareLocations,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClassicLoadBalancerSpec.kt
@@ -4,11 +4,12 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.CLASSIC
+import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
 
 data class ClassicLoadBalancerSpec(
   override val moniker: Moniker,
-  override val locations: SubnetAwareLocations,
+  @Optional override val locations: SubnetAwareLocations,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupSpec.kt
@@ -19,10 +19,11 @@ import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.schema.Optional
 
 data class SecurityGroupSpec(
   override val moniker: Moniker,
-  override val locations: SimpleLocations,
+  @Optional override val locations: SimpleLocations,
   val description: String?,
   val inboundRules: Set<SecurityGroupRule> = emptySet(),
   val overrides: Map<String, SecurityGroupOverride> = emptyMap()

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1Spec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1Spec.kt
@@ -10,11 +10,12 @@ import com.netflix.spinnaker.keel.api.ec2.LoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
 import com.netflix.spinnaker.keel.api.ec2.TargetGroupAttributes
+import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
 
 data class ApplicationLoadBalancerV1Spec(
   override val moniker: Moniker,
-  override val locations: SubnetAwareLocations,
+  @Optional override val locations: SubnetAwareLocations,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/_clusterDeployStrategies.kt
@@ -42,4 +42,5 @@ fun ClusterDeployStrategy.toOrcaJobProperties(vararg instanceOnlyHealthProviders
         AUTO -> null
       }
     )
+    else -> error("Unhandled cluster deploy strategy ${javaClass.name}")
   }

--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Generator.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Generator.kt
@@ -317,7 +317,10 @@ class Generator(
         .first { it.supports(type.jvmErasure) }
         .buildSchema()
       type.isSingleton -> buildSchema(type.jvmErasure)
-      type.isEnum -> EnumSchema(description = description, enum = type.enumNames)
+      type.isEnum -> EnumSchema(
+        description = description,
+        enum = type.enumNames
+      )
       type.isString -> StringSchema(description = description, format = type.stringFormat)
       type.isBoolean -> BooleanSchema(description = description)
       type.isInteger -> IntegerSchema(description = description)

--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
@@ -18,7 +18,6 @@ data class RootSchema(
   val description: String?,
   val properties: Map<String, Schema>,
   val required: SortedSet<String>,
-  val discriminator: OneOf.Discriminator? = null,
   val allOf: List<ConditionalSubschema>? = null,
   val `$defs`: SortedMap<String, Schema>
 ) {
@@ -32,7 +31,6 @@ data class ObjectSchema(
   override val description: String?,
   val properties: Map<String, Schema>,
   val required: SortedSet<String>,
-  val discriminator: OneOf.Discriminator? = null,
   val allOf: List<ConditionalSubschema>? = null
 ) : TypedProperty("object")
 
@@ -86,14 +84,8 @@ data class Reference(
 
 data class OneOf(
   override val description: String?,
-  val oneOf: Set<Schema>,
-  val discriminator: Discriminator? = null
-) : Schema {
-  data class Discriminator(
-    val propertyName: String,
-    val mapping: SortedMap<String, String>
-  )
-}
+  val oneOf: Set<Schema>
+) : Schema
 
 data class AllOf(
   val allOf: List<Schema>

--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
@@ -19,6 +19,7 @@ data class RootSchema(
   val properties: Map<String, Schema>,
   val required: SortedSet<String>,
   val discriminator: OneOf.Discriminator? = null,
+  val allOf: List<ConditionalSubschema>? = null,
   val `$defs`: SortedMap<String, Schema>
 ) {
   @Suppress("unused", "PropertyName")
@@ -31,7 +32,8 @@ data class ObjectSchema(
   override val description: String?,
   val properties: Map<String, Schema>,
   val required: SortedSet<String>,
-  val discriminator: OneOf.Discriminator? = null
+  val discriminator: OneOf.Discriminator? = null,
+  val allOf: List<ConditionalSubschema>? = null
 ) : TypedProperty("object")
 
 object NullSchema : TypedProperty("null") {
@@ -71,6 +73,11 @@ data class EnumSchema(
   val enum: List<String>
 ) : Schema
 
+data class ConstSchema(
+  override val description: String?,
+  val const: String
+) : Schema
+
 data class Reference(
   val `$ref`: String
 ) : Schema {
@@ -93,6 +100,20 @@ data class AllOf(
 ) : Schema {
   override val description: String? = null
 }
+
+data class ConditionalSubschema(
+  val `if`: Condition,
+  val then: Subschema
+)
+
+data class Condition(
+  val properties: Map<String, ConstSchema>
+)
+
+data class Subschema(
+  val properties: Map<String, Schema>,
+  val required: SortedSet<String> = emptySet<String>().toSortedSet()
+)
 
 /**
  * Yes, I really had to implement an either monad to get this all to work.

--- a/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
+++ b/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
@@ -604,23 +604,21 @@ internal class GeneratorTests {
         .one { isA<Reference>().get { `$ref` } isEqualTo "#/\$defs/${IntegerWrapper::class.java.simpleName}" }
     }
 
-    @Test
-    fun `the discriminator property is based on the presence of the @Discriminator annotation`() {
-      expectThat(schema.`$defs`[Wrapper::class.java.simpleName])
-        .isA<OneOf>()
-        .get { discriminator?.propertyName }
-        .isEqualTo(Wrapper<*>::type.name)
-    }
-
-    @Test
-    fun `discriminator mappings tie values to references`() {
-      expectThat(schema.`$defs`[Wrapper::class.java.simpleName])
-        .isA<OneOf>()
-        .get { discriminator?.mapping }
-        .isNotNull()
-        .hasEntry("string", "#/\$defs/${StringWrapper::class.java.simpleName}")
-        .hasEntry("integer", "#/\$defs/${IntegerWrapper::class.java.simpleName}")
-    }
+    @TestFactory
+    fun subTypeDiscriminatorConst() =
+      mapOf(
+        "string" to StringWrapper::class.java.simpleName,
+        "integer" to IntegerWrapper::class.java.simpleName
+      ).map { (fixedValue, subType) ->
+        dynamicTest("the sub-type discriminator property for $subType is an const with the fixed value") {
+          expectThat(schema.`$defs`[subType])
+            .isA<ObjectSchema>()
+            .get { properties[Wrapper<*>::type.name] }
+            .isA<ConstSchema>()
+            .get { const }
+            .isEqualTo(fixedValue)
+        }
+      }
 
     @TestFactory
     fun `the discriminator property in the sub-type is an enum with a single value`() =

--- a/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/TitusClusterSpec.kt
+++ b/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/TitusClusterSpec.kt
@@ -60,7 +60,7 @@ data class TitusClusterSpec(
   constructor(
     moniker: Moniker,
     deployWith: ClusterDeployStrategy = RedBlack(),
-    locations: SimpleLocations,
+    @Optional locations: SimpleLocations,
     container: ContainerProvider,
     capacity: Capacity?,
     constraints: TitusServerGroup.Constraints?,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
@@ -2,6 +2,9 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.actuation.ArtifactHandler
+import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
+import com.netflix.spinnaker.keel.api.Highlander
+import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
@@ -93,6 +96,12 @@ class KeelConfigurationFinalizer(
         log.info("Registering VersioningStrategy sub-type {}: {}", name, strategyClass.simpleName)
         extensionRegistry.register(strategyClass, name)
       }
+  }
+
+  @PostConstruct
+  fun registerClusterDeployStrategySubtypes() {
+    extensionRegistry.register<ClusterDeployStrategy>(RedBlack::class.java, "red-black")
+    extensionRegistry.register<ClusterDeployStrategy>(Highlander::class.java, "highlander")
   }
 
   @PostConstruct

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -283,18 +283,13 @@ class ApiDocTests : JUnit5Minutests {
         )
     }
 
-    test("schema for DeliveryArtifact has a discriminator") {
-      at("/\$defs/DeliveryArtifact")
-        .isObject()
-        .path("discriminator")
-        .and {
-          path("propertyName").textValue().isEqualTo("type")
-        }
-        .path("mapping")
-        .and {
-          path("deb").textValue().isEqualTo("#/\$defs/DebianArtifact")
-          path("docker").textValue().isEqualTo("#/\$defs/DockerArtifact")
-        }
+    test("schemas for DeliveryArtifact sub-types specify the fixed discriminator value") {
+      at("/\$defs/DebianArtifact/properties/type/const")
+        .textValue()
+        .isEqualTo("deb")
+      at("/\$defs/DockerArtifact/properties/type/const")
+        .textValue()
+        .isEqualTo("docker")
     }
 
     test("data class parameters without default values are required") {

--- a/keel-web/src/test/resources/examples/cluster-example.yml
+++ b/keel-web/src/test/resources/examples/cluster-example.yml
@@ -22,7 +22,7 @@ environments:
     spec:
       health:
         terminationPolicies:
-        - Default
+        - default
       moniker:
         app: fnord
         stack: main

--- a/keel-web/src/test/resources/examples/delivery-config-example.yml
+++ b/keel-web/src/test/resources/examples/delivery-config-example.yml
@@ -52,12 +52,12 @@ environments:
         app: fnord
       description: Application Security Group for fnord
       inboundRules:
-      - protocol: TCP
+      - protocol: tcp
         name: fnord-elb
         portRange:
           startPort: 7001
           endPort: 7002
-      - protocol: TCP
+      - protocol: tcp
         portRange:
           startPort: 6565
           endPort: 6565
@@ -74,7 +74,7 @@ environments:
         stack: sql
       description: fnord RDS
       inboundRules:
-      - protocol: TCP
+      - protocol: tcp
         name: fnord
         portRange:
           startPort: 3306
@@ -144,12 +144,12 @@ environments:
         app: fnord
       description: Application Security Group for fnord
       inboundRules:
-      - protocol: TCP
+      - protocol: tcp
         name: fnord-elb
         portRange:
           startPort: 7001
           endPort: 7002
-      - protocol: TCP
+      - protocol: tcp
         portRange:
           startPort: 6379
           endPort: 6379
@@ -166,7 +166,7 @@ environments:
         stack: sql
       description: fnord RDS
       inboundRules:
-      - protocol: TCP
+      - protocol: tcp
         name: fnord
         portRange:
           startPort: 3306

--- a/keel-web/src/test/resources/examples/ec2-cluster-with-autoscaling-example.yml
+++ b/keel-web/src/test/resources/examples/ec2-cluster-with-autoscaling-example.yml
@@ -39,7 +39,7 @@ environments:
         max: 10
       scaling:
         suspendedProcesses:
-        - "AZRebalance"
+        - "azrebalance"
         targetTrackingPolicies:
         - warmup: "PT7M"
           targetValue: 50.0

--- a/keel-web/src/test/resources/examples/titus-cluster-with-artifact-example.yml
+++ b/keel-web/src/test/resources/examples/titus-cluster-with-artifact-example.yml
@@ -26,7 +26,6 @@ environments:
         min: 1
         max: 1
         desired: 1
-      overrides: {}
       dependencies:
         loadBalancerNames: []
         securityGroupNames:

--- a/keel-web/src/test/resources/examples/wrong-resource-kind.yml
+++ b/keel-web/src/test/resources/examples/wrong-resource-kind.yml
@@ -4,21 +4,19 @@ serviceAccount: delivery-engineering@netflix.com
 environments:
 - name: test
   resources:
-  - kind: ec2/security-group@v1
+  - kind: titus/cluster@v1
     spec:
       moniker:
-        app: keeldemo
-        stack: example
-        detail: ec2v1
+        app: fnord
       locations:
         account: test
         vpc: vpc0
         regions:
         - name: us-west-2
         - name: us-east-1
-      description: Managed Security Group for keeldemo example
+      description: Security Group for fnord application
       inboundRules:
-      - protocol: tcp
+      - protocol: TCP
         portRange:
           startPort: 7001
           endPort: 7001


### PR DESCRIPTION
Now each type of resource specifies the kind alongside the matching spec format in a way JSON schema validation can pick up.

Instead of being: 
```yaml
$defs:
  SubmittedResource:
    properties:
      metadata:
        type: object
      kind:
        enum:
        - ec2/cluster@v1
        - titus/cluster@v1

  ClusterSpecSubmittedResource:
    allOf:
    - $ref: #/$defs/SubmittedResource
    - type: object
      properties:
        spec:
          $ref: #/$defs/ClusterSpec

  TitusClusterSpecSubmittedResource:
    allOf:
    - $ref: #/$defs/SubmittedResource
    - type: object
      properties:
        spec:
          $ref: #/$defs/TitusClusterSpec
```

It will now be:
```yaml
$defs:
  SubmittedResource:
    properties:
      kind:
        enum:
        - ec2/cluster@v1
        - titus/cluster@v1
    allOf:
    - if:
        properties:
          kind:
            const: ec2/cluster@v1
      then:
        properties:
          spec:
            $ref: #/$defs/ClusterSpec
    - if:
        properties:
          kind:
            const: titus/cluster@v1
      then:
        properties:
          spec:
            $ref: #/$defs/TitusClusterSpec
```

This means that the JSON schema can enforce that the correct `kind` goes with the correct type of `spec`. Note how there's not actually any association between `kind` and the type of `spec` beforehand. There's a good explanation of this format [here](http://json-schema.org/understanding-json-schema/reference/conditionals.html).

This also let me drop the `discriminator` and `mapping` fields that are a convention from Open API and not actually enforced by JSON schema tools.