### PR TITLE
refactor(plugins): Define Java-friendly versions of ResourceHandler methods

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ResourceHandler.kt
@@ -12,6 +12,8 @@ import com.netflix.spinnaker.keel.api.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
 
 /**
  * A [ResourceHandler] is a keel plugin that provides resource state monitoring and actuation capabilities
@@ -59,9 +61,24 @@ interface ResourceHandler<S : ResourceSpec, R : Any> : SpinnakerExtensionPoint {
    * The value returned by this method is used as the basis of the diff (with the result of
    * [current] in order to decide whether to call [create]/[update]/[upsert].
    *
+   * Note: Java-based plugins should override [desiredAsync] instead.
+   *
    * @param resource the resource as persisted in the Keel database.
    */
-  suspend fun desired(resource: Resource<S>): R
+  @JvmDefault
+  suspend fun desired(resource: Resource<S>): R =
+    TODO("Not implemented")
+
+  /**
+   * Asynchronous implementation of [desired] which returns a [CompletableFuture] encapsulating
+   * the execution of desired state retrieval for the [resource] using the specified [executor].
+   *
+   * This method should *only* be overridden by Java-based implementations. Kotlin-based implementations
+   * should override [desired] instead.
+   */
+  @JvmDefault
+  fun desiredAsync(resource: Resource<S>, executor: Executor): CompletableFuture<R> =
+    TODO("Not implemented")
 
   /**
    * Return the current _actual_ representation of what [resource] looks like in the cloud.
@@ -72,8 +89,23 @@ interface ResourceHandler<S : ResourceSpec, R : Any> : SpinnakerExtensionPoint {
    * [desired] in order to decide whether to call [create]/[update]/[upsert].
    *
    * Implementations of this method should not actuate any changes.
+   *
+   * Note: Java-based plugins should override [currentAsync] instead.
    */
-  suspend fun current(resource: Resource<S>): R?
+  @JvmDefault
+  suspend fun current(resource: Resource<S>): R? =
+    TODO("Not implemented")
+
+  /**
+   * Asynchronous implementation of [current] which returns a [CompletableFuture] encapsulating
+   * the execution of current state retrieval for the [resource] using the specified [executor].
+   *
+   * This method should *only* be overridden by Java-based implementations. Kotlin-based implementations
+   * should override [current] instead.
+   */
+  @JvmDefault
+  fun currentAsync(resource: Resource<S>, executor: Executor): CompletableFuture<R?> =
+    TODO("Not implemented")
 
   /**
    * Evaluates the resource diff and determines whether it can take action to resolve the diff.

--- a/keel-core/src/test/java/com/netflix/spinnaker/keel/actuation/MapBackedResourceSpec.java
+++ b/keel-core/src/test/java/com/netflix/spinnaker/keel/actuation/MapBackedResourceSpec.java
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.keel.actuation;
+
+import com.netflix.spinnaker.keel.api.ResourceSpec;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+public class MapBackedResourceSpec implements ResourceSpec {
+  private String id;
+  private String application;
+  private Map<String, Object> data;
+
+  public MapBackedResourceSpec(String id, String application, Map<String, Object> data) {
+    this.id = id;
+    this.application = application;
+    this.data = data;
+  }
+
+  @Nonnull
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Nonnull
+  @Override
+  public String getApplication() {
+    return application;
+  }
+
+  @Nonnull
+  @Override
+  public String getDisplayName() {
+    return application + "-" + id;
+  }
+
+  public Map<String, Object> getData() {
+    return data;
+  }
+}

--- a/keel-core/src/test/java/com/netflix/spinnaker/keel/actuation/SleepyJavaResourceHandler.java
+++ b/keel-core/src/test/java/com/netflix/spinnaker/keel/actuation/SleepyJavaResourceHandler.java
@@ -1,0 +1,81 @@
+package com.netflix.spinnaker.keel.actuation;
+
+import com.netflix.spinnaker.keel.api.Resource;
+import com.netflix.spinnaker.keel.api.ResourceKind;
+import com.netflix.spinnaker.keel.api.plugins.ResourceHandler;
+import com.netflix.spinnaker.keel.api.plugins.SupportedKind;
+import com.netflix.spinnaker.keel.api.support.EventPublisher;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple Java resource handler whose only feature is to be able to block before returning results
+ * to [currentAsync] and [desiredAsync] by sleeping a configurable amount of milliseconds.
+ *
+ * <p>Pass a `delay` entry in the `data` map of the [MapBackedResourceSpec] to configure the sleep
+ * time.
+ */
+public class SleepyJavaResourceHandler
+    implements ResourceHandler<MapBackedResourceSpec, MapBackedResourceSpec> {
+  public static final ResourceKind SLEEPY_RESOURCE_KIND = new ResourceKind("test", "sleepy", "1");
+  public static final Logger LOG = LoggerFactory.getLogger(SleepyJavaResourceHandler.class);
+
+  private EventPublisher eventPublisher;
+
+  public SleepyJavaResourceHandler(EventPublisher eventPublisher) {
+    this.eventPublisher = eventPublisher;
+  }
+
+  @Nonnull
+  @Override
+  public SupportedKind<MapBackedResourceSpec> getSupportedKind() {
+    return new SupportedKind<>(SLEEPY_RESOURCE_KIND, MapBackedResourceSpec.class);
+  }
+
+  @Nullable
+  @Override
+  public EventPublisher getEventPublisher() {
+    return eventPublisher;
+  }
+
+  @Nonnull
+  @Override
+  public CompletableFuture<MapBackedResourceSpec> desiredAsync(
+      @Nonnull Resource<? extends MapBackedResourceSpec> resource, @Nonnull Executor executor) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          sleep(resource);
+          return resource.getSpec();
+        },
+        executor);
+  }
+
+  @Nonnull
+  @Override
+  public CompletableFuture<MapBackedResourceSpec> currentAsync(
+      @Nonnull Resource<? extends MapBackedResourceSpec> resource, @Nonnull Executor executor) {
+    return CompletableFuture.supplyAsync(
+        () -> {
+          sleep(resource);
+          return resource.getSpec();
+        },
+        executor);
+  }
+
+  private void sleep(Resource<? extends MapBackedResourceSpec> resource) {
+    String delay = (String) resource.getSpec().getData().get("delay");
+    if (delay != null) {
+      try {
+        LOG.debug("Sleeping for {} millis...", delay);
+        Thread.sleep(Long.parseLong(delay));
+        LOG.debug("Done sleeping.");
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.actuation
 
+import com.netflix.spinnaker.keel.actuation.SleepyJavaResourceHandler.SLEEPY_RESOURCE_KIND
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
@@ -9,6 +10,7 @@ import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.plugins.ActionDecision
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
+import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
@@ -37,7 +39,9 @@ import com.netflix.spinnaker.keel.plugin.CannotResolveDesiredState
 import com.netflix.spinnaker.keel.telemetry.ArtifactVersionVetoed
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckSkipped
 import com.netflix.spinnaker.keel.test.DummyArtifactVersionedResourceSpec
+import com.netflix.spinnaker.keel.test.artifactReferenceResource
 import com.netflix.spinnaker.keel.test.artifactVersionedResource
+import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.veto.Veto
 import com.netflix.spinnaker.keel.veto.VetoEnforcer
 import com.netflix.spinnaker.keel.veto.VetoResponse
@@ -47,10 +51,14 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.spyk
 import io.mockk.verifySequence
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
+import strikt.api.expectThrows
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import java.time.Clock
@@ -74,9 +82,10 @@ internal class ResourceActuatorTests : JUnit5Minutests {
     val springEnv: SpringEnvironment = mockk(relaxed = true) {
       every { getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, false) } returns true
     }
+    val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
     val plugin1 = mockk<ResourceHandler<DummyArtifactVersionedResourceSpec, DummyArtifactVersionedResourceSpec>>(relaxUnitFun = true)
     val plugin2 = mockk<ResourceHandler<DummyArtifactVersionedResourceSpec, DummyArtifactVersionedResourceSpec>>(relaxUnitFun = true)
-    val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
+    val javaPlugin = spyk(SleepyJavaResourceHandler(SpringEventPublisherBridge(publisher)))
     val veto = mockk<Veto>()
     val vetoEnforcer = VetoEnforcer(listOf(veto))
     val clock = Clock.systemUTC()
@@ -85,7 +94,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       artifactRepository,
       deliveryConfigRepository,
       diffFingerprintRepository,
-      listOf(plugin1, plugin2),
+      listOf(plugin1, plugin2, javaPlugin),
       actuationPauser,
       vetoEnforcer,
       publisher,
@@ -595,6 +604,40 @@ internal class ResourceActuatorTests : JUnit5Minutests {
           }
         }
 
+      }
+    }
+
+    context("Java plugin compatibility") {
+      context("plugin blocks in calls to get current/desired state") {
+        val resource = resource(
+          kind = SLEEPY_RESOURCE_KIND,
+          spec = MapBackedResourceSpec("test", "fnord", mapOf("delay" to "2000"))
+        )
+
+        before {
+          every { resourceRepository.lastEvent(resource.id) } returns ResourceCreated(resource)
+          every {
+            deliveryConfigRepository.deliveryConfigFor(resource.id)
+          } returns DeliveryConfig(
+            name = "fnord-manifest",
+            application = "fnord",
+            serviceAccount = "keel@spin",
+            artifacts = setOf(DebianArtifact("fnord", vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")))),
+            environments = setOf(Environment(name = "staging", resources = setOf(resource)))
+          )
+          every { deliveryConfigRepository.deliveryConfigLastChecked(any()) } returns Instant.now().minus(Duration.ofSeconds(30))
+          every { veto.check(resource) } returns VetoResponse(true, "all")
+        }
+
+        test("coroutine timeout applies even when plugin implementation is in Java") {
+          runBlocking {
+            expectThrows<TimeoutCancellationException> {
+              withTimeout(1000) {
+                subject.checkResource(resource)
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -140,10 +140,9 @@ fun artifactReferenceResource(
   kind: ResourceKind = TEST_API_V1.qualify("artifactReference"),
   id: String = randomString(),
   application: String = "fnord",
-  artifactReference: String = "fnord",
-  data: Map<String, Any> = mapOf("aString" to randomString())
+  artifactReference: String = "fnord"
 ): Resource<DummyArtifactReferenceResourceSpec> =
-  DummyArtifactReferenceResourceSpec(id = id, application = application, artifactReference = artifactReference, data = data)
+  DummyArtifactReferenceResourceSpec(id = id, application = application, artifactReference = artifactReference)
     .let { spec ->
       resource(
         kind = kind,
@@ -193,7 +192,7 @@ data class DummyArtifactVersionedResourceSpec(
 data class DummyArtifactReferenceResourceSpec(
   @get:ExcludedFromDiff
   override val id: String = randomString(),
-  val data: Map<String, Any> = mapOf("aString" to randomString()),
+  val data: String = randomString(),
   override val application: String = "fnord",
   override val artifactType: ArtifactType? = DEBIAN,
   override val artifactReference: String? = "fnord",

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -140,9 +140,10 @@ fun artifactReferenceResource(
   kind: ResourceKind = TEST_API_V1.qualify("artifactReference"),
   id: String = randomString(),
   application: String = "fnord",
-  artifactReference: String = "fnord"
+  artifactReference: String = "fnord",
+  data: Map<String, Any> = mapOf("aString" to randomString())
 ): Resource<DummyArtifactReferenceResourceSpec> =
-  DummyArtifactReferenceResourceSpec(id = id, application = application, artifactReference = artifactReference)
+  DummyArtifactReferenceResourceSpec(id = id, application = application, artifactReference = artifactReference, data = data)
     .let { spec ->
       resource(
         kind = kind,
@@ -192,7 +193,7 @@ data class DummyArtifactVersionedResourceSpec(
 data class DummyArtifactReferenceResourceSpec(
   @get:ExcludedFromDiff
   override val id: String = randomString(),
-  val data: String = randomString(),
+  val data: Map<String, Any> = mapOf("aString" to randomString()),
   override val application: String = "fnord",
   override val artifactType: ArtifactType? = DEBIAN,
   override val artifactReference: String? = "fnord",


### PR DESCRIPTION
### What
Introduces Java-friendly counterparts to the `current` and `desired` methods in `ResourceHandler` that can be safely implemented in Java to avoid issues with shared threads with coroutines.

### Why
This is intended to address an issue we found where a Java-based plugin blocks in either of those calls, causing all of keel's resource actuation to also block since the Java code is entirely oblivious to coroutine management, but was blocking a coroutine thread.

### How
My approach was to define methods that take in an `Executor` passed in by keel and that are expected to return a `CompletableFuture` that runs in that executor to complete its work. This allows keel to convert the future to a coroutine-friendly `Deferred` object that respects coroutine-specific behaviors like timeouts and cancellations.

This should be 100% backwards-compatible with both Java- and Kotlin-based implementations, so I expect all the tests to pass.