### PR TITLE
feat(artifacts): Add artifact creation timestamp

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/ArtifactVersion.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/ArtifactVersion.kt
@@ -9,7 +9,7 @@ import java.time.Instant
  * One notable difference from the kork counterpart is that this class enforces non-nullability of a few
  * key fields without which it doesn't make sense for an artifact to exist in Managed Delivery terms.
  */
-data class PublishedArtifact(
+data class ArtifactVersion(
   val name: String,
   val type: String,
   val reference: String,
@@ -59,5 +59,6 @@ data class PublishedArtifact(
       }
     }
 
+  // FIXME: it's silly that we're prepending the artifact name for Debian only...
   fun normalized() = copy(version = if (type == DEBIAN && !version.startsWith(name)) "$name-$version" else version)
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.api.artifacts
 
 import com.netflix.spinnaker.keel.api.schema.Discriminator
+import java.time.Instant
 
 typealias ArtifactType = String
 
@@ -31,13 +32,16 @@ abstract class DeliveryArtifact {
   abstract val deliveryConfigName: String? // the delivery config this artifact is a part of
   open val statuses: Set<ArtifactStatus> = emptySet()
 
-  fun toPublishedArtifact(version: String, status: ArtifactStatus? = null) =
+  fun toPublishedArtifact(version: String, status: ArtifactStatus? = null, createdAt: Instant? = null) =
     PublishedArtifact(
       name = name,
       type = type,
       reference = reference,
       version = version,
-      metadata = mapOf("releaseStatus" to status)
+      metadata = mapOf(
+        "releaseStatus" to status,
+        "createdAt" to createdAt
+      )
     ).normalized()
 
   override fun toString() = "${type.toUpperCase()} artifact $name (ref: $reference)"

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -32,8 +32,8 @@ abstract class DeliveryArtifact {
   abstract val deliveryConfigName: String? // the delivery config this artifact is a part of
   open val statuses: Set<ArtifactStatus> = emptySet()
 
-  fun toPublishedArtifact(version: String, status: ArtifactStatus? = null, createdAt: Instant? = null) =
-    PublishedArtifact(
+  fun toArtifactVersion(version: String, status: ArtifactStatus? = null, createdAt: Instant? = null) =
+    ArtifactVersion(
       name = name,
       type = type,
       reference = reference,

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/PublishedArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/PublishedArtifact.kt
@@ -50,9 +50,14 @@ data class PublishedArtifact(
   val status: ArtifactStatus? = metadata["releaseStatus"]?.toString()
     ?.let { ArtifactStatus.valueOf(it) }
 
-  val createdAt = (metadata["createdAt"] as? Long)
-    ?.let { Instant.ofEpochMilli(it) }
+  val createdAt = metadata["createdAt"]
+    ?.let {
+      when (it) {
+        is Long -> Instant.ofEpochMilli(it) // to accommodate for artifact events from CI integration
+        is Instant -> it
+        else -> null
+      }
+    }
 
-  // FIXME: it's silly that we're prepending the artifact name for Debian only...
   fun normalized() = copy(version = if (type == DEBIAN && !version.startsWith(name)) "$name-$version" else version)
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/events/artifacts.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/events/artifacts.kt
@@ -1,14 +1,14 @@
 package com.netflix.spinnaker.keel.api.events
 
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 
 /**
- * An event that conveys information about one or more [PublishedArtifact] that are
+ * An event that conveys information about one or more [ArtifactVersion] that are
  * potentially relevant to keel.
  */
 data class ArtifactPublishedEvent(
-  val artifacts: List<PublishedArtifact>,
+  val artifacts: List<ArtifactVersion>,
   val details: Map<String, Any>? = emptyMap()
 )
 

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
@@ -2,12 +2,11 @@ package com.netflix.spinnaker.keel.api.plugins
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.VersioningStrategy
 import com.netflix.spinnaker.keel.api.events.ArtifactPublishedEvent
 import com.netflix.spinnaker.keel.api.support.EventPublisher
@@ -39,56 +38,56 @@ interface ArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy> : Spinn
    * and should typically *not* be overridden by implementors.
    */
   @JvmDefault
-  fun publishArtifact(artifact: PublishedArtifact) =
+  fun publishArtifact(artifact: ArtifactVersion) =
     eventPublisher.publishEvent(ArtifactPublishedEvent(listOf(artifact)))
 
   /**
    * Returns the latest available version for the given [DeliveryArtifact], represented
-   * as a [PublishedArtifact].
+   * as a [ArtifactVersion].
    *
    * This function may interact with external systems to retrieve artifact information as needed.
    */
-  fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact?
+  fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): ArtifactVersion?
 
   /**
    * Returns the published artifact [DeliveryArtifact] by version, represented
-   * as a [PublishedArtifact].
+   * as a [ArtifactVersion].
    *
    * This function may interact with external systems to retrieve artifact information as needed.
    */
-  fun getArtifactByVersion(artifact: DeliveryArtifact, version: String): PublishedArtifact?
+  fun getArtifactByVersion(artifact: DeliveryArtifact, version: String): ArtifactVersion?
 
   /**
-   * Given a [PublishedArtifact] supported by this [ArtifactSupplier], return the display name for the
-   * artifact version, if different from [PublishedArtifact.version].
+   * Given a [ArtifactVersion] supported by this [ArtifactSupplier], return the display name for the
+   * artifact version, if different from [ArtifactVersion.version].
    */
-  fun getVersionDisplayName(artifact: PublishedArtifact): String = artifact.version
+  fun getVersionDisplayName(artifact: ArtifactVersion): String = artifact.version
 
   /**
-   * Given a [PublishedArtifact] and a [VersioningStrategy] supported by this [ArtifactSupplier],
+   * Given a [ArtifactVersion] and a [VersioningStrategy] supported by this [ArtifactSupplier],
    * return the [BuildMetadata] for the artifact, if available.
    *
    * This function is currently *not* expected to make calls to other systems, but only look into
-   * the metadata available within the [PublishedArtifact] object itself.
+   * the metadata available within the [ArtifactVersion] object itself.
    */
-  fun parseDefaultBuildMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): BuildMetadata? = null
+  fun parseDefaultBuildMetadata(artifact: ArtifactVersion, versioningStrategy: VersioningStrategy): BuildMetadata? = null
 
   /**
-   * Given a [PublishedArtifact] and a [VersioningStrategy] supported by this [ArtifactSupplier],
+   * Given a [ArtifactVersion] and a [VersioningStrategy] supported by this [ArtifactSupplier],
    * return the [GitMetadata] for the artifact, if available.
    *
    * This function is currently *not* expected to make calls to other systems, but only look into
-   * the metadata available within the [PublishedArtifact] object itself.
+   * the metadata available within the [ArtifactVersion] object itself.
    */
-  fun parseDefaultGitMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): GitMetadata? = null
+  fun parseDefaultGitMetadata(artifact: ArtifactVersion, versioningStrategy: VersioningStrategy): GitMetadata? = null
 
   /**
-   * Given a [PublishedArtifact] supported by this [ArtifactSupplier],
+   * Given a [ArtifactVersion] supported by this [ArtifactSupplier],
    * return the [ArtifactMetadata] for the artifact, if available.
    *
    * This function is currently expected to make calls to CI systems.
    */
-  suspend fun getArtifactMetadata(artifact: PublishedArtifact): ArtifactMetadata?
+  suspend fun getArtifactMetadata(artifact: ArtifactVersion): ArtifactMetadata?
 }
 
 /**

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -7,8 +7,6 @@ import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
-import com.netflix.spinnaker.keel.api.events.ArtifactPublishedEvent
 import com.netflix.spinnaker.keel.api.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.api.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.api.support.EventPublisher

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -65,6 +65,8 @@ class ArtifactListener(
                 publisher.publishEvent(ArtifactVersionUpdated(artifact.name, artifact.artifactType))
               }
             }
+        } else {
+          log.debug("Artifact $artifact is not registered. Ignoring new artifact version.")
         }
       }
   }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.activation.ApplicationUp
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.events.ArtifactPublishedEvent
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.api.events.ArtifactSyncEvent
@@ -149,9 +149,9 @@ class ArtifactListener(
     repository.artifactVersions(artifact).sortedWith(artifact.versioningStrategy.comparator).firstOrNull()
 
   /**
-   * Returns a copy of the [PublishedArtifact] with the git and build metadata populated, if available.
+   * Returns a copy of the [ArtifactVersion] with the git and build metadata populated, if available.
    */
-  private fun ArtifactSupplier<*,*>.addMetadata(artifact: PublishedArtifact): PublishedArtifact {
+  private fun ArtifactSupplier<*,*>.addMetadata(artifact: ArtifactVersion): ArtifactVersion {
     val artifactMetadata = runBlocking {
       try {
         getArtifactMetadata(artifact)
@@ -168,7 +168,7 @@ class ArtifactListener(
       ?.let { repository.getDeliveryConfig(it) }
       ?: throw InvalidSystemStateException("Delivery config name missing in artifact object")
 
-  private val PublishedArtifact.artifactType: ArtifactType
+  private val ArtifactVersion.artifactType: ArtifactType
     get() = artifactTypeNames.find { it == type.toLowerCase() }
       ?.let { type.toLowerCase() }
       ?: throw InvalidSystemStateException("Unable to find registered artifact type for '$type'")

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BaseArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BaseArtifactSupplier.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.artifacts
 
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.VersioningStrategy
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.services.ArtifactMetadataService
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory
 abstract class BaseArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy>(
   open val artifactMetadataService: ArtifactMetadataService
 ) : ArtifactSupplier<A, V> {
-  override suspend fun getArtifactMetadata(artifact: PublishedArtifact): ArtifactMetadata? {
+  override suspend fun getArtifactMetadata(artifact: ArtifactVersion): ArtifactMetadata? {
 
     val buildNumber = artifact.metadata["buildNumber"]?.toString()
     val commitId = artifact.metadata["commitId"]?.toString()

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_JOB
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_SEMVER
@@ -33,12 +33,12 @@ class DockerArtifactSupplier(
   override val supportedVersioningStrategy =
     SupportedVersioningStrategy("docker", DockerVersioningStrategy::class.java)
 
-  override fun getArtifactByVersion(artifact: DeliveryArtifact, version: String): PublishedArtifact? {
+  override fun getArtifactByVersion(artifact: DeliveryArtifact, version: String): ArtifactVersion? {
     return runWithIoContext {
       cloudDriverService.findDockerImages(account = "*", repository = artifact.name, tag = version)
         .firstOrNull()
         ?.let { dockerImage ->
-          PublishedArtifact(
+          ArtifactVersion(
             name = dockerImage.repository,
             type = DOCKER,
             reference = dockerImage.repository.substringAfter(':', dockerImage.repository),
@@ -60,7 +60,7 @@ class DockerArtifactSupplier(
 
 
 
-  override fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact? {
+  override fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): ArtifactVersion? {
     if (artifact !is DockerArtifact) {
       throw IllegalArgumentException("Only Docker artifacts are supported by this implementation.")
     }
@@ -80,7 +80,7 @@ class DockerArtifactSupplier(
         cloudDriverService.findDockerImages(account = "*", repository = artifact.name, tag = latestTag)
           .firstOrNull()
           ?.let { dockerImage ->
-            PublishedArtifact(
+            ArtifactVersion(
               name = dockerImage.repository,
               type = DOCKER,
               reference = dockerImage.repository.substringAfter(':', dockerImage.repository),
@@ -103,7 +103,7 @@ class DockerArtifactSupplier(
     }
   }
 
-  override fun parseDefaultBuildMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): BuildMetadata? {
+  override fun parseDefaultBuildMetadata(artifact: ArtifactVersion, versioningStrategy: VersioningStrategy): BuildMetadata? {
       if (versioningStrategy.hasBuild()) {
         val regex = Regex("""^.*-h(\d+).*$""")
         val result = regex.find(artifact.version)
@@ -114,7 +114,7 @@ class DockerArtifactSupplier(
     return null
   }
 
-  override fun parseDefaultGitMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): GitMetadata? {
+  override fun parseDefaultGitMetadata(artifact: ArtifactVersion, versioningStrategy: VersioningStrategy): GitMetadata? {
       if (versioningStrategy.hasCommit()) {
         return GitMetadata(commit = artifact.version.substringAfterLast("."))
       }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
@@ -2,19 +2,17 @@ package com.netflix.spinnaker.keel.artifacts
 
 import com.netflix.spinnaker.igor.ArtifactService
 import com.netflix.spinnaker.keel.api.DeliveryConfig
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.NPM
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.VersioningStrategy
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedVersioningStrategy
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.services.ArtifactMetadataService
-import com.netflix.spinnaker.kork.exceptions.IntegrationException
 import org.springframework.stereotype.Component
 
 /**
@@ -35,7 +33,7 @@ class NpmArtifactSupplier(
   override val supportedVersioningStrategy =
     SupportedVersioningStrategy(NPM, NpmVersioningStrategy::class.java)
 
-  override fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): PublishedArtifact? =
+  override fun getLatestArtifact(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact): ArtifactVersion? =
     runWithIoContext {
       artifactService
         .getVersions(artifact.nameForQuery, artifact.statusesForQuery, NPM)
@@ -46,7 +44,7 @@ class NpmArtifactSupplier(
         }
     }
 
-  override fun getArtifactByVersion(artifact: DeliveryArtifact, version: String): PublishedArtifact? =
+  override fun getArtifactByVersion(artifact: DeliveryArtifact, version: String): ArtifactVersion? =
     runWithIoContext {
       artifactService.getArtifact(artifact.nameForQuery, version, NPM)
     }
@@ -54,14 +52,14 @@ class NpmArtifactSupplier(
   /**
    * Extracts a version display name from version string using the Netflix semver convention.
    */
-  override fun getVersionDisplayName(artifact: PublishedArtifact): String {
+  override fun getVersionDisplayName(artifact: ArtifactVersion): String {
     return NetflixVersions.getVersionDisplayName(artifact)
   }
 
   /**
    * Extracts the build number from the version string using the Netflix semver convention.
    */
-  override fun parseDefaultBuildMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): BuildMetadata? {
+  override fun parseDefaultBuildMetadata(artifact: ArtifactVersion, versioningStrategy: VersioningStrategy): BuildMetadata? {
     return NetflixVersions.getBuildNumber(artifact)
       ?.let { BuildMetadata(it) }
   }
@@ -69,7 +67,7 @@ class NpmArtifactSupplier(
   /**
    * Extracts the commit hash from the version string using the Netflix semver convention.
    */
-  override fun parseDefaultGitMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): GitMetadata? {
+  override fun parseDefaultGitMetadata(artifact: ArtifactVersion, versioningStrategy: VersioningStrategy): GitMetadata? {
     return NetflixVersions.getCommitHash(artifact)
       ?.let { GitMetadata(it) }
   }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
@@ -9,7 +9,7 @@ import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Job
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.PullRequest
 import com.netflix.spinnaker.keel.api.artifacts.Repo
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
@@ -42,7 +42,7 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
       statuses = setOf(SNAPSHOT)
     )
     val versions = listOf("2.0.0-h120.608bd90", "2.1.0-h130.18ed1dc")
-    val latestArtifact = PublishedArtifact(
+    val latestArtifact = ArtifactVersion(
       name = debianArtifact.name,
       type = debianArtifact.type,
       reference = debianArtifact.reference,

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplierTests.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.artifacts
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.INCREASING_TAG
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_JOB_COMMIT_BY_SEMVER
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
@@ -37,14 +37,14 @@ internal class DockerArtifactSupplierTests : JUnit5Minutests {
       tagVersionStrategy = SEMVER_TAG
     )
     val versions = listOf("v1.12.1-h1188.35b8b29", "v1.12.2-h1182.8a5b962")
-    val latestArtifact = PublishedArtifact(
+    val latestArtifact = ArtifactVersion(
       name = dockerArtifact.name,
       type = dockerArtifact.type,
       reference = dockerArtifact.reference,
       version = versions.last()
     )
 
-    val latestArtifactWithMetadata = PublishedArtifact(
+    val latestArtifactWithMetadata = ArtifactVersion(
       name = dockerArtifact.name,
       type = dockerArtifact.type,
       reference = dockerArtifact.reference,

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
@@ -8,7 +8,7 @@ import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Job
 import com.netflix.spinnaker.keel.api.artifacts.NPM
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.PullRequest
 import com.netflix.spinnaker.keel.api.artifacts.Repo
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
@@ -37,7 +37,7 @@ internal class NpmArtifactSupplierTests : JUnit5Minutests {
       statuses = setOf(CANDIDATE)
     )
     val versions = listOf("1.0.0-rc", "1.0.0-rc.1", "1.0.0", "1.0.1-5", "1.0.2-h6", "1.0.3-rc-h7.gc0c603")
-    val latestArtifact = PublishedArtifact(
+    val latestArtifact = ArtifactVersion(
       name = npmArtifact.name,
       type = npmArtifact.type,
       reference = npmArtifact.reference,

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
@@ -60,7 +60,7 @@ abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit
     with(subject) {
       register(artifact)
       setOf(version1, version2).forEach {
-        storeVersion(artifact.toPublishedArtifact(it, RELEASE))
+        storeArtifactVersion(artifact.toPublishedArtifact(it, RELEASE))
       }
     }
     persist(manifest)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
@@ -60,7 +60,7 @@ abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit
     with(subject) {
       register(artifact)
       setOf(version1, version2).forEach {
-        storeArtifactVersion(artifact.toPublishedArtifact(it, RELEASE))
+        storeArtifactVersion(artifact.toArtifactVersion(it, RELEASE))
       }
     }
     persist(manifest)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApproveOldVersionTests.kt
@@ -149,8 +149,8 @@ abstract class ApproveOldVersionTests<T : KeelRepository> : JUnit5Minutests {
       before {
         repository.register(artifact)
         repository.storeDeliveryConfig(deliveryConfig)
-        repository.storeArtifactVersion(artifact.toPublishedArtifact(version1, ArtifactStatus.RELEASE))
-        repository.storeArtifactVersion(artifact.toPublishedArtifact(version2, ArtifactStatus.RELEASE))
+        repository.storeArtifactVersion(artifact.toArtifactVersion(version1, ArtifactStatus.RELEASE))
+        repository.storeArtifactVersion(artifact.toArtifactVersion(version2, ArtifactStatus.RELEASE))
         repository.storeConstraintState(pendingManualJudgement1)
         repository.storeConstraintState(pendingManualJudgement2)
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -146,21 +146,21 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     with(subject) {
       register(artifact1)
       setOf(version1, version2, version3).forEach {
-        storeArtifactVersion(artifact1.toPublishedArtifact(it, SNAPSHOT))
+        storeArtifactVersion(artifact1.toArtifactVersion(it, SNAPSHOT))
       }
       setOf(version4, version5).forEach {
-        storeArtifactVersion(artifact1.toPublishedArtifact(it, RELEASE))
+        storeArtifactVersion(artifact1.toArtifactVersion(it, RELEASE))
       }
       register(artifact2)
       setOf(version1, version2, version3).forEach {
-        storeArtifactVersion(artifact2.toPublishedArtifact(it, SNAPSHOT))
+        storeArtifactVersion(artifact2.toArtifactVersion(it, SNAPSHOT))
       }
       setOf(version4, version5).forEach {
-        storeArtifactVersion(artifact2.toPublishedArtifact(it, RELEASE))
+        storeArtifactVersion(artifact2.toArtifactVersion(it, RELEASE))
       }
       register(artifact3)
       setOf(version6, versionBad).forEach {
-        storeArtifactVersion(artifact3.toPublishedArtifact(it))
+        storeArtifactVersion(artifact3.toArtifactVersion(it))
       }
     }
     persist(manifest)
@@ -196,7 +196,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       test("storing a new version throws an exception") {
         expectThrows<NoSuchArtifactException> {
-          subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
+          subject.storeArtifactVersion(artifact1.toArtifactVersion(version1, SNAPSHOT))
         }
       }
 
@@ -235,7 +235,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       context("an artifact version already exists") {
         before {
-          subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
+          subject.storeArtifactVersion(artifact1.toArtifactVersion(version1, SNAPSHOT))
         }
 
         test("release status for the version is returned correctly") {
@@ -243,13 +243,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         }
 
         test("registering the same version is a no-op") {
-          val result = subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
+          val result = subject.storeArtifactVersion(artifact1.toArtifactVersion(version1, SNAPSHOT))
           expectThat(result).isFalse()
           expectThat(subject.versions(artifact1)).hasSize(1)
         }
 
         test("adding a new version adds it to the list") {
-          val result = subject.storeArtifactVersion(artifact1.toPublishedArtifact(version2, SNAPSHOT))
+          val result = subject.storeArtifactVersion(artifact1.toArtifactVersion(version2, SNAPSHOT))
 
           expectThat(result).isTrue()
           expectThat(subject.versions(artifact1)).containsExactly(version2, version1)
@@ -257,7 +257,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
         test("querying the list for returns both artifacts") {
           // status is stored on the artifact
-          subject.storeArtifactVersion(artifact1.toPublishedArtifact(version2, SNAPSHOT))
+          subject.storeArtifactVersion(artifact1.toArtifactVersion(version2, SNAPSHOT))
           expectThat(subject.versions(artifact1)).containsExactly(version2, version1)
         }
       }
@@ -268,9 +268,9 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             .shuffled()
             .forEach {
               if (it == version4 || it == version5) {
-                subject.storeArtifactVersion(artifact1.toPublishedArtifact(it, RELEASE))
+                subject.storeArtifactVersion(artifact1.toArtifactVersion(it, RELEASE))
               } else {
-                subject.storeArtifactVersion(artifact1.toPublishedArtifact(it, SNAPSHOT))
+                subject.storeArtifactVersion(artifact1.toArtifactVersion(it, SNAPSHOT))
               }
             }
         }
@@ -692,8 +692,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     context("getting all filters by type") {
       before {
         persist()
-        subject.storeArtifactVersion(artifact1.toPublishedArtifact(version4, FINAL))
-        subject.storeArtifactVersion(artifact3.toPublishedArtifact(version6, FINAL))
+        subject.storeArtifactVersion(artifact1.toArtifactVersion(version4, FINAL))
+        subject.storeArtifactVersion(artifact3.toArtifactVersion(version6, FINAL))
       }
 
       test("querying works") {
@@ -779,34 +779,34 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     context("artifact metadata exists") {
       before {
         subject.register(artifact1)
-        subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT).copy(
+        subject.storeArtifactVersion(artifact1.toArtifactVersion(version1, SNAPSHOT).copy(
           gitMetadata = artifactMetadata.gitMetadata,
           buildMetadata = artifactMetadata.buildMetadata
         ))
       }
 
       test("retrieves successfully") {
-        val publishedArtifact = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
+        val artifactVersion = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
 
-        expectThat(publishedArtifact.buildMetadata)
+        expectThat(artifactVersion.buildMetadata)
           .isEqualTo(artifactMetadata.buildMetadata)
 
-        expectThat(publishedArtifact.gitMetadata)
+        expectThat(artifactVersion.gitMetadata)
           .isEqualTo(artifactMetadata.gitMetadata)
       }
 
       test("update with non-prefixed version works") {
-        subject.storeArtifactVersion(artifact1.toPublishedArtifact(versionOnly, SNAPSHOT).copy(
+        subject.storeArtifactVersion(artifact1.toArtifactVersion(versionOnly, SNAPSHOT).copy(
           gitMetadata = artifactMetadata.gitMetadata,
           buildMetadata = artifactMetadata.buildMetadata
         ))
 
-        val publishedArtifact = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
+        val artifactVersion = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
 
-        expectThat(publishedArtifact.buildMetadata)
+        expectThat(artifactVersion.buildMetadata)
           .isEqualTo(artifactMetadata.buildMetadata)
 
-        expectThat(publishedArtifact.gitMetadata)
+        expectThat(artifactVersion.gitMetadata)
           .isEqualTo(artifactMetadata.gitMetadata)
       }
     }
@@ -816,12 +816,12 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       before {
         subject.register(artifact1)
-        subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT, createdAt = createdAt))
+        subject.storeArtifactVersion(artifact1.toArtifactVersion(version1, SNAPSHOT, createdAt = createdAt))
       }
 
       test("retrieves timestamp successfully") {
-        val publishedArtifact = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
-        expectThat(publishedArtifact.createdAt).isEqualTo(createdAt)
+        val artifactVersion = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
+        expectThat(artifactVersion.createdAt).isEqualTo(createdAt)
       }
     }
   }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -146,21 +146,21 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     with(subject) {
       register(artifact1)
       setOf(version1, version2, version3).forEach {
-        storeVersion(artifact1.toPublishedArtifact(it, SNAPSHOT))
+        storeArtifactVersion(artifact1.toPublishedArtifact(it, SNAPSHOT))
       }
       setOf(version4, version5).forEach {
-        storeVersion(artifact1.toPublishedArtifact(it, RELEASE))
+        storeArtifactVersion(artifact1.toPublishedArtifact(it, RELEASE))
       }
       register(artifact2)
       setOf(version1, version2, version3).forEach {
-        storeVersion(artifact2.toPublishedArtifact(it, SNAPSHOT))
+        storeArtifactVersion(artifact2.toPublishedArtifact(it, SNAPSHOT))
       }
       setOf(version4, version5).forEach {
-        storeVersion(artifact2.toPublishedArtifact(it, RELEASE))
+        storeArtifactVersion(artifact2.toPublishedArtifact(it, RELEASE))
       }
       register(artifact3)
       setOf(version6, versionBad).forEach {
-        storeVersion(artifact3.toPublishedArtifact(it))
+        storeArtifactVersion(artifact3.toPublishedArtifact(it))
       }
     }
     persist(manifest)
@@ -196,7 +196,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       test("storing a new version throws an exception") {
         expectThrows<NoSuchArtifactException> {
-          subject.storeVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
+          subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
         }
       }
 
@@ -235,7 +235,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       context("an artifact version already exists") {
         before {
-          subject.storeVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
+          subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
         }
 
         test("release status for the version is returned correctly") {
@@ -243,13 +243,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         }
 
         test("registering the same version is a no-op") {
-          val result = subject.storeVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
+          val result = subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT))
           expectThat(result).isFalse()
           expectThat(subject.versions(artifact1)).hasSize(1)
         }
 
         test("adding a new version adds it to the list") {
-          val result = subject.storeVersion(artifact1.toPublishedArtifact(version2, SNAPSHOT))
+          val result = subject.storeArtifactVersion(artifact1.toPublishedArtifact(version2, SNAPSHOT))
 
           expectThat(result).isTrue()
           expectThat(subject.versions(artifact1)).containsExactly(version2, version1)
@@ -257,7 +257,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
         test("querying the list for returns both artifacts") {
           // status is stored on the artifact
-          subject.storeVersion(artifact1.toPublishedArtifact(version2, SNAPSHOT))
+          subject.storeArtifactVersion(artifact1.toPublishedArtifact(version2, SNAPSHOT))
           expectThat(subject.versions(artifact1)).containsExactly(version2, version1)
         }
       }
@@ -268,9 +268,9 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             .shuffled()
             .forEach {
               if (it == version4 || it == version5) {
-                subject.storeVersion(artifact1.toPublishedArtifact(it, RELEASE))
+                subject.storeArtifactVersion(artifact1.toPublishedArtifact(it, RELEASE))
               } else {
-                subject.storeVersion(artifact1.toPublishedArtifact(it, SNAPSHOT))
+                subject.storeArtifactVersion(artifact1.toPublishedArtifact(it, SNAPSHOT))
               }
             }
         }
@@ -692,8 +692,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     context("getting all filters by type") {
       before {
         persist()
-        subject.storeVersion(artifact1.toPublishedArtifact(version4, FINAL))
-        subject.storeVersion(artifact3.toPublishedArtifact(version6, FINAL))
+        subject.storeArtifactVersion(artifact1.toPublishedArtifact(version4, FINAL))
+        subject.storeArtifactVersion(artifact3.toPublishedArtifact(version6, FINAL))
       }
 
       test("querying works") {
@@ -779,7 +779,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     context("artifact metadata exists") {
       before {
         subject.register(artifact1)
-        subject.storeVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT).copy(
+        subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT).copy(
           gitMetadata = artifactMetadata.gitMetadata,
           buildMetadata = artifactMetadata.buildMetadata
         ))
@@ -796,7 +796,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       }
 
       test("update with non-prefixed version works") {
-        subject.storeVersion(artifact1.toPublishedArtifact(versionOnly, SNAPSHOT).copy(
+        subject.storeArtifactVersion(artifact1.toPublishedArtifact(versionOnly, SNAPSHOT).copy(
           gitMetadata = artifactMetadata.gitMetadata,
           buildMetadata = artifactMetadata.buildMetadata
         ))
@@ -816,7 +816,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       before {
         subject.register(artifact1)
-        subject.storeVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT, createdAt = createdAt))
+        subject.storeArtifactVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT, createdAt = createdAt))
       }
 
       test("retrieves timestamp successfully") {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -48,6 +48,7 @@ import strikt.assertions.isSuccess
 import strikt.assertions.isTrue
 import java.time.Clock
 import java.time.Duration
+import java.time.Instant
 
 abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests {
   abstract fun factory(clock: Clock): T
@@ -784,7 +785,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         ))
       }
 
-      test ("retrieves successfully") {
+      test("retrieves successfully") {
         val publishedArtifact = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
 
         expectThat(publishedArtifact.buildMetadata)
@@ -807,6 +808,20 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
         expectThat(publishedArtifact.gitMetadata)
           .isEqualTo(artifactMetadata.gitMetadata)
+      }
+    }
+
+    context("artifact creation timestamp exists") {
+      val createdAt = Instant.now()
+
+      before {
+        subject.register(artifact1)
+        subject.storeVersion(artifact1.toPublishedArtifact(version1, SNAPSHOT, createdAt = createdAt))
+      }
+
+      test("retrieves timestamp successfully") {
+        val publishedArtifact = subject.getArtifactVersion(artifact1.name, artifact1.type, version1, SNAPSHOT)!!
+        expectThat(publishedArtifact.createdAt).isEqualTo(createdAt)
       }
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixVersions.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixVersions.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 
 /**
  * Netflix-specific conventions for artifact versions.
@@ -27,7 +27,7 @@ object NetflixVersions {
   /**
    * Extracts a version display name from the longer version string, leaving out build and git details if present.
    */
-  fun getVersionDisplayName(artifact: PublishedArtifact): String {
+  fun getVersionDisplayName(artifact: ArtifactVersion): String {
     val match = NETFLIX_VERSION_REGEX.find(artifact.version)
     val mainVersion = match?.groups?.get(1)?.value
     val preRelease = match?.groups?.get(2)?.value
@@ -41,7 +41,7 @@ object NetflixVersions {
   /**
    * Extracts the build number from the version string, if available.
    */
-  fun getBuildNumber(artifact: PublishedArtifact): Int? {
+  fun getBuildNumber(artifact: ArtifactVersion): Int? {
     return try {
       NETFLIX_VERSION_REGEX.find(artifact.version)?.groups?.get(6)?.value?.toInt()
     } catch (e: NumberFormatException) {
@@ -52,7 +52,7 @@ object NetflixVersions {
   /**
    * Extracts the commit hash from the version string, if available.
    */
-  fun getCommitHash(artifact: PublishedArtifact): String? {
+  fun getCommitHash(artifact: ArtifactVersion): String? {
     return NETFLIX_VERSION_REGEX.find(artifact.version)?.groups?.get(8)?.value
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -4,8 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
@@ -36,12 +35,12 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
    * @return `true` if a new version is persisted, `false` if the specified version was already
    * known (in which case this method is a no-op).
    */
-  fun storeArtifactVersion(artifact: PublishedArtifact): Boolean
+  fun storeArtifactVersion(artifact: ArtifactVersion): Boolean
 
   /**
-   * @return The given artifact version as a [PublishedArtifact]
+   * @return The given artifact version as a [ArtifactVersion]
    */
-  fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): PublishedArtifact?
+  fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): ArtifactVersion?
 
   /**
    * Deletes an artifact from a delivery config.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -36,7 +36,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
    * @return `true` if a new version is persisted, `false` if the specified version was already
    * known (in which case this method is a no-op).
    */
-  fun storeVersion(artifact: PublishedArtifact): Boolean
+  fun storeArtifactVersion(artifact: PublishedArtifact): Boolean
 
   /**
    * @return The given artifact version as a [PublishedArtifact]

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -9,7 +9,7 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
@@ -311,10 +311,10 @@ class CombinedRepository(
   override fun getAllArtifacts(type: ArtifactType?): List<DeliveryArtifact> =
     artifactRepository.getAll(type)
 
-  override fun storeArtifactVersion(artifact: PublishedArtifact): Boolean =
+  override fun storeArtifactVersion(artifact: ArtifactVersion): Boolean =
     artifactRepository.storeArtifactVersion(artifact)
 
-  override fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): PublishedArtifact? =
+  override fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): ArtifactVersion? =
     artifactRepository.getArtifactVersion(name, type, version, status)
 
   override fun deleteArtifact(artifact: DeliveryArtifact) =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -9,7 +9,6 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
@@ -313,7 +312,7 @@ class CombinedRepository(
     artifactRepository.getAll(type)
 
   override fun storeArtifactVersion(artifact: PublishedArtifact): Boolean =
-    artifactRepository.storeVersion(artifact)
+    artifactRepository.storeArtifactVersion(artifact)
 
   override fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): PublishedArtifact? =
     artifactRepository.getArtifactVersion(name, type, version, status)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -6,8 +6,7 @@ import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.persistence.KeelReadOnlyRepository
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
@@ -143,9 +142,9 @@ interface KeelRepository : KeelReadOnlyRepository {
 
   fun getAllArtifacts(type: ArtifactType? = null): List<DeliveryArtifact>
 
-  fun storeArtifactVersion(artifact: PublishedArtifact): Boolean
+  fun storeArtifactVersion(artifact: ArtifactVersion): Boolean
 
-  fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): PublishedArtifact?
+  fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): ArtifactVersion?
 
   fun deleteArtifact(artifact: DeliveryArtifact)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -312,19 +312,19 @@ class ApplicationService(
   ): ArtifactVersionSummary {
     val artifactSupplier = artifactSuppliers.supporting(artifact.type)
     val releaseStatus = repository.getReleaseStatus(artifact, version)
-    val publishedArtifact = repository.getArtifactVersion(artifact.name, artifact.type, version, releaseStatus)
+    val artifactVersion = repository.getArtifactVersion(artifact.name, artifact.type, version, releaseStatus)
       ?: throw InvalidSystemStateException("Loading artifact version $version failed for known artifact $artifact.")
 
     return ArtifactVersionSummary(
       version = version,
       environments = environments,
-      displayName = artifactSupplier.getVersionDisplayName(publishedArtifact),
+      displayName = artifactSupplier.getVersionDisplayName(artifactVersion),
 
       // first attempt to use the artifact metadata fetched from the DB, then fallback to the default if not found
-      build = publishedArtifact.buildMetadata
-        ?: artifactSupplier.parseDefaultBuildMetadata(publishedArtifact, artifact.versioningStrategy),
-      git = publishedArtifact.gitMetadata
-        ?: artifactSupplier.parseDefaultGitMetadata(publishedArtifact, artifact.versioningStrategy)
+      build = artifactVersion.buildMetadata
+        ?: artifactSupplier.parseDefaultBuildMetadata(artifactVersion, artifact.versioningStrategy),
+      git = artifactVersion.gitMetadata
+        ?: artifactSupplier.parseDefaultGitMetadata(artifactVersion, artifact.versioningStrategy)
     )
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -1,9 +1,7 @@
 package com.netflix.spinnaker.keel.telemetry
 
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 
 sealed class TelemetryEvent
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixVersionsTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NetflixVersionsTests.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectThat
@@ -36,7 +36,7 @@ class NetflixVersionsTests : JUnit5Minutests {
         "1.0.0~snapshot.1-15.4cbd040533a2f43fc6691d773d510cda70f4126a" to Triple("1.0.0~snapshot.1",15, "4cbd040533a2f43fc6691d773d510cda70f4126a"),
         "1.0.0~rc.2-h15.4cbd040533a2f43fc6691d773d510cda70f4126a" to Triple("1.0.0~rc.2",15, "4cbd040533a2f43fc6691d773d510cda70f4126a")
       ).forEach { version, (displayName, build, commit) ->
-        val artifact = PublishedArtifact("test", "DEB", "test", version)
+        val artifact = ArtifactVersion("test", "DEB", "test", version)
 
         // check with and without debian package name prefix
         listOf("", "mydebian-").forEach { prefix ->
@@ -65,7 +65,7 @@ class NetflixVersionsTests : JUnit5Minutests {
         "1.0.0-foo-h12.123456",
         "1.0.0beta"
       ).forEach { version ->
-        val artifact = PublishedArtifact("test", "DEB", "test", version)
+        val artifact = ArtifactVersion("test", "DEB", "test", version)
 
         test("returns null build number for version $version") {
           expectThat(getBuildNumber(artifact)).isNull()

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.SNAPSHOT
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
@@ -33,7 +33,6 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.test.DummyArtifact
 import com.netflix.spinnaker.keel.test.DummyVersioningStrategy
 import com.netflix.spinnaker.keel.test.artifactReferenceResource
-import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
 import com.netflix.spinnaker.keel.test.versionedArtifactResource
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
@@ -112,13 +111,13 @@ class ApplicationServiceTests : JUnit5Minutests {
       every { supportedType } returns SupportedConstraintType<DependsOnConstraint>("depends-on")
     }
 
-    private val publishedArtifact = slot<PublishedArtifact>()
+    private val artifactVersion = slot<ArtifactVersion>()
     private val artifactSupplier = mockk<ArtifactSupplier<DummyArtifact, DummyVersioningStrategy>>(relaxUnitFun = true) {
       every { supportedArtifact } returns SupportedArtifact("dummy", DummyArtifact::class.java)
       every {
-        getVersionDisplayName(capture(publishedArtifact))
+        getVersionDisplayName(capture(artifactVersion))
       } answers {
-        publishedArtifact.captured.version
+        artifactVersion.captured.version
       }
       every { parseDefaultBuildMetadata(any(), any()) } returns null
       every { parseDefaultGitMetadata(any(), any()) } returns null
@@ -154,7 +153,7 @@ class ApplicationServiceTests : JUnit5Minutests {
       every {
         repository.getArtifactVersion(any(), any(), any(), any())
       } answers {
-        PublishedArtifact(arg<String>(0), arg<String>(1), arg<String>(2))
+        ArtifactVersion(arg<String>(0), arg<String>(1), arg<String>(2))
       }
 
       every {
@@ -190,7 +189,7 @@ class ApplicationServiceTests : JUnit5Minutests {
           every {
             repository.getArtifactVersion(any(), any(), any(), any())
           } answers {
-            PublishedArtifact(arg<String>(0), arg<String>(1), arg<String>(2), gitMetadata = gitMetadata, buildMetadata = buildMetadata)
+            ArtifactVersion(arg<String>(0), arg<String>(1), arg<String>(2), gitMetadata = gitMetadata, buildMetadata = buildMetadata)
           }
         }
 

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -10,7 +10,7 @@ import com.netflix.spinnaker.keel.api.artifacts.BaseLabel.RELEASE
 import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.artifacts.Repo
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
@@ -204,7 +204,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
         before {
           every {
             repository.getArtifactVersion("mypkg", DEBIAN, "v1.0.0", any())
-          } returns PublishedArtifact(
+          } returns ArtifactVersion(
             name = "mypkg",
             type = DEBIAN,
             version = "v1.0.0",

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ArtifactService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/igor/ArtifactService.kt
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.igor
 
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -13,7 +13,7 @@ interface ArtifactService {
     @Path("packageName", encoded = true) packageName: String,
     @Path("version") version: String,
     @Query("type") artifactType: String
-  ): PublishedArtifact
+  ): ArtifactVersion
 
   @GET("/artifacts/rocket/{packageName}")
   suspend fun getVersions(

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -8,7 +8,7 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactVersion
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
@@ -169,7 +169,7 @@ class SqlArtifactRepository(
       } ?: throw ArtifactNotFoundException(reference, deliveryConfigName)
   }
 
-  override fun storeArtifactVersion(artifact: PublishedArtifact): Boolean {
+  override fun storeArtifactVersion(artifact: ArtifactVersion): Boolean {
     with(artifact) {
       if (!isRegistered(name, type)) {
         throw NoSuchArtifactException(name, type)
@@ -190,7 +190,7 @@ class SqlArtifactRepository(
     }
   }
 
-  override fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): PublishedArtifact? {
+  override fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): ArtifactVersion? {
     return sqlRetry.withRetry(READ) {
       jooq
         .select(
@@ -209,7 +209,7 @@ class SqlArtifactRepository(
         .apply { if (status != null) and(ARTIFACT_VERSIONS.RELEASE_STATUS.eq(status.toString())) }
         .fetchOne()
         ?.let { (name, type, version, status, createdAt, gitMetadata, buildMetadata) ->
-          PublishedArtifact(
+          ArtifactVersion(
             name = name,
             type = type,
             version = version,

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -181,6 +181,7 @@ class SqlArtifactRepository(
           .set(ARTIFACT_VERSIONS.TYPE, type)
           .set(ARTIFACT_VERSIONS.VERSION, version)
           .set(ARTIFACT_VERSIONS.RELEASE_STATUS, status?.toString())
+          .set(ARTIFACT_VERSIONS.CREATED_AT, createdAt?.toTimestamp())
           .set(ARTIFACT_VERSIONS.GIT_METADATA, gitMetadata?.let { objectMapper.writeValueAsString(it) })
           .set(ARTIFACT_VERSIONS.BUILD_METADATA, buildMetadata?.let { objectMapper.writeValueAsString(it) })
           .onDuplicateKeyIgnore()
@@ -192,23 +193,30 @@ class SqlArtifactRepository(
   override fun getArtifactVersion(name: String, type: ArtifactType, version: String, status: ArtifactStatus?): PublishedArtifact? {
     return sqlRetry.withRetry(READ) {
       jooq
-        // TODO: add CREATED_AT
-        .select(ARTIFACT_VERSIONS.NAME, ARTIFACT_VERSIONS.TYPE, ARTIFACT_VERSIONS.VERSION, ARTIFACT_VERSIONS.RELEASE_STATUS, ARTIFACT_VERSIONS.GIT_METADATA, ARTIFACT_VERSIONS.BUILD_METADATA)
+        .select(
+          ARTIFACT_VERSIONS.NAME,
+          ARTIFACT_VERSIONS.TYPE,
+          ARTIFACT_VERSIONS.VERSION,
+          ARTIFACT_VERSIONS.RELEASE_STATUS,
+          ARTIFACT_VERSIONS.CREATED_AT,
+          ARTIFACT_VERSIONS.GIT_METADATA,
+          ARTIFACT_VERSIONS.BUILD_METADATA
+        )
         .from(ARTIFACT_VERSIONS)
         .where(ARTIFACT_VERSIONS.NAME.eq(name))
         .and(ARTIFACT_VERSIONS.TYPE.eq(type))
         .and(ARTIFACT_VERSIONS.VERSION.eq(version))
         .apply { if (status != null) and(ARTIFACT_VERSIONS.RELEASE_STATUS.eq(status.toString())) }
         .fetchOne()
-        ?.let { (name, type, version, status, gitMetadata, buildMetadata) ->
+        ?.let { (name, type, version, status, createdAt, gitMetadata, buildMetadata) ->
           PublishedArtifact(
             name = name,
             type = type,
             version = version,
             status = status?.let { ArtifactStatus.valueOf(it) },
-            // TODO: createdAt
-            gitMetadata = objectMapper.readValue(gitMetadata),
-            buildMetadata = objectMapper.readValue(buildMetadata),
+            createdAt = createdAt?.toInstant(UTC),
+            gitMetadata = gitMetadata?.let { objectMapper.readValue(it) },
+            buildMetadata = buildMetadata?.let { objectMapper.readValue(it) },
           )
         }
     }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -169,7 +169,7 @@ class SqlArtifactRepository(
       } ?: throw ArtifactNotFoundException(reference, deliveryConfigName)
   }
 
-  override fun storeVersion(artifact: PublishedArtifact): Boolean {
+  override fun storeArtifactVersion(artifact: PublishedArtifact): Boolean {
     with(artifact) {
       if (!isRegistered(name, type)) {
         throw NoSuchArtifactException(name, type)

--- a/keel-sql/src/main/resources/db/changelog/20200923-add-created-at-to-artifact-versions.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200923-add-created-at-to-artifact-versions.yml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-created-at-to-artifact-versions
+      author: lpollo
+      changes:
+        - addColumn:
+            tableName: artifact_versions
+            columns:
+              - column:
+                  name: created_at
+                  type: timestamp(6)
+                  constraints:
+                    nullable: true
+                  afterColumn: release_status

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -173,3 +173,6 @@ databaseChangeLog:
   - include:
       file: changelog/20200812-add-build-and-git-metadata-columns.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200923-add-created-at-to-artifact-versions.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Adds a `CREATED_AT` column to the `ARTIFACT_VERSIONS` table to store the artifact creation timestamp, as reported through artifact events via `POST /artifacts/events`.

The ultimate purpose of this field/column, alongside git branch information obtained from CI integration, is to replace the use of artifact versions for sorting. This puts us one little step closer. 🙂 

This PR also renames `PublishedArtifact` to `ArtifactVersion` as discussed here: https://github.com/spinnaker/keel/pull/1530#discussion_r493864519