### PR TITLE
Cut down log noise in Spring tests

### DIFF
--- a/keel-spring-test-support/src/main/kotlin/com/netflix/spinnaker/keel/spring/test/DisableSpringScheduling.kt
+++ b/keel-spring-test-support/src/main/kotlin/com/netflix/spinnaker/keel/spring/test/DisableSpringScheduling.kt
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.keel.spring.test
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
+import kotlin.annotation.AnnotationRetention.RUNTIME
+import kotlin.annotation.AnnotationTarget.CLASS
+import kotlin.annotation.AnnotationTarget.TYPE
+
+/**
+ * Disables `@Scheduled` tasks. This is useful in Spring tests where you don't want stuff running in
+ * the background.
+ */
+@Target(CLASS, TYPE)
+@Retention(RUNTIME)
+@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+annotation class DisableSpringScheduling

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.sql.SqlArtifactRepository
 import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
 import com.netflix.spinnaker.keel.sql.SqlResourceRepository
@@ -28,6 +29,7 @@ import strikt.assertions.isA
     "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
   ]
 )
+@DisableSpringScheduling
 internal class SpringStartupTests {
 
   @Autowired

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.test.DummyResourceHandlerV1
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
@@ -49,6 +50,7 @@ import strikt.assertions.isFalse
     "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
   ]
 )
+@DisableSpringScheduling
 internal class DeliveryConfigTransactionTests : JUnit5Minutests {
 
   @SpykBean

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/config/IntegrationTestConfiguration.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/config/IntegrationTestConfiguration.kt
@@ -1,9 +1,0 @@
-package com.netflix.spinnaker.config
-
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
-import org.springframework.context.annotation.Configuration
-
-@Configuration
-@EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
-class IntegrationTestConfiguration

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.schema.Generator
 import com.netflix.spinnaker.keel.schema.generateSchema
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.networknt.schema.JsonSchema
 import com.networknt.schema.JsonSchemaFactory
@@ -18,8 +19,6 @@ import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.TestFactory
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
@@ -36,7 +35,7 @@ import strikt.api.expectThat
   webEnvironment = NONE
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 class ApiDocCompatibilityTests {
   @Autowired
   lateinit var generator: Generator

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -21,14 +21,13 @@ import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.docker.ContainerProvider
 import com.netflix.spinnaker.keel.schema.Generator
 import com.netflix.spinnaker.keel.schema.generateSchema
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import dev.minutest.experimental.SKIP
 import dev.minutest.experimental.minus
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
@@ -65,7 +64,7 @@ import kotlin.reflect.KClass
   webEnvironment = NONE
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 class ApiDocTests : JUnit5Minutests {
 
   @Autowired

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.integration.AuthPropagationTests.MockFiat
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.kork.common.Header.ACCOUNTS
 import com.netflix.spinnaker.kork.common.Header.USER
 import com.netflix.spinnaker.kork.common.Header.USER_ORIGIN
@@ -23,8 +24,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.context.annotation.Bean
@@ -40,7 +39,7 @@ import strikt.assertions.isNotNull
   classes = [KeelApplication::class, MockFiat::class],
   webEnvironment = MOCK
 )
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class AuthPropagationTests : JUnit5Minutests {
 
   @Autowired

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
@@ -1,9 +1,7 @@
 package com.netflix.spinnaker.keel.integration
 
 import com.netflix.spinnaker.keel.KeelApplication
-import java.io.IOException
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit.SECONDS
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import okhttp3.Interceptor
@@ -12,8 +10,6 @@ import okhttp3.ResponseBody
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.context.annotation.Bean
@@ -21,6 +17,9 @@ import retrofit2.Retrofit
 import retrofit2.http.GET
 import strikt.api.Assertion
 import strikt.api.expectThat
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.SECONDS
 
 // TODO: this doesn't really need to be an integration test except that it's painful to configure
 //       the retrofit client without Spring
@@ -28,7 +27,7 @@ import strikt.api.expectThat
   classes = [KeelApplication::class, TestConfiguration::class],
   webEnvironment = MOCK
 )
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class SchedulingResilienceTests {
 
   @Autowired

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/SpringStartupTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/SpringStartupTests.kt
@@ -1,11 +1,10 @@
 package com.netflix.spinnaker.keel.integration
 
 import com.netflix.spinnaker.keel.KeelApplication
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
@@ -15,7 +14,7 @@ import org.springframework.context.ApplicationListener
   classes = [KeelApplication::class],
   webEnvironment = MOCK
 )
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class SpringStartupTests {
 
   @MockkBean(relaxUnitFun = true)

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
@@ -5,14 +5,13 @@ import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.services.AdminService
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.ninjasquad.springmockk.MockkBean
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
@@ -26,7 +25,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
   webEnvironment = SpringBootTest.WebEnvironment.MOCK
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class AdminControllerTests : JUnit5Minutests {
 
   @Autowired

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -15,11 +15,11 @@ import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.pause.ActuationPauser
-import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.APPLICATION
 import com.netflix.spinnaker.keel.services.ApplicationService
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.ninjasquad.springmockk.MockkBean
 import dev.minutest.junit.JUnit5Minutests
@@ -28,8 +28,6 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
@@ -49,7 +47,7 @@ import strikt.assertions.isEqualTo
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class ApplicationControllerTests : JUnit5Minutests {
   @MockkBean
   lateinit var authorizationSupport: AuthorizationSupport

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
@@ -1,14 +1,9 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.KeelApplication
-import java.time.Duration
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit.MILLISECONDS
-import java.util.concurrent.TimeoutException
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.context.ApplicationEvent
@@ -18,12 +13,16 @@ import org.springframework.stereotype.Component
 import strikt.api.expectThat
 import strikt.assertions.isNotEqualTo
 import strikt.assertions.startsWith
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit.MILLISECONDS
+import java.util.concurrent.TimeoutException
 
 @SpringBootTest(
   classes = [KeelApplication::class, ThreadCapturingEventListener::class],
   webEnvironment = MOCK
 )
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class ApplicationEventTests {
 
   @Autowired

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -2,34 +2,25 @@ package com.netflix.spinnaker.keel.rest
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.KeelApplication
-import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
-import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
-import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
 import com.ninjasquad.springmockk.MockkBean
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.clearAllMocks
-import io.mockk.every
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest(
   classes = [KeelApplication::class, MockEurekaConfiguration::class],
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class ArtifactControllerTests : JUnit5Minutests {
   @Autowired
   lateinit var mvc: MockMvc

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.APPLICATION
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.services.DeliveryConfigImporter
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.TEST_API_V1
@@ -33,8 +34,6 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.verify
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
@@ -58,7 +57,7 @@ import strikt.jackson.isMissing
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class DeliveryConfigControllerTests : JUnit5Minutests {
 
   @Autowired

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ErrorSimulationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ErrorSimulationControllerTests.kt
@@ -1,11 +1,10 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.KeelApplication
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.web.servlet.MockMvc
@@ -19,7 +18,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 )
 
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class ErrorSimulationControllerTests {
   @Autowired
   lateinit var mvc: MockMvc

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -17,6 +17,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.RESOURCE
 import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML
@@ -24,13 +25,7 @@ import com.netflix.spinnaker.time.MutableClock
 import com.ninjasquad.springmockk.MockkBean
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.coEvery as every
-import java.net.URI
-import java.time.Clock
-import java.time.Duration
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
@@ -50,13 +45,17 @@ import strikt.assertions.hasSize
 import strikt.assertions.map
 import strikt.jackson.hasSize
 import strikt.jackson.isArray
+import java.net.URI
+import java.time.Clock
+import java.time.Duration
+import io.mockk.coEvery as every
 
 @SpringBootTest(
   classes = [KeelApplication::class, MockEurekaConfiguration::class, MockTimeConfiguration::class],
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class EventControllerTests : JUnit5Minutests {
   @Autowired
   lateinit var mvc: MockMvc

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.APPLICATION
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.RESOURCE
+import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.test.submittedResource
@@ -19,8 +20,6 @@ import dev.minutest.rootContext
 import io.mockk.every
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration
-import org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
@@ -41,7 +40,7 @@ import strikt.assertions.isNotNull
   webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
-@EnableAutoConfiguration(exclude = [TaskSchedulingAutoConfiguration::class])
+@DisableSpringScheduling
 internal class ResourceControllerTests : JUnit5Minutests {
   @Autowired
   lateinit var mvc: MockMvc


### PR DESCRIPTION
Noticed a bunch of noise in the CI build logs for #1660 where scheduled tasks were calling mocked repositories and there was no answer set up. I discovered a couple of tests where we'd missed disabling the scheduling. I also thought it might make sense to introduce a simpler annotation for that so the intent is clearer.