### PR TITLE
feature(ec2): Add support for launch templates

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -105,10 +105,8 @@ data class ServerGroup(
  * It is intended to be called from the init block of classes that implement BaseEc2ServerGroup
  */
 fun ensureLaunchConfigInfoIsPresent(sg : BaseEc2ServerGroup) {
-  sg.run {
-    if(launchConfig == null && launchTemplate == null) {
-      throw SystemException("Server group info contains neither launchConfig nor launchTemplate fields: ${sg.name}")
-    }
+  if(sg.launchConfig == null && sg.launchTemplate == null) {
+    throw SystemException("Server group info contains neither launchConfig nor launchTemplate fields: ${sg.name}")
   }
 }
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -44,7 +44,20 @@ data class InstanceCounts(
 interface BaseEc2ServerGroup : BaseServerGroup {
   val zones: Set<String>
   val image: ActiveServerGroupImage
-  val launchConfig: LaunchConfig
+
+  /**
+   * One of these two fields is always null, and the other is always
+   * non-null.
+   *
+   * If AWS launch templates are enabled in clouddriver for this app,
+   * associated with this server group, then the launchTemplate
+   * field will be populated.
+   *
+   * Otherwise, the launchConfig field will be populated.
+   */
+  val launchConfig: LaunchConfig?
+  val launchTemplate: LaunchTemplate?
+
   val asg: AutoScalingGroup
   val scalingPolicies: List<ScalingPolicy>
   val vpcId: String
@@ -63,7 +76,8 @@ data class ServerGroup(
   override val region: String,
   override val zones: Set<String>,
   override val image: ActiveServerGroupImage,
-  override val launchConfig: LaunchConfig,
+  override val launchConfig: LaunchConfig? = null,
+  override val launchTemplate: LaunchTemplate? = null,
   override val asg: AutoScalingGroup,
   override val scalingPolicies: List<ScalingPolicy>,
   override val vpcId: String,
@@ -77,7 +91,26 @@ data class ServerGroup(
   override val disabled: Boolean,
   override val instanceCounts: InstanceCounts,
   override val createdTime: Long
-) : BaseEc2ServerGroup
+) : BaseEc2ServerGroup {
+  init {
+    ensureLaunchConfigInfoIsPresent(this)
+  }
+}
+
+/**
+ * Clouddriver should always return either a launchConfig field or a launchTemplate
+ * field for an EC2 server group.
+ *
+ * This is a helper function that asserts that one of these fields must be present.
+ * It is intended to be called from the init block of classes that implement BaseEc2ServerGroup
+ */
+fun ensureLaunchConfigInfoIsPresent(sg : BaseEc2ServerGroup) {
+  sg.run {
+    if(launchConfig == null && launchTemplate == null) {
+      throw SystemException("Server group info contains neither launchConfig nor launchTemplate fields: ${sg.name}")
+    }
+  }
+}
 
 fun ServerGroup.toActive(accountName: String) =
   ActiveServerGroup(
@@ -86,6 +119,7 @@ fun ServerGroup.toActive(accountName: String) =
     zones = zones,
     image = image,
     launchConfig = launchConfig,
+    launchTemplate = launchTemplate,
     asg = asg,
     scalingPolicies = scalingPolicies,
     vpcId = vpcId,
@@ -107,7 +141,8 @@ data class ActiveServerGroup(
   override val region: String,
   override val zones: Set<String>,
   override val image: ActiveServerGroupImage,
-  override val launchConfig: LaunchConfig,
+  override val launchConfig: LaunchConfig? = null,
+  override val launchTemplate: LaunchTemplate? = null,
   override val asg: AutoScalingGroup,
   override val scalingPolicies: List<ScalingPolicy>,
   override val vpcId: String,
@@ -121,7 +156,11 @@ data class ActiveServerGroup(
   override val buildInfo: BuildInfo? = null,
   override val instanceCounts: InstanceCounts,
   override val createdTime: Long
-) : BaseEc2ServerGroup
+) : BaseEc2ServerGroup {
+  init {
+    ensureLaunchConfigInfoIsPresent(this)
+  }
+}
 
 fun ActiveServerGroup.subnet(cloudDriverCache: CloudDriverCache): String =
   asg.vpczoneIdentifier.substringBefore(",").let { subnetId ->
@@ -171,6 +210,23 @@ data class LaunchConfig(
   val keyName: String,
   val iamInstanceProfile: String,
   val instanceMonitoring: InstanceMonitoring
+)
+
+data class LaunchTemplate(
+  val launchTemplateData: LaunchTemplateData
+)
+
+data class LaunchTemplateData(
+  val ebsOptimized: Boolean,
+  val imageId: String,
+  val instanceType: String,
+  val keyName: String,
+  val iamInstanceProfile: IamInstanceProfile,
+  val monitoring: InstanceMonitoring
+)
+
+data class IamInstanceProfile(
+  val name: String
 )
 
 data class AutoScalingGroup(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -222,7 +222,8 @@ data class LaunchTemplateData(
   val instanceType: String,
   val keyName: String,
   val iamInstanceProfile: IamInstanceProfile,
-  val monitoring: InstanceMonitoring
+  val monitoring: InstanceMonitoring,
+  val ramDiskId: String?
 )
 
 data class IamInstanceProfile(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -216,6 +216,7 @@ data class LaunchTemplate(
   val launchTemplateData: LaunchTemplateData
 )
 
+// See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-launchtemplate-launchtemplatedata.html
 data class LaunchTemplateData(
   val ebsOptimized: Boolean,
   val imageId: String,

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
@@ -1,0 +1,199 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import dev.minutest.ContextBuilder
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+import strikt.assertions.isSuccess
+
+
+/**
+ * Use ContextBuilder so we can use the same test assertions when constructing both ActiveServerGroup and
+ * ServerGroup objects
+ */
+
+fun<T : BaseEc2ServerGroup> ContextBuilder<FixtureMaker<T>>.checkServerGroupConstructorBehavior() {
+  context("constructing subclasses of BaseEc2ServerGroup") {
+
+    test("when neither launch config nor launch template specified, throw an exception") {
+      expectCatching { make(launchConfig = null, launchTemplate = null) }
+        .isFailure()
+        .isA<SystemException>()
+    }
+
+    test("when launch config specified, don't throw an exception") {
+      expectCatching {
+        make(launchConfig = LaunchConfig(
+          ramdiskId = null,
+          ebsOptimized = true,
+          imageId = "image",
+          instanceType = "t2.micro",
+          keyName = "mykey",
+          iamInstanceProfile = "profile",
+          instanceMonitoring = InstanceMonitoring(enabled = true)
+        ))
+      }.isSuccess()
+    }
+
+    test("when launch template specified, don't throw an exception") {
+      expectCatching {
+        make(launchTemplate = LaunchTemplate(
+          launchTemplateData = LaunchTemplateData(
+            ebsOptimized = true,
+            imageId = "image",
+            instanceType = "t2.micro",
+            keyName = "mykey",
+            iamInstanceProfile = IamInstanceProfile(name = "profile"),
+            monitoring = InstanceMonitoring(enabled = true)
+          )))
+      }.isSuccess()
+    }
+  }
+}
+
+
+class ActiveServerGroupTests : JUnit5Minutests {
+  fun tests() = rootContext<FixtureMaker<ActiveServerGroup>> {
+    fixture { ActiveServerGroupFixtureMaker() } // makes ActiveServerGroup fixtures
+
+    checkServerGroupConstructorBehavior()
+  }
+}
+
+class ServerGroupTests : JUnit5Minutests {
+  fun tests() = rootContext<FixtureMaker<ServerGroup>> {
+    fixture { ServerGroupFixtureMaker() } // makes ServerGroup fixtures
+
+    checkServerGroupConstructorBehavior()
+  }
+}
+
+
+// Code to instantiate fixture objects
+
+
+interface FixtureMaker<T : BaseEc2ServerGroup> {
+  fun make(launchConfig: LaunchConfig? = null, launchTemplate: LaunchTemplate? = null) : T
+}
+
+class ActiveServerGroupFixtureMaker : FixtureMaker<ActiveServerGroup> {
+  override fun make(launchConfig: LaunchConfig?, launchTemplate: LaunchTemplate?) =
+    ActiveServerGroup(
+      launchConfig = launchConfig,
+      launchTemplate = launchTemplate,
+
+      // unused boilerplate data
+      name = "fnord",
+      region = "us-east-1",
+      zones = setOf("us-east-1c"),
+      image = ActiveServerGroupImage(
+        imageId = "image",
+        appVersion = null,
+        baseImageVersion = null,
+        name = "name",
+        imageLocation = "somewhere",
+        description = null
+      ),
+      asg = AutoScalingGroup(
+        autoScalingGroupName = "asgName",
+        defaultCooldown = 0,
+        healthCheckType = "known",
+        healthCheckGracePeriod = 0,
+        suspendedProcesses = emptySet(),
+        enabledMetrics = emptySet(),
+        tags = emptySet(),
+        terminationPolicies = emptySet(),
+        vpczoneIdentifier = "vpc-zone"
+      ),
+      scalingPolicies = emptyList(),
+      vpcId = "vpcId",
+      targetGroups = emptySet(),
+      loadBalancers = emptySet(),
+      capacity = Capacity(
+        min = 1,
+        max = 1,
+        desired = 1
+      ),
+      cloudProvider = "aws",
+      securityGroups = emptySet(),
+      accountName = "test",
+      moniker = Moniker(
+        app = "fnord",
+        stack = null,
+        detail = null,
+        sequence = 1
+      ),
+      instanceCounts = InstanceCounts (
+        total = 1,
+        up = 1,
+        down = 0,
+        unknown = 0,
+        outOfService = 0,
+        starting = 0
+      ),
+      createdTime = 0
+    )
+}
+
+class ServerGroupFixtureMaker: FixtureMaker<ServerGroup> {
+  override fun make(launchConfig: LaunchConfig?, launchTemplate: LaunchTemplate?) =
+    ServerGroup(
+      launchConfig = launchConfig,
+      launchTemplate = launchTemplate,
+
+      // unused boilerplate data
+      disabled = false,
+      name = "fnord",
+      region = "us-east-1",
+      zones = setOf("us-east-1c"),
+      image = ActiveServerGroupImage(
+        imageId = "image",
+        appVersion = null,
+        baseImageVersion = null,
+        name = "name",
+        imageLocation = "somewhere",
+        description = null
+      ),
+      asg = AutoScalingGroup(
+        autoScalingGroupName = "asgName",
+        defaultCooldown = 0,
+        healthCheckType = "known",
+        healthCheckGracePeriod = 0,
+        suspendedProcesses = emptySet(),
+        enabledMetrics = emptySet(),
+        tags = emptySet(),
+        terminationPolicies = emptySet(),
+        vpczoneIdentifier = "vpc-zone"
+      ),
+      scalingPolicies = emptyList(),
+      vpcId = "vpcId",
+      targetGroups = emptySet(),
+      loadBalancers = emptySet(),
+      capacity = Capacity(
+        min = 1,
+        max = 1,
+        desired = 1
+      ),
+      cloudProvider = "aws",
+      securityGroups = emptySet(),
+      moniker = Moniker(
+        app = "fnord",
+        stack = null,
+        detail = null,
+        sequence = 1
+      ),
+      instanceCounts = InstanceCounts (
+        total = 1,
+        up = 1,
+        down = 0,
+        unknown = 0,
+        outOfService = 0,
+        starting = 0
+      ),
+      createdTime = 0
+    )
+}

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
@@ -43,6 +43,7 @@ fun<T : BaseEc2ServerGroup> ContextBuilder<FixtureMaker<T>>.checkServerGroupCons
       expectCatching {
         make(launchTemplate = LaunchTemplate(
           launchTemplateData = LaunchTemplateData(
+            ramDiskId = null,
             ebsOptimized = true,
             imageId = "image",
             instanceType = "t2.micro",

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -139,6 +139,7 @@ class Ec2CanaryConstraintDeployHandler(
     image: String
   ): Map<String, Any?> {
     val moniker = parseMoniker(name)
+    val launchTemplateData = launchTemplate?.launchTemplateData
     return mutableMapOf(
       "application" to moniker.app,
       "stack" to moniker.stack,
@@ -149,13 +150,13 @@ class Ec2CanaryConstraintDeployHandler(
       "amiName" to image,
       "availabilityZones" to mapOf(region to zones),
       "capacity" to Capacity(capacity, capacity, capacity),
-      "ebsOptimized" to launchConfig.ebsOptimized,
+      "ebsOptimized" to (launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized),
       "healthCheckGracePeriod" to asg.healthCheckGracePeriod,
       "healthCheckType" to asg.healthCheckType,
-      "iamRole" to launchConfig.iamInstanceProfile,
-      "instanceMonitoring" to launchConfig.instanceMonitoring.enabled,
-      "instanceType" to launchConfig.instanceType,
-      "keyPair" to launchConfig.keyName,
+      "iamRole" to (launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name),
+      "instanceMonitoring" to (launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled),
+      "instanceType" to (launchConfig?.instanceType ?: launchTemplateData!!.instanceType),
+      "keyPair" to (launchConfig?.keyName ?: launchTemplateData!!.keyName),
       "loadBalancers" to loadBalancers,
       "targetGroups" to targetGroups,
       "securityGroups" to securityGroups,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -965,7 +965,9 @@ class ClusterHandler(
           iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,
           keyPair = launchConfig?.keyName ?: launchTemplateData!!.keyName,
           instanceMonitoring = launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled,
-          ramdiskId = launchConfig?.ramdiskId ?: launchTemplateData!!.ramDiskId.orNull()
+
+          // Because launchConfig.ramdiskId can be null, need to do launchTemplateData?. instead of launchTemplateData!!
+          ramdiskId = launchConfig?.ramdiskId ?: launchTemplateData?.ramDiskId.orNull()
         ),
       buildInfo = buildInfo?.toEc2Api(),
       capacity = capacity.let {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -944,8 +944,9 @@ class ClusterHandler(
   /**
    * Transforms CloudDriver response to our server group model.
    */
-  private fun ActiveServerGroup.toServerGroup() =
-    ServerGroup(
+  private fun ActiveServerGroup.toServerGroup() : ServerGroup {
+    val launchTemplateData = launchTemplate?.launchTemplateData
+    return ServerGroup(
       name = name,
       location = Location(
         account = accountName,
@@ -954,19 +955,18 @@ class ClusterHandler(
         subnet = subnet(cloudDriverCache),
         availabilityZones = zones
       ),
-      launchConfiguration = launchConfig.run {
+      launchConfiguration =
         LaunchConfiguration(
-          imageId = imageId,
+          imageId = launchConfig?.imageId ?: launchTemplateData!!.imageId,
           appVersion = image.appVersion,
           baseImageVersion = image.baseImageVersion,
-          instanceType = instanceType,
-          ebsOptimized = ebsOptimized,
-          iamRole = iamInstanceProfile,
-          keyPair = keyName,
-          instanceMonitoring = instanceMonitoring.enabled,
-          ramdiskId = ramdiskId.orNull()
-        )
-      },
+          instanceType = launchConfig?.instanceType ?: launchTemplateData!!.instanceType,
+          ebsOptimized = launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized,
+          iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,
+          keyPair = launchConfig?.keyName ?: launchTemplateData!!.keyName,
+          instanceMonitoring = launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled,
+          ramdiskId = launchConfig?.ramdiskId.orNull() // not in launchTemplateData
+        ),
       buildInfo = buildInfo?.toEc2Api(),
       capacity = capacity.let {
         when (scalingPolicies.isEmpty()) {
@@ -995,6 +995,7 @@ class ClusterHandler(
       image = image.toEc2Api(),
       instanceCounts = instanceCounts.toEc2Api()
     )
+  }
 
   private fun List<MetricDimensionModel>?.toSpec(): Set<MetricDimension> =
     when (this) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -961,7 +961,7 @@ class ClusterHandler(
       ),
       launchConfiguration =
         LaunchConfiguration(
-          imageId = launchConfig?.imageId ?: launchTemplateData!!.imageId,
+          imageId = image.imageId,
           appVersion = image.appVersion,
           baseImageVersion = image.baseImageVersion,
           instanceType = launchConfig?.instanceType ?: launchTemplateData!!.instanceType,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -965,7 +965,7 @@ class ClusterHandler(
           iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,
           keyPair = launchConfig?.keyName ?: launchTemplateData!!.keyName,
           instanceMonitoring = launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled,
-          ramdiskId = launchConfig?.ramdiskId.orNull() // not in launchTemplateData
+          ramdiskId = launchConfig?.ramdiskId ?: launchTemplateData!!.ramDiskId.orNull()
         ),
       buildInfo = buildInfo?.toEc2Api(),
       capacity = capacity.let {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -372,7 +372,7 @@ private fun ActiveServerGroup.withNonDefaultHealthProps(): ActiveServerGroup =
 
 private fun ActiveServerGroup.withNonDefaultLaunchConfigProps(): ActiveServerGroup =
   copy(
-    launchConfig = launchConfig.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
+    launchConfig = launchConfig?.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
   )
 
 private fun ActiveServerGroup.withDifferentSize(): ActiveServerGroup =

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -950,7 +950,7 @@ private fun ActiveServerGroup.withOlderAppVersion(): ActiveServerGroup =
       imageId = "ami-573e1b2650a5",
       appVersion = "keel-0.251.0-h167.9ea0465"
     ),
-    launchConfig = launchConfig.copy(
+    launchConfig = launchConfig?.copy(
       imageId = "ami-573e1b2650a5"
     )
   )


### PR DESCRIPTION
## Summary

Add support for managing EC2 apps that have been configured to use AWS launch templates.

## Background

Clouddriver now support AWS [launch templates](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html). Clouddriver opts in apps to use launch templates, on a per-app basis.

## What changed from keel's perspective

For apps that are configured to use launch templates, the response payload from clouddriver changes when querying for server group information. For these apps, there is no longer a `launchConfig` field. Instead, there is a `launchTemplate` field. The `launchTemplate` field contains similar information, but the data has a different shape.

## PR details

With this PR, we can now handle response payloads from clouddriver where there is a `launchTemplate` field instead of a `launchConfig` field.

Note that this PR does not change:

* the delivery config schema (the section called `launchConfiguration` remains unchanged)
* the shape of the data that we send to orca when actuating EC2 clusters



