### PR TITLE
Disambiguate ingress rule types in schema

### DIFF
--- a/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
+++ b/keel-schema-generator/src/main/kotlin/com/netflix/spinnaker/keel/schema/Schema.kt
@@ -31,7 +31,8 @@ data class ObjectSchema(
   override val description: String?,
   val properties: Map<String, Schema>,
   val required: SortedSet<String>,
-  val allOf: List<ConditionalSubschema>? = null
+  val allOf: List<ConditionalSubschema>? = null,
+  val additionalProperties: Boolean? = null
 ) : TypedProperty("object")
 
 object NullSchema : TypedProperty("null") {

--- a/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
+++ b/keel-schema-generator/src/test/kotlin/com/netflix/spinnaker/keel/schema/GeneratorTests.kt
@@ -903,11 +903,11 @@ internal class GeneratorTests {
     val schema by lazy { generateSchema<Foo>() }
 
     @Test
-    fun `literals are represented as enum with a single value`() {
+    fun `literals are represented as a const`() {
       expectThat(schema.properties[Foo::bar.name])
-        .isA<EnumSchema>()
-        .get { enum }
-        .containsExactly("BAR")
+        .isA<ConstSchema>()
+        .get { const }
+        .isEqualTo("BAR")
     }
   }
 
@@ -934,9 +934,9 @@ internal class GeneratorTests {
         .isA<OneOf>()
         .get { oneOf }
         .one {
-          isA<EnumSchema>()
-            .get { enum }
-            .containsExactly("BAR")
+          isA<ConstSchema>()
+            .get { const }
+            .isEqualTo("BAR")
         }
         .one {
           isA<Reference>()

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
@@ -66,6 +66,7 @@ class ApiDocCompatibilityTests {
       "/examples/clb-example.yml",
       "/examples/ec2-cluster-with-autoscaling-example.yml",
       "/examples/security-group-example.yml",
+      "/examples/security-group-with-cidr-rule-example.yml",
       "/examples/titus-cluster-example.yml",
       "/examples/titus-cluster-with-artifact-example.yml"
     ).map {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -329,7 +329,7 @@ class ApiDocTests : JUnit5Minutests {
           path("\$ref").textValue().isEqualTo("#/\$defs/PortRange")
         }
         .one {
-          path("enum").isArray().textValues().containsExactly("ALL")
+          path("const").isTextual().textValue().isEqualTo("ALL")
         }
     }
 

--- a/keel-web/src/test/resources/examples/security-group-with-cidr-rule-example.yml
+++ b/keel-web/src/test/resources/examples/security-group-with-cidr-rule-example.yml
@@ -1,0 +1,25 @@
+---
+application: fnord
+serviceAccount: delivery-engineering@netflix.com
+environments:
+- name: test
+  resources:
+  - kind: ec2/security-group@v1
+    spec:
+      moniker:
+        app: keeldemo
+        stack: example
+        detail: ec2v1
+      locations:
+        account: test
+        vpc: vpc0
+        regions:
+        - name: us-west-2
+        - name: us-east-1
+      description: Managed Security Group for keeldemo example
+      inboundRules:
+      - protocol: tcp
+        blockRange: "2600:1f1f:4b2:3a00::/56"
+        portRange:
+          startPort: 7001
+          endPort: 7001


### PR DESCRIPTION
Without specifying `additionalProperties: false` some ingress rules can look like other types. That caused errors for users because the schema couldn't distinguish between the ingress rule types. I've made `additionalProperties: false` be the default for objects except where it's creating parameterized types.

Also, fixed values, such as singleton objects were being rendered as an `enum` with a single value when they can just be a `const`.

Addresses one of the things in #1535 