### PR TITLE
refactor(constraints): cache results of AMI lookup

### DIFF
--- a/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
+++ b/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
   implementation("com.netflix.spinnaker.kork:kork-exceptions")
   implementation("com.netflix.spinnaker.kork:kork-security")
   implementation("com.netflix.frigga:frigga")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
+  implementation("com.github.ben-manes.caffeine:caffeine")
 
   testImplementation(project(":keel-test"))
   testImplementation("dev.minutest:minutest")

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.keel.bakery.constraint
 
+import com.github.benmanes.caffeine.cache.AsyncCacheLoader
+import com.github.benmanes.caffeine.cache.Caffeine
 import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
@@ -15,6 +17,10 @@ import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.exceptions.SystemException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers.IO
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -56,26 +62,31 @@ class ImageExistsConstraintEvaluator(
     val regions: Set<String>
   )
 
-  private val cache = mutableMapOf<CacheKey, NamedImage?>()
+  private val cache = Caffeine.newBuilder()
+    .buildAsync(
+      AsyncCacheLoader<CacheKey, NamedImage> { key, _ ->
+        CoroutineScope(IO).future(block = {
+          log.debug("Searching for baked image for {} in {}", key.appVersion, key.regions.joinToString())
+          imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+            key.appVersion,
+            key.account,
+            key.regions
+          )
+        })
+      }
+    )
 
-  private fun findMatchingImage(version: String, vmOptions: VirtualMachineOptions): NamedImage? {
-    val key = CacheKey(
+  private fun findMatchingImage(version: String, vmOptions: VirtualMachineOptions): NamedImage? =
+    CacheKey(
       // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-      AppVersion.parseName(version),
+      AppVersion.parseName(version) ?: throw SystemException("Invalid AMI app version: $version"),
       defaultImageAccount,
       vmOptions.regions
-    )
-    return cache.computeIfAbsent(key) { (appVersion, account, regions) ->
+    ).let {
       runBlocking {
-        log.debug("Searching for baked image for {} in {}", version, regions.joinToString())
-        imageService.getLatestNamedImageWithAllRegionsForAppVersion(
-          appVersion,
-          account,
-          regions
-        )
+        cache.get(it).await()
       }
     }
-  }
 
   private val defaultImageAccount: String
     get() = dynamicConfigService.getConfig("images.default-account", "test")


### PR DESCRIPTION
AMI lookup can be slow-ish (~ .75 seconds) and results do not change (until old AMIs get cleaned up at least) so we might as well cache the results of the lookup. We cannot cache a negative result since that would stop us responding to newly baked AMIs.