### PR TITLE
fix(actuator): check for resource by id

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -265,7 +265,11 @@ class ResourceActuator(
     }
 
   private fun DeliveryConfig.environmentFor(resource: Resource<*>): Environment? =
-    environments.firstOrNull { it.resources.contains(resource) }
+    environments.firstOrNull {
+      it.resources
+        .map { r -> r.id }
+        .contains(resource.id)
+    }
 
   // These extensions get round the fact tht we don't know the spec type of the resource from
   // the repository. I don't want the `ResourceHandler` interface to be untyped though.


### PR DESCRIPTION
# Problem

We are seeing resource check errors that look like:

```
java.lang.IllegalStateException: Failed to find environment for
ec2:application-load-balancer:test:foo in deliveryConfig foo-manifest
```
It appears that the `DeliveryConfig.environmentFor` method is returning null, even though the resource exists in an environment in the delivery config.

# Failure mode hypothesis

PR #1557 changed when `DeliveryConfig.environmentFor` gets called. Previously, it was only invoked for resources associated with versioned artifacts. After that PR, it was invoked for all resources.

It appears that this call isn't working for the application load balancer resource. Not sure why. 

# Proposed solution

Change the implementation of `DeliveryConfig.environmentFor` so that it looks up a resource by id instead of doing an equality check.