### PR TITLE
feat(processArtifacts): Move artifact processing decision to individual suppliers

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ArtifactSupplier.kt
@@ -88,6 +88,11 @@ interface ArtifactSupplier<A : DeliveryArtifact, V : VersioningStrategy> : Spinn
    * This function is currently expected to make calls to CI systems.
    */
   suspend fun getArtifactMetadata(artifact: PublishedArtifact): ArtifactMetadata?
+
+  /**
+   * Given an actual artifact version as [PublishedArtifact], return whether this artifact should be processed and saved
+   */
+  fun shouldProcessArtifact(artifact: PublishedArtifact): Boolean
 }
 
 /**

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -109,7 +109,7 @@ class DebianArtifactSupplier(
     artifact.hasReleaseStatus() && artifact.hasCorrectVersion()
 
 
-  // Debian Artifacts should contain a releaseStatus in the metadata	  // Debian Artifacts should contain a releaseStatus in the metadata
+  // Debian Artifacts should contain a releaseStatus in the metadata
   private fun PublishedArtifact.hasReleaseStatus() : Boolean {
     return if (this.metadata.containsKey("releaseStatus") && this.metadata["releaseStatus"] != null) {
       true
@@ -121,11 +121,12 @@ class DebianArtifactSupplier(
 
   // Debian Artifacts should not have "local" as a part of their version string
   private fun PublishedArtifact.hasCorrectVersion() : Boolean {
-    return if (!this.version.contains("local")) {
-      true
-    } else {
+    val appversion = this.version.parseAppVersionOrNull()
+    return if (appversion?.buildNumber?.contains("local")!!) {
       log.debug("Ignoring artifact which contains local is its version string: $this")
       false
+    } else {
+      true
     }
   }
 }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -101,10 +101,31 @@ class DebianArtifactSupplier(
     return null
   }
 
-  // Debian Artifacts should contain a releaseStatus in the metadata
-  private fun PublishedArtifact.hasReleaseStatus() =
-    this.metadata.containsKey("releaseStatus") && this.metadata["releaseStatus"] != null
 
   private val DeliveryArtifact.statusesForQuery: List<String>
     get() = statuses.map { it.name }
+
+  override fun shouldProcessArtifact(artifact: PublishedArtifact): Boolean =
+    artifact.hasReleaseStatus() && artifact.hasCorrectVersion()
+
+
+  // Debian Artifacts should contain a releaseStatus in the metadata	  // Debian Artifacts should contain a releaseStatus in the metadata
+  private fun PublishedArtifact.hasReleaseStatus() : Boolean {
+    return if (this.metadata.containsKey("releaseStatus") && this.metadata["releaseStatus"] != null) {
+      true
+    } else {
+      log.debug("Ignoring artifact event without release status: $this")
+      false
+    }
+  }
+
+  // Debian Artifacts should not have "local" as a part of their version string
+  private fun PublishedArtifact.hasCorrectVersion() : Boolean {
+    return if (!this.version.contains("local")) {
+      true
+    } else {
+      log.debug("Ignoring artifact which contains local is its version string: $this")
+      false
+    }
+  }
 }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
@@ -136,4 +136,8 @@ class DockerArtifactSupplier(
       ?.let { it.strategy in listOf(BRANCH_JOB_COMMIT_BY_JOB, SEMVER_JOB_COMMIT_BY_JOB, SEMVER_JOB_COMMIT_BY_SEMVER) }
       ?: false
   }
+
+  override fun shouldProcessArtifact(artifact: PublishedArtifact): Boolean =
+    artifact.version != "latest"
+
 }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
@@ -79,4 +79,7 @@ class NpmArtifactSupplier(
 
   private val DeliveryArtifact.statusesForQuery: List<String>
     get() = statuses.map { it.name }
+
+  // Currently, we don't have any limitations for NPM artifact versions
+  override fun shouldProcessArtifact(artifact: PublishedArtifact) = true
 }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -124,6 +124,9 @@ internal class ArtifactListenerTests : JUnit5Minutests {
         every {
           debianArtifactSupplier.getArtifactMetadata(publishedDeb)
         } returns artifactMetadata
+        every {
+          debianArtifactSupplier.shouldProcessArtifact(any())
+        } returns true
       }
 
       context("the version was already known") {

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
@@ -168,7 +168,8 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
         expectThat(results)
           .isEqualTo(artifactMetadata)
       }
-      test (" should process artifact successfully") {
+
+      test ("should process artifact successfully") {
         expectThat(debianArtifactSupplier.shouldProcessArtifact(latestArtifact))
           .isTrue()
       }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
@@ -25,7 +25,9 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
 import strikt.assertions.isNull
+import strikt.assertions.isTrue
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
 
@@ -56,6 +58,13 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
       reference = debianArtifact.reference,
       version = "etcd-3.4.10-hlocal.856d0b1",
       metadata = mapOf("releaseStatus" to SNAPSHOT, "buildNumber" to "1", "commitId" to "a15p0")
+    )
+
+    val artifactWithoutStatus = PublishedArtifact (
+      name = debianArtifact.name,
+      type = debianArtifact.type,
+      reference = debianArtifact.reference,
+      version = "${debianArtifact.name}-${versions.last()}"
     )
 
     val artifactMetadata = ArtifactMetadata(
@@ -158,6 +167,20 @@ internal class DebianArtifactSupplierTests : JUnit5Minutests {
         }
         expectThat(results)
           .isEqualTo(artifactMetadata)
+      }
+      test (" should process artifact successfully") {
+        expectThat(debianArtifactSupplier.shouldProcessArtifact(latestArtifact))
+          .isTrue()
+      }
+
+      test ("should not process artifact with local in its version string") {
+        expectThat(debianArtifactSupplier.shouldProcessArtifact(artifactWithInvalidVersion))
+          .isFalse()
+      }
+
+      test ("should not process artifact without a status") {
+        expectThat(debianArtifactSupplier.shouldProcessArtifact(artifactWithoutStatus))
+          .isFalse()
       }
     }
   }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplierTests.kt
@@ -22,7 +22,9 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
 import strikt.assertions.isNull
+import strikt.assertions.isTrue
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
 
@@ -57,6 +59,14 @@ internal class DockerArtifactSupplierTests : JUnit5Minutests {
         "date" to "1598707355157"
       )
     )
+
+    val latestArtifactWithBadVersion = PublishedArtifact(
+      name = dockerArtifact.name,
+      type = dockerArtifact.type,
+      reference = dockerArtifact.reference,
+      version = "latest"
+    )
+
     val dockerArtifactSupplier = DockerArtifactSupplier(eventBridge, clouddriverService, artifactMetadataService)
   }
 
@@ -116,6 +126,16 @@ internal class DockerArtifactSupplierTests : JUnit5Minutests {
           .isEqualTo(BuildMetadata(id = 1182))
         expectThat(dockerArtifactSupplier.parseDefaultBuildMetadata(latestArtifact, DockerVersioningStrategy(INCREASING_TAG)))
           .isNull()
+      }
+
+      test("should not process artifact with latest version") {
+        expectThat(dockerArtifactSupplier.shouldProcessArtifact(latestArtifact))
+          .isTrue()
+      }
+
+      test("should not process artifact with latest version") {
+        expectThat(dockerArtifactSupplier.shouldProcessArtifact(latestArtifactWithBadVersion))
+          .isFalse()
       }
     }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -162,7 +162,6 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     val version4 = "keeldemo-1.0.0-h11.518aea2" // release
     val version5 = "keeldemo-1.0.0-h12.4ea8a9d" // release
     val version6 = "master-h12.4ea8a9d"
-    val versionBad = "latest"
     val versionOnly = "0.0.1~dev.8-h8.41595c4"
 
     val pin1 = EnvironmentArtifactPin(
@@ -223,7 +222,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         storeArtifactInstance(versionedReleaseDebian.toArtifactInstance(it, RELEASE))
       }
       register(versionedDockerArtifact)
-      setOf(version6, versionBad).forEach {
+      setOf(version6).forEach {
         storeArtifactInstance(versionedDockerArtifact.toArtifactInstance(it))
       }
       register(debianFilteredByBranch)
@@ -371,7 +370,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
         context("docker") {
           test("querying for all returns all") {
-            expectThat(subject.versions(versionedDockerArtifact.name, versionedDockerArtifact.type)).containsExactlyInAnyOrder(version6, versionBad)
+            expectThat(subject.versions(versionedDockerArtifact.name, versionedDockerArtifact.type)).containsExactlyInAnyOrder(version6)
           }
 
           test("querying the artifact filters out the bad tag") {


### PR DESCRIPTION
This PR move that responsibility to each artifact provider in a unified way, giving us an easy way to control the versions we want to filter at the API level.