### PR TITLE
Fix missing discriminator for instance provider

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/InstanceProvider.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/InstanceProvider.kt
@@ -1,9 +1,12 @@
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.netflix.spinnaker.keel.api.schema.Discriminator
+
 /**
  * Extensible mechanism allowing for abstraction of details of the VM instance (e.g.
  * [LaunchConfigurationSpec.instanceType], [LaunchConfigurationSpec.ebsOptimized], etc.)
  */
 interface InstanceProvider {
+  @Discriminator
   val type: String
 }


### PR DESCRIPTION
The instance profiles plugin needs this