### PR TITLE
fix(schema): specify duration as a regex

### DIFF
--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Generator.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Generator.kt
@@ -297,6 +297,12 @@ class Generator(
       type.isBoolean -> BooleanSchema(description = description)
       type.isInteger -> IntegerSchema(description = description)
       type.isNumber -> NumberSchema(description = description)
+      type.jvmErasure == Duration::class -> Duration::class.buildRef()
+        .also {
+          if (!definitions.containsKey(Duration::class.java.simpleName)) {
+            definitions[Duration::class.java.simpleName] = DurationSchema
+          }
+        }
       type.isArray -> {
         ArraySchema(
           description = description,
@@ -478,7 +484,6 @@ class Generator(
     memberProperties.find { it.name == param.name } // this is a pretty heinous assumption
 
   private val formattedTypes = mapOf(
-    Duration::class to "duration",
     Instant::class to "date-time",
     ZonedDateTime::class to "date-time",
     OffsetDateTime::class to "date-time",

--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
@@ -44,8 +44,16 @@ data class IntegerSchema(override val description: String?) : TypedProperty("int
 
 data class NumberSchema(override val description: String?) : TypedProperty("number")
 
+object DurationSchema : TypedProperty("string") {
+  override val description = "ISO 8601 duration"
+
+  @Suppress("MayBeConstant", "unused") // doesn't serialize if declared as const
+  // see https://rgxdb.com/r/MD2234J
+  val pattern: String = """^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$"""
+}
+
 data class AnySchema(override val description: String?) : TypedProperty("object") {
-  @Suppress("MayBeConstant") // TODO: doesn't serialize if declared as const
+  @Suppress("MayBeConstant") // doesn't serialize if declared as const
   val additionalProperties: Boolean = true
 }
 
@@ -63,7 +71,8 @@ data class MapSchema(
 
 data class StringSchema(
   override val description: String?,
-  val format: String? = null
+  val format: String? = null,
+  val pattern: String? = null
 ) : TypedProperty("string")
 
 data class EnumSchema(
@@ -86,12 +95,6 @@ data class OneOf(
   override val description: String?,
   val oneOf: Set<Schema>
 ) : Schema
-
-data class AllOf(
-  val allOf: List<Schema>
-) : Schema {
-  override val description: String? = null
-}
 
 data class ConditionalSubschema(
   val `if`: Condition,

--- a/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
+++ b/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
@@ -543,8 +543,7 @@ internal class GeneratorTests {
       mapOf(
         Foo::instant.name to "datetime",
         Foo::localDate.name to "date",
-        Foo::localTime.name to "time",
-        Foo::duration.name to "duration"
+        Foo::localTime.name to "time"
       ).map { (property, format) ->
         dynamicTest("$property property is a string with '$format' format") {
           expectThat(schema.properties[property])
@@ -553,6 +552,20 @@ internal class GeneratorTests {
             .isEqualTo(format)
         }
       }
+
+    @Test
+    fun `duration property is a reference`() {
+      expectThat(schema.properties[Foo::duration.name])
+        .isA<Reference>()
+        .get { `$ref` }
+        .isEqualTo("#/${RootSchema::`$defs`.name}/${Duration::class.simpleName}")
+    }
+
+    @Test
+    fun `duration schema is a string schema with a regex pattern`() {
+      expectThat(schema.`$defs`[Duration::class.simpleName])
+        .isA<DurationSchema>()
+    }
   }
 
   @Nested

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
@@ -1,9 +1,7 @@
 package com.netflix.spinnaker.keel.apidocs
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.databind.SerializationFeature.INDENT_OUTPUT
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -18,7 +16,6 @@ import com.networknt.schema.SpecVersion.VersionFlag.V201909
 import com.networknt.schema.ValidationMessage
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.DynamicTest.dynamicTest
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration


### PR DESCRIPTION
Previously I was using `format: duration` for properties that are `java.time.Duration` however that's not actually one of the formats supported by JSON schema and is an extension from Open API. Here I've replaced it with a regex pattern that enforces correct duration format.