### PR TITLE
chore(frigga): handle frigga exceptions gracefully

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -14,7 +14,6 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedVersioningStrategy
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.services.ArtifactMetadataService
-import org.apache.logging.log4j.util.Strings
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
@@ -63,48 +62,45 @@ class DebianArtifactSupplier(
 
   override fun getVersionDisplayName(artifact: PublishedArtifact): String {
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    return try {
-      val appversion = AppVersion.parseName(artifact.version)
-      if (appversion?.version != null) {
+    val appversion = parseName(artifact)
+    if (appversion != null) {
+      if (appversion.version != null) {
         return appversion.version
       } else {
         return artifact.version.removePrefix("${artifact.name}-")
       }
-    } catch (ex: Exception) {
-      log.warn("trying to parse artifact ${artifact.name} with version ${artifact.version} but got an exception", ex)
-      Strings.EMPTY
     }
+    return artifact.version
   }
 
   override fun parseDefaultBuildMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): BuildMetadata? {
     // attempt to parse helpful info from the appversion.
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    return try {
-      val appversion = AppVersion.parseName(artifact.version)
+      val appversion = parseName(artifact)
       if (appversion?.buildNumber != null) {
         return BuildMetadata(id = appversion.buildNumber.toInt())
       }
-      null
-    } catch (ex: Exception) {
-      log.warn("trying to parse build metadata for artifact ${artifact.name} with version ${artifact.version} but got an exception", ex)
-      null
-    }
+      return null
+
   }
 
   override fun parseDefaultGitMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): GitMetadata? {
     // attempt to parse helpful info from the appversion.
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    return try {
-      val appversion = AppVersion.parseName(artifact.version)
+      val appversion = parseName(artifact)
       if (appversion?.commit != null) {
         return GitMetadata(commit = appversion.commit)
       }
-      null
+      return null
+  }
+
+  private fun parseName(artifact: PublishedArtifact): AppVersion? =
+    try {
+      AppVersion.parseName(artifact.version)
     } catch (ex: Exception) {
-      log.warn("trying to parse git metadata for artifact ${artifact.name} with version ${artifact.version} but got an exception", ex)
+      log.warn("trying to parse artifact ${artifact.name} with version ${artifact.version} but got an exception", ex)
       null
     }
-  }
 
 
   // Debian Artifacts should contain a releaseStatus in the metadata

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -79,9 +79,9 @@ class DebianArtifactSupplier(
     return try {
       val appversion = AppVersion.parseName(artifact.version)
       if (appversion?.buildNumber != null) {
-        BuildMetadata(id = appversion.buildNumber.toInt())
+        return BuildMetadata(id = appversion.buildNumber.toInt())
       }
-      null
+      return null
     } catch (ex: NumberFormatException) {
       log.warn("parsed appversion.buildNumber for artifact version ${artifact.version} is not a number! ")
       null

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -76,22 +76,29 @@ class DebianArtifactSupplier(
   override fun parseDefaultBuildMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): BuildMetadata? {
     // attempt to parse helpful info from the appversion.
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-      val appversion = parseName(artifact)
+    return try {
+      val appversion = AppVersion.parseName(artifact.version)
       if (appversion?.buildNumber != null) {
-        return BuildMetadata(id = appversion.buildNumber.toInt())
+        BuildMetadata(id = appversion.buildNumber.toInt())
       }
-      return null
-
+      null
+    } catch (ex: NumberFormatException) {
+      log.warn("parsed appversion.buildNumber for artifact version ${artifact.version} is not a number! ")
+      null
+    } catch (ex: Exception) {
+      log.warn("trying to parse artifact ${artifact.name} with version ${artifact.version} but got an exception", ex)
+      null
+    }
   }
 
   override fun parseDefaultGitMetadata(artifact: PublishedArtifact, versioningStrategy: VersioningStrategy): GitMetadata? {
     // attempt to parse helpful info from the appversion.
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-      val appversion = parseName(artifact)
-      if (appversion?.commit != null) {
-        return GitMetadata(commit = appversion.commit)
-      }
-      return null
+    val appversion = parseName(artifact)
+    if (appversion?.commit != null) {
+      return GitMetadata(commit = appversion.commit)
+    }
+    return null
   }
 
   private fun parseName(artifact: PublishedArtifact): AppVersion? =

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
@@ -25,6 +25,7 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNull
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
 
@@ -46,6 +47,14 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
       type = debianArtifact.type,
       reference = debianArtifact.reference,
       version = "${debianArtifact.name}-${versions.last()}",
+      metadata = mapOf("releaseStatus" to SNAPSHOT, "buildNumber" to "1", "commitId" to "a15p0")
+    )
+
+    val artifactWithInvalidVersion = PublishedArtifact(
+      name = debianArtifact.name,
+      type = debianArtifact.type,
+      reference = debianArtifact.reference,
+      version = "etcd-3.4.10-hlocal.856d0b1",
       metadata = mapOf("releaseStatus" to SNAPSHOT, "buildNumber" to "1", "commitId" to "a15p0")
     )
 
@@ -136,6 +145,11 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
         val buildMeta = BuildMetadata(id = AppVersion.parseName(latestArtifact.version)!!.buildNumber.toInt())
         expectThat(debianArtifactSupplier.parseDefaultBuildMetadata(latestArtifact, debianArtifact.versioningStrategy))
           .isEqualTo(buildMeta)
+      }
+
+      test("frigga parser can't parse this version") {
+        expectThat(debianArtifactSupplier.parseDefaultBuildMetadata(artifactWithInvalidVersion, debianArtifact.versioningStrategy))
+          .isNull()
       }
 
       test("returns artifact metadata based on ci provider") {

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -126,8 +126,7 @@ class ImageHandler(
     val appVersion = try {
       AppVersion.parseName(desiredVersion)
     } catch (ex: Exception) {
-      log.error("trying to parse desired version for artifact ${artifact.name} with version $desiredVersion but got an exception", ex)
-      throw SystemException("Invalid for artifact ${artifact.name} with version $desiredVersion")
+      throw SystemException("trying to parse desired version for artifact ${artifact.name} with version $desiredVersion but got an exception", ex)
     }
     val packageName = appVersion.packageName
     val version = desiredVersion.substringAfter("$packageName-")

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.clouddriver.model.hasAppVersion
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import com.netflix.spinnaker.kork.exceptions.SystemException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -75,7 +76,12 @@ class ImageService(
       .sortedWith(NamedImageComparator)
       .firstOrNull {
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-        AppVersion.parseName(it.appVersion).packageName == packageName
+        try {
+          AppVersion.parseName(it.appVersion).packageName == packageName
+        } catch (ex: Exception) {
+          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
+          throw SystemException("Invalid for version ${it.appVersion}")
+        }
       }
 
   /**
@@ -95,8 +101,13 @@ class ImageService(
       .sortedWith(NamedImageComparator)
       .firstOrNull {
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-        AppVersion.parseName(it.appVersion).run {
-          packageName == appVersion.packageName && version == appVersion.version && commit == appVersion.commit
+        try {
+          AppVersion.parseName(it.appVersion).run {
+            packageName == appVersion.packageName && version == appVersion.version && commit == appVersion.commit
+          }
+        } catch (ex: Exception) {
+          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
+          throw SystemException("Invalid for version ${it.appVersion}")
         }
       }
 
@@ -114,7 +125,12 @@ class ImageService(
       .sortedWith(NamedImageComparator)
       .find { namedImage ->
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-        val curAppVersion = AppVersion.parseName(namedImage.appVersion)
+        val curAppVersion = try {
+          AppVersion.parseName(namedImage.appVersion)
+        } catch (ex: Exception) {
+          log.error("trying to parse name for image ${namedImage.imageName} with version ${namedImage.appVersion} but got an exception", ex)
+          throw SystemException("Invalid app version for image ${namedImage.imageName} with version ${namedImage.appVersion}")
+        }
         curAppVersion.packageName == appVersion.packageName &&
           curAppVersion.version == appVersion.version &&
           curAppVersion.commit == appVersion.commit &&
@@ -143,7 +159,12 @@ class ImageService(
       .find {
         val errors = mutableListOf<String>()
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-        val curAppVersion = AppVersion.parseName(it.appVersion)
+        val curAppVersion = try {
+          AppVersion.parseName(it.appVersion)
+        } catch (ex: Exception) {
+          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
+          throw SystemException("Invalid for version ${it.appVersion}")
+        }
         if (curAppVersion.packageName != packageName) {
           errors.add("[package name ${curAppVersion.packageName} does not match required package]")
         }
@@ -178,7 +199,12 @@ class ImageService(
       .sortedWith(NamedImageComparator)
       .filter {
         // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-        AppVersion.parseName(it.appVersion).packageName == packageName
+        try {
+          AppVersion.parseName(it.appVersion).packageName == packageName
+        } catch (ex: Exception) {
+          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
+          throw SystemException("Invalid for version ${it.appVersion}")
+        }
       }
       .firstOrNull { namedImage ->
         val allTags = getAllTags(namedImage)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -79,8 +79,7 @@ class ImageService(
         try {
           AppVersion.parseName(it.appVersion).packageName == packageName
         } catch (ex: Exception) {
-          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
-          throw SystemException("Invalid for version ${it.appVersion}")
+          throw SystemException("trying to parse name for version ${it.appVersion} but got an exception", ex)
         }
       }
 
@@ -106,8 +105,7 @@ class ImageService(
             packageName == appVersion.packageName && version == appVersion.version && commit == appVersion.commit
           }
         } catch (ex: Exception) {
-          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
-          throw SystemException("Invalid for version ${it.appVersion}")
+          throw SystemException("trying to parse name for version ${it.appVersion} but got an exception", ex)
         }
       }
 
@@ -128,8 +126,7 @@ class ImageService(
         val curAppVersion = try {
           AppVersion.parseName(namedImage.appVersion)
         } catch (ex: Exception) {
-          log.error("trying to parse name for image ${namedImage.imageName} with version ${namedImage.appVersion} but got an exception", ex)
-          throw SystemException("Invalid app version for image ${namedImage.imageName} with version ${namedImage.appVersion}")
+          throw SystemException("trying to parse name for image ${namedImage.imageName} with version ${namedImage.appVersion} but got an exception", ex)
         }
         curAppVersion.packageName == appVersion.packageName &&
           curAppVersion.version == appVersion.version &&
@@ -162,8 +159,7 @@ class ImageService(
         val curAppVersion = try {
           AppVersion.parseName(it.appVersion)
         } catch (ex: Exception) {
-          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
-          throw SystemException("Invalid for version ${it.appVersion}")
+          throw SystemException("trying to parse name for version ${it.appVersion} but got an exception", ex)
         }
         if (curAppVersion.packageName != packageName) {
           errors.add("[package name ${curAppVersion.packageName} does not match required package]")
@@ -202,8 +198,7 @@ class ImageService(
         try {
           AppVersion.parseName(it.appVersion).packageName == packageName
         } catch (ex: Exception) {
-          log.error("trying to parse name for version ${it.appVersion} but got an exception", ex)
-          throw SystemException("Invalid for version ${it.appVersion}")
+          throw SystemException("trying to parse name for version ${it.appVersion} but got an exception", ex)
         }
       }
       .firstOrNull { namedImage ->

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -59,8 +59,7 @@ class Ec2CanaryConstraintDeployHandler(
       appVersion = try {
         AppVersion.parseName(version.replace("~", "_"))
       } catch (ex: Exception) {
-        log.error("trying to parse name for version $version but got an exception", ex)
-        throw SystemException("Invalid for version $version")
+        throw SystemException("trying to parse name for version $version but got an exception", ex)
       },
       account = imageResolver.defaultImageAccount,
       regions = constraint.regions.toList()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoMatchingArtifactException
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.exceptions.SystemException
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -89,7 +90,12 @@ class ImageResolver(
     ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
     val image = imageService.getLatestNamedImageWithAllRegionsForAppVersion(
       // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-      appVersion = AppVersion.parseName(artifactVersion),
+      appVersion = try {
+        AppVersion.parseName(artifactVersion)
+      } catch (ex: Exception) {
+        log.error("trying to parse name for version $artifactVersion but got an exception", ex)
+        throw SystemException("Invalid for version $artifactVersion")
+      },
       account = account,
       regions = regions
     ) ?: throw NoImageFoundForRegions(artifactVersion, regions)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -93,8 +93,7 @@ class ImageResolver(
       appVersion = try {
         AppVersion.parseName(artifactVersion)
       } catch (ex: Exception) {
-        log.error("trying to parse name for version $artifactVersion but got an exception", ex)
-        throw SystemException("Invalid for version $artifactVersion")
+        throw SystemException("trying to parse name for version $artifactVersion but got an exception", ex)
       },
       account = account,
       regions = regions

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -79,6 +79,7 @@ import com.netflix.spinnaker.keel.orca.waitStage
 import com.netflix.spinnaker.keel.plugin.buildSpecFromDiff
 import com.netflix.spinnaker.keel.retrofit.isNotFound
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.kork.exceptions.SystemException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -433,7 +434,12 @@ class ClusterHandler(
     ) ?: RedBlack()
 
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val appversion = AppVersion.parseName(base.image?.appVersion).packageName
+    val appversion = try {
+      AppVersion.parseName(base.image?.appVersion).packageName
+    } catch (ex: Exception) {
+      log.error("trying to parse name for image ${base.image?.name} with version ${base.image?.appVersion} but got an exception", ex)
+      throw SystemException("Invalid for image ${base.image?.name} with version ${base.image?.appVersion}")
+    }
 
     val spec = ClusterSpec(
       moniker = exportable.moniker,
@@ -482,7 +488,12 @@ class ClusterHandler(
     }
 
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val artifactName = AppVersion.parseName(base.launchConfiguration.appVersion).packageName
+    val artifactName = try {
+      AppVersion.parseName(base.launchConfiguration.appVersion).packageName
+    } catch (ex: Exception) {
+      log.error("trying to parse name for configuration ${base.launchConfiguration} with version ${base.launchConfiguration.appVersion} but got an exception", ex)
+      throw SystemException("Invalid for configuration ${base.launchConfiguration} with version ${base.launchConfiguration.appVersion}")
+    }
 
     val status = debianArtifactParser.parseStatus(base.launchConfiguration.appVersion?.substringAfter("$artifactName-"))
     if (status == UNKNOWN) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -437,8 +437,7 @@ class ClusterHandler(
     val appversion = try {
       AppVersion.parseName(base.image?.appVersion).packageName
     } catch (ex: Exception) {
-      log.error("trying to parse name for image ${base.image?.name} with version ${base.image?.appVersion} but got an exception", ex)
-      throw SystemException("Invalid for image ${base.image?.name} with version ${base.image?.appVersion}")
+      throw SystemException("trying to parse name for image ${base.image?.name} with version ${base.image?.appVersion} but got an exception", ex)
     }
 
     val spec = ClusterSpec(
@@ -491,8 +490,7 @@ class ClusterHandler(
     val artifactName = try {
       AppVersion.parseName(base.launchConfiguration.appVersion).packageName
     } catch (ex: Exception) {
-      log.error("trying to parse name for configuration ${base.launchConfiguration} with version ${base.launchConfiguration.appVersion} but got an exception", ex)
-      throw SystemException("Invalid for configuration ${base.launchConfiguration} with version ${base.launchConfiguration.appVersion}")
+      throw SystemException("trying to parse name for configuration ${base.launchConfiguration} with version ${base.launchConfiguration.appVersion} but got an exception", ex)
     }
 
     val status = debianArtifactParser.parseStatus(base.launchConfiguration.appVersion?.substringAfter("$artifactName-"))


### PR DESCRIPTION
This PR is wrapping all calls to Frigga to parse a version with try/catch, adding logs around it, and throw `systemException` if needed.