### PR TITLE
Allow resource updates to change version

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
@@ -36,6 +36,8 @@ interface KeelReadOnlyRepository {
 
   fun getResource(id: String): Resource<ResourceSpec>
 
+  fun getRawResource(id: String): Resource<ResourceSpec>
+
   fun hasManagedResources(application: String): Boolean
 
   fun getResourceIdsByApplication(application: String): List<String>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -25,14 +25,14 @@ import com.netflix.spinnaker.keel.core.api.normalize
 import com.netflix.spinnaker.keel.events.ApplicationEvent
 import com.netflix.spinnaker.keel.events.ResourceEvent
 import com.netflix.spinnaker.keel.events.ResourceHistoryEvent
-import java.time.Clock
-import java.time.Duration
-import java.time.Instant
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Propagation.REQUIRED
 import org.springframework.transaction.annotation.Transactional
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 
 /**
  * A combined repository for delivery configs, artifacts, and resources.
@@ -253,6 +253,9 @@ class CombinedRepository(
 
   override fun getResource(id: String): Resource<ResourceSpec> =
     resourceRepository.get(id)
+
+  override fun getRawResource(id: String): Resource<ResourceSpec> =
+    resourceRepository.getRaw(id)
 
   override fun hasManagedResources(application: String): Boolean =
     resourceRepository.hasManagedResources(application)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -45,12 +45,23 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<ResourceSp
   fun allResources(callback: (ResourceHeader) -> Unit)
 
   /**
-   * Retrieves a single resource by its unique [id].
+   * Retrieves a single resource by its unique [id]. If the resource is of an obsolete kind, the
+   * result is automatically migrated to the latest version of that kind.
    *
    * @return The resource represented by [id] or `null` if [id] is unknown.
    * @throws NoSuchResourceException if [id] does not map to a resource in the repository.
    */
   fun get(id: String): Resource<ResourceSpec>
+
+  /**
+   * Retrieves a single resource by its unique [id]. No migration is performed if the resource is of
+   * an obsolete kind.
+   *
+   * This is only intended for use when updating resources as automatically migration can mask the
+   * difference between current and updated resource states when a user is trying to update to a
+   * newer kind.
+   */
+  fun getRaw(id: String): Resource<ResourceSpec>
 
   fun hasManagedResources(application: String): Boolean
 


### PR DESCRIPTION
Previously on updating a resource the migrators were applied so the "current" resource compared with the request payload would be the latest spec version. If the only change in the payload was to update the version (and associated changes in spec format) the update would appear to be a no-op. This PR introduces a new repository method `getRaw` that retrieves the resource as currently stored in the database (without applying migrators). This is only intended for use in the update request flow.