### PR TITLE
feat(titus): default container attrs resolver

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolver.kt
@@ -1,0 +1,96 @@
+package com.netflix.spinnaker.keel.titus
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
+import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
+import com.netflix.spinnaker.keel.titus.exceptions.AwsAccountConfigurationException
+import com.netflix.spinnaker.keel.titus.exceptions.TitusAccountConfigurationException
+import kotlinx.coroutines.runBlocking
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+
+/**
+ * A [Resolver] that looks up the needed titus default container attributes and
+ * populates them, if they are not specified by the user.
+ */
+@Component
+@EnableConfigurationProperties(DefaultContainerAttributes::class)
+class ContainerAttributesResolver(
+  val defaults: DefaultContainerAttributes,
+  val cloudDriverService: CloudDriverService,
+  val springEnv: Environment
+) : Resolver<TitusClusterSpec> {
+
+  private val enabled: Boolean
+    get() = springEnv.getProperty("keel.titus.resolvers.container-attributes.enabled", Boolean::class.java, true)
+
+  override val supportedKind = TITUS_CLUSTER_V1
+
+  override fun invoke(resource: Resource<TitusClusterSpec>): Resource<TitusClusterSpec> {
+    if (!enabled) {
+      return resource
+    }
+
+    val topLevelAttrs = resource.spec.defaults.containerAttributes?.toMutableMap() ?: mutableMapOf()
+    val overrides = resource.spec.overrides.toMutableMap()
+
+    val account = resource.spec.locations.account
+    // account key will be the same for all regions, so add it to the top level
+    if (!keyPresentInAllRegions(resource, defaults.getAccountKey())) {
+      val awsAccountId = getAwsAccountId(account)
+      topLevelAttrs.putIfAbsent(defaults.getAccountKey(), awsAccountId)
+    }
+
+    if (!keyPresentInAllRegions(resource, defaults.getSubnetKey())){
+      val regions = resource.spec.locations.regions.map { it.name }
+      regions.forEach { region ->
+        var override = overrides[region] ?: TitusServerGroupSpec()
+        val subnetDefault = mapOf(defaults.getSubnetKey() to defaults.getSubnetValue(account, region))
+        val containerAttributes = override.containerAttributes ?: mutableMapOf()
+        override = if (!containerAttributes.containsKey(defaults.getSubnetKey())) {
+          override.copy(containerAttributes = containerAttributes + subnetDefault)
+        } else {
+          override.copy(containerAttributes = containerAttributes)
+        }
+
+        overrides[region] = override
+      }
+    }
+    val resourceDefaults = resource.spec.defaults.copy(containerAttributes = topLevelAttrs)
+    val newSpec = resource.spec.copy(overrides = overrides, _defaults = resourceDefaults)
+    return resource.copy(spec = newSpec)
+  }
+
+  /**
+   * Returns true if when resolved, each region contains the desired key
+   */
+  private fun keyPresentInAllRegions(resource: Resource<TitusClusterSpec>, key: String): Boolean {
+    val regions = resource.spec.locations.regions.map { it.name }
+    var allPresent = true
+    regions.forEach{ region ->
+      val resolvedAttrs = resource.spec.resolveContainerAttributes(region)
+      if (!resolvedAttrs.containsKey(key)) {
+        allPresent = false
+      }
+    }
+    return allPresent
+  }
+
+  private fun getAwsAccountId(titusAccount: String): String =
+    runBlocking {
+      val awsName = getAwsAccountNameForTitusAccount(titusAccount)
+      getAccountId(awsName)
+    }
+
+  private suspend fun getAwsAccountNameForTitusAccount(titusAccount: String): String =
+    cloudDriverService.getAccountInformation(titusAccount, DEFAULT_SERVICE_ACCOUNT)["awsAccount"]?.toString()
+      ?: throw TitusAccountConfigurationException(titusAccount, "awsAccount")
+
+  private suspend fun getAccountId(accountName: String): String =
+    cloudDriverService.getAccountInformation(accountName, DEFAULT_SERVICE_ACCOUNT)["accountId"]?.toString()
+      ?: throw AwsAccountConfigurationException(accountName, "accountId")
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/DefaultContainerAttributes.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/DefaultContainerAttributes.kt
@@ -1,0 +1,17 @@
+package com.netflix.spinnaker.keel.titus
+
+import com.netflix.spinnaker.keel.titus.exceptions.DefaultContainerAttributesException
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "keel.titus.default-container-attributes")
+class DefaultContainerAttributes {
+  var subnets: Map<String, String> = mutableMapOf()
+
+  fun getAccountKey() = "titusParameter.agent.accountId"
+
+  fun getSubnetKey() = "titusParameter.agent.subnets"
+
+  fun getSubnetValue(account: String, region: String): String {
+    return subnets["$account-$region"] ?: throw DefaultContainerAttributesException(account, region)
+  }
+}

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/exceptions/AwsAccountConfigurationException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/exceptions/AwsAccountConfigurationException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.titus.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+
+class AwsAccountConfigurationException(
+  val awsAccount: String,
+  val missingProperty: String
+) : IntegrationException("AWS account $awsAccount misconfigured: missing value for $missingProperty")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/exceptions/DefaultContainerAttributesException.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/exceptions/DefaultContainerAttributesException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.titus.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+
+class DefaultContainerAttributesException(
+  val account: String,
+  val region: String
+) : IntegrationException("Missing default subnets for titus account $account in region $region")

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolverTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolverTests.kt
@@ -1,0 +1,130 @@
+package com.netflix.spinnaker.keel.titus
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
+import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.docker.ReferenceProvider
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.core.env.Environment
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isEqualTo
+
+internal class ContainerAttributesResolverTests : JUnit5Minutests {
+
+  val accountKey = "titus.account"
+  val subnetKey = "titus.subnet"
+  val eastSubnets = "subnet-east-1, subnet-east-2"
+  val westSubnets = "subnet-west-3, subnet-west-4"
+  val account = "titus"
+  val awsAccountId = "1234"
+
+  val defaults = mockk<DefaultContainerAttributes> {
+    every { getAccountKey() } returns accountKey
+    every { getSubnetKey() } returns subnetKey
+    every { getSubnetValue(account, "east")} returns eastSubnets
+    every { getSubnetValue(account, "west")} returns westSubnets
+  }
+
+  val baseSpec = TitusClusterSpec(
+    moniker = Moniker(app = "keel", stack = "test"),
+    locations = SimpleLocations(
+      account = account,
+      regions = setOf(SimpleRegionSpec("east"), SimpleRegionSpec("west"))
+    ),
+    container = ReferenceProvider("my-artifact"),
+    _defaults = TitusServerGroupSpec(),
+    overrides = emptyMap()
+  )
+
+  val clouddriverService = mockk<CloudDriverService>() {
+    coEvery { getAccountInformation(account, any()) } returns mapOf("awsAccount" to "aws")
+    coEvery { getAccountInformation("aws", any()) } returns mapOf("accountId" to awsAccountId)
+  }
+  val springEnv: Environment = mockk(relaxed = true) {
+    coEvery { getProperty("keel.titus.resolvers.container-attributes.enabled", Boolean::class.java, true) } returns true
+  }
+  data class Fixture(val subject: ContainerAttributesResolver, val spec: TitusClusterSpec) {
+    val resource = resource(
+      kind = TITUS_CLUSTER_V1.kind,
+      spec = spec
+    )
+    val resolved by lazy { subject(resource) }
+  }
+
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture(
+        ContainerAttributesResolver(defaults, clouddriverService, springEnv),
+        baseSpec
+      )
+    }
+
+    test("supports the resource kind") {
+      expectThat(listOf(subject).supporting(resource))
+        .containsExactly(subject)
+    }
+
+    context("spec has no defaults set") {
+      test("account and subnet are set") {
+        validateKeysSet(resolved)
+      }
+    }
+
+    context("account is set") {
+      fixture {
+        Fixture(
+          ContainerAttributesResolver(defaults, clouddriverService, springEnv),
+          baseSpec.copy(_defaults = baseSpec.defaults.copy(containerAttributes = mapOf(accountKey to awsAccountId)))
+        )
+      }
+
+      test("account is set, subnets get added"){
+        validateKeysSet(resolved)
+      }
+    }
+
+    context("non-default values are present") {
+      fixture {
+        Fixture(
+          ContainerAttributesResolver(defaults, clouddriverService, springEnv),
+          baseSpec.copy(_defaults = baseSpec.defaults.copy(containerAttributes = mapOf(accountKey to "blah", subnetKey to "fake-subnets")))
+        )
+      }
+
+      test("we leave the values that are set") {
+        val resolvedEast = resource.spec.resolveContainerAttributes("east")
+        val resolvedWest = resource.spec.resolveContainerAttributes("west")
+        expect {
+          that(resolvedEast[accountKey]).isEqualTo("blah")
+          that(resolvedEast[subnetKey]).isEqualTo("fake-subnets")
+          that(resolvedWest[accountKey]).isEqualTo("blah")
+          that(resolvedWest[subnetKey]).isEqualTo("fake-subnets")
+        }
+      }
+    }
+  }
+
+  private fun validateKeysSet(resource: Resource<TitusClusterSpec>) {
+    val resolvedEast = resource.spec.resolveContainerAttributes("east")
+    val resolvedWest = resource.spec.resolveContainerAttributes("west")
+    expect {
+      that(resolvedEast[accountKey]).isEqualTo(awsAccountId)
+      that(resolvedEast[subnetKey]).isEqualTo(eastSubnets)
+      that(resolvedWest[accountKey]).isEqualTo(awsAccountId)
+      that(resolvedWest[subnetKey]).isEqualTo(westSubnets)
+    }
+  }
+}


### PR DESCRIPTION
The titus team recently started setting some default container attributes. This adds them to a user spec if they're not present.

Default values are pulled from the config.

You can turn it off via fast property in case we mess something up :) 