### PR TITLE
basic metrics for start / end of verifications

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -7,11 +7,18 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import java.time.Instant
 
 interface VerificationRepository {
+  /**
+   * @return the current state of [verification] as run against [context], or `null` if it has not
+   * yet been run.
+   */
   fun getState(
     context: VerificationContext,
     verification: Verification
-  ) : VerificationState?
+  ): VerificationState?
 
+  /**
+   * Updates the state of [verification] as run against [context].
+   */
   fun updateState(
     context: VerificationContext,
     verification: Verification,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -1,7 +1,10 @@
 package com.netflix.spinnaker.keel.telemetry
 
 import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 import java.time.Duration
 
 sealed class TelemetryEvent
@@ -61,3 +64,49 @@ data class ArtifactCheckTimedOut(
 data class ArtifactVersionVetoed(
   val application: String,
 ) : TelemetryEvent()
+
+data class VerificationStarted(
+  val application: String,
+  val deliveryConfigName: String,
+  val environmentName: String,
+  val artifactName: String,
+  val artifactType: ArtifactType,
+  val artifactVersion: String,
+  val verificationType: String
+) : TelemetryEvent() {
+  constructor(context: VerificationContext, verification: Verification) : this(
+    context.deliveryConfig.application,
+    context.deliveryConfig.name,
+    context.environmentName,
+    context.artifact.name,
+    context.artifact.type,
+    context.version,
+    verification.type
+  )
+}
+
+data class VerificationCompleted(
+  val application: String,
+  val deliveryConfigName: String,
+  val environmentName: String,
+  val artifactName: String,
+  val artifactType: ArtifactType,
+  val artifactVersion: String,
+  val verificationType: String,
+  val status: VerificationStatus
+) : TelemetryEvent() {
+  constructor(
+    context: VerificationContext,
+    verification: Verification,
+    status: VerificationStatus
+  ) : this(
+    context.deliveryConfig.application,
+    context.deliveryConfig.name,
+    context.environmentName,
+    context.artifact.name,
+    context.artifact.type,
+    context.version,
+    verification.type,
+    status
+  )
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -11,12 +11,15 @@ import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 import com.netflix.spinnaker.keel.api.verification.VerificationStatus.PASSED
 import com.netflix.spinnaker.keel.api.verification.VerificationStatus.RUNNING
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.telemetry.VerificationCompleted
+import com.netflix.spinnaker.keel.telemetry.VerificationStarted
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Instant.now
 
 internal class VerificationRunnerTests {
@@ -29,10 +32,12 @@ internal class VerificationRunnerTests {
   private val evaluator = mockk<VerificationEvaluator<DummyVerification>>(relaxUnitFun = true) {
     every { supportedVerification } returns ("dummy" to DummyVerification::class.java)
   }
+  private val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
 
   private val subject = VerificationRunner(
     repository,
-    listOf(evaluator)
+    listOf(evaluator),
+    publisher
   )
 
   @Test
@@ -55,9 +60,8 @@ internal class VerificationRunnerTests {
 
     subject.runVerificationsFor(context)
 
-    verify(exactly = 0) {
-      evaluator.start(any())
-    }
+    verify(exactly = 0) { evaluator.start(any()) }
+    verify(exactly = 0) { publisher.publishEvent(any()) }
   }
 
   @Test
@@ -81,14 +85,13 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
-    every {
-      repository.getState(any(), any())
-    } returns null
+    every { repository.getState(any(), any()) } returns null
 
     subject.runVerificationsFor(context)
 
     verify { evaluator.start(DummyVerification("1")) }
     verify { repository.updateState(any(), DummyVerification("1"), RUNNING) }
+    verify { publisher.publishEvent(ofType<VerificationStarted>()) }
   }
 
   @Test
@@ -112,25 +115,16 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
-    every {
-      repository.getState(any(), DummyVerification("1"))
-    } returns RUNNING.toState()
-    every {
-      repository.getState(any(), DummyVerification("2"))
-    } returns null
+    every { repository.getState(any(), DummyVerification("1")) } returns RUNNING.toState()
+    every { repository.getState(any(), DummyVerification("2")) } returns null
 
-    every {
-      evaluator.evaluate()
-    } returns RUNNING
+    every { evaluator.evaluate() } returns RUNNING
 
     subject.runVerificationsFor(context)
 
-    verify {
-      evaluator.evaluate()
-    }
-    verify(exactly = 0) {
-      evaluator.start(any())
-    }
+    verify { evaluator.evaluate() }
+    verify(exactly = 0) { evaluator.start(any()) }
+    verify(exactly = 0) { publisher.publishEvent(any()) }
   }
 
   @ParameterizedTest(
@@ -160,28 +154,19 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
-    every {
-      repository.getState(any(), DummyVerification("1"))
-    } returns RUNNING.toState()
-    every {
-      repository.getState(any(), DummyVerification("2"))
-    } returns null
+    every { repository.getState(any(), DummyVerification("1")) } returns RUNNING.toState()
+    every { repository.getState(any(), DummyVerification("2")) } returns null
 
-    every {
-      evaluator.evaluate()
-    } returns status
+    every { evaluator.evaluate() } returns status
 
     subject.runVerificationsFor(context)
 
-    verify {
-      repository.updateState(any(), DummyVerification("1"), status)
-    }
-    verify {
-      evaluator.start(DummyVerification("2"))
-    }
-    verify {
-      repository.updateState(any(), DummyVerification("2"), RUNNING)
-    }
+    verify { repository.updateState(any(), DummyVerification("1"), status) }
+    verify { publisher.publishEvent(ofType<VerificationCompleted>()) }
+
+    verify { evaluator.start(DummyVerification("2")) }
+    verify { repository.updateState(any(), DummyVerification("2"), RUNNING) }
+    verify { publisher.publishEvent(ofType<VerificationStarted>()) }
   }
 
   @ParameterizedTest(


### PR DESCRIPTION
Not sure if we really need timing metrics since performance of verifications is not down to Keel. I'll add the usual metrics for scheduled check lag when I add the scheduled check itself.