### PR TITLE
chore(monitoring): Enable New Relic tracing in select methods

### DIFF
--- a/keel-core/keel-core.gradle.kts
+++ b/keel-core/keel-core.gradle.kts
@@ -37,9 +37,9 @@ dependencies {
   api("com.github.ben-manes.caffeine:caffeine")
 
   implementation("org.springframework:spring-tx")
-
   implementation ("io.github.resilience4j:resilience4j-kotlin")
   implementation ("io.github.resilience4j:resilience4j-retry")
+  implementation("com.newrelic.agent.java:newrelic-api:6.1.0")
 
   testImplementation(project(":keel-test"))
   testImplementation(project(":keel-core-test"))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactVersionApproved
+import com.newrelic.api.agent.Trace
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
@@ -22,6 +23,7 @@ class EnvironmentPromotionChecker(
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
+  @Trace(dispatcher=true)
   suspend fun checkEnvironments(deliveryConfig: DeliveryConfig) {
     val pinnedEnvs: Map<String, PinnedEnvironment> = repository
       .pinnedEnvironments(deliveryConfig)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -39,6 +39,7 @@ import com.netflix.spinnaker.keel.veto.VetoResponse
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.exceptions.UserException
+import com.newrelic.api.agent.Trace
 import kotlinx.coroutines.async
 import kotlinx.coroutines.supervisorScope
 import org.slf4j.LoggerFactory
@@ -75,6 +76,7 @@ class ResourceActuator(
   private val diffNotActionableEnabled: Boolean
     get() = springEnv.getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, false)
 
+  @Trace(dispatcher=true)
   suspend fun <T : ResourceSpec> checkResource(resource: Resource<T>) {
     withTracingContext(resource) {
       val id = resource.id


### PR DESCRIPTION
Annotates `ResourceActuator.checkResource` and `EnvironmentPromotionChecker.checkEnvironments` so that New Relic will record traces for them (which doesn't happen by default for Kotlin suspend functions).

This won't have any practical effects in any environment where the New Relic agent is not actually running.

Reference: https://docs.newrelic.com/docs/agents/java-agent/api-guides/java-agent-api-instrument-using-annotation