### PR TITLE
feat(processArtifacts): Move artifact processing decision to individual suppliers

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
@@ -50,6 +50,8 @@ interface KeelReadOnlyRepository {
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
+  fun getDeliveryArtifact(name: String, type: ArtifactType): DeliveryArtifact?
+
   fun artifactVersions(artifact: DeliveryArtifact, limit: Int = DEFAULT_MAX_ARTIFACT_VERSIONS): List<String>
 
   fun artifactVersions(name: String, type: ArtifactType): List<String>

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
@@ -88,6 +88,11 @@ interface ArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy> : Spinn
    * This function is currently expected to make calls to CI systems.
    */
   suspend fun getArtifactMetadata(artifact: PublishedArtifact): ArtifactMetadata?
+
+  /**
+   * Given an artifact definition [DeliveryArtifact], and an actual artifact version as [PublishedArtifact], return whether this artifact should be processed and saved
+   */
+  fun shouldProcessArtifact(artifactDefinition: DeliveryArtifact, artifact: PublishedArtifact): Boolean
 }
 
 /**

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
@@ -72,6 +72,10 @@ class NpmArtifactSupplier(
       ?.let { GitMetadata(it) }
   }
 
+  override fun shouldProcessArtifact(artifactDefinition:DeliveryArtifact, artifact: PublishedArtifact): Boolean {
+    //currently, we don't have any limitations for NPM artifact versions
+    return true
+  }
 
   // The API requires colons in place of slashes to avoid path pattern conflicts
   private val DeliveryArtifact.nameForQuery: String

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -102,7 +102,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
 
     context("the artifact is not something we're tracking") {
       before {
-        every { repository.isRegistered(any(), any()) } returns false
+        every { repository.getDeliveryArtifact(any(), any()) } returns null
         listener.onArtifactPublished(event)
       }
 
@@ -117,13 +117,16 @@ internal class ArtifactListenerTests : JUnit5Minutests {
 
     context("the artifact is registered with versions") {
       before {
-        every { repository.isRegistered(artifact.name, artifact.type) } returns true
+        every { repository.getDeliveryArtifact(artifact.name, artifact.type) } returns debianArtifact
         every {
           debianArtifactSupplier.getLatestArtifact(deliveryConfig, artifact)
         } returns publishedDeb
         every {
           debianArtifactSupplier.getArtifactMetadata(publishedDeb)
         } returns artifactMetadata
+        every {
+          debianArtifactSupplier.shouldProcessArtifact(any(), any())
+        } returns true
       }
 
       context("the version was already known") {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -162,7 +162,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     val version4 = "keeldemo-1.0.0-h11.518aea2" // release
     val version5 = "keeldemo-1.0.0-h12.4ea8a9d" // release
     val version6 = "master-h12.4ea8a9d"
-    val versionBad = "latest"
     val versionOnly = "0.0.1~dev.8-h8.41595c4"
 
     val pin1 = EnvironmentArtifactPin(
@@ -223,7 +222,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         storeArtifactInstance(versionedReleaseDebian.toArtifactInstance(it, RELEASE))
       }
       register(versionedDockerArtifact)
-      setOf(version6, versionBad).forEach {
+      setOf(version6).forEach {
         storeArtifactInstance(versionedDockerArtifact.toArtifactInstance(it))
       }
       register(debianFilteredByBranch)
@@ -371,21 +370,11 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
         context("docker") {
           test("querying for all returns all") {
-            expectThat(subject.versions(versionedDockerArtifact.name, versionedDockerArtifact.type)).containsExactlyInAnyOrder(version6, versionBad)
+            expectThat(subject.versions(versionedDockerArtifact.name, versionedDockerArtifact.type)).containsExactlyInAnyOrder(version6)
           }
 
           test("querying the artifact filters out the bad tag") {
             expectThat(subject.versions(versionedDockerArtifact)).containsExactly(version6)
-          }
-
-          test("querying with a wrong strategy filters out everything") {
-            val incorrectArtifact = DockerArtifact(
-              name = "docker",
-              deliveryConfigName = "my-manifest",
-              reference = "docker-artifact",
-              tagVersionStrategy = SEMVER_JOB_COMMIT_BY_JOB
-            )
-            expectThat(subject.versions(incorrectArtifact)).isEmpty()
           }
         }
       }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -31,6 +31,8 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
+  fun getDeliveryArtifact(name: String, type: ArtifactType): DeliveryArtifact?
+
   fun getAll(type: ArtifactType? = null): List<DeliveryArtifact>
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -313,6 +313,9 @@ class CombinedRepository(
   override fun isRegistered(name: String, type: ArtifactType): Boolean =
     artifactRepository.isRegistered(name, type)
 
+  override fun getDeliveryArtifact (name: String, type: ArtifactType): DeliveryArtifact? =
+    artifactRepository.getDeliveryArtifact(name, type)
+
   override fun getAllArtifacts(type: ArtifactType?): List<DeliveryArtifact> =
     artifactRepository.getAll(type)
 


### PR DESCRIPTION
Until now, we had some filtering mechanism to filter artifacts at the repository level, or at the publishing time.

This PR move that responsibility to each artifact provider in a unified way, giving us an easy way to control the versions we want to filter at the API level.