### PR TITLE
fix(diff): reset actions taken count for new diff

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DiffFingerprintRepositoryTests.kt
@@ -95,6 +95,16 @@ abstract class DiffFingerprintRepositoryTests<T : DiffFingerprintRepository> : J
         subject.store(r.id, diff2)
         expectThat(subject.diffCount(r.id)).isEqualTo(1)
       }
+
+      test("resets action count when different hash") {
+        val diff = DefaultResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "bye"))
+        subject.store(r.id, diff)
+        subject.markActionTaken(r.id)
+        expectThat(subject.actionTakenCount(r.id)).isEqualTo(1)
+        val diff2 = DefaultResourceDiff(mapOf("spec" to "hi"), mapOf("spec" to "byeBYEbyeee"))
+        subject.store(r.id, diff2)
+        expectThat(subject.actionTakenCount(r.id)).isEqualTo(0)
+      }
     }
 
     context("querying when nothing exists") {


### PR DESCRIPTION
We were not resetting the action taken count on a new diff. We hadn't seen that before because usually a diff is cleared before a new diff comes in.