### PR TITLE
Update inappropriate use of any() to ofType() in tests

### DIFF
--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -177,7 +177,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
         }
 
         test("a telemetry event is recorded") {
-          verify { publisher.publishEvent(any<ArtifactVersionUpdated>()) }
+          verify { publisher.publishEvent(ofType<ArtifactVersionUpdated>()) }
         }
       }
     }

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -183,7 +183,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
         }
 
         test("an event gets published") {
-          verify { publisher.publishEvent(any<ArtifactRegisteredEvent>()) }
+          verify { publisher.publishEvent(ofType<ArtifactRegisteredEvent>()) }
         }
       }
 
@@ -373,7 +373,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
               test("an event is triggered because we want to track region mismatches") {
                 verify {
-                  publisher.publishEvent(any<ImageRegionMismatchDetected>())
+                  publisher.publishEvent(ofType<ImageRegionMismatchDetected>())
                 }
               }
             }
@@ -395,7 +395,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
               test("no region mismatch event is triggered") {
                 verify(exactly = 0) {
-                  publisher.publishEvent(any<ImageRegionMismatchDetected>())
+                  publisher.publishEvent(ofType<ImageRegionMismatchDetected>())
                 }
               }
             }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -530,7 +530,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
 
         test("no action is taken and event is emitted") {
           verify { publisher.publishEvent(ofType<ResourceDeltaDetected>()) }
-          verify { publisher.publishEvent(any<ResourceDiffNotActionable>()) }
+          verify { publisher.publishEvent(ofType<ResourceDiffNotActionable>()) }
           verify(exactly = 0) { plugin1.create(any(), any()) }
           verify(exactly = 0) { plugin1.update(any(), any()) }
           verify(exactly = 0) { plugin1.delete(any()) }
@@ -564,10 +564,10 @@ internal class ResourceActuatorTests : JUnit5Minutests {
           every { plugin1.actuationInProgress(resource) } returns false
           every { deliveryConfigRepository.deliveryConfigLastChecked(any()) } returns Instant.now().minus(Duration.ofSeconds(30))
         }
-        
+
         context("the version has not been deployed successfully before") {
           before {
-            every { artifactRepository.wasSuccessfullyDeployedTo(any(), any(), any(), any()) } returns 
+            every { artifactRepository.wasSuccessfullyDeployedTo(any(), any(), any(), any()) } returns
               false
             every { artifactRepository.markAsVetoedIn(any(), any(), false) } returns true
             runBlocking {

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -293,7 +293,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
         }
 
         test("a deployed event fires") {
-          verify { publisher.publishEvent(any<ArtifactVersionDeployed>()) }
+          verify { publisher.publishEvent(ofType<ArtifactVersionDeployed>()) }
         }
       }
     }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -269,7 +269,7 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
         derivedContext<ResultActions>("persisting a delivery config as $contentType") {
           fixture {
             every {
-              repository.upsertDeliveryConfig(any<SubmittedDeliveryConfig>())
+              repository.upsertDeliveryConfig(ofType<SubmittedDeliveryConfig>())
             } answers {
               firstArg<SubmittedDeliveryConfig>().toDeliveryConfig()
             }
@@ -344,7 +344,7 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
     context("importing a delivery config from source control") {
       before {
         every {
-          repository.upsertDeliveryConfig(any<SubmittedDeliveryConfig>())
+          repository.upsertDeliveryConfig(ofType<SubmittedDeliveryConfig>())
         } returns deliveryConfig.toDeliveryConfig()
       }
 


### PR DESCRIPTION
`any()` just satisfies the compile-time type check, it doesn't assert that the runtime type of the parameter matches the generic. For that you need `ofType()`. I just discovered this yesterday. I've updated tests that _are_ attempting to verify the parameter type to use the correct matcher function.