### PR TITLE
Fix DB index size

### DIFF
--- a/keel-sql/keel-sql.gradle.kts
+++ b/keel-sql/keel-sql.gradle.kts
@@ -1,6 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
 import org.liquibase.gradle.LiquibaseTask
-import java.lang.Thread.sleep
 
 val buildingInDocker = project.properties["buildingInDocker"]?.toString().let { it == "true" }
 
@@ -83,7 +82,7 @@ tasks.getByName<LiquibaseTask>("liquibaseUpdate") {
         commandLine("sh", "-c", "docker stop mysqlJooq >/dev/null 2>&1 || true")
       }
       exec {
-        commandLine("sh", "-c", "docker run --name mysqlJooq --health-cmd='mysqladmin ping -s' -d --rm -e MYSQL_ROOT_PASSWORD=sa -e MYSQL_DATABASE=keel -p 6603:3306 mysql:5.7 >/dev/null 2>&1; while STATUS=\$(docker inspect --format \"{{.State.Health.Status}}\" mysqlJooq); [ \$STATUS != \"healthy\" ]; do if [ \$STATUS = \"unhealthy\" ]; then echo \"Docker failed to start\"; exit -1; fi; sleep 1; done")
+        commandLine("sh", "-c", "docker run --name mysqlJooq --health-cmd='mysqladmin ping -s' -d --rm -e MYSQL_ROOT_PASSWORD=sa -e MYSQL_DATABASE=keel -p 6603:3306 mysql:5.7 --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci >/dev/null 2>&1; while STATUS=\$(docker inspect --format \"{{.State.Health.Status}}\" mysqlJooq); [ \$STATUS != \"healthy\" ]; do if [ \$STATUS = \"unhealthy\" ]; then echo \"Docker failed to start\"; exit -1; fi; sleep 1; done")
       }
     }
   }

--- a/keel-sql/src/main/resources/db/changelog/20200925-environment-related-indices.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200925-environment-related-indices.yml
@@ -12,8 +12,6 @@ databaseChangeLog:
         - column:
             name: type
         - column:
-            name: version
-        - column:
             name: release_status
     - createIndex:
         indexName: environment_artifact_constraint_uid_status_idx


### PR DESCRIPTION
PR #1540 adds an index composed of 4 `varchar(255)` columns. Therefore the size of the index you'd think would be 1020 bytes (4 * 255). The max index size in MySQL InnoDB tables is 3072 bytes. However, when using utf8mb4 character data the columns use 4 bytes per character so the index is actually 4080 bytes -- larger than the 3072 byte limit.

This was exacerbated by the fact that the dockerized mySQL database we use to run the `jooqGenerate` task in Gradle was not set up to use utf8 so the problem was not caught until deployment time.