### PR TITLE
fix(ui): disable new status

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -33,6 +33,7 @@ import java.time.Clock
 import java.time.Instant
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
+import org.springframework.core.env.Environment as SpringEnvironment
 
 /**
  * This class tests a specific scenario:
@@ -53,6 +54,9 @@ class IntermittentFailureTests : JUnit5Minutests {
     val actuationPauser: ActuationPauser = mockk() {
       every { isPaused(any<String>()) } returns false
       every { isPaused(any<Resource<*>>()) } returns false
+    }
+    val springEnv: SpringEnvironment = mockk(relaxed = true) {
+      io.mockk.coEvery { getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, false) } returns true
     }
     val plugin1 = mockk<ResourceHandler<DummyResourceSpec, DummyResourceSpec>>(relaxUnitFun = true) {
       every { name } returns "plugin1"
@@ -93,7 +97,8 @@ class IntermittentFailureTests : JUnit5Minutests {
       actuationPauser,
       vetoEnforcer,
       publisher,
-      Clock.systemUTC()
+      Clock.systemUTC(),
+      springEnv
     )
     val desired = DummyResourceSpec(data = "fnord")
     val current = DummyResourceSpec()

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -57,6 +57,7 @@ import java.time.Duration
 import java.time.Instant
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
+import org.springframework.core.env.Environment as SpringEnvironment
 
 internal class ResourceActuatorTests : JUnit5Minutests {
 
@@ -68,6 +69,9 @@ internal class ResourceActuatorTests : JUnit5Minutests {
     val actuationPauser: ActuationPauser = mockk() {
       every { isPaused(any<String>()) } returns false
       every { isPaused(any<Resource<*>>()) } returns false
+    }
+    val springEnv: SpringEnvironment = mockk(relaxed = true) {
+      every { getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, false) } returns true
     }
     val plugin1 = mockk<ResourceHandler<DummyArtifactVersionedResourceSpec, DummyArtifactVersionedResourceSpec>>(relaxUnitFun = true)
     val plugin2 = mockk<ResourceHandler<DummyArtifactVersionedResourceSpec, DummyArtifactVersionedResourceSpec>>(relaxUnitFun = true)
@@ -84,7 +88,8 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       actuationPauser,
       vetoEnforcer,
       publisher,
-      clock
+      clock,
+      springEnv
     )
   }
 


### PR DESCRIPTION
disabling new status with fast property backed property.

we can turn on (then remove this code) once the UI is all set.
