### PR TITLE
chore(artifacts): Update DebianArtifactParser

### DIFF
--- a/keel-core/src/main/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParser.java
+++ b/keel-core/src/main/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParser.java
@@ -1,10 +1,5 @@
 package com.netflix.rocket.api.artifact.internal.debian;
 
-import static com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE;
-import static org.apache.commons.lang3.StringUtils.substringAfterLast;
-import static org.apache.commons.lang3.StringUtils.substringBefore;
-import static org.apache.commons.lang3.StringUtils.substringBetween;
-
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -15,22 +10,22 @@ public class DebianArtifactParser {
   public ArtifactStatus parseStatus(String raw) {
     String version = parseVersion(raw);
     if (version == null) {
-      // we got passed the version
-      version = raw;
+      log.debug("Non expected debian name {}", raw);
+      return ArtifactStatus.UNKNOWN;
     }
     String[] parts = version.split("-");
     if (parts.length < 2) {
       return ArtifactStatus.UNKNOWN;
     }
     String status = parts[0];
-    if (status.matches("\\S+dev\\.\\d+[+.0-9a-z]*$")) {
+    if (status.matches("\\S+dev\\.\\d+[+.0-9a-z]*$|\\S+snapshot\\.\\d+[+.0-9a-z]*$")) {
       return ArtifactStatus.SNAPSHOT;
     }
     if (status.matches("\\S+~rc\\.\\d+$")) {
       return ArtifactStatus.CANDIDATE;
     }
     if (status.matches("\\d+\\.\\d+\\.\\d+$") || status.matches("\\d+\\.\\d+$")) {
-      return RELEASE;
+      return ArtifactStatus.RELEASE;
     }
     if (status.matches("\\d+\\.\\d+\\.\\d+[r]+\\d+$")) {
       return ArtifactStatus.RELEASE;
@@ -40,17 +35,17 @@ public class DebianArtifactParser {
   }
 
   public String parseName(String raw) {
-    String last = substringAfterLast(raw, "/");
-    return substringBefore(last, "_");
+    String last = StringUtils.substringAfterLast(raw, "/");
+    return StringUtils.substringBefore(last, "_");
   }
 
   public String parseVersion(String raw) {
-    String last = substringAfterLast(raw, "/");
-    return substringBetween(last, "_");
+    String last = StringUtils.substringAfterLast(raw, "/");
+    return StringUtils.substringBetween(last, "_");
   }
 
   public String parseArchitecture(String raw) {
-    String last = substringAfterLast(raw, "/");
+    String last = StringUtils.substringAfterLast(raw, "/");
     String debianWithoutExtenstion = StringUtils.removeEnd(last, ".deb");
     return StringUtils.substringAfterLast(debianWithoutExtenstion, "_");
   }

--- a/keel-core/src/test/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParserTests.java
+++ b/keel-core/src/test/java/com/netflix/rocket/api/artifact/internal/debian/DebianArtifactParserTests.java
@@ -10,8 +10,7 @@ public class DebianArtifactParserTests {
 
   @Test
   void shouldParseStandardVersionString() {
-    String rawVersion =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.1.2-h2.afc245_all.deb";
+    String rawVersion = "debian-local:pool/o/ocadmin-server/ocadmin-server_0.1.2-h2.afc245_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.RELEASE);
   }
@@ -25,8 +24,7 @@ public class DebianArtifactParserTests {
 
   @Test
   void shouldReturnReleaseForLocalReleaseBuild() {
-    String rawVersion =
-        "debian-local:pool/o/mypackage-server/mypackage-server_1.100.5-LOCAL_all.deb";
+    String rawVersion = "debian-local:pool/o/ocadmin-server/ocadmin-server_1.100.5-LOCAL_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.RELEASE);
   }
@@ -34,7 +32,7 @@ public class DebianArtifactParserTests {
   @Test
   void shouldParseCandidateVersionString() {
     String rawVersion =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.1.2~rc.11-h2.afc245_all.deb";
+        "debian-local:pool/o/ocadmin-server/ocadmin-server_0.1.2~rc.11-h2.afc245_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.CANDIDATE);
   }
@@ -42,7 +40,7 @@ public class DebianArtifactParserTests {
   @Test
   void shouldReturnCandidateForLocalFinalBuild() {
     String rawVersion =
-        "debian-local:pool/o/mypackage-server/mypackage-server_1.100.5~rc.23-LOCAL_all.deb";
+        "debian-local:pool/o/ocadmin-server/ocadmin-server_1.100.5~rc.23-LOCAL_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.CANDIDATE);
   }
@@ -50,7 +48,15 @@ public class DebianArtifactParserTests {
   @Test
   void shouldParseSnapshotVersionString() {
     String rawVersion =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176~dev.34267+2345af-h1886.4246bc3_all.deb";
+        "debian-local:pool/o/ocadmin-server/ocadmin-server_0.0.1176~dev.34267+2345af-h1886.4246bc3_all.deb";
+
+    assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.SNAPSHOT);
+  }
+
+  @Test
+  void shouldParseImmutableSnapshotVersionString() {
+    String rawVersion =
+        "debian-local:pool/o/ocadmin-server/ocadmin-server_4.0.57~snapshot.202008211804+0e673e3-h1886.4246bc3_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.SNAPSHOT);
   }
@@ -58,7 +64,7 @@ public class DebianArtifactParserTests {
   @Test
   void shouldParseLocallyPublishedSnapshot() {
     String raw =
-        "debian-local:pool/g/bottle-netflix-web/bottle-netflix-web_4.1.0~dev.294.uncommitted-LOCAL_all.deb";
+        "debian-local:pool/g/genie-netflix-web/genie-netflix-web_4.1.0~dev.294.uncommitted-LOCAL_all.deb";
 
     ArtifactStatus status = parser.parseStatus(raw);
 
@@ -68,7 +74,7 @@ public class DebianArtifactParserTests {
   @Test
   void shouldParseSnapshotAfterCandidateVersionString() {
     String rawVersion =
-        "debian-local:pool/g/bottle-netflix-web/bottle-netflix-web_4.0.1~rc.1.dev.1-h250.1c1dacc_all.deb";
+        "debian-local:pool/g/genie-netflix-web/genie-netflix-web_4.0.1~rc.1.dev.1-h250.1c1dacc_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.SNAPSHOT);
   }
@@ -83,31 +89,28 @@ public class DebianArtifactParserTests {
 
   @Test
   void shouldReturnUnknownForUnparseableString() {
-    String rawVersion = "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176_all.deb";
+    String rawVersion = "debian-local:pool/o/ocadmin-server/ocadmin-server_0.0.1176_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.UNKNOWN);
   }
 
   @Test
   void shouldParseArtifactoryDebianNameString() {
-    String raw =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_all.deb";
+    String raw = "debian-local:pool/o/ocadmin-server/ocadmin-server_0.0.1176-h1886.4246bc3_all.deb";
 
-    assertThat(parser.parseName(raw)).isEqualTo("mypackage-server");
+    assertThat(parser.parseName(raw)).isEqualTo("ocadmin-server");
   }
 
   @Test
   void shouldParseArtifactoryDebianVersionString() {
-    String raw =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_all.deb";
+    String raw = "debian-local:pool/o/ocadmin-server/ocadmin-server_0.0.1176-h1886.4246bc3_all.deb";
 
     assertThat(parser.parseVersion(raw)).isEqualTo("0.0.1176-h1886.4246bc3");
   }
 
   @Test
   void shouldParseArtifactoryDebianArchitectureString() {
-    String raw =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_all.deb";
+    String raw = "debian-local:pool/o/ocadmin-server/ocadmin-server_0.0.1176-h1886.4246bc3_all.deb";
 
     assertThat(parser.parseArchitecture(raw)).isEqualTo("all");
   }
@@ -115,7 +118,7 @@ public class DebianArtifactParserTests {
   @Test
   void shouldParseArtifactoryDebianArchitectureStringForAmd64() {
     String raw =
-        "debian-local:pool/o/mypackage-server/mypackage-server_0.0.1176-h1886.4246bc3_amd64.deb";
+        "debian-local:pool/o/ocadmin-server/ocadmin-server_0.0.1176-h1886.4246bc3_amd64.deb";
 
     assertThat(parser.parseArchitecture(raw)).isEqualTo("amd64");
   }
@@ -123,7 +126,7 @@ public class DebianArtifactParserTests {
   @Test
   void shouldDefaultToUnknownForUnrecognizedVersion() {
     String rawVersion =
-        "debian-local:pool/o/mypackage-server/mypackage-server_1.100.HOTFIX-LOCAL_all.deb";
+        "debian-local:pool/o/ocadmin-server/ocadmin-server_1.100.HOTFIX-LOCAL_all.deb";
 
     assertThat(parser.parseStatus(rawVersion)).isEqualTo(ArtifactStatus.UNKNOWN);
   }


### PR DESCRIPTION
Our current version of `DebianArtifactParser` is barfing on version strings like `lpollo-meme-lab-server-0.0.1~snapshot.202010092150-h1.8ae7d58`. This updates to the latest code from Rocket to fix it.