### PR TITLE
fix(veto): Do not mark never-deployed versions as bad

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
+import com.netflix.spinnaker.keel.core.api.PromotionStatus
 import com.netflix.spinnaker.kork.exceptions.UserException
 import java.time.Duration
 
@@ -242,6 +243,17 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
     artifactReference: String,
     version: String
   ): ArtifactSummaryInEnvironment?
+
+  /**
+   * Given identifying information about an artifact version in an environment, return the version's promotion
+   * status in that environment, or null if not found.
+   */
+  fun getArtifactPromotionStatus(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    environmentName: String
+  ): PromotionStatus?
 
   /**
    * Returns between zero and [limit] artifacts that have not been checked (i.e. returned by this

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/veto/unhappy/UnhappyVeto.kt
@@ -52,8 +52,8 @@ class UnhappyVeto(
     val resourceId = resource.id
     val application = resource.application
 
-    // maxDiff count represents the number of times we're allowed to see a diff and take action to try and fix it.
-    if (diffFingerprintRepository.actionTakenCount(resourceId) <= maxDiffCount(resource)) {
+    // maxActionCountPerDiff represents the number of times we're allowed to see a diff and take action to try and fix it.
+    if (diffFingerprintRepository.actionTakenCount(resourceId) <= maxActionCountPerDiff(resource)) {
       unhappyVetoRepository.delete(resourceId)
       return allowedResponse()
     }
@@ -90,7 +90,7 @@ class UnhappyVeto(
   override fun currentRejectionsByApp(application: String) =
     unhappyVetoRepository.getAllForApp(application).toList()
 
-  private fun maxDiffCount(resource: Resource<*>) =
+  private fun maxActionCountPerDiff(resource: Resource<*>) =
     when (resource.spec) {
       is UnhappyControl -> (resource.spec as UnhappyControl).maxDiffCount ?: maxDiffCount
       else -> maxDiffCount
@@ -124,7 +124,7 @@ class UnhappyVeto(
     }
 
   private fun unhappyMessage(resource: Resource<*>): String {
-    val maxDiffs = maxDiffCount(resource)
+    val maxDiffs = maxActionCountPerDiff(resource)
     val waitingTime = waitingTime(resource)
     if (waitingTime == Duration.ZERO) {
       return "Resource is unhappy and our $maxDiffs actions have not fixed it. " +

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -1261,6 +1261,26 @@ class SqlArtifactRepository(
     }
   }
 
+  override fun getArtifactPromotionStatus(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    environmentName: String
+  ): PromotionStatus? {
+    return sqlRetry.withRetry(READ) {
+
+      jooq
+        .select(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS)
+        .from(ENVIRONMENT_ARTIFACT_VERSIONS)
+        .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
+        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
+        .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
+        .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.desc())
+        .fetchOne(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS)
+        ?.let { PromotionStatus.valueOf(it) }
+    }
+  }
+
   override fun itemsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact> {
     val now = clock.instant()
     val cutoff = now.minus(minTimeSinceLastCheck).toTimestamp()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -1268,14 +1268,12 @@ class SqlArtifactRepository(
     environmentName: String
   ): PromotionStatus? {
     return sqlRetry.withRetry(READ) {
-
       jooq
         .select(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS)
         .from(ENVIRONMENT_ARTIFACT_VERSIONS)
         .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(version))
-        .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.desc())
         .fetchOne(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS)
         ?.let { PromotionStatus.valueOf(it) }
     }


### PR DESCRIPTION
### Context
One of our customers reported the following problems:
> - The automatic ‘mark as bad’ logic can mark artifacts bad that have never been deployed and is what’s blocking me
> -  There’s no way to manually ‘mark as good’ an artifact that was actually fine, but deployment failed due to a transient failure
> - The candidate waiting for approval to production (build 16) is the build currently healthy in test, despite it being marked bad. Looks like it went healthy just a couple of minutes after the deployment timed out
> - The automatic ‘mark as bad’ doesn’t mark bad for the production environment, so I bet if I accidentally approved build 16 it’d try to deploy. I guess I’d expect it to mark both as bad to prevent accidental deployment, or at least have the approval workflow not fire
> - Spinnaker has tried to deploy the last version not marked bad (build 12) twice as a fallback after the other artifacts were taken out of consideration, but it itself hasn’t been marked as bad due to failing deployment

I believe these problems were caused by a combination of issues, a "perfect storm" where a resource was stuck in an unhappy state, and new artifact versions were approved for deployment into that resource. This PR is specifically intended to address the first problem on the list above.

### Problem
The logic that decides whether to mark an artifact version as bad as a result of the deployment target resource being unhappy was checking whether that particular artifact version was either currently or had been previously successfully deployed. However, this leaves out several other promotion statuses, such as when the artifact version has just been approved for deployment.

### Proposed solution
In my understanding, the only promotion status in which we should actually consider marking a version as bad is `DEPLOYING`, meaning we've been attempting to deploy the artifact to the corresponding resource, and the deployment has failed. All other promotion statuses should be ignored for the purpose of this check.