### PR TITLE
fix(veto): Fix never-expiring resource vetos

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/UnhappyVetoRepository.kt
@@ -37,12 +37,12 @@ abstract class UnhappyVetoRepository(
   /**
    * Marks [resourceId] as unhappy for [waitingTime]
    *
-   * @param wait the time to wait before re-checking the resource, `null` means "never re-check".
+   * @param recheckTime the time to wait before re-checking the resource, `null` means "never re-check".
    */
-  abstract fun markUnhappyForWaitingTime(
+  abstract fun markUnhappy(
     resourceId: String,
     application: String,
-    wait: Duration? = Duration.parse(waitingTime)
+    recheckTime: Instant? = clock.instant() + Duration.parse(waitingTime)
   )
 
   /**
@@ -55,11 +55,9 @@ abstract class UnhappyVetoRepository(
    *
    * @param wait the time to wait before re-checking the resource, `null` means "never re-check".
    */
-  abstract fun getOrCreateVetoStatus(
-    resourceId: String,
-    application: String,
-    wait: Duration? = Duration.parse(waitingTime)
-  ): UnhappyVetoStatus
+  abstract fun getRecheckTime(
+    resourceId: String
+  ): Instant?
 
   /**
    * Returns all currently vetoed resources
@@ -70,12 +68,4 @@ abstract class UnhappyVetoRepository(
    * Returns all currently vetoed resources for an [application]
    */
   abstract fun getAllForApp(application: String): Set<String>
-
-  fun calculateExpirationTime(wait: Duration?): Instant? =
-    wait?.let { clock.instant().plus(it) }
-
-  data class UnhappyVetoStatus(
-    val shouldSkip: Boolean = false,
-    val shouldRecheck: Boolean = false
-  )
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -29,6 +29,8 @@ import java.time.format.DateTimeParseException
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.Instant
 
 /**
  * A veto that stops keel from checking a resource for a configurable
@@ -40,7 +42,8 @@ class UnhappyVeto(
   private val unhappyVetoRepository: UnhappyVetoRepository,
   private val dynamicConfigService: DynamicConfigService,
   @Value("\${veto.unhappy.waiting-time:PT10M}")
-  private val configuredWaitingTime: String
+  private val configuredWaitingTime: String,
+  private val clock: Clock
 ) : Veto {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -56,20 +59,29 @@ class UnhappyVeto(
     }
 
     val wait = waitingTime(resource)
-    val vetoStatus = unhappyVetoRepository.getOrCreateVetoStatus(resourceId, application, wait)
-    // allow for a check every [waitingTime] even if the resource is unhappy
-    if (vetoStatus.shouldRecheck) {
-      log.debug("Marking resource $resourceId unhappy for $wait, but allowing resource check.")
-      unhappyVetoRepository.markUnhappyForWaitingTime(resourceId, application, wait)
-      return allowedResponse()
-    }
+    val recheckTime = unhappyVetoRepository.getRecheckTime(resourceId)
 
-    if (vetoStatus.shouldSkip) {
+    /**
+     * We deny the resource check if it's the first time we detected the resource being unhappy with this diff
+     * (there's no record for it in the database), or if the recheck time has not expired yet. In the latter
+     * case, we *don't* update the recheck time so that it will eventually expire and the resource re-checked.
+     *
+     * If the recheck time has expired, the resource remains marked unhappy in the database, but we allow it
+     * to be rechecked and update the recheck time.
+     */
+    val response = if (recheckTime == null || recheckTime > clock.instant()) {
+      if (recheckTime == null) {
+        unhappyVetoRepository.markUnhappy(resourceId, application, calculateRecheckTime(wait))
+      }
       log.debug("Resource $resourceId is unhappy. Denying resource check.")
-      return deniedResponse(unhappyMessage(resource))
+      deniedResponse(unhappyMessage(resource))
+    } else {
+      log.debug("Marking resource $resourceId unhappy for $wait, but allowing resource check.")
+      unhappyVetoRepository.markUnhappy(resourceId, application, calculateRecheckTime(wait))
+      allowedResponse()
     }
 
-    return allowedResponse()
+    return response
   }
 
   override fun currentRejections(): List<String> =
@@ -121,4 +133,7 @@ class UnhappyVeto(
     return "Resource is unhappy and our $maxDiffs actions have not fixed it. We will try again after " +
       "$waitingTime, or if the diff changes."
   }
+
+  fun calculateRecheckTime(wait: Duration?): Instant? =
+    wait?.let { clock.instant().plus(it) }
 }


### PR DESCRIPTION
After much debugging, I found that, if a resource had been previously vetoed and a new diff detected, instead of rechecking the resource as expected after the wait period, we were just repeatedly vetoing it because we were always updating the `recheckTime` in that case, so it never expired.

This PR fixes that by introducing a check for only inserting a record when the veto is first created for the resource, and only updating it when the recheck time has expired, but _not_ in the in-between checks. I found it pretty hard to reason about this code because half of the business logic was in the `SqlUnhappyVetoRepository`, so this PR also refactors the code a bit to consolidate all the logic in `UnhappyVeto` which makes it easier to follow and to test.