### PR TITLE
refactor(environments): delay delivery config last checked at write

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PeriodicallyCheckedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PeriodicallyCheckedRepositoryTests.kt
@@ -35,6 +35,9 @@ abstract class PeriodicallyCheckedRepositoryTests<T : Any, S : PeriodicallyCheck
 
     fun nextResults(): Collection<T> =
       subject.itemsDueForCheck(ifNotCheckedInLast, limit)
+        .also {
+          it.forEach(subject::markCheckComplete)
+        }
   }
 
   fun tests() = rootContext<Fixture<T, S>> {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -8,10 +8,6 @@ import com.netflix.spinnaker.keel.telemetry.ArtifactCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.EnvironmentsCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceLoadFailed
-import java.time.Duration
-import java.util.concurrent.atomic.AtomicBoolean
-import kotlin.coroutines.CoroutineContext
-import kotlin.math.max
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
@@ -25,6 +21,10 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.coroutines.CoroutineContext
+import kotlin.math.max
 
 @Component
 class CheckScheduler(
@@ -121,6 +121,8 @@ class CheckScheduler(
               } catch (e: TimeoutCancellationException) {
                 log.error("Timed out checking environments for ${it.application}/${it.name}", e)
                 publisher.publishEvent(EnvironmentsCheckTimedOut(it.application, it.name))
+              } finally {
+                repository.markDeliveryConfigCheckComplete(it)
               }
             }
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -37,12 +37,13 @@ import com.netflix.spinnaker.keel.veto.VetoResponse
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.exceptions.UserException
-import java.time.Clock
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Duration
 
 /**
  * The core component in keel responsible for resource state monitoring and actuation.
@@ -85,6 +86,17 @@ class ResourceActuator(
         return@withTracingContext
       }
 
+      val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
+      val environment = checkNotNull(deliveryConfig.environmentFor(resource)) {
+        "Failed to find environment for ${resource.id} in deliveryConfig ${deliveryConfig.name}"
+      }
+
+      if (deliveryConfig.isPromotionCheckStale()) {
+        log.debug("Environment check for {} is {} old, skipping checks", id, deliveryConfig.isPromotionCheckStale())
+        publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "PromotionCheckStale"))
+        return@withTracingContext
+      }
+
       try {
         val (desired, current) = plugin.resolve(resource)
         val diff = DefaultResourceDiff(desired, current)
@@ -120,12 +132,6 @@ class ResourceActuator(
 
               if (versionedArtifact != null) {
                 with(versionedArtifact) {
-                  val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
-                  val environment = deliveryConfig.environmentFor(resource)?.name
-                    ?: error(
-                      "Failed to find environment for ${resource.id} in deliveryConfig ${deliveryConfig.name} " +
-                        "while attempting to veto artifact $artifactType:$artifactName version $artifactVersion"
-                    )
                   val artifact = deliveryConfig.matchingArtifactByName(versionedArtifact.artifactName, artifactType)
                     ?: error("Artifact $artifactType:$artifactName not found in delivery config ${deliveryConfig.name}")
 
@@ -134,7 +140,7 @@ class ResourceActuator(
                     veto = EnvironmentArtifactVeto(
                       reference = artifact.reference,
                       version = artifactVersion,
-                      targetEnvironment = environment,
+                      targetEnvironment = environment.name,
                       vetoedBy = "Spinnaker",
                       comment = "Automatically marked as bad because multiple deployments of this version failed."
                     )
@@ -212,6 +218,14 @@ class ResourceActuator(
         publisher.publishEvent(ResourceCheckError(resource, e.toSpinnakerException(), clock))
       }
     }
+  }
+
+  private fun DeliveryConfig.isPromotionCheckStale(): Boolean {
+    val age = Duration.between(
+      deliveryConfigRepository.deliveryConfigLastChecked(this),
+      clock.instant()
+    )
+    return age > Duration.ofMinutes(5)
   }
 
   private fun Exception.toSpinnakerException(): SpinnakerException =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -92,7 +92,7 @@ class ResourceActuator(
       }
 
       if (deliveryConfig.isPromotionCheckStale()) {
-        log.debug("Environment check for {} is {} old, skipping checks", id, deliveryConfig.isPromotionCheckStale())
+        log.debug("Environments check for {} is stale, skipping checks", deliveryConfig.name)
         publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "PromotionCheckStale"))
         return@withTracingContext
       }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -239,6 +239,10 @@ class CombinedRepository(
   override fun deliveryConfigsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig> =
     deliveryConfigRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
 
+  override fun markDeliveryConfigCheckComplete(deliveryConfig: DeliveryConfig) {
+    deliveryConfigRepository.markCheckComplete(deliveryConfig)
+  }
+
   override fun getApplicationSummaries(): Collection<ApplicationSummary> =
     deliveryConfigRepository.getApplicationSummaries()
   // END DeliveryConfigRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.kork.exceptions.ConfigurationException
 import com.netflix.spinnaker.kork.exceptions.SystemException
+import java.time.Instant
 
 interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfig> {
 
@@ -157,6 +158,8 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun deleteQueuedConstraintApproval(deliveryConfigName: String, environmentName: String, artifactVersion: String, artifactReference: String?)
 
   fun getApplicationSummaries(): Collection<ApplicationSummary>
+
+  fun deliveryConfigLastChecked(deliveryConfig: DeliveryConfig): Instant
 }
 
 abstract class NoSuchDeliveryConfigException(message: String) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -111,6 +111,8 @@ interface KeelRepository : KeelReadOnlyRepository {
 
   fun deliveryConfigsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryConfig>
 
+  fun markDeliveryConfigCheckComplete(deliveryConfig: DeliveryConfig)
+
   fun getApplicationSummaries(): Collection<ApplicationSummary>
   // END DeliveryConfigRepository methods
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PeriodicallyCheckedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/PeriodicallyCheckedRepository.kt
@@ -12,4 +12,10 @@ interface PeriodicallyCheckedRepository<T : Any> {
    * different values.
    */
   fun itemsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<T>
+
+  /**
+   * Optional operation to mark a check as complete. If this is not implemented it's assumed that
+   * [itemsDueForCheck] takes care of that.
+   */
+  fun markCheckComplete(deliveryConfig: T) {}
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.core.api.parseUID
 import com.netflix.spinnaker.keel.core.api.randomUID
+import com.netflix.spinnaker.keel.pause.PauseScope
 import com.netflix.spinnaker.keel.pause.PauseScope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
@@ -1046,6 +1047,12 @@ class SqlDeliveryConfigRepository(
           .where(DELIVERY_CONFIG.UID.eq(DELIVERY_CONFIG_LAST_CHECKED.DELIVERY_CONFIG_UID))
           .and(DELIVERY_CONFIG_LAST_CHECKED.LOCKED_BY.isNull)
           .and(DELIVERY_CONFIG_LAST_CHECKED.AT.lessOrEqual(cutoff))
+          .andNotExists(
+            selectOne()
+              .from(PAUSED)
+              .where(PAUSED.NAME.eq(DELIVERY_CONFIG.APPLICATION))
+              .and(PAUSED.SCOPE.eq(APPLICATION.name))
+          )
           .orderBy(DELIVERY_CONFIG_LAST_CHECKED.AT)
           .limit(limit)
           .forUpdate()

--- a/keel-sql/src/main/resources/db/changelog/20200930-environment-check-lock.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200930-environment-check-lock.yml
@@ -11,6 +11,11 @@ databaseChangeLog:
             type: varchar(64)
             constraints:
               nullable: true
+        - column:
+            name: locked_at
+            type: timestamp(3)
+            constraints:
+              nullable: true
     - dropIndex:
         tableName: delivery_config_last_checked
         indexName: delivery_config_last_checked_at_idx

--- a/keel-sql/src/main/resources/db/changelog/20200930-environment-check-lock.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200930-environment-check-lock.yml
@@ -7,12 +7,12 @@ databaseChangeLog:
         tableName: delivery_config_last_checked
         columns:
         - column:
-            name: locked_by
+            name: leased_by
             type: varchar(64)
             constraints:
               nullable: true
         - column:
-            name: locked_at
+            name: leased_at
             type: timestamp(3)
             constraints:
               nullable: true
@@ -21,9 +21,11 @@ databaseChangeLog:
         indexName: delivery_config_last_checked_at_idx
     - createIndex:
         tableName: delivery_config_last_checked
-        indexName: delivery_config_last_checked_at_locked_by_idx
+        indexName: delivery_config_last_checked_at_leased_by_leased_at_idx
         columns:
         - column:
             name: at
         - column:
-            name: locked_by
+            name: leased_by
+        - column:
+            name: leased_at

--- a/keel-sql/src/main/resources/db/changelog/20200930-environment-check-lock.yml
+++ b/keel-sql/src/main/resources/db/changelog/20200930-environment-check-lock.yml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+- changeSet:
+    id: environment-check-lock
+    author: fletch
+    changes:
+    - addColumn:
+        tableName: delivery_config_last_checked
+        columns:
+        - column:
+            name: locked_by
+            type: varchar(64)
+            constraints:
+              nullable: true
+    - dropIndex:
+        tableName: delivery_config_last_checked
+        indexName: delivery_config_last_checked_at_idx
+    - createIndex:
+        tableName: delivery_config_last_checked
+        indexName: delivery_config_last_checked_at_locked_by_idx
+        columns:
+        - column:
+            name: at
+        - column:
+            name: locked_by

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -185,3 +185,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201001-diff-action-count.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20200930-environment-check-lock.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Instead of continuing to check environment promotions for paused apps, just ensure that resource checks wait until environment checks are reasonably recent. This is to allow for environment checks to catch up if the application has been paused, and we'll therefore deploy an up-to-date artifact rather than whatever was approved last time the app was un-paused. If manual intervention has happened during the pause time we could roll back to an unwanted older version.