### PR TITLE
Fix missing primary keys following foreign key changes

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20201116-foreign-keys.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201116-foreign-keys.yml
@@ -252,6 +252,14 @@ databaseChangeLog:
         tableName: unhappy_veto
         columnName: application
 - changeSet:
+    id: primary-key-on-unhappy_veto
+    author: fletch
+    changes:
+    - addPrimaryKey:
+        tableName: unhappy_veto
+        columnNames: resource_uid
+        constraintName: pk_unhappy_veto
+- changeSet:
     id: resource_uid-on-unhealthy
     author: fletch
     changes:
@@ -288,3 +296,11 @@ databaseChangeLog:
     - dropColumn:
         tableName: unhealthy
         columnName: resource_id
+- changeSet:
+    id: primary-key-on-unhealthy
+    author: fletch
+    changes:
+    - addPrimaryKey:
+        tableName: unhealthy
+        columnNames: resource_uid
+        constraintName: pk_unhealthy


### PR DESCRIPTION
The `unhappy_veto` and `unhealthy` tables had a primary key of `resource_id`. I dropped that column and replaced it with `resource_uid` but didn't add a new primary key. Becuase `SqlUnhappyRepository` relies on `onDuplicateKeyIgnore` to avoid getting duplicate rows, this resulted in data corruption on that table.