### PR TITLE
feature(ec2): Add support for launch templates, take 2

### DIFF
--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
@@ -1,0 +1,200 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.kork.exceptions.SystemException
+import dev.minutest.ContextBuilder
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+import strikt.assertions.isSuccess
+
+
+/**
+ * Use ContextBuilder so we can use the same test assertions when constructing both ActiveServerGroup and
+ * ServerGroup objects
+ */
+
+fun<T : BaseEc2ServerGroup> ContextBuilder<FixtureMaker<T>>.checkServerGroupConstructorBehavior() {
+  context("constructing subclasses of BaseEc2ServerGroup") {
+
+    test("when neither launch config nor launch template specified, throw an exception") {
+      expectCatching { make(launchConfig = null, launchTemplate = null) }
+        .isFailure()
+        .isA<SystemException>()
+    }
+
+    test("when launch config specified, don't throw an exception") {
+      expectCatching {
+        make(launchConfig = LaunchConfig(
+          ramdiskId = null,
+          ebsOptimized = true,
+          imageId = "image",
+          instanceType = "t2.micro",
+          keyName = "mykey",
+          iamInstanceProfile = "profile",
+          instanceMonitoring = InstanceMonitoring(enabled = true)
+        ))
+      }.isSuccess()
+    }
+
+    test("when launch template specified, don't throw an exception") {
+      expectCatching {
+        make(launchTemplate = LaunchTemplate(
+          launchTemplateData = LaunchTemplateData(
+            ramDiskId = null,
+            ebsOptimized = true,
+            imageId = "image",
+            instanceType = "t2.micro",
+            keyName = "mykey",
+            iamInstanceProfile = IamInstanceProfile(name = "profile"),
+            monitoring = InstanceMonitoring(enabled = true)
+          )))
+      }.isSuccess()
+    }
+  }
+}
+
+
+class ActiveServerGroupTests : JUnit5Minutests {
+  fun tests() = rootContext<FixtureMaker<ActiveServerGroup>> {
+    fixture { ActiveServerGroupFixtureMaker() } // makes ActiveServerGroup fixtures
+
+    checkServerGroupConstructorBehavior()
+  }
+}
+
+class ServerGroupTests : JUnit5Minutests {
+  fun tests() = rootContext<FixtureMaker<ServerGroup>> {
+    fixture { ServerGroupFixtureMaker() } // makes ServerGroup fixtures
+
+    checkServerGroupConstructorBehavior()
+  }
+}
+
+
+// Code to instantiate fixture objects
+
+
+interface FixtureMaker<T : BaseEc2ServerGroup> {
+  fun make(launchConfig: LaunchConfig? = null, launchTemplate: LaunchTemplate? = null) : T
+}
+
+class ActiveServerGroupFixtureMaker : FixtureMaker<ActiveServerGroup> {
+  override fun make(launchConfig: LaunchConfig?, launchTemplate: LaunchTemplate?) =
+    ActiveServerGroup(
+      launchConfig = launchConfig,
+      launchTemplate = launchTemplate,
+
+      // unused boilerplate data
+      name = "fnord",
+      region = "us-east-1",
+      zones = setOf("us-east-1c"),
+      image = ActiveServerGroupImage(
+        imageId = "image",
+        appVersion = null,
+        baseImageVersion = null,
+        name = "name",
+        imageLocation = "somewhere",
+        description = null
+      ),
+      asg = AutoScalingGroup(
+        autoScalingGroupName = "asgName",
+        defaultCooldown = 0,
+        healthCheckType = "known",
+        healthCheckGracePeriod = 0,
+        suspendedProcesses = emptySet(),
+        enabledMetrics = emptySet(),
+        tags = emptySet(),
+        terminationPolicies = emptySet(),
+        vpczoneIdentifier = "vpc-zone"
+      ),
+      scalingPolicies = emptyList(),
+      vpcId = "vpcId",
+      targetGroups = emptySet(),
+      loadBalancers = emptySet(),
+      capacity = Capacity(
+        min = 1,
+        max = 1,
+        desired = 1
+      ),
+      cloudProvider = "aws",
+      securityGroups = emptySet(),
+      accountName = "test",
+      moniker = Moniker(
+        app = "fnord",
+        stack = null,
+        detail = null,
+        sequence = 1
+      ),
+      instanceCounts = InstanceCounts (
+        total = 1,
+        up = 1,
+        down = 0,
+        unknown = 0,
+        outOfService = 0,
+        starting = 0
+      ),
+      createdTime = 0
+    )
+}
+
+class ServerGroupFixtureMaker: FixtureMaker<ServerGroup> {
+  override fun make(launchConfig: LaunchConfig?, launchTemplate: LaunchTemplate?) =
+    ServerGroup(
+      launchConfig = launchConfig,
+      launchTemplate = launchTemplate,
+
+      // unused boilerplate data
+      disabled = false,
+      name = "fnord",
+      region = "us-east-1",
+      zones = setOf("us-east-1c"),
+      image = ActiveServerGroupImage(
+        imageId = "image",
+        appVersion = null,
+        baseImageVersion = null,
+        name = "name",
+        imageLocation = "somewhere",
+        description = null
+      ),
+      asg = AutoScalingGroup(
+        autoScalingGroupName = "asgName",
+        defaultCooldown = 0,
+        healthCheckType = "known",
+        healthCheckGracePeriod = 0,
+        suspendedProcesses = emptySet(),
+        enabledMetrics = emptySet(),
+        tags = emptySet(),
+        terminationPolicies = emptySet(),
+        vpczoneIdentifier = "vpc-zone"
+      ),
+      scalingPolicies = emptyList(),
+      vpcId = "vpcId",
+      targetGroups = emptySet(),
+      loadBalancers = emptySet(),
+      capacity = Capacity(
+        min = 1,
+        max = 1,
+        desired = 1
+      ),
+      cloudProvider = "aws",
+      securityGroups = emptySet(),
+      moniker = Moniker(
+        app = "fnord",
+        stack = null,
+        detail = null,
+        sequence = 1
+      ),
+      instanceCounts = InstanceCounts (
+        total = 1,
+        up = 1,
+        down = 0,
+        unknown = 0,
+        outOfService = 0,
+        starting = 0
+      ),
+      createdTime = 0
+    )
+}

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -26,4 +26,5 @@ dependencies {
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   testImplementation("org.funktionale:funktionale-partials")
   testImplementation("org.apache.commons:commons-lang3")
+  testImplementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/constraints/Ec2CanaryConstraintDeployHandler.kt
@@ -139,6 +139,7 @@ class Ec2CanaryConstraintDeployHandler(
     image: String
   ): Map<String, Any?> {
     val moniker = parseMoniker(name)
+    val launchTemplateData = launchTemplate?.launchTemplateData
     return mutableMapOf(
       "application" to moniker.app,
       "stack" to moniker.stack,
@@ -149,13 +150,13 @@ class Ec2CanaryConstraintDeployHandler(
       "amiName" to image,
       "availabilityZones" to mapOf(region to zones),
       "capacity" to Capacity(capacity, capacity, capacity),
-      "ebsOptimized" to launchConfig.ebsOptimized,
+      "ebsOptimized" to (launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized),
       "healthCheckGracePeriod" to asg.healthCheckGracePeriod,
       "healthCheckType" to asg.healthCheckType,
-      "iamRole" to launchConfig.iamInstanceProfile,
-      "instanceMonitoring" to launchConfig.instanceMonitoring.enabled,
-      "instanceType" to launchConfig.instanceType,
-      "keyPair" to launchConfig.keyName,
+      "iamRole" to (launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name),
+      "instanceMonitoring" to (launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled),
+      "instanceType" to (launchConfig?.instanceType ?: launchTemplateData!!.instanceType),
+      "keyPair" to (launchConfig?.keyName ?: launchTemplateData!!.keyName),
       "loadBalancers" to loadBalancers,
       "targetGroups" to targetGroups,
       "securityGroups" to securityGroups,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -990,8 +990,9 @@ class ClusterHandler(
   /**
    * Transforms CloudDriver response to our server group model.
    */
-  private fun ActiveServerGroup.toServerGroup() =
-    ServerGroup(
+  private fun ActiveServerGroup.toServerGroup() : ServerGroup {
+    val launchTemplateData = launchTemplate?.launchTemplateData
+    return ServerGroup(
       name = name,
       location = Location(
         account = accountName,
@@ -1000,19 +1001,20 @@ class ClusterHandler(
         subnet = subnet(cloudDriverCache),
         availabilityZones = zones
       ),
-      launchConfiguration = launchConfig.run {
+      launchConfiguration =
         LaunchConfiguration(
-          imageId = imageId,
+          imageId = image.imageId,
           appVersion = image.appVersion,
           baseImageVersion = image.baseImageVersion,
-          instanceType = instanceType,
-          ebsOptimized = ebsOptimized,
-          iamRole = iamInstanceProfile,
-          keyPair = keyName,
-          instanceMonitoring = instanceMonitoring.enabled,
-          ramdiskId = ramdiskId.orNull()
-        )
-      },
+          instanceType = launchConfig?.instanceType ?: launchTemplateData!!.instanceType,
+          ebsOptimized = launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized,
+          iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,
+          keyPair = launchConfig?.keyName ?: launchTemplateData!!.keyName,
+          instanceMonitoring = launchConfig?.instanceMonitoring?.enabled ?: launchTemplateData!!.monitoring.enabled,
+
+          // Because launchConfig.ramdiskId can be null, need to do launchTemplateData?. instead of launchTemplateData!!
+          ramdiskId = (launchConfig?.ramdiskId ?: launchTemplateData?.ramDiskId).orNull()
+        ),
       buildInfo = buildInfo?.toEc2Api(),
       capacity = capacity.let {
         when (scalingPolicies.isEmpty()) {
@@ -1041,6 +1043,7 @@ class ClusterHandler(
       image = image.toEc2Api(),
       instanceCounts = instanceCounts.toEc2Api()
     )
+  }
 
   private fun List<MetricDimensionModel>?.toSpec(): Set<MetricDimension> =
     when (this) {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -372,7 +372,7 @@ private fun ActiveServerGroup.withNonDefaultHealthProps(): ActiveServerGroup =
 
 private fun ActiveServerGroup.withNonDefaultLaunchConfigProps(): ActiveServerGroup =
   copy(
-    launchConfig = launchConfig.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
+    launchConfig = launchConfig?.copy(iamInstanceProfile = "NotTheDefaultInstanceProfile", keyName = "not-the-default-key")
   )
 
 private fun ActiveServerGroup.withDifferentSize(): ActiveServerGroup =

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -79,13 +79,14 @@ import strikt.assertions.isSuccess
 import strikt.assertions.isTrue
 import strikt.assertions.map
 
+@Suppress("MemberVisibilityCanBePrivate")
 internal class ClusterHandlerTests : JUnit5Minutests {
 
   val cloudDriverService = mockk<CloudDriverService>()
   val cloudDriverCache = mockk<CloudDriverCache>()
   val orcaService = mockk<OrcaService>()
   val normalizers = emptyList<Resolver<ClusterSpec>>()
-  val clock = Clock.systemUTC()
+  val clock = Clock.systemUTC()!!
   val publisher: EventPublisher = mockk(relaxUnitFun = true)
   val repository = mockk<KeelRepository>()
   val taskLauncher = OrcaTaskLauncher(
@@ -1016,7 +1017,7 @@ private fun ActiveServerGroup.withOlderAppVersion(): ActiveServerGroup =
       imageId = "ami-573e1b2650a5",
       appVersion = "keel-0.251.0-h167.9ea0465"
     ),
-    launchConfig = launchConfig.copy(
+    launchConfig = launchConfig?.copy(
       imageId = "ami-573e1b2650a5"
     )
   )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
@@ -1,0 +1,185 @@
+package com.netflix.spinnaker.keel.ec2.resource
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.RedBlack
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.StaggeredRegion
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.Capacity
+import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
+import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
+import com.netflix.spinnaker.keel.api.ec2.CustomizedMetricSpecification
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1
+import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
+import com.netflix.spinnaker.keel.api.ec2.Scaling
+import com.netflix.spinnaker.keel.api.ec2.ServerGroup
+import com.netflix.spinnaker.keel.api.ec2.TargetTrackingPolicy
+import com.netflix.spinnaker.keel.api.ec2.VirtualMachineImage
+import com.netflix.spinnaker.keel.api.ec2.resolve
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.clouddriver.model.Network
+import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
+import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCollection
+import com.netflix.spinnaker.keel.clouddriver.model.Subnet
+import com.netflix.spinnaker.keel.orca.ClusterExportHelper
+import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
+import com.netflix.spinnaker.keel.test.resource
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import strikt.api.expectThat
+import strikt.assertions.hasSize
+import strikt.assertions.isNull
+import java.time.Clock
+import io.mockk.coEvery as every
+
+@Suppress("MemberVisibilityCanBePrivate")
+internal class LaunchConfigTests {
+  @ParameterizedTest
+  @EnumSource(LaunchInfo::class)
+  fun `empty ramdisk id string is converted to null`(launchInfo: LaunchInfo) {
+    setup(ramdiskId = "", launchInfo=launchInfo)
+
+    // code under test
+    val currentState = runBlocking { clusterHandler.current(resource) }
+
+    expectThat(serverGroup(currentState).launchConfiguration.ramdiskId).isNull()
+  }
+
+  /**
+   * Given the output of ClusterHandler.current, return the ServerGroup object
+   *
+   * Assumes there is only one server group, will error otherwise
+   */
+  fun serverGroup(currentState : Map<String, ServerGroup>) : ServerGroup {
+    expectThat(currentState).hasSize(1)
+    return currentState.values.iterator().next()
+  }
+
+  fun clusterSpec(vpc: Network, subnet: Subnet, ramdiskId: String?) =
+    ClusterSpec(
+      moniker = Moniker(app = "keel", stack = "test"),
+      locations = SubnetAwareLocations(
+        account = vpc.account,
+        vpc = "vpc0",
+        subnet = subnet.purpose!!,
+        regions = listOf(vpc).map { sn ->
+          SubnetAwareRegionSpec(
+            name = sn.region,
+            availabilityZones = listOf("a", "b", "c").map { "${sn.region}$it" }.toSet()
+          )
+        }.toSet()
+      ),
+      deployWith = RedBlack(
+        stagger = listOf(
+          StaggeredRegion(region = vpc.region, hours = "16-02")
+        )
+      ),
+      _defaults = serverGroupSpec(ramdiskId)
+    )
+
+  fun serverGroupSpec(ramdiskId: String?) =
+    ClusterSpec.ServerGroupSpec(
+      launchConfiguration = launchConfigurationSpec(ramdiskId=ramdiskId),
+      capacity = Capacity(1, 6),
+      scaling = Scaling(
+        targetTrackingPolicies = setOf(
+          TargetTrackingPolicy(
+            name = "keel-test-target-tracking-policy",
+            targetValue = 560.0,
+            disableScaleIn = true,
+            customMetricSpec = CustomizedMetricSpecification(
+              name = "RPS per instance",
+              namespace = "SPIN/ACH",
+              statistic = "Average"
+            )
+          )
+        )
+      ),
+      dependencies = ClusterDependencies(
+        loadBalancerNames = setOf("keel-test-frontend"),
+        securityGroupNames = setOf(sg1.name, sg2.name)
+      )
+    )
+
+  fun launchConfigurationSpec(ramdiskId : String?) =
+    LaunchConfigurationSpec(
+      image = VirtualMachineImage(
+        id = "ami-123543254134",
+        appVersion = "keel-0.287.0-h208.fe2e8a1",
+        baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+      ),
+      instanceType = "r4.8xlarge",
+      ebsOptimized = false,
+      iamRole = ServerGroup.LaunchConfiguration.defaultIamRoleFor("keel"),
+      keyPair = "nf-keypair-test-fake",
+      instanceMonitoring = false,
+      ramdiskId = ramdiskId
+    )
+
+  val sg1 = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
+  val sg2 = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
+
+  val vpc = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
+  val subnet = Subnet("subnet-1", vpc.id, vpc.account, vpc.region, "${vpc.region}a", "internal (vpc0)")
+
+  lateinit var spec : ClusterSpec
+  lateinit var resource : Resource<ClusterSpec>
+
+  val cloudDriverService = mockk<CloudDriverService>()
+  val cloudDriverCache = mockk<CloudDriverCache>()
+  val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
+
+
+  val clusterHandler = ClusterHandler(
+    cloudDriverService,
+    cloudDriverCache,
+    mockk(),
+    mockk<OrcaTaskLauncher>(),
+    Clock.systemUTC(),
+    mockk(relaxUnitFun = true),
+    emptyList<Resolver<ClusterSpec>>(),
+    clusterExportHelper
+  )
+
+  fun setup(ramdiskId : String?, launchInfo: LaunchInfo) {
+    spec = clusterSpec(vpc, subnet, ramdiskId)
+    resource = resource(
+      kind = EC2_CLUSTER_V1.kind,
+      spec = spec
+    )
+
+    val serverGroup = spec.resolve().first()
+    val activeServerGroupResponse = serverGroup.toCloudDriverResponse(
+      vpc=vpc,
+      subnets=listOf(subnet),
+      securityGroups=listOf(sg1, sg2),
+      launchInfo=launchInfo)
+
+    with(cloudDriverCache) {
+      every { networkBy(vpc.id) } returns vpc
+      every { subnetBy(subnet.id) } returns subnet
+      every { securityGroupById(vpc.account, vpc.region, sg1.id) } returns sg1
+      every { securityGroupById(vpc.account, vpc.region, sg2.id) } returns sg2
+    }
+
+    every { cloudDriverService.activeServerGroup(any(), any()) } returns activeServerGroupResponse
+    every { cloudDriverService.listServerGroups(any(), any(), any(), any()) } returns
+      ServerGroupCollection(vpc.account, setOf(activeServerGroupResponse.toAllServerGroupsResponse()))
+
+  }
+
+  private suspend fun CloudDriverService.activeServerGroup(user: String, region: String) = activeServerGroup(
+    user = user,
+    app = spec.moniker.app,
+    account = spec.locations.account,
+    cluster = spec.moniker.toString(),
+    region = region,
+    cloudProvider = CLOUD_PROVIDER
+  )
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
@@ -40,6 +40,7 @@ import io.mockk.coEvery as every
 
 @Suppress("MemberVisibilityCanBePrivate")
 internal class LaunchConfigTests {
+
   @ParameterizedTest
   @EnumSource(LaunchInfo::class)
   fun `empty ramdisk id string is converted to null`(launchInfo: LaunchInfo) {
@@ -50,6 +51,11 @@ internal class LaunchConfigTests {
 
     expectThat(serverGroup(currentState).launchConfiguration.ramdiskId).isNull()
   }
+
+  //
+  // Everything below is just fixture and mocking setup
+  //
+
 
   /**
    * Given the output of ClusterHandler.current, return the ServerGroup object


### PR DESCRIPTION
## Summary

Add support for managing EC2 apps that have been configured to use AWS launch templates. This is a second 
attempt at #1566, which was reverted in #1573 because of a bug.

## What was the original bug?

When resolving the current status of a cluster, if the current launch configuration contains a ramdisk id field that is
an empty string: `""`, keel is supposed to treat it as a `null`.

#1566 introduced a regression where it did not convert the blank string to a null. This led to false diffs where
the current state of an EC2 cluster had a ramdisk id of `""` and the desired state of an cluster had a ramdisk id of `null`.

A test has been added for this case. 

The rest of this description is identical to #1566.

## Background

Clouddriver now support AWS [launch templates](https://docs.aws.amazon.com/autoscaling/ec2/userguide/LaunchTemplates.html). Clouddriver opts in apps to use launch templates, on a per-app basis.

## What changed from keel's perspective

For apps that are configured to use launch templates, the response payload from clouddriver changes when querying for server group information. For these apps, there is no longer a `launchConfig` field. Instead, there is a `launchTemplate` field. The `launchTemplate` field contains similar information, but the data has a different shape.


## PR details

With this PR, we can now handle response payloads from clouddriver where there is a `launchTemplate` field instead of a `launchConfig` field.

Note that this PR does not change:

* the delivery config schema (the section called `launchConfiguration` remains unchanged)
* the shape of the data that we send to orca when actuating EC2 clusters


