### PR TITLE
feat(api): API support for limiting artifact versions

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/constants.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/constants.kt
@@ -1,0 +1,3 @@
+package com.netflix.spinnaker.keel.api.artifacts
+
+const val DEFAULT_MAX_ARTIFACT_VERSIONS = 50

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 
@@ -49,7 +50,7 @@ interface KeelReadOnlyRepository {
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
-  fun artifactVersions(artifact: DeliveryArtifact, limit: Int = 30): List<String>
+  fun artifactVersions(artifact: DeliveryArtifact, limit: Int = DEFAULT_MAX_ARTIFACT_VERSIONS): List<String>
 
   fun artifactVersions(name: String, type: ArtifactType): List<String>
 

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -146,7 +146,7 @@ class ArtifactListener(
   }
 
   private fun getLatestStoredVersion(artifact: DeliveryArtifact): String? =
-    repository.artifactVersions(artifact).sortedWith(artifact.versioningStrategy.comparator).firstOrNull()
+    repository.artifactVersions(artifact, 1).firstOrNull()
 
   /**
    * Returns a copy of the [PublishedArtifact] with the git and build metadata populated, if available.

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -302,8 +302,8 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     context("we don't have any versions of the artifacts") {
       before {
         every { repository.getAllArtifacts() } returns listOf(debArtifact, dockerArtifact)
-        every { repository.artifactVersions(debArtifact) } returns emptyList()
-        every { repository.artifactVersions(dockerArtifact) } returns emptyList()
+        every { repository.artifactVersions(debArtifact, any()) } returns emptyList()
+        every { repository.artifactVersions(dockerArtifact, any()) } returns emptyList()
       }
 
       context("versions are available") {
@@ -349,8 +349,8 @@ internal class ArtifactListenerTests : JUnit5Minutests {
     context("there are artifacts with versions stored") {
       before {
         every { repository.getAllArtifacts() } returns listOf(debArtifact, dockerArtifact)
-        every { repository.artifactVersions(debArtifact) } returns listOf(publishedDeb.version)
-        every { repository.artifactVersions(dockerArtifact) } returns listOf(publishedDocker.version)
+        every { repository.artifactVersions(debArtifact, any()) } returns listOf(publishedDeb.version)
+        every { repository.artifactVersions(dockerArtifact, any()) } returns listOf(publishedDocker.version)
       }
 
       context("no newer versions are available") {

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -88,7 +88,7 @@ class ImageHandler(
   private suspend fun DebianArtifact.findLatestArtifactVersion(): String {
     try {
       val knownVersion = repository
-        .artifactVersions(this)
+        .artifactVersions(this, 1)
         .firstOrNull()
       if (knownVersion != null) {
         log.debug("Latest known version of $name = $knownVersion")

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -171,7 +171,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
       context("the artifact is not registered") {
         before {
-          every { repository.artifactVersions(artifact) } throws NoSuchArtifactException(artifact)
+          every { repository.artifactVersions(artifact, any()) } throws NoSuchArtifactException(artifact)
           every { repository.isRegistered(artifact.name, artifact.type) } returns false
           every { igorService.getVersions(any(), any(), DEBIAN) } returns listOf(image.appVersion)
 
@@ -194,7 +194,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
         context("there are no known versions for the artifact in the repository or in Igor") {
           before {
-            every { repository.artifactVersions(artifact) } returns emptyList()
+            every { repository.artifactVersions(artifact, any()) } returns emptyList()
             every { repository.isRegistered(artifact.name, artifact.type) } returns true
             every { igorService.getVersions(any(), any(), DEBIAN) } returns emptyList()
 
@@ -225,7 +225,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
           context("the desired version is known") {
             before {
-              every { repository.artifactVersions(artifact) } returns listOf(image.appVersion)
+              every { repository.artifactVersions(artifact, any()) } returns listOf(image.appVersion)
             }
 
             context("an AMI for the desired version and base image already exists") {
@@ -409,7 +409,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
               baseImageCache.getBaseAmiVersion(artifact.vmOptions.baseOs, artifact.vmOptions.baseLabel)
             } returns newerBaseAmiVersion
 
-            every { repository.artifactVersions(artifact) } returns listOf(image.appVersion)
+            every { repository.artifactVersions(artifact, any()) } returns listOf(image.appVersion)
 
             every {
               imageService.getLatestImage(artifact.name, "test")

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.SNAPSHOT
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
+import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
@@ -255,7 +256,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
           expectThat(subject.versions(artifact1)).containsExactly(version2, version1)
         }
 
-        test("querying the list for returns both artifacts") {
+        test("querying for the list of versions returns both versions") {
           // status is stored on the artifact
           subject.storeArtifactInstance(artifact1.toArtifactInstance(version2, SNAPSHOT))
           expectThat(subject.versions(artifact1)).containsExactly(version2, version1)
@@ -322,6 +323,23 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             )
             expectThat(subject.versions(incorrectArtifact)).isEmpty()
           }
+        }
+      }
+
+      context("limiting versions works") {
+        before {
+          (1..100).map { "1.0.$it"}.forEach {
+            subject.storeArtifactInstance(artifact1.toArtifactInstance(it, SNAPSHOT))
+          }
+        }
+
+        test("default cap applies with no limit specified") {
+          expectThat(subject.versions(artifact1)).hasSize(DEFAULT_MAX_ARTIFACT_VERSIONS)
+        }
+
+        test("limit parameter takes effect when specified") {
+          expectThat(subject.versions(artifact1, 20)).hasSize(20)
+          expectThat(subject.versions(artifact1, 100)).hasSize(100)
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
@@ -47,7 +48,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
    */
   fun versions(
     artifact: DeliveryArtifact,
-    limit: Int = 30
+    limit: Int = DEFAULT_MAX_ARTIFACT_VERSIONS
   ): List<String>
 
   /**

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
@@ -62,7 +63,8 @@ class ApplicationController(
   fun get(
     @PathVariable("application") application: String,
     @RequestParam("includeDetails", required = false, defaultValue = "false") includeDetails: Boolean,
-    @RequestParam("entities", required = false, defaultValue = "") entities: MutableList<String>
+    @RequestParam("entities", required = false, defaultValue = "") entities: MutableList<String>,
+    @RequestParam("maxArtifactVersions") maxArtifactVersions: Int?
   ): Map<String, Any> {
     return mutableMapOf(
       "applicationPaused" to actuationPauser.applicationIsPaused(application),
@@ -77,7 +79,8 @@ class ApplicationController(
         results[entity] = when (entity) {
           "resources" -> applicationService.getResourceSummariesFor(application)
           "environments" -> applicationService.getEnvironmentSummariesFor(application)
-          "artifacts" -> applicationService.getArtifactSummariesFor(application)
+          "artifacts" -> applicationService.getArtifactSummariesFor(application,
+            maxArtifactVersions ?: DEFAULT_MAX_ARTIFACT_VERSIONS)
           else -> throw InvalidRequestException("Unknown entity type: $entity")
         }
       }


### PR DESCRIPTION
Introduces the `maxArtifactVersions` query parameter to the `GET /application` API, which allows the caller to specify the maximum number of artifact versions to return (in descending order). This will give us more flexibility in the UI, and allow us to run performance tests with a higher number of versions.