### PR TITLE
refactor(ec2): extract method

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -207,11 +207,11 @@ class ClusterHandler(
         }
         when {
           diff.shouldDeployAndModifyScalingPolicies() -> {
-            stages.add(diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon"))
+            stages.add(createServerGroupOrcaJob(diff, refId, resource))
             refId++
             stages.addAll(diff.modifyScalingPolicyJob(refId))
           }
-          else -> stages.add(diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon"))
+          else -> stages.add(createServerGroupOrcaJob(diff, refId, resource))
         }
 
         if (stages.isEmpty()) {
@@ -268,8 +268,7 @@ class ClusterHandler(
           refId++
         }
 
-        val stage = (diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon"))
-          .toMutableMap()
+        val stage = createServerGroupOrcaJob(diff, refId, resource).toMutableMap()
 
         refId++
 
@@ -329,6 +328,9 @@ class ClusterHandler(
 
       return@coroutineScope tasks
     }
+
+  private fun createServerGroupOrcaJob(diff: ResourceDiff<ServerGroup>, refId: Int, resource: Resource<ClusterSpec>): Map<String, Any?> =
+    diff.createServerGroupJob(refId) + resource.spec.deployWith.toOrcaJobProperties("Amazon")
 
   override suspend fun export(exportable: Exportable): ClusterSpec {
     // Get existing infrastructure

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -374,7 +374,7 @@ class ClusterHandler(
       .toSet()
 
     // let's assume that the largest server group is the most important and should be the base
-    val base = serverGroups.values.maxBy { it.capacity.desired ?: it.capacity.max }
+    val base = serverGroups.values.maxByOrNull { it.capacity.desired ?: it.capacity.max }
       ?: throw ExportError("Unable to calculate the server group with the largest capacity from server groups $serverGroups")
 
     // Construct the minimal locations object

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -1174,7 +1174,6 @@ class ClusterHandler(
     )
 
     private const val REGION_PLACEHOLDER = "{{region}}"
-    private const val REGION_PATTERN = "([a-z]{2}(-gov)?)-([a-z]+)-\\d"
   }
 }
 


### PR DESCRIPTION
Extract common code into a method. This is code that generates the payload for the orca job that creates new server groups.

No (intentional)) behavior changes in this PR.

This is prep work for adding support for different [EBS volume types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html). That future work should only require modifying the new function.