### PR TITLE
chore(diff): clean up property

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -84,9 +84,6 @@ class ResourceActuator(
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
-  private val diffNotActionableEnabled: Boolean
-    get() = springEnv.getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, false)
-
   @Trace(dispatcher=true)
   suspend fun <T : ResourceSpec> checkResource(resource: Resource<T>) {
     withTracingContext(resource) {
@@ -192,9 +189,7 @@ class ResourceActuator(
           if (diff.hasChanges()) {
             publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
           }
-          if (diffNotActionableEnabled) { // todo eb: remove this conditional once ui support exists
-            publisher.publishEvent(ResourceDiffNotActionable(resource, decision.message))
-          }
+          publisher.publishEvent(ResourceDiffNotActionable(resource, decision.message))
         }
       } catch (e: ResourceCurrentlyUnresolvable) {
         log.warn("Resource check for {} failed (hopefully temporarily) due to {}", id, e.message)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -82,9 +82,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       every { isPaused(any<String>()) } returns false
       every { isPaused(any<Resource<*>>()) } returns false
     }
-    val springEnv: SpringEnvironment = mockk(relaxed = true) {
-      every { getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, false) } returns true
-    }
+    val springEnv: SpringEnvironment = mockk(relaxed = true)
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
     val plugin1 = mockk<ResourceHandler<DummyArtifactVersionedResourceSpec, DummyArtifactVersionedResourceSpec>>(relaxUnitFun = true)
     val plugin2 = mockk<ResourceHandler<DummyArtifactVersionedResourceSpec, DummyArtifactVersionedResourceSpec>>(relaxUnitFun = true)


### PR DESCRIPTION
Rolled out successfully, so no longer need to hide this behind a flag