### PR TITLE
Metrics for clouddriver cache

### DIFF
--- a/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
+++ b/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
@@ -14,9 +14,6 @@ dependencies {
   implementation("com.netflix.spinnaker.kork:kork-exceptions")
   implementation("com.netflix.spinnaker.kork:kork-security")
   implementation("com.netflix.frigga:frigga")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
-  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
-  implementation("com.github.ben-manes.caffeine:caffeine")
 
   testImplementation(project(":keel-test"))
   testImplementation("dev.minutest:minutest")

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -1,7 +1,5 @@
 package com.netflix.spinnaker.keel.bakery.constraint
 
-import com.github.benmanes.caffeine.cache.AsyncCacheLoader
-import com.github.benmanes.caffeine.cache.Caffeine
 import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
@@ -17,10 +15,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.exceptions.SystemException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers.IO
-import kotlinx.coroutines.future.await
-import kotlinx.coroutines.future.future
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -56,40 +50,20 @@ class ImageExistsConstraintEvaluator(
     return image != null
   }
 
-  private data class CacheKey(
-    val appVersion: AppVersion,
-    val account: String,
-    val regions: Set<String>
-  )
-
-  private val cache = Caffeine.newBuilder()
-    .buildAsync(
-      AsyncCacheLoader<CacheKey, NamedImage> { key, _ ->
-        CoroutineScope(IO).future(block = {
-          log.debug("Searching for baked image for {} in {}", key.appVersion, key.regions.joinToString())
-          imageService.getLatestNamedImageWithAllRegionsForAppVersion(
-            key.appVersion,
-            key.account,
-            key.regions
-          )
-        })
-      }
-    )
-
   private fun findMatchingImage(version: String, vmOptions: VirtualMachineOptions): NamedImage? =
-    CacheKey(
-      // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-      AppVersion.parseName(version) ?: throw SystemException("Invalid AMI app version: $version"),
-      defaultImageAccount,
-      vmOptions.regions
-    ).let {
-      runBlocking {
-        cache.get(it).await()
-      }
+    runBlocking {
+      log.debug("Searching for baked image for {} in {}", version, vmOptions.regions.joinToString())
+      imageService.getLatestNamedImageWithAllRegionsForAppVersion(
+        // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
+        AppVersion.parseName(version) ?: throw SystemException("Invalid AMI app version: $version"),
+        defaultImageAccount,
+        vmOptions.regions
+      )
     }
 
   private val defaultImageAccount: String
     get() = dynamicConfigService.getConfig("images.default-account", "test")
+
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -64,6 +64,5 @@ class ImageExistsConstraintEvaluator(
   private val defaultImageAccount: String
     get() = dynamicConfigService.getConfig("images.default-account", "test")
 
-
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }

--- a/keel-clouddriver/keel-clouddriver.gradle.kts
+++ b/keel-clouddriver/keel-clouddriver.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
+  implementation("com.netflix.spectator:spectator-reg-micrometer")
 
   testImplementation(project(":keel-retrofit-test-support"))
   testImplementation("com.squareup.retrofit2:retrofit-mock")

--- a/keel-clouddriver/keel-clouddriver.gradle.kts
+++ b/keel-clouddriver/keel-clouddriver.gradle.kts
@@ -17,7 +17,6 @@ dependencies {
   implementation("org.springframework:spring-context")
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
-  implementation("com.netflix.spectator:spectator-reg-micrometer")
 
   testImplementation(project(":keel-retrofit-test-support"))
   testImplementation("com.squareup.retrofit2:retrofit-mock")

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -62,6 +62,7 @@ class ClouddriverConfiguration {
 
   @Bean
   fun imageService(
-    cloudDriverService: CloudDriverService
-  ) = ImageService(cloudDriverService)
+    cloudDriverService: CloudDriverService,
+    cloudDriverCache: CloudDriverCache
+  ) = ImageService(cloudDriverService, cloudDriverCache)
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.MemoryCloudDriverCache
+import io.micrometer.core.instrument.MeterRegistry
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.springframework.beans.factory.BeanCreationException
@@ -57,8 +58,11 @@ class ClouddriverConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(CloudDriverCache::class)
-  fun cloudDriverCache(cloudDriverService: CloudDriverService) =
-    MemoryCloudDriverCache(cloudDriverService)
+  fun cloudDriverCache(
+    cloudDriverService: CloudDriverService,
+    meterRegistry: MeterRegistry
+  ) =
+    MemoryCloudDriverCache(cloudDriverService, meterRegistry)
 
   @Bean
   fun imageService(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.clouddriver
 
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
+import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
@@ -32,6 +33,7 @@ interface CloudDriverCache {
   fun credentialBy(name: String): Credential
   fun defaultKeyPairForAccount(account: String) =
     credentialBy(account).attributes["defaultKeyPair"] as String
+  fun namedImages(imageName: String, account: String): List<NamedImage>
 }
 
 class ResourceNotFound(message: String) : IntegrationException(message)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -29,7 +29,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
 class ImageService(
-  private val cloudDriverService: CloudDriverService
+  private val cloudDriverService: CloudDriverService,
+  private val cloudDriverCache: CloudDriverCache
 ) {
   val log: Logger by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -105,8 +106,7 @@ class ImageService(
    * Each ami must have tags.
    */
   suspend fun getLatestNamedImageWithAllRegionsForAppVersion(appVersion: AppVersion, account: String, regions: Collection<String>): NamedImage? =
-    cloudDriverService.namedImages(
-      user = DEFAULT_SERVICE_ACCOUNT,
+    cloudDriverCache.namedImages(
       imageName = appVersion.toImageName().replace("~", "_"),
       account = account
     )

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.retrofit.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.retrofit.RETROFIT_SERVICE_UNAVAILABLE
-import io.mockk.coEvery as every
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import strikt.api.expectThat
@@ -15,11 +15,13 @@ import strikt.assertions.containsExactly
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
+import io.mockk.coEvery as every
 
 object MemoryCloudDriverCacheTest {
 
   val cloudDriver = mockk<CloudDriverService>()
-  val subject = MemoryCloudDriverCache(cloudDriver)
+  val meterRegistry = SimpleMeterRegistry()
+  val subject = MemoryCloudDriverCache(cloudDriver, meterRegistry)
 
   val sg1 = SecurityGroupSummary("foo", "sg-1", "vpc-1")
   val sg2 = SecurityGroupSummary("bar", "sg-2", "vpc-1")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
@@ -33,15 +33,16 @@ import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.coEvery
 import io.mockk.mockk
-import java.time.Duration
 import org.apache.commons.lang3.RandomStringUtils
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.hasSize
 import strikt.assertions.isEqualTo
+import java.time.Duration
 
 internal abstract class NetworkResolverTests<T : Locatable<SubnetAwareLocations>> : JUnit5Minutests {
 
@@ -122,7 +123,7 @@ internal abstract class NetworkResolverTests<T : Locatable<SubnetAwareLocations>
     val cloudDriverService = mockk<CloudDriverService>() {
       coEvery { listSubnets("aws") } returns subnets
     }
-    val cloudDriverCache = MemoryCloudDriverCache(cloudDriverService)
+    val cloudDriverCache = MemoryCloudDriverCache(cloudDriverService, SimpleMeterRegistry())
     val subject = subjectFactory(cloudDriverCache)
     val resolved by lazy { subject(resource) }
 


### PR DESCRIPTION
Adds metrics to Clouddriver cache, also moves AMI caching into `ClouddriverCache` instead of being a standalone thing