### PR TITLE
fix(artifacts): Fix summaries for same artifact with different release statuses

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/EnvironmentSummary.kt
@@ -34,7 +34,7 @@ data class EnvironmentSummary(
   }
 
   fun getArtifactPromotionStatus(artifact: DeliveryArtifact, version: String) =
-    artifacts.find { it.name == artifact.name && it.type == artifact.type }
+    artifacts.find { it.reference == artifact.reference && it.type == artifact.type }
       ?.let {
         when (version) {
           it.versions.current -> CURRENT

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -137,9 +137,10 @@ fun versionedArtifactResource(
 fun artifactReferenceResource(
   kind: ResourceKind = TEST_API_V1.qualify("artifactReference"),
   id: String = randomString(),
-  application: String = "fnord"
+  application: String = "fnord",
+  artifactReference: String = "fnord"
 ): Resource<DummyArtifactReferenceResourceSpec> =
-  DummyArtifactReferenceResourceSpec(id = id, application = application)
+  DummyArtifactReferenceResourceSpec(id = id, application = application, artifactReference = artifactReference)
     .let { spec ->
       resource(
         kind = kind,


### PR DESCRIPTION
We got a bug report for a scenario where the user had a delivery config with two artifacts pointing to the same Debian package but with different release statuses. The `/application` API would return an incorrect artifact summary (with empty environments) for one of the artifacts. It turns out we were looking up the corresponding environment summary by artifact type and name only (as opposed to by reference), which was causing results not to be found.

I recommend viewing the diff with "ignore whitespace" enabled.