### PR TITLE
chore(debug): Add debug logs around resource vetoing

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -112,8 +112,10 @@ class ResourceActuator(
         val (desired, current) = plugin.resolve(resource)
         val diff = DefaultResourceDiff(desired, current)
         if (diff.hasChanges()) {
+          log.debug("Storing diff fingerprint for resource {} delta: {}", id, diff.toDebug())
           diffFingerprintRepository.store(id, diff)
         } else {
+          log.debug("Clearing diff fingerprint for resource {} (current == desired)", id)
           diffFingerprintRepository.clear(id)
         }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -55,14 +55,17 @@ class UnhappyVeto(
       return allowedResponse()
     }
 
-    val vetoStatus = unhappyVetoRepository.getOrCreateVetoStatus(resourceId, application, waitingTime(resource))
+    val wait = waitingTime(resource)
+    val vetoStatus = unhappyVetoRepository.getOrCreateVetoStatus(resourceId, application, wait)
     // allow for a check every [waitingTime] even if the resource is unhappy
     if (vetoStatus.shouldRecheck) {
-      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application, waitingTime(resource))
+      log.debug("Marking resource $resourceId unhappy for $wait, but allowing resource check.")
+      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application, wait)
       return allowedResponse()
     }
 
     if (vetoStatus.shouldSkip) {
+      log.debug("Resource $resourceId is unhappy. Denying resource check.")
       return deniedResponse(unhappyMessage(resource))
     }
 


### PR DESCRIPTION
I'm having a hard time troubleshooting an issue without logs in this area of the code.