### PR TITLE
Don't serialize resources at top level of delivery config

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.Serializers
 import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.api.Constraint
+import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.Resource
@@ -38,6 +39,7 @@ import com.netflix.spinnaker.keel.jackson.mixins.ClusterDeployStrategyMixin
 import com.netflix.spinnaker.keel.jackson.mixins.CommitMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ConstraintStateMixin
 import com.netflix.spinnaker.keel.jackson.mixins.DeliveryArtifactMixin
+import com.netflix.spinnaker.keel.jackson.mixins.DeliveryConfigMixin
 import com.netflix.spinnaker.keel.jackson.mixins.LocatableMixin
 import com.netflix.spinnaker.keel.jackson.mixins.MonikeredMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ResourceKindMixin
@@ -58,6 +60,7 @@ object KeelApiModule : SimpleModule("Keel API") {
       setMixInAnnotations<ClusterDeployStrategy, ClusterDeployStrategyMixin>()
       setMixInAnnotations<ConstraintState, ConstraintStateMixin>()
       setMixInAnnotations<DeliveryArtifact, DeliveryArtifactMixin>()
+      setMixInAnnotations<DeliveryConfig, DeliveryConfigMixin>()
       setMixInAnnotations<Locatable<*>, LocatableMixin<*>>()
       setMixInAnnotations<Monikered, MonikeredMixin>()
       setMixInAnnotations<ResourceKind, ResourceKindMixin>()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/DeliveryConfigMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/DeliveryConfigMixin.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.jackson.mixins
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.Resource
+
+interface DeliveryConfigMixin {
+  @get:JsonIgnore
+  val resources: List<Resource<*>>
+}


### PR DESCRIPTION
I happened to notice the resources are included as an array at the top level of the delivery config JSON/YAML response as well as being under their respective environments. This is because `DeliveryConfig.resources` is a transient property not being ignored by Jackson.