### PR TITLE
feat(artifact): veto only if never deployed successfully

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.keel.actuation
 
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.keel.api.CompleteVersionedArtifact
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
@@ -33,6 +35,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.plugin.CannotResolveCurrentState
 import com.netflix.spinnaker.keel.plugin.CannotResolveDesiredState
 import com.netflix.spinnaker.keel.plugin.ResourceResolutionException
+import com.netflix.spinnaker.keel.telemetry.ArtifactVersionVetoed
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckSkipped
 import com.netflix.spinnaker.keel.veto.VetoEnforcer
 import com.netflix.spinnaker.keel.veto.VetoResponse
@@ -69,7 +72,7 @@ class ResourceActuator(
   private val vetoEnforcer: VetoEnforcer,
   private val publisher: ApplicationEventPublisher,
   private val clock: Clock,
-  private val springEnv: SpringEnvironment,
+  private val springEnv: SpringEnvironment
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -117,53 +120,9 @@ class ResourceActuator(
 
         val response = vetoEnforcer.canCheck(resource)
         if (!response.allowed) {
-          /**
-           * [VersionedArtifactProvider] is a special [resource] sub-type. When a veto response sets
-           * [VetoResponse.vetoArtifact] and the resource under evaluation is of type
-           * [VersionedArtifactProvider], disallow the desired artifact version from being deployed to
-           * the environment containing [resource]. This ensures that the environment will be fully restored to
-           * a prior good-state.
-           */
-          if (response.vetoArtifact && resource.spec is VersionedArtifactProvider) {
-            try {
-              val versionedArtifact = when (desired) {
-                is Map<*, *> -> {
-                  if (desired.size > 0) {
-                    @Suppress("UNCHECKED_CAST")
-                    (desired as Map<String, VersionedArtifactProvider>).values.first()
-                  } else {
-                    null
-                  }
-                }
-                is VersionedArtifactProvider -> desired
-                else -> null
-              }?.completeVersionedArtifactOrNull()
-
-              if (versionedArtifact != null) {
-                with(versionedArtifact) {
-                  val artifact = deliveryConfig.matchingArtifactByName(versionedArtifact.artifactName, artifactType)
-                    ?: error("Artifact $artifactType:$artifactName not found in delivery config ${deliveryConfig.name}")
-
-                  artifactRepository.markAsVetoedIn(
-                    deliveryConfig = deliveryConfig,
-                    veto = EnvironmentArtifactVeto(
-                      reference = artifact.reference,
-                      version = artifactVersion,
-                      targetEnvironment = environment.name,
-                      vetoedBy = "Spinnaker",
-                      comment = "Automatically marked as bad because multiple deployments of this version failed."
-                    )
-                  )
-                  // TODO: emit event + metric
-                }
-              }
-            } catch (e: Exception) {
-              log.warn("Failed to veto presumed bad artifact version for ${resource.id}", e)
-              // TODO: emit metric
-            }
-          }
-          log.debug("Skipping actuation for resource {} because it was vetoed: {}", id, response.message)
-          publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, response.vetoName))
+          handleVetoingArtifact(response, resource, deliveryConfig, environment, desired)
+          log.debug("Skipping actuation for resource {} because it was vetoed: {}", resource.id, response.message)
+          publisher.publishEvent(ResourceCheckSkipped(resource.kind, resource.id, response.vetoName))
           publisher.publishEvent(
             ResourceActuationVetoed(
               resource.kind,
@@ -236,6 +195,91 @@ class ResourceActuator(
       }
     }
   }
+
+  /**
+   * [VersionedArtifactProvider] is a special [resource] sub-type. When a veto response sets
+   * [VetoResponse.vetoArtifact], the resource under evaluation is of type
+   * [VersionedArtifactProvider], and the version has never before been deployed successfully to an environment,
+   * disallow the desired artifact version from being deployed to
+   * the environment containing [resource]. This ensures that the environment will be fully restored to
+   * a prior good-state.
+   *
+   * If the version has previously been deployed successfully do not veto the artifact because
+   * we do not want to veto the artifact in the case of a bad config change or other downstream problem.
+   * Rolling back most likely will not help in these cases and it will probably cause confusion.
+   */
+  private fun handleVetoingArtifact(
+    response: VetoResponse,
+    resource: Resource<*>,
+    deliveryConfig: DeliveryConfig,
+    environment: Environment,
+    desired: Any?
+  ) {
+    if (response.vetoArtifact && resource.spec is VersionedArtifactProvider) {
+      try {
+        val versionedArtifact = desired.findArtifact()
+
+        if (versionedArtifact != null) {
+          val artifact = deliveryConfig.matchingArtifactByName(versionedArtifact.artifactName, versionedArtifact.artifactType)
+            ?: error("Artifact ${versionedArtifact.artifactType}:${versionedArtifact.artifactName} not found in delivery config ${deliveryConfig.name}")
+
+          val previousSuccess = artifactRepository.wasSuccessfullyDeployedTo(
+            deliveryConfig = deliveryConfig,
+            artifact = artifact,
+            version = versionedArtifact.artifactVersion,
+            targetEnvironment = environment.name
+          )
+
+          if (!previousSuccess) {
+            artifactRepository.markAsVetoedIn(
+              deliveryConfig = deliveryConfig,
+              veto = EnvironmentArtifactVeto(
+                reference = artifact.reference,
+                version = versionedArtifact.artifactVersion,
+                targetEnvironment = environment.name,
+                vetoedBy = "Spinnaker",
+                comment = "Automatically marked as bad because multiple deployments of this version failed and none have ever succeeded."
+              )
+            )
+            log.info(
+              "Vetoing artifact version {} of artifact {} for config {} and env {} because multiple deploys failed",
+              versionedArtifact,
+              artifact.reference,
+              deliveryConfig.name,
+              environment.name
+            )
+            publisher.publishEvent(ArtifactVersionVetoed(artifact.reference))
+          } else {
+            log.info(
+              "Not vetoing artifact version {} of artifact {} for config {} and env {} because it was previously successfully deployed",
+              versionedArtifact,
+              artifact.reference,
+              deliveryConfig.name,
+              environment.name
+            )
+          }
+        }
+      } catch (e: Exception) {
+        log.warn("Failed to veto presumed bad artifact version for ${resource.id}", e)
+        // TODO: emit metric
+      }
+    }
+  }
+
+  private fun Any?.findArtifact() : CompleteVersionedArtifact? =
+    when (this) {
+      is Map<*, *> -> {
+        if (this.size > 0) {
+          @Suppress("UNCHECKED_CAST")
+          (this as Map<String, VersionedArtifactProvider>).values.first()
+        } else {
+          null
+        }
+      }
+      is VersionedArtifactProvider -> this
+      else -> null
+    }?.completeVersionedArtifactOrNull()
+
 
   private fun DeliveryConfig.isPromotionCheckStale(): Boolean {
     val age = Duration.between(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -203,9 +203,13 @@ class ResourceActuator(
    * the environment containing [resource]. This ensures that the environment will be fully restored to
    * a prior good-state.
    *
-   * If the version has previously been deployed successfully do not veto the artifact because
-   * we do not want to veto the artifact in the case of a bad config change or other downstream problem.
-   * Rolling back most likely will not help in these cases and it will probably cause confusion.
+   * This method can override a veto's request to veto an artifact. In this method we have more
+   * information about the diff and the artifact version, and so we can make a better decision about
+   * whether or not to veto an artifact version
+   *
+   * If the version has previously been deployed successfully do not veto the artifact version because
+   * we do not want to veto the artifact version in the case of a bad config change or other downstream
+   * problem. Rolling back most likely will not help in these cases and it will probably cause confusion.
    */
   private fun handleArtifactVetoing(
     response: VetoResponse,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -52,5 +52,5 @@ data class ArtifactCheckTimedOut(
 ) : TelemetryEvent()
 
 data class ArtifactVersionVetoed(
-  val artifactReference: String,
+  val application: String,
 ) : TelemetryEvent()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -50,3 +50,7 @@ data class ArtifactCheckTimedOut(
   val name: String,
   val deliveryConfigName: String?
 ) : TelemetryEvent()
+
+data class ArtifactVersionVetoed(
+  val artifactReference: String,
+) : TelemetryEvent()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -134,7 +134,7 @@ class TelemetryListener(
   fun onArtifactVersionVetoed(event: ArtifactVersionVetoed) {
     spectator.counter(
       ARTIFACT_VERSION_VETOED,
-      listOf(BasicTag("artifactReference", event.artifactReference))
+      listOf(BasicTag("application", event.application))
     )
       .safeIncrement()
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -130,6 +130,15 @@ class TelemetryListener(
     lastArtifactCheck.set(clock.instant())
   }
 
+  @EventListener(ArtifactVersionVetoed::class)
+  fun onArtifactVersionVetoed(event: ArtifactVersionVetoed) {
+    spectator.counter(
+      ARTIFACT_VERSION_VETOED,
+      listOf(BasicTag("artifactReference", event.artifactReference))
+    )
+      .safeIncrement()
+  }
+
   private fun createDriftGauge(name: String): AtomicReference<Instant> {
     return PolledMeter
       .using(spectator)
@@ -164,5 +173,6 @@ class TelemetryListener(
     private const val RESOURCE_CHECK_DRIFT_GAUGE = "keel.resource.check.drift"
     private const val ENVIRONMENT_CHECK_DRIFT_GAUGE = "keel.environment.check.drift"
     private const val ENVIRONMENT_CHECK_TIMED_OUT_ID = "keel.environment.check.timeout"
+    private const val ARTIFACT_VERSION_VETOED = "keel.artifact.version.vetoed"
   }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
@@ -38,7 +38,7 @@ internal class ApplicationEventTests {
 
     publisher.publishEvent(TestEvent(this))
 
-    val eventThread = listener.awaitInvoked(Duration.ofMillis(100))
+    val eventThread = listener.awaitInvoked(Duration.ofMillis(300))
 
     expectThat(eventThread)
       .isNotEqualTo(testThread)


### PR DESCRIPTION
**Problem:**
One of the most helpful things we can do in MD is veto an artifact when the version isn't good (like, when the deploy times out because the instances never came up). 

One of the most _unhelpful_ things we can do is veto artifacts en mass when there is a problem (either with keel, with spinnaker, or with a cloud provider).

**Solution:**
This PR aims to narrow the scope of vetoing artifact versions to only veto versions that have **never** been successfully deployed. That means that we will no longer veto artifact versions that have been happy in an environment. 

We will not veto an artifact version if:
- there was a config change that is causing the instances to not start up
- there is a keel bug that causes the desired state of everything to change in a way that causes bad deploys (like what happened when we accidentally shrunk all the titus memory requirements)
- there is an AWS / titus bug that causes behavior like ^

In this case, we will just mark the cluster as unhappy and not do anything else. 

**Thoughts:**
I implemented this in the resource actuator because that's where we have information about the desired state as well as the resource. I wanted to implement this in the `UnhappyVeto` but we don't know what the desired state is there (it hasn't been calculated) so we can't do the right thing. Also, we don't have the artifact repository wired into the veto. Does that seem reasonable or is this a bad idea?

I also did a bit of refactoring of the veto stuff into a method or two since @lorin suggested this last time I touched this code. I think it makes it easier to read. But it does make it harder to tell what logic is new in this PR.

**I'm looking for:**
- Feedback on this general idea. Is it good? 
- Cases that I missed where we should actually veto the artifact