### PR TITLE
fix(heath): consider 0 instances unhealthy when you've asked for > 0

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -99,12 +99,13 @@ data class ServerGroup(
     val outOfService: Int,
     val starting: Int
   ) {
-    // active asg is healthy if all instances are up
-    fun isHealthy(health: DeployHealth): Boolean =
-      when (health) {
-        AUTO -> up == total
-        NONE -> (up + unknown) == total
-      }
+    // active asg is healthy if all instances are up and the correct number of instances exist
+    fun isHealthy(health: DeployHealth, capacity: Capacity): Boolean =
+      (capacity.min <= total && total <= capacity.max) &&
+        when (health) {
+          AUTO -> up == total
+          NONE -> (up + unknown) == total
+        }
   }
 
   data class LaunchConfiguration(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -42,6 +42,7 @@ import com.netflix.spinnaker.keel.api.ec2.TargetTrackingPolicy
 import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.api.ec2.byRegion
 import com.netflix.spinnaker.keel.api.ec2.resolve
+import com.netflix.spinnaker.keel.api.ec2.resolveCapacity
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
@@ -874,7 +875,7 @@ class ClusterHandler(
 
     val allSame: Boolean = activeServerGroups.distinctBy { it.launchConfiguration.appVersion }.size == 1
     val healthy: Boolean = activeServerGroups.all {
-      it.instanceCounts?.isHealthy(resource.spec.deployWith.health) == true
+      it.instanceCounts?.isHealthy(resource.spec.deployWith.health, resource.spec.resolveCapacity(it.location.region)) == true
     }
 
     eventPublisher.publishEvent(ResourceHealthEvent(resource, healthy))

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -495,7 +495,7 @@ class TitusClusterHandler(
     // publish health events
     val sameContainer: Boolean = activeServerGroups.distinctBy { it.container.digest }.size == 1
     val healthy: Boolean = activeServerGroups.all {
-      it.instanceCounts?.isHealthy(resource.spec.deployWith.health) == true
+      it.instanceCounts?.isHealthy(resource.spec.deployWith.health, resource.spec.resolveCapacity(it.location.region)) == true
     }
 
     eventPublisher.publishEvent(ResourceHealthEvent(resource, healthy))


### PR DESCRIPTION
my titus cluster was "healthy" even though it had 0 instances (I asked for one). That's not healthy. 