### PR TITLE
fix(bakery): better exception message on bad AMI version string

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -52,7 +52,7 @@ class ImageExistsConstraintEvaluator(
 
   private fun findMatchingImage(version: String, vmOptions: VirtualMachineOptions): NamedImage? {
     log.debug("Searching for baked image for {} in {}", version, vmOptions.regions.joinToString())
-    val appVersion = AppVersion.parseName(version) ?: throw SystemException("Invalid ami app version: $version")
+    val appVersion = AppVersion.parseName(version) ?: throw SystemException("Invalid AMI app version: $version")
     return runBlocking {
       imageService.getLatestNamedImageWithAllRegionsForAppVersion(
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -14,6 +14,7 @@ import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.exceptions.SystemException
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -51,10 +52,11 @@ class ImageExistsConstraintEvaluator(
 
   private fun findMatchingImage(version: String, vmOptions: VirtualMachineOptions): NamedImage? {
     log.debug("Searching for baked image for {} in {}", version, vmOptions.regions.joinToString())
+    val appVersion = AppVersion.parseName(version) ?: throw SystemException("Invalid ami app version: $version")
     return runBlocking {
       imageService.getLatestNamedImageWithAllRegionsForAppVersion(
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-        AppVersion.parseName(version),
+        appVersion,
         defaultImageAccount,
         vmOptions.regions
       )


### PR DESCRIPTION
If the app version associated with an AMI does not conform to the Frigga library convention, the exception thrown is:

```
java.lang.NullPointerException: AppVersion.parseName(version) must not be null
	at com.netflix.spinnaker.keel.bakery.constraint.ImageExistsConstraintEvaluator$findMatchingImage$1.invokeSuspend(ImageExistsConstraintEvaluator.kt:57)
```

This change displays the problematic app version string to the exception message.