### PR TITLE
Support AMIs where regions were baked individually

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.bakery.artifact
 
-import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.igor.ArtifactService
 import com.netflix.spinnaker.keel.actuation.ArtifactHandler
 import com.netflix.spinnaker.keel.api.ResourceDiff
@@ -16,11 +15,11 @@ import com.netflix.spinnaker.keel.clouddriver.model.Image
 import com.netflix.spinnaker.keel.core.NoKnownArtifactVersions
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.model.Job
+import com.netflix.spinnaker.keel.parseAppVersion
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
 import com.netflix.spinnaker.keel.telemetry.ArtifactCheckSkipped
-import com.netflix.spinnaker.kork.exceptions.SystemException
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 
@@ -123,11 +122,7 @@ class ImageHandler(
     diff: DefaultResourceDiff<Image>
   ): List<Task> {
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val appVersion = try {
-      AppVersion.parseName(desiredVersion)
-    } catch (ex: Exception) {
-      throw SystemException("trying to parse desired version for artifact ${artifact.name} with version $desiredVersion but got an exception", ex)
-    }
+    val appVersion = desiredVersion.parseAppVersion()
     val packageName = appVersion.packageName
     val version = desiredVersion.substringAfter("$packageName-")
     val artifactRef = "/${packageName}_${version}_all.deb"

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -11,7 +11,7 @@ import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.bakery.api.ImageExistsConstraint
 import com.netflix.spinnaker.keel.clouddriver.ImageService
-import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImageForAppVersionInRegions
+import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -46,7 +46,7 @@ class ImageExistsConstraintEvaluator(
 
   private fun imagesExistInAllRegions(version: String, vmOptions: VirtualMachineOptions): Boolean =
     runBlocking {
-      imageService.getLatestNamedImageForAppVersionInRegions(
+      imageService.getLatestNamedImages(
         appVersion = version.parseAppVersion(),
         account = defaultImageAccount,
         regions = vmOptions.regions

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.bakery.constraint
 
-import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
@@ -13,8 +12,8 @@ import com.netflix.spinnaker.keel.bakery.api.ImageExistsConstraint
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
 import com.netflix.spinnaker.keel.getConfig
+import com.netflix.spinnaker.keel.parseAppVersion
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
-import com.netflix.spinnaker.kork.exceptions.SystemException
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -53,9 +52,6 @@ class ImageExistsConstraintEvaluator(
       )
     }
       .keys.containsAll(vmOptions.regions)
-
-  private fun String.parseAppVersion() =
-    AppVersion.parseName(this) ?: throw SystemException("Invalid AMI app version: $this")
 
   private val defaultImageAccount: String
     get() = dynamicConfigService.getConfig("images.default-account", "test")

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -20,12 +20,12 @@ import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService.NoopDynamic
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.Called
-import io.mockk.coEvery
 import io.mockk.mockk
-import io.mockk.verify
 import strikt.api.expectThat
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
+import io.mockk.coEvery as every
+import io.mockk.coVerify as verify
 
 internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
 
@@ -103,7 +103,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
 
     context("CloudDriver cannot find an image for an artifact version") {
       before {
-        coEvery {
+        every {
           imageService.getLatestNamedImage(any(), any(), any())
         } returns null
 
@@ -119,7 +119,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
 
     context("CloudDriver finds a matching image for an artifact version") {
       before {
-        coEvery {
+        every {
           imageService.getLatestNamedImage(
             AppVersion.parseName(appVersion),
             "test",

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -107,7 +107,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
       before {
         coEvery {
           imageService.getLatestNamedImageWithAllRegionsForAppVersion(any(), any(), any())
-        } returns null
+        } returns emptyList()
 
         canPromote()
       }
@@ -127,20 +127,18 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
             "test",
             (artifact as DebianArtifact).vmOptions.regions
           )
-        } returns NamedImage(
-          imageName = appVersion,
-          attributes = mapOf(
-            "creationDate" to "2020-03-17T12:09:00.000Z"
-          ),
-          tagsByImageId = mapOf(
-            "ami-1" to mapOf("appversion" to appVersion, "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
-          ),
-          accounts = setOf(
-            "test" +
-              ""
-          ),
-          amis = mapOf(
-            "us-west-2" to listOf("ami-1")
+        } returns listOf(
+          NamedImage(
+            imageName = appVersion,
+            attributes = mapOf("creationDate" to "2020-03-17T12:09:00.000Z"),
+            tagsByImageId = mapOf(
+              "ami-1" to mapOf(
+                "appversion" to appVersion,
+                "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8"
+              )
+            ),
+            accounts = setOf("test"),
+            amis = mapOf("us-west-2" to listOf("ami-1"))
           )
         )
 

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -104,7 +104,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
     context("CloudDriver cannot find an image for an artifact version") {
       before {
         coEvery {
-          imageService.getLatestNamedImageForAppVersionInRegion(any(), any(), any())
+          imageService.getLatestNamedImage(any(), any(), any())
         } returns null
 
         canPromote()
@@ -120,7 +120,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
     context("CloudDriver finds a matching image for an artifact version") {
       before {
         coEvery {
-          imageService.getLatestNamedImageForAppVersionInRegion(
+          imageService.getLatestNamedImage(
             AppVersion.parseName(appVersion),
             "test",
             any()

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/config/ClouddriverConfiguration.kt
@@ -67,7 +67,7 @@ class ClouddriverConfiguration {
   @Bean
   fun imageService(
     cloudDriverService: CloudDriverService,
-    cloudDriverCache: CloudDriverCache
-  ) = ImageService(cloudDriverService)
+    cacheFactory: CacheFactory
+  ) = ImageService(cloudDriverService, cacheFactory)
 }
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -128,7 +128,7 @@ class ImageService(
    * As a side effect this method will prime the cache for any additional regions where the image is
    * available.
    */
-  suspend fun getLatestNamedImageForAppVersionInRegion(
+  suspend fun getLatestNamedImage(
     appVersion: AppVersion,
     account: String,
     region: String
@@ -216,7 +216,7 @@ class ImageService(
 
 /**
  * Find the latest properly tagged images in [account] for each of [regions] using
- * [ImageService.getLatestNamedImageForAppVersionInRegion] in parallel for each region.
+ * [ImageService.getLatestNamedImage] in parallel for each region.
  *
  * In many cases all the values in the resulting map will be the same [NamedImage] instance, but
  * this may not be the case if images were baked separately in each region.
@@ -224,14 +224,14 @@ class ImageService(
  * The resulting map will contain no entry for regions where an image is not found. The calling
  * code must check this if it requires all regions to be present.
  */
-suspend fun ImageService.getLatestNamedImageForAppVersionInRegions(
+suspend fun ImageService.getLatestNamedImages(
   appVersion: AppVersion,
   account: String,
   regions: Collection<String>
 ): Map<String, NamedImage> = coroutineScope {
   regions.associateWith { region ->
     async {
-      getLatestNamedImageForAppVersionInRegion(
+      getLatestNamedImage(
         appVersion = appVersion,
         account = account,
         region = region

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -107,7 +107,7 @@ class ImageService(
           // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
           runCatching { AppVersion.parseName(image.appVersion) }
             .getOrElse { ex ->
-              throw SystemException("trying to parse name for image ${image.imageName} with version ${image.appVersion} but got an exception", ex)
+              throw SystemException("Error parsing name for image ${image.imageName} with version ${image.appVersion}: ${ex.message}", ex)
             }
             .run {
               packageName == appVersion.packageName && version == appVersion.version && commit == appVersion.commit

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import retrofit2.HttpException
 import java.time.Duration
+import java.util.concurrent.CompletableFuture.completedFuture
 
 /**
  * An in-memory cache for calls against cloud driver
@@ -51,7 +52,7 @@ class MemoryCloudDriverCache(
         val credential = credentialBy(account)
         cloudDriver.getSecurityGroupSummaryById(account, credential.type, region, id, DEFAULT_SERVICE_ACCOUNT)
           .also {
-            securityGroupsByName.synchronous().put(Triple(account, region, it.name), it)
+            securityGroupsByName.put(Triple(account, region, it.name), completedFuture(it))
           }
       }
         .handleNotFound()
@@ -67,7 +68,7 @@ class MemoryCloudDriverCache(
         val credential = credentialBy(account)
         cloudDriver.getSecurityGroupSummaryByName(account, credential.type, region, name, DEFAULT_SERVICE_ACCOUNT)
           .also {
-            securityGroupsById.synchronous().put(Triple(account, region, it.id), it)
+            securityGroupsById.put(Triple(account, region, it.id), completedFuture(it))
           }
       }
         .handleNotFound()
@@ -80,7 +81,7 @@ class MemoryCloudDriverCache(
         cloudDriver.listNetworks(DEFAULT_SERVICE_ACCOUNT)["aws"]
           ?.firstOrNull { it.id == id }
           ?.also {
-            networksByName.synchronous().put(Triple(it.account, it.region, it.name), it)
+            networksByName.put(Triple(it.account, it.region, it.name), completedFuture(it))
           }
       }
         .handleNotFound()
@@ -94,7 +95,7 @@ class MemoryCloudDriverCache(
           .listNetworks(DEFAULT_SERVICE_ACCOUNT)["aws"]
           ?.firstOrNull { it.name == name && it.account == account && it.region == region }
           ?.also {
-            networksById.synchronous().put(it.id, it)
+            networksById.put(it.id, completedFuture(it))
           }
       }
         .handleNotFound()

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -39,7 +39,6 @@ import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import java.time.Instant
 import io.mockk.coEvery as every
-import io.mockk.coVerify as verify
 
 class ImageServiceTests : JUnit5Minutests {
   class Fixture {
@@ -236,6 +235,7 @@ class ImageServiceTests : JUnit5Minutests {
           )
         } returns listOf(image2, image4, image3, image1, image5, image6)
       }
+
       test("latest image returns actual image") {
         runBlocking {
           val image = subject.getLatestImage(
@@ -260,6 +260,7 @@ class ImageServiceTests : JUnit5Minutests {
           )
         } returns listOf(image2, image4, image3, image1, image5)
       }
+
       test("get latest named image returns actual latest image") {
         runBlocking {
           val image = subject.getLatestNamedImage(
@@ -318,6 +319,7 @@ class ImageServiceTests : JUnit5Minutests {
           )
         } returns emptyList()
       }
+
       test("no image provided") {
         runBlocking {
           val image = subject.getLatestNamedImage(
@@ -330,40 +332,13 @@ class ImageServiceTests : JUnit5Minutests {
       }
     }
 
-    context("searching for a very specific image version") {
-      before {
-        every {
-          cloudDriver.namedImages(any(), any(), any())
-        } returns listOf(image2)
-      }
-
-      test("returns correct version") {
-        runBlocking {
-          val image = subject.getLatestNamedImage(
-            appVersion = AppVersion.parseName("my-package-0.0.1~rc.98-h99.4cb755c"),
-            account = "test"
-          )
-          expectThat(image)
-            .isNotNull()
-            .isEqualTo(image2)
-        }
-
-        verify {
-          cloudDriver.namedImages(
-            user = DEFAULT_SERVICE_ACCOUNT,
-            imageName = "my-package-0.0.1_rc.98-h99.4cb755c",
-            account = "test"
-          )
-        }
-      }
-    }
-
     context("given jenkins info") {
       before {
         every {
           cloudDriver.namedImages(DEFAULT_SERVICE_ACCOUNT, "my-package", "test")
         } returns listOf(image2, image4, image3, image1)
       }
+
       test("finds named image") {
         runBlocking {
           val image = subject.getNamedImageFromJenkinsInfo(
@@ -381,28 +356,6 @@ class ImageServiceTests : JUnit5Minutests {
       }
     }
 
-    context("given images in varying stages of completeness") {
-      val packageName = "keel"
-      val regions = listOf("us-west-2", "us-east-1")
-      before {
-        every {
-          cloudDriver.namedImages(
-            user = DEFAULT_SERVICE_ACCOUNT,
-            imageName = packageName,
-            account = "test"
-          )
-        } returns realImages
-      }
-      test("searching by package name finds latest complete image") {
-        runBlocking {
-          val image = subject.getLatestNamedImageWithAllRegions(packageName, "test", regions)
-          expectThat(image)
-            .isNotNull()
-            .get { imageName }
-            .isEqualTo("keel-0.312.0-h240.44eaaa3-x86_64-20191025212812-xenial-hvm-sriov-ebs")
-        }
-      }
-    }
 
     context("given images in varying stages of completeness") {
       val appVersion = "my-package-0.0.1~rc.97-h98.1c684a9"

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -358,7 +358,7 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("searching for a specific appversion finds latest complete image") {
         val images = runBlocking {
-          subject.getLatestNamedImageForAppVersionInRegions(
+          subject.getLatestNamedImages(
             appVersion = appVersion,
             account = "test",
             regions = regions
@@ -376,7 +376,7 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("the newest image is selected when searching in a single region") {
         val image = runBlocking {
-          subject.getLatestNamedImageForAppVersionInRegion(appVersion, "test", regions.first())
+          subject.getLatestNamedImage(appVersion, "test", regions.first())
         }
 
         expectThat(image)
@@ -387,10 +387,10 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("any other regions supported by the same image are subsequently served from cache") {
         val r1Image = runBlocking {
-          subject.getLatestNamedImageForAppVersionInRegion(appVersion, "test", regions.first())
+          subject.getLatestNamedImage(appVersion, "test", regions.first())
         }
         val r2Image = runBlocking {
-          subject.getLatestNamedImageForAppVersionInRegion(appVersion, "test", regions.last())
+          subject.getLatestNamedImage(appVersion, "test", regions.last())
         }
 
         expectThat(r1Image).isEqualTo(r2Image)
@@ -412,7 +412,7 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("searching for a specific appversion finds all images for required regions") {
         val images = runBlocking {
-          subject.getLatestNamedImageForAppVersionInRegions(
+          subject.getLatestNamedImages(
             appVersion = appVersion,
             account = "test",
             regions = regions
@@ -442,7 +442,7 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("images that were found are returned") {
         val images = runBlocking {
-          subject.getLatestNamedImageForAppVersionInRegions(
+          subject.getLatestNamedImages(
             appVersion = appVersion,
             account = "test",
             regions = regions

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -28,7 +28,6 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.DynamicTest.dynamicTest
 import strikt.api.expectThat
 import strikt.assertions.all
 import strikt.assertions.containsExactly
@@ -254,47 +253,14 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("get latest named image returns actual latest image") {
         runBlocking {
-          val image = subject.getLatestNamedImage(
-            packageName = "my-package",
+          val image = subject.getLatestImage(
+            artifactName = "my-package",
             account = "test"
           )
           expectThat(image)
             .isNotNull()
-            .get { imageName }
-            .isEqualTo(newestImage.imageName)
-        }
-      }
-    }
-
-    context("get latest named image can be filtered by region") {
-      mapOf("us-west-1" to "ami-003", "ap-south-1" to "ami-005").map { (region, imageId) ->
-        dynamicTest("get latest image can be filtered by region ($region)") {
-          before {
-            every {
-              cloudDriver.namedImages(
-                user = DEFAULT_SERVICE_ACCOUNT,
-                imageName = "my-package",
-                account = "test",
-                region = region
-              )
-            } answers {
-              listOf(image2, image4, image3, image1, image5).filter { it.amis.keys.contains(region) }
-            }
-          }
-
-          test("it works") {
-            runBlocking {
-              val image = subject.getLatestNamedImage(
-                packageName = "my-package",
-                account = "test",
-                region = region
-              )
-              expectThat(image)
-                .isNotNull()
-                .get { imageId }
-                .isEqualTo(imageId)
-            }
-          }
+            .get { appVersion }
+            .isEqualTo(newestImage.appVersion)
         }
       }
     }
@@ -313,8 +279,8 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("no image provided") {
         runBlocking {
-          val image = subject.getLatestNamedImage(
-            packageName = "my-package",
+          val image = subject.getLatestImage(
+            artifactName = "my-package",
             account = "test"
           )
           expectThat(image)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/_appVersions.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/_appVersions.kt
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.keel
+
+import com.netflix.frigga.ami.AppVersion
+import com.netflix.spinnaker.kork.exceptions.SystemException
+
+fun String.parseAppVersionOrNull(): AppVersion? =
+  runCatching {
+    AppVersion.parseName(this)
+  }
+    .getOrElse { ex ->
+      throw SystemException("Error parsing appVersion string from '$this'", ex)
+    }
+
+fun String.parseAppVersion(): AppVersion =
+  parseAppVersionOrNull() ?: throw SystemException("Invalid appVersion string: '$this'")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/_maps.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/_maps.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel
+
+/**
+ * Filters a map to retain only those entries that have non-null values. Also narrows the
+ * value type on the map.
+ */
+@Suppress("UNCHECKED_CAST")
+fun <K, V : Any> Map<out K, V?>.filterNotNullValues(): Map<K, V> =
+  filterValues { it != null } as Map<K, V>

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.ec2.constraints
 
-import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.actuation.Task
@@ -18,6 +17,7 @@ import com.netflix.spinnaker.keel.constraints.toStageBase
 import com.netflix.spinnaker.keel.core.api.CanaryConstraint
 import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.ec2.resolvers.ImageResolver
+import com.netflix.spinnaker.keel.parseAppVersion
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.GlobalScope
@@ -55,7 +55,7 @@ class Ec2CanaryConstraintDeployHandler(
     val judge = "canary:${deliveryConfig.application}:${targetEnvironment.name}:${constraint.canaryConfigId}"
 
     val images = imageService.getLatestNamedImages(
-      appVersion = AppVersion.parseName(version.replace("~", "_")),
+      appVersion = version.replace("~", "_").parseAppVersion(),
       account = imageResolver.defaultImageAccount,
       regions = regions
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -9,7 +9,7 @@ import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ImageService
-import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImageForAppVersionInRegions
+import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.subnet
 import com.netflix.spinnaker.keel.constraints.CanaryConstraintConfigurationProperties
@@ -54,7 +54,7 @@ class Ec2CanaryConstraintDeployHandler(
     val scope = CoroutineScope(GlobalScope.coroutineContext)
     val judge = "canary:${deliveryConfig.application}:${targetEnvironment.name}:${constraint.canaryConfigId}"
 
-    val images = imageService.getLatestNamedImageForAppVersionInRegions(
+    val images = imageService.getLatestNamedImages(
       appVersion = AppVersion.parseName(version.replace("~", "_")),
       account = imageResolver.defaultImageAccount,
       regions = regions

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -62,7 +62,7 @@ class Ec2CanaryConstraintDeployHandler(
 
     val missingRegions = regions - images.keys
     if (missingRegions.isNotEmpty()) {
-      error("Image not found for $version in all requested regions ($regions)")
+      error("Image not found for $version in all requested regions ($regions.joinToString())")
     }
 
     val source = getSourceServerGroups(deliveryConfig.application, constraint, deliveryConfig.serviceAccount)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.keel.ec2.resolvers
 
-import com.netflix.frigga.ami.AppVersion
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
@@ -24,6 +23,7 @@ import com.netflix.spinnaker.keel.ec2.NoImageFoundForRegions
 import com.netflix.spinnaker.keel.ec2.NoImageSatisfiesConstraints
 import com.netflix.spinnaker.keel.filterNotNullValues
 import com.netflix.spinnaker.keel.getConfig
+import com.netflix.spinnaker.keel.parseAppVersion
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoMatchingArtifactException
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -91,7 +91,7 @@ class ImageResolver(
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
 
     val images = imageService.getLatestNamedImages(
-      appVersion = AppVersion.parseName(artifactVersion),
+      appVersion = artifactVersion.parseAppVersion(),
       account = account,
       regions = regions
     )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -15,7 +15,7 @@ import com.netflix.spinnaker.keel.api.ec2.VirtualMachineImage
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService
-import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImageForAppVersionInRegions
+import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.clouddriver.model.baseImageVersion
@@ -90,7 +90,7 @@ class ImageResolver(
       environment.name
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
 
-    val images = imageService.getLatestNamedImageForAppVersionInRegions(
+    val images = imageService.getLatestNamedImages(
       appVersion = AppVersion.parseName(artifactVersion),
       account = account,
       regions = regions

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -15,17 +15,18 @@ import com.netflix.spinnaker.keel.api.ec2.VirtualMachineImage
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService
+import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImageForAppVersionInRegions
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.clouddriver.model.baseImageVersion
 import com.netflix.spinnaker.keel.ec2.NoImageFound
 import com.netflix.spinnaker.keel.ec2.NoImageFoundForRegions
 import com.netflix.spinnaker.keel.ec2.NoImageSatisfiesConstraints
+import com.netflix.spinnaker.keel.filterNotNullValues
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoMatchingArtifactException
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
-import com.netflix.spinnaker.kork.exceptions.SystemException
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -42,9 +43,9 @@ class ImageResolver(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   data class VersionedNamedImage(
-    val namedImages: Collection<NamedImage>,
-    val artifact: DeliveryArtifact?,
-    val version: String?
+    val namedImages: Map<String, NamedImage>,
+    val artifact: DeliveryArtifact?, // TODO: make this non-nullable
+    val version: String
   )
 
   override fun invoke(resource: Resource<ClusterSpec>): Resource<ClusterSpec> {
@@ -88,19 +89,12 @@ class ImageResolver(
       artifact,
       environment.name
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
-    val images = imageService.getLatestNamedImageWithAllRegionsForAppVersion(
-      // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-      appVersion = try {
-        AppVersion.parseName(artifactVersion)
-      } catch (ex: Exception) {
-        throw SystemException("trying to parse name for version $artifactVersion but got an exception", ex)
-      },
+
+    val images = imageService.getLatestNamedImageForAppVersionInRegions(
+      appVersion = AppVersion.parseName(artifactVersion),
       account = account,
       regions = regions
     )
-    if (images.isEmpty()) {
-      throw NoImageFoundForRegions(artifactVersion, regions)
-    }
 
     return VersionedNamedImage(images, artifact, artifactVersion)
   }
@@ -117,28 +111,32 @@ class ImageResolver(
     ) ?: throw NoImageFound(imageProvider.packageName)
 
     log.info("Image found for {}: {}", imageProvider.packageName, image)
-    return VersionedNamedImage(listOf(image), null, null)
+    return VersionedNamedImage(
+      namedImages = image.amis.keys.associateWith { image },
+      artifact = null,
+      version = image.appVersion
+    )
   }
 
   private fun Resource<ClusterSpec>.withVirtualMachineImages(image: VersionedNamedImage): Resource<ClusterSpec> {
+    val requiredRegions = spec.locations.regions.map { it.name }
+
+    val missingRegions = requiredRegions - image.namedImages.keys
+    if (missingRegions.isNotEmpty()) {
+      throw NoImageFoundForRegions(image.version, missingRegions)
+    }
+
     val imageIdByRegion = image
       .namedImages
-      .map { it.amis }
-      .reduceRight { acc, map -> acc + map }
+      .mapValues { (region, image) -> image.amis[region]?.first() }
       .filterNotNullValues()
-      .filterValues { it.isNotEmpty() }
-      .mapValues { it.value.first() }
-    val missingRegions = spec.locations.regions.map { it.name } - imageIdByRegion.keys
-    if (missingRegions.isNotEmpty()) {
-      throw NoImageFoundForRegions(image.artifact?.name
-        ?: image.namedImages.first().imageName, missingRegions)
-    }
 
     val overrides = mutableMapOf<String, ServerGroupSpec>()
     overrides.putAll(spec.overrides)
-    spec.locations.regions.map { it.name }.forEach { region ->
+
+    requiredRegions.forEach { region ->
       val amiId = imageIdByRegion.getValue(region)
-      val namedImage = checkNotNull(image.namedImages.find { it.tagsByImageId.containsKey(amiId) })
+      val namedImage = image.namedImages.getValue(region)
       overrides[region] = overrides[region]
         .withVirtualMachineImage(
           VirtualMachineImage(
@@ -153,7 +151,7 @@ class ImageResolver(
       spec = spec.copy(
         overrides = overrides,
         _artifactName = image.artifact?.name
-          ?: error("Artifact not found in images ${image.namedImages.map { it.imageName }}"),
+          ?: error("Artifact not found in images ${image.namedImages.values.map { it.imageName }}"),
         artifactVersion = image.version
       )
     )
@@ -167,8 +165,4 @@ class ImageResolver(
         }
       )
     }
-
-  @Suppress("UNCHECKED_CAST")
-  private fun <K, V> Map<out K, V?>.filterNotNullValues(): Map<K, V> =
-    filterValues { it != null } as Map<K, V>
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
 import com.fasterxml.jackson.module.kotlin.convertValue
-import com.netflix.frigga.ami.AppVersion
 import com.netflix.rocket.api.artifact.internal.debian.DebianArtifactParser
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.Moniker
@@ -57,7 +56,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.CustomizedMetricSpecificatio
 import com.netflix.spinnaker.keel.clouddriver.model.MetricDimensionModel
 import com.netflix.spinnaker.keel.clouddriver.model.PredefinedMetricSpecificationModel
 import com.netflix.spinnaker.keel.clouddriver.model.ScalingPolicy
-import com.netflix.spinnaker.keel.clouddriver.model.ServerGroup as ClouddriverServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.StepAdjustmentModel
 import com.netflix.spinnaker.keel.clouddriver.model.Tag
 import com.netflix.spinnaker.keel.clouddriver.model.subnet
@@ -76,10 +74,11 @@ import com.netflix.spinnaker.keel.orca.dependsOn
 import com.netflix.spinnaker.keel.orca.restrictedExecutionWindow
 import com.netflix.spinnaker.keel.orca.toOrcaJobProperties
 import com.netflix.spinnaker.keel.orca.waitStage
+import com.netflix.spinnaker.keel.parseAppVersion
+import com.netflix.spinnaker.keel.parseAppVersionOrNull
 import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
-import com.netflix.spinnaker.kork.exceptions.SystemException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -90,6 +89,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import com.netflix.spinnaker.keel.clouddriver.model.ServerGroup as ClouddriverServerGroup
 
 class ClusterHandler(
   private val cloudDriverService: CloudDriverService,
@@ -205,7 +205,8 @@ class ClusterHandler(
           diff.isAutoScalingOnly() -> diff.modifyScalingPolicyJob() to "Modify auto-scaling of server group ${diff.desired.moniker} in " +
             "${diff.desired.location.account}/${diff.desired.location.region}"
           diff.isEnabledOnly() -> {
-            val appVersion = diff.desired.launchConfiguration.appVersion ?: throw MissingAppVersionException(resource.id)
+            val appVersion = diff.desired.launchConfiguration.appVersion
+              ?: throw MissingAppVersionException(resource.id)
             val job = diff.disableOtherServerGroupJob(resource, appVersion)
             listOf(job) to "Disable extra active server group ${job["asgName"]} in " +
               "${diff.desired.location.account}/${diff.desired.location.region}"
@@ -401,15 +402,15 @@ class ClusterHandler(
       SubnetAwareRegionSpec(
         name = region,
         availabilityZones =
-          if (!serverGroup.location.availabilityZones.containsAll(
+        if (!serverGroup.location.availabilityZones.containsAll(
             zonesByRegion[region]
               ?: error("Failed resolving availabilityZones for account: ${exportable.account}, region: $region")
           )
-          ) {
-            serverGroup.location.availabilityZones
-          } else {
-            emptySet()
-          }
+        ) {
+          serverGroup.location.availabilityZones
+        } else {
+          emptySet()
+        }
       )
     }
       .toSet()
@@ -434,11 +435,7 @@ class ClusterHandler(
     ) ?: RedBlack()
 
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val appversion = try {
-      AppVersion.parseName(base.image?.appVersion).packageName
-    } catch (ex: Exception) {
-      throw SystemException("trying to parse name for image ${base.image?.name} with version ${base.image?.appVersion} but got an exception", ex)
-    }
+    val appversion = base.image?.appVersion?.parseAppVersionOrNull()?.packageName
 
     val spec = ClusterSpec(
       moniker = exportable.moniker,
@@ -487,11 +484,7 @@ class ClusterHandler(
     }
 
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val artifactName = try {
-      AppVersion.parseName(base.launchConfiguration.appVersion).packageName
-    } catch (ex: Exception) {
-      throw SystemException("trying to parse name for configuration ${base.launchConfiguration} with version ${base.launchConfiguration.appVersion} but got an exception", ex)
-    }
+    val artifactName = checkNotNull(base.launchConfiguration.appVersion).parseAppVersion().packageName
 
     val status = debianArtifactParser.parseStatus(base.launchConfiguration.appVersion?.substringAfter("$artifactName-"))
     if (status == UNKNOWN) {
@@ -767,139 +760,139 @@ class ClusterHandler(
 
   private fun ResourceDiff<ServerGroup>.toDeletePolicyJob(startingRefId: Int):
     Pair<Int, MutableList<Map<String, Any?>>> {
-      var refId = startingRefId
-      val stages: MutableList<Map<String, Any?>> = mutableListOf()
-      if (current == null) {
-        return Pair(refId, stages)
-      }
-      val current = current!!
-      val targetPoliciesToRemove = current.scaling.targetTrackingPolicies.filterNot {
-        desired.scaling.targetTrackingPolicies.contains(it)
-      }
-      val stepPoliciesToRemove = current.scaling.stepScalingPolicies.filterNot {
-        desired.scaling.stepScalingPolicies.contains(it)
-      }
-      val policyNamesToRemove = targetPoliciesToRemove.mapNotNull { it.name } +
-        stepPoliciesToRemove.mapNotNull { it.name }
-          .toSet()
-
-      stages.addAll(
-        policyNamesToRemove
-          .map {
-            refId++
-            mapOf(
-              "refId" to refId.toString(),
-              "requisiteStageRefIds" to when (refId) {
-                0, 1 -> listOf()
-                else -> listOf((refId - 1).toString())
-              },
-              "type" to "deleteScalingPolicy",
-              "policyName" to it,
-              "cloudProvider" to CLOUD_PROVIDER,
-              "credentials" to desired.location.account,
-              "moniker" to current.moniker.orcaClusterMoniker,
-              "region" to current.location.region
-            )
-          }
-          .toMutableList()
-      )
-
+    var refId = startingRefId
+    val stages: MutableList<Map<String, Any?>> = mutableListOf()
+    if (current == null) {
       return Pair(refId, stages)
     }
+    val current = current!!
+    val targetPoliciesToRemove = current.scaling.targetTrackingPolicies.filterNot {
+      desired.scaling.targetTrackingPolicies.contains(it)
+    }
+    val stepPoliciesToRemove = current.scaling.stepScalingPolicies.filterNot {
+      desired.scaling.stepScalingPolicies.contains(it)
+    }
+    val policyNamesToRemove = targetPoliciesToRemove.mapNotNull { it.name } +
+      stepPoliciesToRemove.mapNotNull { it.name }
+        .toSet()
+
+    stages.addAll(
+      policyNamesToRemove
+        .map {
+          refId++
+          mapOf(
+            "refId" to refId.toString(),
+            "requisiteStageRefIds" to when (refId) {
+              0, 1 -> listOf()
+              else -> listOf((refId - 1).toString())
+            },
+            "type" to "deleteScalingPolicy",
+            "policyName" to it,
+            "cloudProvider" to CLOUD_PROVIDER,
+            "credentials" to desired.location.account,
+            "moniker" to current.moniker.orcaClusterMoniker,
+            "region" to current.location.region
+          )
+        }
+        .toMutableList()
+    )
+
+    return Pair(refId, stages)
+  }
 
   private fun Set<TargetTrackingPolicy>.toCreateJob(startingRefId: Int, serverGroup: ServerGroup):
     Pair<Int, List<Map<String, Any?>>> {
-      var refId = startingRefId
-      val stages = map {
-        refId++
-        mapOf(
-          "refId" to refId.toString(),
-          "requisiteStageRefIds" to when (refId) {
-            0, 1 -> listOf()
-            else -> listOf((refId - 1).toString())
-          },
-          "type" to "upsertScalingPolicy",
-          "cloudProvider" to CLOUD_PROVIDER,
-          "credentials" to serverGroup.location.account,
-          "moniker" to serverGroup.moniker.orcaClusterMoniker,
-          "region" to serverGroup.location.region,
-          "estimatedInstanceWarmup" to it.warmup.seconds,
-          "targetTrackingConfiguration" to mapOf(
-            "targetValue" to it.targetValue,
-            "disableScaleIn" to it.disableScaleIn,
-            "predefinedMetricSpecification" to when (val metricsSpec = it.predefinedMetricSpec) {
-              null -> null
-              else -> with(metricsSpec) {
-                PredefinedMetricSpecificationModel(
-                  predefinedMetricType = type,
-                  resourceLabel = label
-                )
-              }
-            },
-            "customizedMetricSpecification" to when (val metricsSpec = it.customMetricSpec) {
-              null -> null
-              else -> with(metricsSpec) {
-                CustomizedMetricSpecificationModel(
-                  metricName = name,
-                  namespace = namespace,
-                  statistic = statistic,
-                  unit = unit,
-                  dimensions = dimensions?.map { d ->
-                    MetricDimensionModel(name = d.name, value = d.value)
-                  }
-                )
-              }
+    var refId = startingRefId
+    val stages = map {
+      refId++
+      mapOf(
+        "refId" to refId.toString(),
+        "requisiteStageRefIds" to when (refId) {
+          0, 1 -> listOf()
+          else -> listOf((refId - 1).toString())
+        },
+        "type" to "upsertScalingPolicy",
+        "cloudProvider" to CLOUD_PROVIDER,
+        "credentials" to serverGroup.location.account,
+        "moniker" to serverGroup.moniker.orcaClusterMoniker,
+        "region" to serverGroup.location.region,
+        "estimatedInstanceWarmup" to it.warmup.seconds,
+        "targetTrackingConfiguration" to mapOf(
+          "targetValue" to it.targetValue,
+          "disableScaleIn" to it.disableScaleIn,
+          "predefinedMetricSpecification" to when (val metricsSpec = it.predefinedMetricSpec) {
+            null -> null
+            else -> with(metricsSpec) {
+              PredefinedMetricSpecificationModel(
+                predefinedMetricType = type,
+                resourceLabel = label
+              )
             }
-          )
+          },
+          "customizedMetricSpecification" to when (val metricsSpec = it.customMetricSpec) {
+            null -> null
+            else -> with(metricsSpec) {
+              CustomizedMetricSpecificationModel(
+                metricName = name,
+                namespace = namespace,
+                statistic = statistic,
+                unit = unit,
+                dimensions = dimensions?.map { d ->
+                  MetricDimensionModel(name = d.name, value = d.value)
+                }
+              )
+            }
+          }
         )
-      }
-
-      return Pair(refId, stages)
+      )
     }
+
+    return Pair(refId, stages)
+  }
 
   private fun Set<StepScalingPolicy>.toCreateJob(startingRefId: Int, serverGroup: ServerGroup):
     List<Map<String, Any?>> {
-      var refId = startingRefId
-      return map {
-        refId++
-        mapOf(
-          "refId" to refId.toString(),
-          "requisiteStageRefIds" to when (refId) {
-            0, 1 -> listOf()
-            else -> listOf((refId - 1).toString())
-          },
-          "type" to "upsertScalingPolicy",
-          "cloudProvider" to CLOUD_PROVIDER,
-          "credentials" to serverGroup.location.account,
-          "moniker" to serverGroup.moniker.orcaClusterMoniker,
+    var refId = startingRefId
+    return map {
+      refId++
+      mapOf(
+        "refId" to refId.toString(),
+        "requisiteStageRefIds" to when (refId) {
+          0, 1 -> listOf()
+          else -> listOf((refId - 1).toString())
+        },
+        "type" to "upsertScalingPolicy",
+        "cloudProvider" to CLOUD_PROVIDER,
+        "credentials" to serverGroup.location.account,
+        "moniker" to serverGroup.moniker.orcaClusterMoniker,
+        "region" to serverGroup.location.region,
+        "adjustmentType" to it.adjustmentType,
+        "alarm" to mapOf(
           "region" to serverGroup.location.region,
-          "adjustmentType" to it.adjustmentType,
-          "alarm" to mapOf(
-            "region" to serverGroup.location.region,
-            "actionsEnabled" to it.actionsEnabled,
-            "comparisonOperator" to it.comparisonOperator,
-            "dimensions" to it.dimensions,
-            "evaluationPeriods" to it.evaluationPeriods,
-            "period" to it.period.seconds,
-            "threshold" to it.threshold,
-            "namespace" to it.namespace,
-            "metricName" to it.metricName,
-            "statistic" to it.statistic
-          ),
-          "step" to mapOf(
-            "estimatedInstanceWarmup" to it.warmup.seconds,
-            "metricAggregationType" to it.metricAggregationType,
-            "stepAdjustments" to it.stepAdjustments.map { adjustment ->
-              StepAdjustmentModel(
-                metricIntervalLowerBound = adjustment.lowerBound,
-                metricIntervalUpperBound = adjustment.upperBound,
-                scalingAdjustment = adjustment.scalingAdjustment
-              )
-            }
-          )
+          "actionsEnabled" to it.actionsEnabled,
+          "comparisonOperator" to it.comparisonOperator,
+          "dimensions" to it.dimensions,
+          "evaluationPeriods" to it.evaluationPeriods,
+          "period" to it.period.seconds,
+          "threshold" to it.threshold,
+          "namespace" to it.namespace,
+          "metricName" to it.metricName,
+          "statistic" to it.statistic
+        ),
+        "step" to mapOf(
+          "estimatedInstanceWarmup" to it.warmup.seconds,
+          "metricAggregationType" to it.metricAggregationType,
+          "stepAdjustments" to it.stepAdjustments.map { adjustment ->
+            StepAdjustmentModel(
+              metricIntervalLowerBound = adjustment.lowerBound,
+              metricIntervalUpperBound = adjustment.upperBound,
+              scalingAdjustment = adjustment.scalingAdjustment
+            )
+          }
         )
-      }
+      )
     }
+  }
 
   private suspend fun CloudDriverService.getActiveServerGroups(resource: Resource<ClusterSpec>): Iterable<ServerGroup> {
     val existingServerGroups: Map<String, List<ClouddriverServerGroup>> = getExistingServerGroupsByRegion(resource)
@@ -922,7 +915,7 @@ class ClusterHandler(
 
     val allSame: Boolean = activeServerGroups.distinctBy { it.launchConfiguration.appVersion }.size == 1
     val unhealthyRegions = mutableListOf<String>()
-    activeServerGroups.forEach {serverGroup ->
+    activeServerGroups.forEach { serverGroup ->
       if (serverGroup.instanceCounts?.isHealthy(resource.spec.deployWith.health, resource.spec.resolveCapacity(serverGroup.location.region)) == false) {
         unhealthyRegions.add(serverGroup.location.region)
       }
@@ -999,7 +992,7 @@ class ClusterHandler(
   /**
    * Transforms CloudDriver response to our server group model.
    */
-  private fun ActiveServerGroup.toServerGroup() : ServerGroup {
+  private fun ActiveServerGroup.toServerGroup(): ServerGroup {
     val launchTemplateData = launchTemplate?.launchTemplateData
     return ServerGroup(
       name = name,
@@ -1011,19 +1004,20 @@ class ClusterHandler(
         availabilityZones = zones
       ),
       launchConfiguration =
-        LaunchConfiguration(
-          imageId = image.imageId,
-          appVersion = image.appVersion,
-          baseImageVersion = image.baseImageVersion,
-          instanceType = launchConfig?.instanceType ?: launchTemplateData!!.instanceType,
-          ebsOptimized = launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized,
-          iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,
-          keyPair = launchConfig?.keyName ?: launchTemplateData!!.keyName,
-          instanceMonitoring = launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled,
+      LaunchConfiguration(
+        imageId = image.imageId,
+        appVersion = image.appVersion,
+        baseImageVersion = image.baseImageVersion,
+        instanceType = launchConfig?.instanceType ?: launchTemplateData!!.instanceType,
+        ebsOptimized = launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized,
+        iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,
+        keyPair = launchConfig?.keyName ?: launchTemplateData!!.keyName,
+        instanceMonitoring = launchConfig?.instanceMonitoring?.enabled
+          ?: launchTemplateData!!.monitoring.enabled,
 
-          // Because launchConfig.ramdiskId can be null, need to do launchTemplateData?. instead of launchTemplateData!!
-          ramdiskId = (launchConfig?.ramdiskId ?: launchTemplateData?.ramDiskId).orNull()
-        ),
+        // Because launchConfig.ramdiskId can be null, need to do launchTemplateData?. instead of launchTemplateData!!
+        ramdiskId = (launchConfig?.ramdiskId ?: launchTemplateData?.ramDiskId).orNull()
+      ),
       buildInfo = buildInfo?.toEc2Api(),
       capacity = capacity.let {
         when (scalingPolicies.isEmpty()) {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -102,7 +102,7 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
     context("need to launch canaries in two regions") {
       before {
         coEvery {
-          imageService.getLatestNamedImageForAppVersionInRegion(any(), any(), any())
+          imageService.getLatestNamedImage(any(), any(), any())
         } returns NamedImage(
             imageName = "fnord-42.0.0-h42",
             attributes = emptyMap(),
@@ -158,8 +158,8 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
         }
 
         coVerify(exactly = 1) {
-          imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName(version), "test", "us-west-1")
-          imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName(version), "test", "us-west-2")
+          imageService.getLatestNamedImage(AppVersion.parseName(version), "test", "us-west-1")
+          imageService.getLatestNamedImage(AppVersion.parseName(version), "test", "us-west-2")
           cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-1", any())
           cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-2", any())
         }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -34,8 +34,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
-import java.time.Clock
-import java.time.Duration
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.containsExactlyInAnyOrder
@@ -43,6 +41,8 @@ import strikt.assertions.getValue
 import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
+import java.time.Clock
+import java.time.Duration
 
 internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
 
@@ -103,7 +103,13 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
       before {
         coEvery {
           imageService.getLatestNamedImageWithAllRegionsForAppVersion(any(), any(), any())
-        } returns NamedImage("fnord-42.0.0-h42", emptyMap(), emptyMap(), emptySet(), emptyMap())
+        } returns listOf(NamedImage(
+          imageName = "fnord-42.0.0-h42",
+          attributes = emptyMap(),
+          tagsByImageId = emptyMap(),
+          accounts = emptySet(),
+          amis = mapOf("us-west-1" to listOf("ami-001"), "us-west-2" to listOf("ami-002"))
+        ))
 
         coEvery {
           cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-1", any())

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -102,14 +102,14 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
     context("need to launch canaries in two regions") {
       before {
         coEvery {
-          imageService.getLatestNamedImageWithAllRegionsForAppVersion(any(), any(), any())
-        } returns listOf(NamedImage(
-          imageName = "fnord-42.0.0-h42",
-          attributes = emptyMap(),
-          tagsByImageId = emptyMap(),
-          accounts = emptySet(),
-          amis = mapOf("us-west-1" to listOf("ami-001"), "us-west-2" to listOf("ami-002"))
-        ))
+          imageService.getLatestNamedImageForAppVersionInRegion(any(), any(), any())
+        } returns NamedImage(
+            imageName = "fnord-42.0.0-h42",
+            attributes = emptyMap(),
+            tagsByImageId = emptyMap(),
+            accounts = emptySet(),
+            amis = mapOf("us-west-1" to listOf("ami-001"), "us-west-2" to listOf("ami-002"))
+          )
 
         coEvery {
           cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-1", any())
@@ -158,7 +158,8 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
         }
 
         coVerify(exactly = 1) {
-          imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName(version), "test", any())
+          imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName(version), "test", "us-west-1")
+          imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName(version), "test", "us-west-2")
           cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-1", any())
           cloudDriverService.activeServerGroup(any(), any(), any(), any(), "us-west-2", any())
         }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.coEvery as every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectCatching
@@ -36,6 +35,7 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isNotNull
 import strikt.assertions.propertiesAreEqualTo
+import io.mockk.coEvery as every
 
 internal class ImageResolverTests : JUnit5Minutests {
 
@@ -181,6 +181,8 @@ internal class ImageResolverTests : JUnit5Minutests {
               imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
+                ?.let { listOf(it) }
+                ?: emptyList()
             }
           }
 
@@ -211,7 +213,7 @@ internal class ImageResolverTests : JUnit5Minutests {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
               imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
-            } returns null
+            } returns emptyList()
           }
 
           test("throws an exception") {
@@ -238,6 +240,8 @@ internal class ImageResolverTests : JUnit5Minutests {
               imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
+                ?.let { listOf(it) }
+                ?: emptyList()
             }
           }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -178,11 +178,9 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
+              imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
-                ?.let { listOf(it) }
-                ?: emptyList()
             }
           }
 
@@ -212,8 +210,8 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
-            } returns emptyList()
+              imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
+            } returns null
           }
 
           test("throws an exception") {
@@ -237,11 +235,13 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImageWithAllRegionsForAppVersion(AppVersion.parseName("${artifact.name}-$version2"), any(), listOf(resourceRegion))
+              imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName("${artifact.name}-$version2"), any(), any())
             } answers {
-              images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
-                ?.let { listOf(it) }
-                ?: emptyList()
+              if (thirdArg<String>() == imageRegion) {
+                images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
+              } else {
+                null
+              }
             }
           }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -178,7 +178,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
+              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
             }
@@ -210,7 +210,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
+              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
             } returns null
           }
 
@@ -235,7 +235,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImageForAppVersionInRegion(AppVersion.parseName("${artifact.name}-$version2"), any(), any())
+              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), any())
             } answers {
               if (thirdArg<String>() == imageRegion) {
                 images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }


### PR DESCRIPTION
Keel has always only supported deploying a single "named image" to a cluster. However, there are situations where the correct app version may have different image names in each region. e.g.

* Bakery retries one region
* Multiple bakes happen targeting different individual regions

In this case we can fail to ever resolve the AMI because we only look at the latest image with a matching app version tag.

This led to an issue where a managed cluster in one region existed side-by-side with a pipeline deployed cluster in another.
Keel launched a bake, which succeeded, and it started deploying the cluster.
Meanwhile, the pipeline-initiated bake completed and the image it created was in the "wrong" region for the managed cluster.
Keel was no longer able to resolve the desired state of the cluster, resulting in errors.
Additionally, if anything in the cluster definition had changed, no update would have taken place because the AMI could no longer be found.

This PR allows for an app version to be split across multiple AMIs in different regions.