### PR TITLE
feat(handlers): allow handler to pass on taking action

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ActionDecision.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ActionDecision.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.api.plugins
 
-data class ActionResponse(
-  val willTakeAction: Boolean = true,
+data class ActionDecision(
+  val willAct: Boolean = true,
   val message: String? = null
 )

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ActionResponse.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ActionResponse.kt
@@ -1,0 +1,6 @@
+package com.netflix.spinnaker.keel.api.plugins
+
+data class ActionResponse(
+  val willTakeAction: Boolean = true,
+  val message: String? = null
+)

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -84,7 +84,7 @@ interface ResourceHandler<S : ResourceSpec, R : Any> : SpinnakerExtensionPoint {
   suspend fun willTakeAction(
     resource: Resource<S>,
     resourceDiff: ResourceDiff<R>
-  ): ActionDecision = ActionDecision()
+  ): ActionDecision = ActionDecision(willAct = true)
 
   /**
    * Create a resource so that it matches the desired state represented by [resource].

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -84,7 +84,7 @@ interface ResourceHandler<S : ResourceSpec, R : Any> : SpinnakerExtensionPoint {
   suspend fun willTakeAction(
     resource: Resource<S>,
     resourceDiff: ResourceDiff<R>
-  ): ActionResponse = ActionResponse()
+  ): ActionDecision = ActionDecision()
 
   /**
    * Create a resource so that it matches the desired state represented by [resource].

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -76,6 +76,17 @@ interface ResourceHandler<S : ResourceSpec, R : Any> : SpinnakerExtensionPoint {
   suspend fun current(resource: Resource<S>): R?
 
   /**
+   * Evaluates the resource diff and determines whether it can take action to resolve the diff.
+   * @return a response indicating if it can take action, and a message explaining why if it can't.
+   *
+   * The default value is to take action on all changes. Only override if needed.
+   */
+  suspend fun willTakeAction(
+    resource: Resource<S>,
+    resourceDiff: ResourceDiff<R>
+  ): ActionResponse = ActionResponse()
+
+  /**
    * Create a resource so that it matches the desired state represented by [resource].
    *
    * By default this just delegates to [upsert].

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -7,12 +7,14 @@ import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.VersionedArtifactProvider
 import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.plugins.ActionResponse
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
+import com.netflix.spinnaker.keel.events.ResourceDiffNotActionable
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
@@ -171,44 +173,47 @@ class ResourceActuator(
 
         log.debug("Checking resource {}", id)
 
-        // todo eb: add support for plugins to look at a diff and say "I can't fix this"
-        // todo eb: emit event for ^ with custom message provided by the plugin
+        val actionResponse = plugin.willTakeAction(resource, diff)
+        if (actionResponse.willTakeAction) {
+          when {
+            current == null -> {
+              log.warn("Resource {} is missing", id)
+              publisher.publishEvent(ResourceMissing(resource, clock))
 
-        when {
-          current == null -> {
-            log.warn("Resource {} is missing", id)
-            publisher.publishEvent(ResourceMissing(resource, clock))
+              plugin.create(resource, diff)
+                .also { tasks ->
+                  publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
+                  diffFingerprintRepository.markActionTaken(id)
+                }
+            }
+            diff.hasChanges() -> {
+              log.warn("Resource {} is invalid", id)
+              log.info("Resource {} delta: {}", id, diff.toDebug())
+              publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
 
-            plugin.create(resource, diff)
-              .also { tasks ->
-                publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
-                diffFingerprintRepository.markActionTaken(id)
+              plugin.update(resource, diff)
+                .also { tasks ->
+                  publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
+                  diffFingerprintRepository.markActionTaken(id)
+                }
+            }
+            else -> {
+              log.info("Resource {} is valid", id)
+              val lastEvent = resourceRepository.lastEvent(id)
+              when (lastEvent) {
+                is ResourceActuationLaunched -> log.debug("waiting for actuating task to be completed") // do nothing and wait
+                is ResourceDeltaDetected, is ResourceTaskSucceeded, is ResourceTaskFailed -> {
+                  // if a delta was detected and a task wasn't launched, the delta is resolved
+                  // if a task was launched and it completed, either successfully or not, the delta is resolved
+                  publisher.publishEvent(ResourceDeltaResolved(resource, clock))
+                }
+                else -> publisher.publishEvent(ResourceValid(resource, clock))
               }
-          }
-          diff.hasChanges() -> {
-            log.warn("Resource {} is invalid", id)
-            log.info("Resource {} delta: {}", id, diff.toDebug())
-            publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
-
-            plugin.update(resource, diff)
-              .also { tasks ->
-                publisher.publishEvent(ResourceActuationLaunched(resource, plugin.name, tasks, clock))
-                diffFingerprintRepository.markActionTaken(id)
-              }
-          }
-          else -> {
-            log.info("Resource {} is valid", id)
-            val lastEvent = resourceRepository.lastEvent(id)
-            when (lastEvent) {
-              is ResourceActuationLaunched -> log.debug("waiting for actuating task to be completed") // do nothing and wait
-              is ResourceDeltaDetected, is ResourceTaskSucceeded, is ResourceTaskFailed -> {
-                // if a delta was detected and a task wasn't launched, the delta is resolved
-                // if a task was launched and it completed, either successfully or not, the delta is resolved
-                publisher.publishEvent(ResourceDeltaResolved(resource, clock))
-              }
-              else -> publisher.publishEvent(ResourceValid(resource, clock))
             }
           }
+        } else {
+          log.info("Resource {} skipped because it can't be fixed: ${actionResponse.message}", id)
+          publisher.publishEvent(ResourceDiffNotActionable(resource, actionResponse.message))
         }
       } catch (e: ResourceCurrentlyUnresolvable) {
         log.warn("Resource check for {} failed (hopefully temporarily) due to {}", id, e.message)
@@ -284,6 +289,13 @@ class ResourceActuator(
     resource: Resource<*>
   ): R? =
     current(resource as Resource<S>)
+
+  @Suppress("UNCHECKED_CAST")
+  private suspend fun <S : ResourceSpec, R : Any> ResourceHandler<S, R>.willTakeAction(
+    resource: Resource<*>,
+    resourceDiff: ResourceDiff<*>
+  ): ActionResponse =
+    willTakeAction(resource as Resource<S>, resourceDiff as ResourceDiff<R>)
 
   @Suppress("UNCHECKED_CAST")
   private suspend fun <S : ResourceSpec, R : Any> ResourceHandler<S, R>.create(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -212,7 +212,10 @@ class ResourceActuator(
             }
           }
         } else {
-          log.warn("Resource {} skipped because it can't be fixed: ${decision.message}", id)
+          log.warn("Resource {} skipped because it can't be fixed: {} (diff: {})", id, decision.message, diff.toDeltaJson())
+          if (diff.hasChanges()) {
+            publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
+          }
           publisher.publishEvent(ResourceDiffNotActionable(resource, decision.message))
         }
       } catch (e: ResourceCurrentlyUnresolvable) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -61,7 +61,8 @@ import org.slf4j.LoggerFactory
   Type(value = ResourceActuationResumed::class, name = "ResourceActuationResumed"),
   Type(value = ResourceActuationVetoed::class, name = "ResourceActuationVetoed"),
   Type(value = ResourceTaskFailed::class, name = "ResourceTaskFailed"),
-  Type(value = ResourceTaskSucceeded::class, name = "ResourceTaskSucceeded")
+  Type(value = ResourceTaskSucceeded::class, name = "ResourceTaskSucceeded"),
+  Type(value = ResourceDiffNotActionable::class, name = "ResourceDiffNotActionable")
 )
 abstract class ResourceEvent(
   open val message: String? = null,
@@ -440,5 +441,24 @@ data class ResourceCheckError(
     clock.instant(),
     exception.javaClass,
     exception.message
+  )
+}
+
+data class ResourceDiffNotActionable(
+  override val kind: ResourceKind,
+  override val id: String,
+  override val application: String,
+  override val timestamp: Instant,
+  override val message: String?
+) : ResourceEvent() {
+  @JsonIgnore
+  override val ignoreRepeatedInHistory = true
+
+  constructor(resource: Resource<*>, message: String?, clock: Clock = Companion.clock) : this(
+    resource.kind,
+    resource.id,
+    resource.application,
+    clock.instant(),
+    message
   )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -154,5 +154,6 @@ enum class ResourceStatus {
   ERROR,
   PAUSED,
   RESUMED,
-  UNKNOWN
+  UNKNOWN,
+  DIFF_NOT_ACTIONABLE
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ResourceStatusService.kt
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.keel.services
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationResumed
+import com.netflix.spinnaker.keel.events.ResourceDiffNotActionable
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
 import com.netflix.spinnaker.keel.events.ResourceCheckError
 import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
@@ -21,6 +22,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceStatus.ACTUATING
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CREATED
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.CURRENTLY_UNRESOLVABLE
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF
+import com.netflix.spinnaker.keel.persistence.ResourceStatus.DIFF_NOT_ACTIONABLE
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.ERROR
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.HAPPY
 import com.netflix.spinnaker.keel.persistence.ResourceStatus.MISSING_DEPENDENCY
@@ -60,6 +62,7 @@ class ResourceStatusService(
       history.isUnhappy() -> UNHAPPY // order matters! must be after all other veto-related statuses
       history.isDiff() -> DIFF
       history.isActuating() -> ACTUATING
+      history.isDiffNotActionable() -> DIFF_NOT_ACTIONABLE
       history.isError() -> ERROR
       history.isCreated() -> CREATED
       history.isResumed() -> RESUMED
@@ -70,6 +73,10 @@ class ResourceStatusService(
 
   private fun List<ResourceHistoryEvent>.isHappy(): Boolean {
     return first() is ResourceValid || first() is ResourceDeltaResolved
+  }
+
+  private fun List<ResourceHistoryEvent>.isDiffNotActionable(): Boolean {
+    return first() is ResourceDiffNotActionable
   }
 
   private fun List<ResourceHistoryEvent>.isActuating(): Boolean {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.plugins.ActionDecision
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.api.randomUID
@@ -133,6 +134,7 @@ class IntermittentFailureTests : JUnit5Minutests {
         before {
           // diff has happened twice
           every { diffFingerprintRepository.actionTakenCount(resource.id) } returns 2
+          every { plugin1.willTakeAction(resource, any()) } returns ActionDecision()
 
           runBlocking { subject.checkResource(resource) }
         }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -495,6 +495,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
         }
 
         test("no action is taken and event is emitted") {
+          verify { publisher.publishEvent(ofType<ResourceDeltaDetected>()) }
           verify { publisher.publishEvent(any<ResourceDiffNotActionable>()) }
           verify(exactly = 0) { plugin1.create(any(), any()) }
           verify(exactly = 0) { plugin1.update(any(), any()) }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.plugins.ActionDecision
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
@@ -91,8 +92,10 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
     before {
       every { plugin1.name } returns "plugin1"
+      every { plugin1.willTakeAction(any(), any()) } returns ActionDecision()
       every { plugin1.supportedKind } returns SupportedKind(parseKind("plugin1/foo@v1"), DummyArtifactVersionedResourceSpec::class.java)
       every { plugin2.name } returns "plugin2"
+      every { plugin2.willTakeAction(any(), any()) } returns ActionDecision()
       every { plugin2.supportedKind } returns SupportedKind(parseKind("plugin2/bar@v1"), DummyArtifactVersionedResourceSpec::class.java)
     }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.keel.events.ResourceCheckUnresolvable
 import com.netflix.spinnaker.keel.events.ResourceCreated
 import com.netflix.spinnaker.keel.events.ResourceDeltaDetected
 import com.netflix.spinnaker.keel.events.ResourceDeltaResolved
+import com.netflix.spinnaker.keel.events.ResourceDiffNotActionable
 import com.netflix.spinnaker.keel.events.ResourceMissing
 import com.netflix.spinnaker.keel.events.ResourceTaskFailed
 import com.netflix.spinnaker.keel.events.ResourceTaskSucceeded
@@ -73,6 +74,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
     val veto = mockk<Veto>()
     val vetoEnforcer = VetoEnforcer(listOf(veto))
+    val clock = Clock.systemUTC()
     val subject = ResourceActuator(
       resourceRepository,
       artifactRepository,
@@ -82,7 +84,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       actuationPauser,
       vetoEnforcer,
       publisher,
-      Clock.systemUTC()
+      clock
     )
   }
 
@@ -475,6 +477,28 @@ internal class ResourceActuatorTests : JUnit5Minutests {
               }
             }
           }
+        }
+      }
+
+      context("the plugin can't resolve the diff") {
+        before {
+          every { plugin1.desired(resource) } returns DummyArtifactVersionedResourceSpec()
+          every { plugin1.current(resource) } returns DummyArtifactVersionedResourceSpec(artifactName = "BLAH!BLAH!")
+          every { plugin1.actuationInProgress(resource) } returns false
+          every { veto.check(resource) } returns VetoResponse(allowed = true, vetoName = "aVeto")
+          every { deliveryConfigRepository.deliveryConfigLastChecked(any()) } returns Instant.now().minus(Duration.ofSeconds(30))
+          every { plugin1.willTakeAction(resource, any()) } returns ActionDecision(false, "i just can't right now")
+
+          runBlocking {
+            subject.checkResource(resource)
+          }
+        }
+
+        test("no action is taken and event is emitted") {
+          verify { publisher.publishEvent(any<ResourceDiffNotActionable>()) }
+          verify(exactly = 0) { plugin1.create(any(), any()) }
+          verify(exactly = 0) { plugin1.update(any(), any()) }
+          verify(exactly = 0) { plugin1.delete(any()) }
         }
       }
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -43,6 +43,7 @@ import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.api.ec2.byRegion
 import com.netflix.spinnaker.keel.api.ec2.resolve
 import com.netflix.spinnaker.keel.api.ec2.resolveCapacity
+import com.netflix.spinnaker.keel.api.plugins.ActionResponse
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
@@ -115,6 +116,43 @@ class ClusterHandler(
     cloudDriverService
       .getActiveServerGroups(resource)
       .byRegion()
+
+  override suspend fun willTakeAction(
+    resource: Resource<ClusterSpec>,
+    resourceDiff: ResourceDiff<Map<String, ServerGroup>>
+  ): ActionResponse {
+    // we can't take any action if there is more than one active server group
+    //  AND the current active server group is unhealthy
+    val potentialInactionableRegions = mutableListOf<String>()
+    val inactionableRegions = mutableListOf<String>()
+    resourceDiff.toIndividualDiffs().forEach { diff ->
+      if (diff.hasChanges() && diff.isEnabledOnly()) {
+        potentialInactionableRegions.add(diff.desired.location.region)
+      }
+    }
+    if (potentialInactionableRegions.isNotEmpty()) {
+      val activeServerGroups = cloudDriverService.getActiveServerGroups(resource)
+      activeServerGroups.forEach { serverGroup ->
+        val healthy = serverGroup.instanceCounts?.isHealthy(
+          resource.spec.deployWith.health,
+          resource.spec.resolveCapacity(serverGroup.location.region)
+        ) == true
+        if (!healthy && potentialInactionableRegions.contains(serverGroup.location.region)) {
+          inactionableRegions.add(serverGroup.location.region)
+        }
+      }
+      if (inactionableRegions.isNotEmpty()) {
+        return ActionResponse(
+          willTakeAction = false,
+          message = "There is more than one server group enabled " +
+            "but the latest is not healthy in ${inactionableRegions.joinToString(" and ")}. " +
+            "Spinnaker cannot resolve the problem at this time, " +
+            "manual intervention might be required."
+        )
+      }
+    }
+    return ActionResponse(willTakeAction = true)
+  }
 
   override suspend fun upsert(
     resource: Resource<ClusterSpec>,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -146,8 +146,8 @@ class ClusterHandler(
           willAct = false,
           message = "There is more than one server group enabled " +
             "but the latest is not healthy in ${inactionableRegions.joinToString(" and ")}. " +
-            "Spinnaker cannot resolve the problem at this time, " +
-            "manual intervention might be required."
+            "Spinnaker cannot resolve the problem at this time. " +
+            "Manual intervention might be required."
         )
       }
     }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -43,7 +43,7 @@ import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
 import com.netflix.spinnaker.keel.api.ec2.byRegion
 import com.netflix.spinnaker.keel.api.ec2.resolve
 import com.netflix.spinnaker.keel.api.ec2.resolveCapacity
-import com.netflix.spinnaker.keel.api.plugins.ActionResponse
+import com.netflix.spinnaker.keel.api.plugins.ActionDecision
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
@@ -120,7 +120,7 @@ class ClusterHandler(
   override suspend fun willTakeAction(
     resource: Resource<ClusterSpec>,
     resourceDiff: ResourceDiff<Map<String, ServerGroup>>
-  ): ActionResponse {
+  ): ActionDecision {
     // we can't take any action if there is more than one active server group
     //  AND the current active server group is unhealthy
     val potentialInactionableRegions = mutableListOf<String>()
@@ -142,8 +142,8 @@ class ClusterHandler(
         }
       }
       if (inactionableRegions.isNotEmpty()) {
-        return ActionResponse(
-          willTakeAction = false,
+        return ActionDecision(
+          willAct = false,
           message = "There is more than one server group enabled " +
             "but the latest is not healthy in ${inactionableRegions.joinToString(" and ")}. " +
             "Spinnaker cannot resolve the problem at this time, " +
@@ -151,7 +151,7 @@ class ClusterHandler(
         )
       }
     }
-    return ActionResponse(willTakeAction = true)
+    return ActionDecision(willAct = true)
   }
 
   override suspend fun upsert(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -62,7 +62,6 @@ import java.time.Clock
 import java.time.Duration
 import java.util.UUID.randomUUID
 import kotlinx.coroutines.runBlocking
-import org.springframework.context.ApplicationEventPublisher
 import strikt.api.Assertion
 import strikt.api.expectCatching
 import strikt.api.expectThat
@@ -73,6 +72,7 @@ import strikt.assertions.get
 import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
 import strikt.assertions.isNotEmpty
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
@@ -528,6 +528,72 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         }
       }
     }
+
+    context("will we take action?") {
+      val east = serverGroupEast.toMultiServerGroupResponse(vpc = vpcEast, subnets = listOf(subnet1East, subnet2East, subnet3East), securityGroups = listOf(sg1East, sg2East), allEnabled = true)
+      val west = serverGroupWest.toMultiServerGroupResponse(vpc = vpcWest, subnets = listOf(subnet1West, subnet2West, subnet3West), securityGroups = listOf(sg1West, sg2West))
+
+
+      before {
+        coEvery { cloudDriverService.listServerGroups(any(), any(), any(), any()) } returns
+          ServerGroupCollection(vpcEast.account, east + west)
+      }
+
+      context("there is a diff in more than just enabled/disabled") {
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyEnabledServerGroup = false).withDoubleCapacity(),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+        )
+        val diff = DefaultResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+        test("we will take action"){
+          val response = runBlocking { willTakeAction(resource, diff) }
+          expectThat(response.willTakeAction).isTrue()
+        }
+      }
+
+      context("there is a diff only in enabled/disabled") {
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyEnabledServerGroup = false),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+        )
+        val diff = DefaultResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+        context("active server group is healthy") {
+          before {
+            coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+            coEvery { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+          }
+          test("we will take action"){
+            val response = runBlocking { willTakeAction(resource, diff) }
+            expectThat(response.willTakeAction).isTrue()
+          }
+        }
+
+        context("active server group is not healthy") {
+          before {
+            coEvery { cloudDriverService.listServerGroups(any(), any(), any(), any())} returns ServerGroupCollection(
+              vpcEast.account,
+              setOf(
+                activeServerGroupResponseEast.toAllServerGroupsResponse(false),
+                activeServerGroupResponseWest.toAllServerGroupsResponse(false)
+              )
+            )
+            coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns serverGroupEast.toCloudDriverResponse(vpcEast, listOf(subnet1East, subnet2East, subnet3East), listOf(sg1East, sg2East), null, InstanceCounts(1,0,1,0,0,0))
+            coEvery { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+          }
+          test("we won't take action"){
+            val response = runBlocking { willTakeAction(resource, diff) }
+            expectThat(response.willTakeAction).isFalse()
+          }
+        }
+      }
+    }
+
 
     context("a diff has been detected") {
       context("the diff is only in capacity") {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -550,7 +550,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         )
         test("we will take action"){
           val response = runBlocking { willTakeAction(resource, diff) }
-          expectThat(response.willTakeAction).isTrue()
+          expectThat(response.willAct).isTrue()
         }
       }
 
@@ -570,7 +570,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           }
           test("we will take action"){
             val response = runBlocking { willTakeAction(resource, diff) }
-            expectThat(response.willTakeAction).isTrue()
+            expectThat(response.willAct).isTrue()
           }
         }
 
@@ -588,7 +588,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           }
           test("we won't take action"){
             val response = runBlocking { willTakeAction(resource, diff) }
-            expectThat(response.willTakeAction).isFalse()
+            expectThat(response.willAct).isFalse()
           }
         }
       }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -151,8 +151,8 @@ class TitusClusterHandler(
           willAct = false,
           message = "There is more than one server group enabled " +
             "but the latest is not healthy in ${inactionableRegions.joinToString(" and ")}. " +
-            "Spinnaker cannot resolve the problem at this time, " +
-            "manual intervention might be required."
+            "Spinnaker cannot resolve the problem at this time. " +
+            "Manual intervention might be required."
         )
       }
     }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -36,7 +36,7 @@ import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.InstanceCounts
-import com.netflix.spinnaker.keel.api.plugins.ActionResponse
+import com.netflix.spinnaker.keel.api.plugins.ActionDecision
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
@@ -125,7 +125,7 @@ class TitusClusterHandler(
   override suspend fun willTakeAction(
     resource: Resource<TitusClusterSpec>,
     resourceDiff: ResourceDiff<Map<String, TitusServerGroup>>
-  ): ActionResponse {
+  ): ActionDecision {
     // we can't take any action if there is more than one active server group
     //  AND the current active server group is unhealthy
     val potentialInactionableRegions = mutableListOf<String>()
@@ -147,8 +147,8 @@ class TitusClusterHandler(
         }
       }
       if (inactionableRegions.isNotEmpty()) {
-        return ActionResponse(
-          willTakeAction = false,
+        return ActionDecision(
+          willAct = false,
           message = "There is more than one server group enabled " +
             "but the latest is not healthy in ${inactionableRegions.joinToString(" and ")}. " +
             "Spinnaker cannot resolve the problem at this time, " +
@@ -156,7 +156,7 @@ class TitusClusterHandler(
         )
       }
     }
-    return ActionResponse(willTakeAction = true)
+    return ActionDecision(willAct = true)
   }
 
   override suspend fun upsert(

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.InstanceCounts
+import com.netflix.spinnaker.keel.api.plugins.ActionResponse
 import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
@@ -120,6 +121,43 @@ class TitusClusterHandler(
           .getCorrelatedExecutions("${resource.id}:$region", resource.serviceAccount)
           .isNotEmpty()
       }
+
+  override suspend fun willTakeAction(
+    resource: Resource<TitusClusterSpec>,
+    resourceDiff: ResourceDiff<Map<String, TitusServerGroup>>
+  ): ActionResponse {
+    // we can't take any action if there is more than one active server group
+    //  AND the current active server group is unhealthy
+    val potentialInactionableRegions = mutableListOf<String>()
+    val inactionableRegions = mutableListOf<String>()
+    resourceDiff.toIndividualDiffs().forEach { diff ->
+      if (diff.hasChanges() && diff.isEnabledOnly()) {
+        potentialInactionableRegions.add(diff.desired.location.region)
+      }
+    }
+    if (potentialInactionableRegions.isNotEmpty()) {
+      val activeServerGroups = cloudDriverService.getActiveServerGroups(resource)
+      activeServerGroups.forEach { serverGroup ->
+        val healthy = serverGroup.instanceCounts?.isHealthy(
+            resource.spec.deployWith.health,
+            resource.spec.resolveCapacity(serverGroup.location.region)
+          ) == true
+        if (!healthy && potentialInactionableRegions.contains(serverGroup.location.region)) {
+          inactionableRegions.add(serverGroup.location.region)
+        }
+      }
+      if (inactionableRegions.isNotEmpty()) {
+        return ActionResponse(
+          willTakeAction = false,
+          message = "There is more than one server group enabled " +
+            "but the latest is not healthy in ${inactionableRegions.joinToString(" and ")}. " +
+            "Spinnaker cannot resolve the problem at this time, " +
+            "manual intervention might be required."
+        )
+      }
+    }
+    return ActionResponse(willTakeAction = true)
+  }
 
   override suspend fun upsert(
     resource: Resource<TitusClusterSpec>,

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
@@ -119,7 +119,8 @@ fun TitusServerGroup.toMultiServerGroupResponse(
   }
 
 fun TitusActiveServerGroup.toAllServerGroupsResponse(
-  disabled: Boolean = false
+  disabled: Boolean = false,
+  healthy: Boolean = true
 ): ClouddriverTitusServerGroup =
   ClouddriverTitusServerGroup(
     name = name,
@@ -143,7 +144,7 @@ fun TitusActiveServerGroup.toAllServerGroupsResponse(
     tags = tags,
     resources = resources,
     capacityGroup = capacityGroup,
-    instanceCounts = instanceCounts,
+    instanceCounts = if (healthy) instanceCounts else instanceCounts.copy(down = instanceCounts.total, up = 0),
     createdTime = createdTime,
     disabled = disabled
   )

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -356,7 +356,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         )
         test("we will take action"){
           val response = runBlocking { willTakeAction(resource, diff) }
-          expectThat(response.willTakeAction).isTrue()
+          expectThat(response.willAct).isTrue()
         }
       }
 
@@ -378,7 +378,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
           }
           test("we will take action"){
             val response = runBlocking { willTakeAction(resource, diff) }
-            expectThat(response.willTakeAction).isTrue()
+            expectThat(response.willAct).isTrue()
           }
         }
 
@@ -396,7 +396,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
           }
           test("we won't take action"){
             val response = runBlocking { willTakeAction(resource, diff) }
-            expectThat(response.willTakeAction).isFalse()
+            expectThat(response.willAct).isFalse()
           }
         }
       }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -82,8 +82,10 @@ import strikt.assertions.get
 import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
 import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
+import strikt.assertions.isTrue
 import strikt.assertions.map
 import java.time.Clock
 import java.time.Duration
@@ -323,6 +325,79 @@ class TitusClusterHandlerTests : JUnit5Minutests {
 
         test("no deployed event fires") {
           verify(exactly = 0) { publisher.publishEvent(ArtifactVersionDeployed(resource.id, "master-h2.blah")) }
+        }
+      }
+    }
+
+    context("will we take action?") {
+      val east = serverGroupEast.toMultiServerGroupResponse(listOf(sg1East, sg2East), awsAccount, allEnabled = true)
+      val west = serverGroupWest.toMultiServerGroupResponse(listOf(sg1West, sg2West), awsAccount)
+
+      before {
+        coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any())} returns
+          ServerGroupCollection(
+            titusAccount,
+            east + west
+          )
+        coEvery { cloudDriverService.findDockerImages("testregistry", "spinnaker/keel", any(), any(), any()) } returns
+          listOf(
+            DockerImage("testregistry", "spinnaker/keel", "master-h2.blah", "sha:1111")
+          )
+      }
+
+      context("there is a diff in more than just enabled/disabled") {
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyEnabledServerGroup = false).withDoubleCapacity(),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name).withDoubleCapacity()
+        )
+        val diff = DefaultResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+        test("we will take action"){
+          val response = runBlocking { willTakeAction(resource, diff) }
+          expectThat(response.willTakeAction).isTrue()
+        }
+      }
+
+      context("there is a diff only in enabled/disabled") {
+        val modified = setOf(
+          serverGroupEast.copy(name = activeServerGroupResponseEast.name, onlyEnabledServerGroup = false),
+          serverGroupWest.copy(name = activeServerGroupResponseWest.name)
+        )
+        val diff = DefaultResourceDiff(
+          serverGroups.byRegion(),
+          modified.byRegion()
+        )
+
+        context("active server group is healthy") {
+          before {
+            coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any())} returns allServerGroups
+            coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+            coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+          }
+          test("we will take action"){
+            val response = runBlocking { willTakeAction(resource, diff) }
+            expectThat(response.willTakeAction).isTrue()
+          }
+        }
+
+        context("active server group is not healthy") {
+          before {
+            coEvery { cloudDriverService.listTitusServerGroups(any(), any(), any(), any())} returns ServerGroupCollection(
+              titusAccount,
+              setOf(
+                activeServerGroupResponseEast.toAllServerGroupsResponse(false),
+                activeServerGroupResponseWest.toAllServerGroupsResponse(false)
+              )
+            )
+            coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-east-1") } returns serverGroupEast.toClouddriverResponse(listOf(sg1East, sg2East), awsAccount, InstanceCounts(1,0,1,0,0,0))
+            coEvery { cloudDriverService.titusActiveServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+          }
+          test("we won't take action"){
+            val response = runBlocking { willTakeAction(resource, diff) }
+            expectThat(response.willTakeAction).isFalse()
+          }
         }
       }
     }


### PR DESCRIPTION
Introducing a new behavior for resource handlers: the ability to pass on doing anything.

Why do we want this? Sometimes we can detect that there is a diff but we can't act on it. When might this be? Well, we might have situations where there is a diff (say, instances are unhealthy or there are too many active server groups) but we don't have enough information to fix the problem. Right now we get that way when there are two active server groups and the most recent is unhealthy (*note* I will work towards making this not the case, but I don't think I can make progress unless we have a way to opt out of taking action).

We want to communicate that we can't resolve the diff to the user. I'm doing this by adding a new state called `DIFF_NOT_ACTIONABLE`. 

This is not a great state for the user to see. Basically, it says "hey a human needs to step in". I built this so that we can slowly handle more and more cases that might at first fall into this category. But having this state means we don't need to address them all at once.

Looking for feedback on the approach:
I opted to create a new method (`willTakeAction(..)`) that happens before we call any `upsert` methods so the plugin can do a little check. I did this because I thought it was decently clean to have one method determining this. It's easier to test the various diff scenarios where we want to not take action. It was also pretty easy to publish an event if the plugin passes.

The other option I thought of was to modify the `upsert` method so it could return no tasks and a message, and then if a plugin did this emit the event. That seemed much more complicated. 

_please view with ignore whitespace set_