### PR TITLE
fix(actuator): broaden scope of try block

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -74,6 +74,7 @@ class ResourceActuator(
       try {
         log.debug("checkResource $id")
         val plugin = handlers.supporting(resource.kind)
+
         if (actuationPauser.isPaused(resource)) {
           log.debug("Actuation for resource {} is paused, skipping checks", id)
           publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "ActuationPaused"))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -71,33 +71,32 @@ class ResourceActuator(
   suspend fun <T : ResourceSpec> checkResource(resource: Resource<T>) {
     withTracingContext(resource) {
       val id = resource.id
-      log.debug("checkResource $id")
-      val plugin = handlers.supporting(resource.kind)
-
-      if (actuationPauser.isPaused(resource)) {
-        log.debug("Actuation for resource {} is paused, skipping checks", id)
-        publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "ActuationPaused"))
-        return@withTracingContext
-      }
-
-      if (plugin.actuationInProgress(resource)) {
-        log.debug("Actuation for resource {} is already running, skipping checks", id)
-        publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "ActuationInProgress"))
-        return@withTracingContext
-      }
-
-      val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
-      val environment = checkNotNull(deliveryConfig.environmentFor(resource)) {
-        "Failed to find environment for ${resource.id} in deliveryConfig ${deliveryConfig.name}"
-      }
-
-      if (deliveryConfig.isPromotionCheckStale()) {
-        log.debug("Environments check for {} is stale, skipping checks", deliveryConfig.name)
-        publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "PromotionCheckStale"))
-        return@withTracingContext
-      }
-
       try {
+        log.debug("checkResource $id")
+        val plugin = handlers.supporting(resource.kind)
+        if (actuationPauser.isPaused(resource)) {
+          log.debug("Actuation for resource {} is paused, skipping checks", id)
+          publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "ActuationPaused"))
+          return@withTracingContext
+        }
+
+        if (plugin.actuationInProgress(resource)) {
+          log.debug("Actuation for resource {} is already running, skipping checks", id)
+          publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "ActuationInProgress"))
+          return@withTracingContext
+        }
+
+        val deliveryConfig = deliveryConfigRepository.deliveryConfigFor(resource.id)
+        val environment = checkNotNull(deliveryConfig.environmentFor(resource)) {
+          "Failed to find environment for ${resource.id} in deliveryConfig ${deliveryConfig.name}"
+        }
+
+        if (deliveryConfig.isPromotionCheckStale()) {
+          log.debug("Environments check for {} is stale, skipping checks", deliveryConfig.name)
+          publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "PromotionCheckStale"))
+          return@withTracingContext
+        }
+
         val (desired, current) = plugin.resolve(resource)
         val diff = DefaultResourceDiff(desired, current)
         if (diff.hasChanges()) {


### PR DESCRIPTION
# Problem

We have some resource checks that are failing because of a failed `checkNotNull` check, which consequently throws an exception. However, these failures weren't incrementing our metric that tracks the rate of failed resource check.

It turns out that this check happened outside of the try block, so the relevant catch block which publisehs the `ResourceCheckError` event doesn't get executed in this code path. 

# Implemented solution

This change widens the scope of the try block to ensure that a failed `checkNotNull` call gets properly captured as an error.

You'll want to ignore whitespace when viewing this diff.