### PR TITLE
fix(export): handle missing rollback field

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -128,7 +128,7 @@ class ClusterExportHelper(
           @Suppress("UNCHECKED_CAST")
           it as Map<String, Any>
         }
-        ?.get("onFailure") as Boolean,
+        ?.get("onFailure") as Boolean?,
       resizePreviousToZero = this["scaleDown"] as Boolean,
       maxServerGroups = this["maxRemainingAsgs"].toString().toInt(),
       delayBeforeDisable = Duration.ofSeconds((this["delayBeforeDisableSec"].toString().toInt()).toLong()),


### PR DESCRIPTION
## Problem

When exporting a cluster, if it was deployed by a pipeline using a red-black strategy, and there there was no `rollback` field in the context of the pipeline's deploy stage, then keel throws a null pointer exception when attempting to populate the `RedBlack.rollbackonFailure` field. 

## Proposed solution

Since the [RedBlack.rollbackOnFailure field is nullable][1], just return null if the `rollback` field isn't present in the pipeline's deploy context.

## FAQ

### Why didn't you write any tests?

It felt like a lot of work to do given how much fixture setup is required for testing this. I manually unit tested it like this:

1.  Delete the `rollback` field in the [ClusterExportHelperTests][2] tests code.
2. Run the ClusterExportHelperTests tests and verify the tests fail.
3. Implement the fix
4. Run the tests again and verify they succeed.

[1]: https://github.com/spinnaker/keel/blob/04fbf7a3185d44157064aa6d70c32a4874ffd0e9/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ClusterDeployStrategy.kt#L22

[2]: https://github.com/spinnaker/keel/blob/a4affd62be431d5587aeff457105154b4e7e0b27/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt#L153-L155