### PR TITLE
Fix NPE deleting config by name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ org.gradle.parallel=true
 spinnakerGradleVersion=8.10.0
 buildingInDocker=false
 targetJava11=true
+testContainersVersion=1.15.0
 
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -18,6 +18,7 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.api.expectThrows
 import strikt.assertions.contains
 import strikt.assertions.hasSize
 import strikt.assertions.isA
@@ -62,10 +63,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
 
     fun getByApplication() = expectCatching {
       repository.getByApplication(deliveryConfig.application)
-    }
-
-    fun delete() {
-      repository.deleteByApplication(deliveryConfig.application)
     }
 
     fun store() {
@@ -355,15 +352,37 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         }
       }
 
-      context("creating and deleting an application") {
+      context("deleting a delivery config") {
         before {
           store()
-          delete()
         }
 
-        test("delete application data successfully") {
-          getByName()
-            .isFailure()
+        context("by application name") {
+          test("deletes data successfully for known application") {
+            repository.deleteByApplication(deliveryConfig.application)
+            getByName()
+              .isFailure()
+          }
+
+          test("throws exception for unknown application") {
+            expectThrows<NoSuchDeliveryConfigException> {
+              repository.deleteByApplication("notfound")
+            }
+          }
+        }
+
+        context("by delivery config name") {
+          test("deletes data successfully for known delivery config") {
+            repository.deleteByName(deliveryConfig.name)
+            getByName()
+              .isFailure()
+          }
+
+          test("throws exception for unknown delivery config") {
+            expectThrows<NoSuchDeliveryConfigException> {
+              repository.deleteByName("notfound")
+            }
+          }
         }
       }
     }

--- a/keel-sql/keel-sql.gradle.kts
+++ b/keel-sql/keel-sql.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     // avoid circular dependency which breaks Liquibase
     exclude(module = "keel-sql")
   }
-  testImplementation("org.testcontainers:mysql")
+  testImplementation("org.testcontainers:mysql:${property("testContainersVersion")}")
 
   jooqGenerator(platform("com.netflix.spinnaker.kork:kork-bom:${property("korkVersion")}"))
   jooqGenerator("mysql:mysql-connector-java")

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -17,6 +17,7 @@ import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.pause.PauseScope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
+import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.OrphanedResourceException
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.CURRENT_CONSTRAINT
@@ -186,7 +187,7 @@ class SqlDeliveryConfigRepository(
         .from(DELIVERY_CONFIG)
         .where(DELIVERY_CONFIG.NAME.eq(name))
         .fetchOne(DELIVERY_CONFIG.APPLICATION)
-    }
+    } ?: throw NoSuchDeliveryConfigName(name)
     deleteByApplication(application)
   }
 
@@ -272,7 +273,7 @@ class SqlDeliveryConfigRepository(
         .from(DELIVERY_CONFIG)
         .where(DELIVERY_CONFIG.APPLICATION.eq(application))
         .fetchOne(DELIVERY_CONFIG.UID)
-    }
+    } ?: throw NoDeliveryConfigForApplication(application)
 
   private fun getEnvironmentUIDs(deliveryConfigUIDs: List<String>): List<String> =
     sqlRetry.withRetry(READ) {

--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
   testImplementation(project(":keel-clouddriver"))
   testImplementation("com.netflix.spinnaker.kork:kork-security")
   testImplementation("com.squareup.okhttp3:mockwebserver")
-  testImplementation("org.testcontainers:mysql")
+  testImplementation("org.testcontainers:mysql:${property("testContainersVersion")}")
   testImplementation("com.networknt:json-schema-validator:1.0.43")
   testImplementation("com.netflix.spinnaker.kork:kork-plugins")
 }


### PR DESCRIPTION
We were not checking whether the delivery config existed when deleting by name... This PR adds those checks and the corresponding tests.

I've had to upgrade `testcontainers` in order to test this locally since the latest version of Docker broke it.