### PR TITLE
fix(artifacts): Fix handling of upper-case artifact types

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/PublishedArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/PublishedArtifact.kt
@@ -61,6 +61,9 @@ data class PublishedArtifact(
       }
     }
 
-  // FIXME: it's silly that we're prepending the artifact name for Debian only...
-  fun normalized() = copy(version = if (type == DEBIAN && !version.startsWith(name)) "$name-$version" else version)
+  fun normalized() = copy(
+    type = type.toLowerCase(),
+    // FIXME: it's silly that we're prepending the artifact name for Debian only...
+    version = if (type.toLowerCase() == DEBIAN && !version.startsWith(name)) "$name-$version" else version
+  )
 }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -29,7 +29,7 @@ import io.mockk.coVerify as verify
 
 internal class ArtifactListenerTests : JUnit5Minutests {
   val publishedDeb = PublishedArtifact(
-    type = DEBIAN,
+    type = "DEB",
     customKind = false,
     name = "fnord",
     version = "0.156.0-h58.f67fe09",
@@ -39,7 +39,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
   ).normalized()
 
   val newerPublishedDeb = PublishedArtifact(
-    type = DEBIAN,
+    type = "DEB",
     customKind = false,
     name = "fnord",
     version = "0.161.0-h61.116f116",


### PR DESCRIPTION
I forgot that artifact events coming from echo have upper-case artifact type strings... 😛 