### PR TITLE
fix(export): handle optional fields in context

### DIFF
--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelper.kt
@@ -131,8 +131,8 @@ class ClusterExportHelper(
         ?.get("onFailure") as Boolean?,
       resizePreviousToZero = this["scaleDown"] as Boolean,
       maxServerGroups = this["maxRemainingAsgs"].toString().toInt(),
-      delayBeforeDisable = Duration.ofSeconds((this["delayBeforeDisableSec"].toString().toInt()).toLong()),
-      delayBeforeScaleDown = Duration.ofSeconds((this["delayBeforeScaleDownSec"].toString().toInt()).toLong())
+      delayBeforeDisable = this["delayBeforeDisableSec"]?.toString()?.toInt()?.toLong()?.let{ Duration.ofSeconds(it) },
+      delayBeforeScaleDown = this["delayBeforeScaleDownSec"]?.toString()?.toInt()?.toLong()?.let{ Duration.ofSeconds(it) }
     )
 
   @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
## Problem

When attempting to export a cluster who was deployed by a pipeline whose deploy stage context is missing `delayBeforeDisableSec` or `delayBeforeScaleDownSec`, keel throws a 500 error with the following stack trace:

```
java.lang.NumberFormatException: For input string: "null"
  at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
  at java.lang.Integer.parseInt(Integer.java:652)
  at java.lang.Integer.parseInt(Integer.java:770)
  at com.netflix.spinnaker.keel.orca.ClusterExportHelper.contextToRedBlack(ClusterExportHelper.kt:134)
  at com.netflix.spinnaker.keel.orca.ClusterExportHelper.access$contextToRedBlack(ClusterExportHelper.kt:16)
```

## Proposed solution

Since the `RedBlack` class already supported these two fields as nullable, just return a null if they are not present.

## Notes

This is a follow-up to #1661, which handled one of the optional fields. This PR handles the two fields that were missed perviously.

## FAQ

### Why the extra conversion functions?

You'll notice that the code does this:

```kotlin
delayBeforeDisable = this["delayBeforeDisableSec"]?.toString()?.toInt()?.toLong()?.let{ Duration.ofSeconds(it) },
```

instead of the simpler:

```kotlin
delayBeforeDisable = this["delayBeforeDisableSec"]?.toLong()?.let{ Duration.ofSeconds(it) },
```

The honest answer is that I don't know the reasoning behind those extra conversions.  That's how the code was initially, and so I left it.

I asked @robfletcher, who git blame suggested was the original author, and he couldn't remember the specific reason, but had a vague sense that there was one. So I decided to leave things as-is, a la *Chesterton's fence*.