### PR TITLE
fix(api): Convert crazy Slack markdown syntax

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/CommitMessageSerializer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/CommitMessageSerializer.kt
@@ -1,0 +1,17 @@
+package com.netflix.spinnaker.keel.jackson
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.SerializerProvider
+import com.fasterxml.jackson.databind.ser.std.StdSerializer
+
+internal object CommitMessageSerializer : StdSerializer<String>(String::class.java) {
+  private val SLACK_LINK_REGEX = Regex("<(http.+)\\|(.+)>")
+
+  override fun serialize(value: String, gen: JsonGenerator, provider: SerializerProvider) {
+    gen.writeString(
+      SLACK_LINK_REGEX.replace(value) { match ->
+       "[${match.groups[2]?.value}](${match.groups[1]?.value})"
+      }
+    )
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
@@ -28,12 +28,14 @@ import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
 import com.netflix.spinnaker.keel.api.artifacts.VersioningStrategy
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStateAttributes
 import com.netflix.spinnaker.keel.jackson.mixins.ClusterDeployStrategyMixin
+import com.netflix.spinnaker.keel.jackson.mixins.CommitMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ConstraintStateMixin
 import com.netflix.spinnaker.keel.jackson.mixins.DeliveryArtifactMixin
 import com.netflix.spinnaker.keel.jackson.mixins.LocatableMixin
@@ -63,6 +65,7 @@ object KeelApiModule : SimpleModule("Keel API") {
       setMixInAnnotations<SubnetAwareRegionSpec, SubnetAwareRegionSpecMixin>()
       setMixInAnnotations<Resource<*>, ResourceMixin>()
       setMixInAnnotations<ResourceSpec, ResourceSpecMixin>()
+      setMixInAnnotations<Commit, CommitMixin>()
       insertAnnotationIntrospector(FactoryAnnotationIntrospector())
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/CommitMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/CommitMixin.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.jackson.mixins
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.netflix.spinnaker.keel.jackson.CommitMessageSerializer
+
+internal interface CommitMixin {
+  @get:JsonSerialize(using = CommitMessageSerializer::class)
+  val message: String?
+}


### PR DESCRIPTION
We've been using Slack markdown syntax for hyperlinks in commit messages because they render nicely in Slack, but not so much in the UI. This PR converts the link syntax so that it will render OK in the UI. 

Note: depends on a UI update to run the commit message text through the markdown parser.

Cc: @erikmunson 