### PR TITLE
feat(cli): Keel data generation CLI

### DIFF
--- a/keel-cli/keel-cli.gradle.kts
+++ b/keel-cli/keel-cli.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  `java-library`
+  id("kotlin-spring")
+  application
+}
+
+repositories {
+  maven {
+    url = uri("https://kotlin.bintray.com/kotlinx")
+  }
+}
+
+sourceSets {
+  main {
+    dependencies {
+      implementation("org.jetbrains.kotlinx:kotlinx-cli:0.3")
+    }
+  }
+}
+
+dependencies {
+  implementation(project(":keel-core"))
+  implementation(project(":keel-sql"))
+  implementation(project(":keel-ec2-plugin"))
+  implementation("org.springframework.boot:spring-boot-starter")
+  implementation("org.springframework.boot:spring-boot-autoconfigure")
+}

--- a/keel-cli/src/main/kotlin/com/netflix/spinnaker/config/KeelCliConfiguration.kt
+++ b/keel-cli/src/main/kotlin/com/netflix/spinnaker/config/KeelCliConfiguration.kt
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1
+import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
+import com.netflix.spinnaker.keel.api.support.register
+import com.netflix.spinnaker.keel.ec2.jackson.registerKeelEc2ApiModule
+import com.netflix.spinnaker.keel.serialization.configureForKeel
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+import java.time.Clock
+import javax.annotation.PostConstruct
+
+@Component
+class KeelCliConfiguration(
+  private val extensionRegistry: ExtensionRegistry,
+  private val objectMappers: List<ObjectMapper>,
+) {
+  private val log: Logger = LoggerFactory.getLogger(javaClass)
+
+  @Bean
+  fun clock(): Clock = Clock.systemDefaultZone()
+
+  @PostConstruct
+  fun registerApiExtensionsWithObjectMappers() {
+    objectMappers.forEach {
+      it.configureForKeel()
+      it.registerKeelEc2ApiModule()
+    }
+  }
+
+  @PostConstruct
+  fun registerResourceSpecSubtypes() {
+    extensionRegistry.register<ResourceSpec>(ClusterSpec::class.java, EC2_CLUSTER_V1.kind.toString())
+  }
+}

--- a/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/KeelCli.kt
+++ b/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/KeelCli.kt
@@ -1,0 +1,68 @@
+package com.netflix.spinnaker.keel.cli
+
+import com.netflix.spinnaker.keel.cli.commands.DataGenCommand
+import kotlinx.cli.ArgParser
+import org.springframework.boot.CommandLineRunner
+import org.springframework.boot.WebApplicationType.NONE
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.FilterType
+import java.lang.annotation.ElementType.TYPE
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy.RUNTIME
+import java.lang.annotation.Target
+
+
+private val DEFAULT_PROPS = mapOf(
+  "netflix.environment" to "test",
+  "netflix.account" to "\${netflix.environment}",
+  "netflix.stack" to "test",
+  "spring.config.additional-location" to "\${user.home}/.spinnaker/",
+  "spring.application.name" to "keel-cli",
+  "spring.config.name" to "spinnaker,keel",
+  "spring.profiles.active" to "\${netflix.environment},local,cli",
+  // TODO: not sure why we need this when it should get loaded from application.properties
+  "spring.main.allow-bean-definition-overriding" to "true",
+  "spring.groovy.template.check-template-location" to "false"
+)
+
+/**
+ * A simple Spring Boot console application providing CLI access to Keel.
+ */
+@KeelCliComponentScan
+@SpringBootApplication
+class KeelCli(
+  val dataGenCommand: DataGenCommand
+) : CommandLineRunner {
+  override fun run(args: Array<String>) {
+    val parser = ArgParser("keel-cli")
+    parser.subcommands(dataGenCommand)
+    parser.parse(args)
+  }
+}
+
+@Retention(RUNTIME)
+@Target(TYPE)
+@ComponentScan(
+  basePackages = [
+    "com.netflix.spinnaker.config",
+    "com.netflix.spinnaker.keel"
+  ],
+  excludeFilters = [ComponentScan.Filter(
+    type = FilterType.REGEX,
+    pattern = [
+      "com.netflix.spinnaker.config.DefaultServiceClientProvider",
+      "com.netflix.spinnaker.config.MetricsEndpointConfiguration",
+      "com.netflix.spinnaker.keel.artifacts.ArtifactListener"
+    ]
+  )]
+)
+annotation class KeelCliComponentScan
+
+fun main(args: Array<String>) {
+  SpringApplicationBuilder(KeelCli::class.java)
+    .properties(DEFAULT_PROPS)
+    .web(NONE)
+    .run(*args)
+}

--- a/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/KeelCli.kt
+++ b/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/KeelCli.kt
@@ -6,12 +6,15 @@ import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.WebApplicationType.NONE
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.context.ApplicationContext
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.FilterType
+import org.springframework.core.env.Environment
 import java.lang.annotation.ElementType.TYPE
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy.RUNTIME
 import java.lang.annotation.Target
+import kotlin.system.exitProcess
 
 
 private val DEFAULT_PROPS = mapOf(
@@ -33,9 +36,15 @@ private val DEFAULT_PROPS = mapOf(
 @KeelCliComponentScan
 @SpringBootApplication
 class KeelCli(
+  val springEnv: Environment,
   val dataGenCommand: DataGenCommand
 ) : CommandLineRunner {
   override fun run(args: Array<String>) {
+    if (springEnv.activeProfiles.none { it == "local" }) {
+      println("You must enable the 'local' Spring profile to run this tool.")
+      return
+    }
+
     val parser = ArgParser("keel-cli")
     parser.subcommands(dataGenCommand)
     parser.parse(args)

--- a/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/commands/DataGenCommand.kt
+++ b/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/commands/DataGenCommand.kt
@@ -1,0 +1,139 @@
+package com.netflix.spinnaker.keel.cli.commands
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
+import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1
+import com.netflix.spinnaker.keel.api.ec2.ReferenceArtifactImageProvider
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import kotlinx.cli.ArgType.Int
+import kotlinx.cli.Subcommand
+import kotlinx.cli.default
+import org.springframework.stereotype.Component
+import java.time.Instant
+import kotlin.random.Random
+
+@Component
+class DataGenCommand(
+  val repository: KeelRepository
+): Subcommand("datagen", "Generate test data") {
+  companion object {
+    const val TEST_APP = "datagen"
+    const val TEST_STACK = "local"
+    const val TEST_ACCT = "test"
+    const val TEST_DEB_PACKAGE = "fakedeb"
+    const val TEST_SVC_ACCT = "delivery-engineering@netflix.com"
+    val TEST_ARTIFACT = DebianArtifact(
+      deliveryConfigName = TEST_APP,
+      name = TEST_DEB_PACKAGE,
+      vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-weest-2")),
+      reference = TEST_APP
+    )
+    private val HEX_CHAR_POOL : List<Char> = ('0'..'9') + ('a'..'f')
+  }
+
+  private val deliveryConfigCount by option(
+    type = Int,
+    fullName = "deliveryConfigs",
+    shortName = "c",
+    description = "Number of delivery configs to generate"
+  ).default(1)
+
+
+  private val artifactCount by option(
+    type = Int,
+    fullName = "artifacts",
+    shortName = "a",
+    description = "Number of artifact versions to generate"
+  ).default(1)
+
+
+  private val resourceCount by option(
+    type = Int,
+    fullName = "resources",
+    shortName = "r",
+    description = "Number of resources per delivery config"
+  ).default(1)
+
+  override fun execute() {
+    println("Generating Keel test data: $deliveryConfigCount delivery config(s) with $resourceCount cluster(s) each, $artifactCount artifact version(s)")
+
+    (1..artifactCount).forEach { index ->
+      println("Writing artifact ${TEST_ARTIFACT.name} version 1.0.$index")
+      repository.storeArtifactInstance(
+        PublishedArtifact(
+          name = TEST_ARTIFACT.name,
+          type = TEST_ARTIFACT.type,
+          version = "1.0.$index",
+          createdAt = Instant.now(),
+          gitMetadata = GitMetadata(commit = makeFakeCommitHash(), author = "joesmith", branch = "master"),
+          buildMetadata = BuildMetadata(id = index, status = "SUCCEEDED")
+        )
+      )
+    }
+
+    (1..deliveryConfigCount).forEach { configIndex ->
+      val configName = "${TEST_APP.capitalize()}$configIndex"
+      val resources = (1..resourceCount).map { resourceIndex ->
+        Resource(
+          kind = EC2_CLUSTER_V1.kind,
+          metadata = mapOf(
+            "application" to configName,
+            "id" to "${configName}TestCluster$resourceIndex"
+          ),
+          spec = ClusterSpec(
+            moniker = Moniker(configName, TEST_STACK),
+            imageProvider = ReferenceArtifactImageProvider(
+              reference = TEST_APP
+            ),
+            locations = SubnetAwareLocations(
+              account = TEST_ACCT,
+              regions = setOf(SubnetAwareRegionSpec("us-west-2")),
+              subnet = "internal (vpc0)"
+            )
+          )
+        )
+      }
+
+      val deliveryConfig = DeliveryConfig(
+        application = configName,
+        name = configName,
+        serviceAccount = TEST_SVC_ACCT,
+        artifacts = setOf(TEST_ARTIFACT),
+        environments = setOf(
+          Environment(
+            name = "test",
+            resources = resources.toSet()
+          )
+        )
+      )
+
+      println("Writing delivery config ${deliveryConfig.name} with $resourceCount cluster(s)")
+      repository.upsertDeliveryConfig(deliveryConfig)
+
+      (1..artifactCount).forEach { index ->
+        println("Writing artifact version record for delivery config ${deliveryConfig.name}, environment test, version 1.0.$index")
+        repository.markAsSuccessfullyDeployedTo(deliveryConfig, TEST_ARTIFACT, "1.0.$index", "test")
+      }
+    }
+
+    println("Successfully generated test data. Happy testing!")
+
+    Thread.sleep(10 * 1000)
+  }
+
+  private fun makeFakeCommitHash() =
+    (1..7)
+      .map { i -> Random.nextInt(0, HEX_CHAR_POOL.size) }
+      .map(HEX_CHAR_POOL::get)
+      .joinToString("");
+}

--- a/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/commands/DataGenCommand.kt
+++ b/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/commands/DataGenCommand.kt
@@ -127,8 +127,6 @@ class DataGenCommand(
     }
 
     println("Successfully generated test data. Happy testing!")
-
-    Thread.sleep(10 * 1000)
   }
 
   private fun makeFakeCommitHash() =

--- a/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/commands/DataGenCommand.kt
+++ b/keel-cli/src/main/kotlin/com/netflix/spinnaker/keel/cli/commands/DataGenCommand.kt
@@ -35,7 +35,7 @@ class DataGenCommand(
     val TEST_ARTIFACT = DebianArtifact(
       deliveryConfigName = TEST_APP,
       name = TEST_DEB_PACKAGE,
-      vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-weest-2")),
+      vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
       reference = TEST_APP
     )
     private val HEX_CHAR_POOL : List<Char> = ('0'..'9') + ('a'..'f')

--- a/keel-cli/src/main/resources/logback.xml
+++ b/keel-cli/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>keel-cli.log</file>
+        <encoder>
+            <pattern>%date %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/ObjectMappers.kt
@@ -22,14 +22,14 @@ import java.util.TimeZone
 /**
  * Factory method for [ObjectMapper]s configured how we like 'em.
  */
-fun configuredObjectMapper(): ObjectMapper = ObjectMapper().configureMe()
+fun configuredObjectMapper(): ObjectMapper = ObjectMapper().configureForKeel()
 
 /**
  * Factory method for [YAMLMapper]s configured how we like 'em.
  */
-fun configuredYamlMapper(): YAMLMapper = YAMLMapper().configureMe().disable(USE_NATIVE_TYPE_ID)
+fun configuredYamlMapper(): YAMLMapper = YAMLMapper().configureForKeel().disable(USE_NATIVE_TYPE_ID)
 
-private fun <T : ObjectMapper> T.configureMe(): T =
+fun <T : ObjectMapper> T.configureForKeel(): T =
   apply {
     registerKeelApiModule()
       .registerKotlinModule()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(
   "keel-artifact",
   "keel-bakery-plugin",
   "keel-bom",
+  "keel-cli",
   "keel-clouddriver",
   "keel-core",
   "keel-core-test",


### PR DESCRIPTION
Introduces a simple Spring Boot console application that can be used to aid in development and testing. In this PR, a single command is defined, `datagen`, which populates the local database with test records to assist with testing.