### PR TITLE
fix deserialization injection

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/schema/Optional.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/schema/Optional.kt
@@ -7,4 +7,4 @@ import kotlin.annotation.AnnotationTarget.VALUE_PARAMETER
  * heuristic would normally apply.
  */
 @Target(VALUE_PARAMETER)
-annotation class Optional
+annotation class Optional(val value: String = "")

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.netflix.spinnaker.keel.api.schema.Literal
+import com.netflix.spinnaker.keel.api.schema.Optional
 
 sealed class SecurityGroupRule {
   abstract val protocol: Protocol
@@ -24,18 +25,14 @@ sealed class SecurityGroupRule {
   enum class Protocol {
     ALL, TCP, UDP, ICMP
   }
-
-  open val isSelfReference: Boolean = false
 }
 
 data class ReferenceRule(
   override val protocol: Protocol,
-  val name: String? = null,
+  @Optional("defaults to the name of the security group the rule belongs to")
+  val name: String,
   override val portRange: IngressPorts
-) : SecurityGroupRule() {
-  override val isSelfReference: Boolean
-    get() = name == null
-}
+) : SecurityGroupRule()
 
 data class CrossAccountReferenceRule(
   override val protocol: Protocol,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.CustomizedMetricSpecification
 import com.netflix.spinnaker.keel.api.ec2.IngressPorts
 import com.netflix.spinnaker.keel.api.ec2.InstanceProvider
+import com.netflix.spinnaker.keel.api.ec2.ReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.Scaling
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
@@ -42,8 +43,8 @@ import com.netflix.spinnaker.keel.ec2.jackson.mixins.CustomizedMetricSpecificati
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.HealthMixin
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.HealthSpecMixin
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.InstanceProviderMixin
+import com.netflix.spinnaker.keel.ec2.jackson.mixins.ReferenceRuleMixin
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.ScalingMixin
-import com.netflix.spinnaker.keel.ec2.jackson.mixins.SecurityGroupRuleMixin
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.SecurityGroupSpecMixin
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.ServerGroupSpecMixin
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.StepAdjustmentMixin
@@ -71,8 +72,8 @@ object KeelEc2ApiModule : SimpleModule("Keel EC2 API") {
       setMixInAnnotations<Health, HealthMixin>()
       setMixInAnnotations<HealthSpec, HealthSpecMixin>()
       setMixInAnnotations<InstanceProvider, InstanceProviderMixin>()
+      setMixInAnnotations<ReferenceRule, ReferenceRuleMixin>()
       setMixInAnnotations<Scaling, ScalingMixin>()
-      setMixInAnnotations<SecurityGroupRule, SecurityGroupRuleMixin>()
       setMixInAnnotations<SecurityGroupSpec, SecurityGroupSpecMixin>()
       setMixInAnnotations<ServerGroupSpec, ServerGroupSpecMixin>()
       setMixInAnnotations<StepAdjustment, StepAdjustmentMixin>()
@@ -97,6 +98,7 @@ internal object KeelEc2ApiDeserializers : Deserializers.Base() {
     when (type.rawClass) {
       ActiveServerGroupImage::class.java -> ActiveServerGroupImageDeserializer()
       IngressPorts::class.java -> IngressPortsDeserializer()
+      SecurityGroupSpec::class.java -> SecurityGroupSpecDeserializer()
       SecurityGroupRule::class.java -> SecurityGroupRuleDeserializer()
       else -> null
     }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/SecurityGroupSpecDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/SecurityGroupSpecDeserializer.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.InjectableValues.Std
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyMetadata
+import com.fasterxml.jackson.databind.PropertyName
 import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.keel.api.Moniker
@@ -28,8 +30,22 @@ class SecurityGroupSpecDeserializer : StdNodeBasedDeserializer<SecurityGroupSpec
       )
     }
 
-  private inline fun <reified T> DeserializationContext.findInjectableValue(valueId: String) =
+  private inline fun <reified T> DeserializationContext.findInjectableValue(
+    valueId: String,
+    propertyName: String = valueId
+  ) =
     (parser.codec as ObjectMapper).let { mapper ->
-      mapper.injectableValues.findInjectableValue(valueId, this, BeanProperty.Bogus(), null) as T
+      mapper.injectableValues.findInjectableValue(
+        valueId,
+        this,
+        BeanProperty.Std(
+          PropertyName.construct(propertyName),
+          constructType(T::class.java),
+          PropertyName.construct(propertyName),
+          null,
+          PropertyMetadata.STD_REQUIRED_OR_OPTIONAL
+        ),
+        null
+      ) as T
     }
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/SecurityGroupSpecDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/SecurityGroupSpecDeserializer.kt
@@ -1,0 +1,35 @@
+package com.netflix.spinnaker.keel.ec2.jackson
+
+import com.fasterxml.jackson.databind.BeanProperty
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.InjectableValues.Std
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
+import com.netflix.spinnaker.keel.core.name
+
+class SecurityGroupSpecDeserializer : StdNodeBasedDeserializer<SecurityGroupSpec>(SecurityGroupSpec::class.java) {
+  override fun convert(root: JsonNode, context: DeserializationContext) =
+    with(context.parser.codec as ObjectMapper) {
+      val moniker: Moniker = convertValue(root.path("moniker"))
+      SecurityGroupSpec(
+        moniker = moniker,
+        locations = convertValue(root.path("locations"))
+          ?: context.findInjectableValue("locations"),
+        description = root.get("description")?.textValue(),
+        inboundRules = copy().run {
+          injectableValues = Std(mapOf("name" to moniker.name))
+          root.get("inboundRules")?.let { convertValue(it) } ?: emptySet()
+        },
+        overrides = root.get("overrides")?.let { convertValue(it) } ?: emptyMap()
+      )
+    }
+
+  private inline fun <reified T> DeserializationContext.findInjectableValue(valueId: String) =
+    (parser.codec as ObjectMapper).let { mapper ->
+      mapper.injectableValues.findInjectableValue(valueId, this, BeanProperty.Bogus(), null) as T
+    }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/mixins/ReferenceRuleMixin.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/mixins/ReferenceRuleMixin.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.ec2.jackson.mixins
+
+import com.fasterxml.jackson.annotation.JacksonInject
+
+internal interface ReferenceRuleMixin {
+  @get:JacksonInject("name")
+  val name: String
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/mixins/SecurityGroupRuleMixin.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/mixins/SecurityGroupRuleMixin.kt
@@ -1,8 +1,0 @@
-package com.netflix.spinnaker.keel.ec2.jackson.mixins
-
-import com.fasterxml.jackson.annotation.JsonIgnore
-
-interface SecurityGroupRuleMixin {
-  @get:JsonIgnore
-  val isSelfReference: Boolean
-}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -42,6 +42,7 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel
+import com.netflix.spinnaker.keel.core.name
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.diff.toIndividualDiffs
 import com.netflix.spinnaker.keel.model.Job
@@ -289,7 +290,7 @@ class SecurityGroupHandler(
                   )
                   else -> ReferenceRule(
                     protocol,
-                    if (ingressGroup.name == name) null else ingressGroup.name, // if it's a self-referential rule keel models the name as null
+                    ingressGroup.name,
                     portRange
                   )
                 }
@@ -333,7 +334,7 @@ class SecurityGroupHandler(
           // we have to do a 2-phase create for self-referencing ingress rules as the referenced
           // security group must exist prior to the rule being applied. We filter then out here and
           // the subsequent diff will apply the additional group(s).
-          .filterNot { it.isSelfReference }
+          .filterNot { it is ReferenceRule && it.name == moniker.name }
           .mapNotNull {
             it.referenceRuleToJob(this)
           },

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/DeserializationInjectionTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/DeserializationInjectionTests.kt
@@ -1,0 +1,74 @@
+package com.netflix.spinnaker.keel.api.ec2
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.ec2.jackson.registerKeelEc2ApiModule
+import com.netflix.spinnaker.keel.extensions.DefaultExtensionRegistry
+import com.netflix.spinnaker.keel.jackson.registerKeelApiModule
+import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+import strikt.assertions.isSuccess
+
+internal class DeserializationInjectionTests {
+
+  val mapper = configuredYamlMapper()
+    .registerKeelApiModule()
+    .registerKeelEc2ApiModule()
+  val extensionRegistry = DefaultExtensionRegistry(listOf(mapper)).apply {
+    register(
+      baseType = ResourceSpec::class.java,
+      extensionType = SecurityGroupSpec::class.java,
+      discriminator = EC2_SECURITY_GROUP_V1.kind.toString()
+    )
+  }
+
+  @Test
+  fun `can deserialize a delivery config with injected locations and security group names`() {
+    val yaml = """
+      |name: fnord-manifest
+      |application: fnord
+      |artifacts: []
+      |environments:
+      |- name: test
+      |  constraints: []
+      |  notifications: []
+      |  locations:
+      |    account: test
+      |    regions:
+      |    - name: us-west-2
+      |    - name: us-east-1
+      |  resources:
+      |  - kind: ec2/security-group@v1
+      |    spec:
+      |      moniker:
+      |        app: fnord
+      |      description: self-referential ingress rule
+      |      inboundRules:
+      |      - protocol: TCP
+      |        portRange:
+      |          startPort: 8080
+      |          endPort: 8080
+    """.trimMargin()
+
+    expectCatching {
+      mapper.readValue<SubmittedDeliveryConfig>(yaml)
+    }
+      .isSuccess()
+      .get {
+        environments.first().resources.first().spec
+      }
+      .isA<SecurityGroupSpec>()
+      .and {
+        get { locations.account } isEqualTo "test"
+      }
+      .and {
+        get { inboundRules.first() }
+          .isA<ReferenceRule>()
+          .get { name } isEqualTo "fnord"
+      }
+  }
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupTests.kt
@@ -28,7 +28,7 @@ internal object SecurityGroupTests : JUnit5Minutests {
         ),
         description = "I can see the fnords",
         inboundRules = setOf(
-          ReferenceRule(protocol = TCP, portRange = PortRange(7001, 7002)),
+          ReferenceRule(name = "fnord-ext", protocol = TCP, portRange = PortRange(7001, 7002)),
           CidrRule(TCP, PortRange(443, 443), "127.0.0.1/16")
         )
       )

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -45,6 +45,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel.SecurityG
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel.SecurityGroupRulePortRange
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel.SecurityGroupRuleReference
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
+import com.netflix.spinnaker.keel.core.name
 import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.model.Job
@@ -596,6 +597,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           securityGroupSpec = securityGroupSpec.copy(
             inboundRules = setOf(
               ReferenceRule(
+                name = securityGroupSpec.moniker.name,
                 protocol = TCP,
                 portRange = PortRange(startPort = 443, endPort = 443)
               )
@@ -645,6 +647,7 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
           securityGroupSpec = securityGroupSpec.copy(
             inboundRules = setOf(
               ReferenceRule(
+                name = securityGroupSpec.moniker.name,
                 protocol = TCP,
                 portRange = PortRange(startPort = 443, endPort = 443)
               )


### PR DESCRIPTION
Restores changes made to deserialization of self-referential ingress rules in #1624 but fixes the fact I was assuming the wrong type for the injected `locations` value.