### PR TITLE
Detect AMIs split across multiple named images when checking for latest baked versions

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
@@ -40,6 +40,13 @@ val NamedImage.hasAppVersion: Boolean
       vals.isNotEmpty() && vals.all { it != null && it.containsKey("appversion") }
     }
 
+val NamedImage.hasBaseImageVersion: Boolean
+  get() = tagsByImageId
+    .values
+    .let { vals ->
+      vals.isNotEmpty() && vals.all { it != null && it.containsKey("base_ami_version") }
+    }
+
 val NamedImage.appVersion: String
   get() = tagsByImageId
     .values


### PR DESCRIPTION
`ImageHandler` previously looked at a single `NamedImage` and could potentially think regions were missing if they were split across multiple image names.

This PR changes things so that the method in `ImageService` that finds the latest image for an artifact, looks for all named images that share the latest `appVersion` and `base_ami_version` tags.

This will stop metrics flagging that a region is missing in such a case.