### PR TITLE
fix(pinning): return the right diffing link when a version is pinned

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -1086,13 +1086,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       }
     }
 
-    context("git metadata by promotion status") {
+    context("artifact versions by promotion status") {
       before {
           persist(manifest)
           subject.register(versionedReleaseDebian)
           subject.storeArtifactVersion(versionedReleaseDebian.toArtifactVersion(version1, RELEASE).copy(
-           gitMetadata = artifactMetadata.gitMetadata,
-         ))
+           gitMetadata = artifactMetadata.gitMetadata
+          ))
         subject.storeArtifactVersion(versionedReleaseDebian.toArtifactVersion(version2, RELEASE).copy(
           gitMetadata = artifactMetadata.gitMetadata?.copy(
             commit = "12345"
@@ -1101,12 +1101,12 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         subject.markAsSuccessfullyDeployedTo(manifest, versionedReleaseDebian, version1, testEnvironment.name)
       }
 
-      test ("no metadata for version which is not persisted") {
+      test ("no vertsions for version which is not persisted") {
         expectThat(subject.getArtifactVersionByPromotionStatus(manifest, testEnvironment.name, versionedReleaseDebian, PromotionStatus.PREVIOUS.name))
           .isNull()
       }
 
-      test ("get git metadata for deploying status") {
+      test ("get artifact versions for deploying status") {
         expectThat(subject.getArtifactVersionByPromotionStatus(manifest,testEnvironment.name, versionedReleaseDebian, PromotionStatus.CURRENT.name)?.gitMetadata)
           .isEqualTo(artifactMetadata.gitMetadata)
         }
@@ -1115,6 +1115,12 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         subject.markAsSuccessfullyDeployedTo(manifest, versionedReleaseDebian, version2, testEnvironment.name)
         expectThat(subject.getArtifactVersionByPromotionStatus(manifest,testEnvironment.name, versionedReleaseDebian, PromotionStatus.CURRENT.name)?.gitMetadata)
           .get { this?.commit }.isEqualTo("12345")
+      }
+
+      test ("get artifact version by promotion status and the version it replaced") {
+        subject.markAsSuccessfullyDeployedTo(manifest, versionedReleaseDebian, version2, testEnvironment.name)
+        expectThat(subject.getArtifactVersionByPromotionStatus(manifest,testEnvironment.name, versionedReleaseDebian, PromotionStatus.PREVIOUS.name, version2))
+          .get { this?.version }.isEqualTo("keeldemo-0.0.1~dev.8-h8.41595c4")
       }
 
       test ("unsupported promotion status throws exception") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -224,14 +224,19 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   fun deletePin(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String)
 
   /**
-   * Return the git metadata for the last deployed version of the specified artifact that matches the promotion status
+   * Return a specific artifact version if is pinned, from [targetEnvironment], by [reference], if exists.
    */
-  fun getGitMetadataByPromotionStatus(
+  fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
+
+  /**
+   * Return the published artifact for the last deployed version that matches the promotion status
+   */
+  fun getArtifactVersionByPromotionStatus(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifact: DeliveryArtifact,
     promotionStatus: String
-  ): GitMetadata?
+  ): PublishedArtifact?
 
   /**
    * Given information about a delivery config, environment, artifact and version, returns a summary that can be

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -235,7 +235,8 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifact: DeliveryArtifact,
-    promotionStatus: String
+    promotionStatus: String,
+    version: String? = null
   ): PublishedArtifact?
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -401,14 +401,17 @@ class CombinedRepository(
     deliveryConfig, environmentName, artifactReference, version
   )
 
-  override fun getGitMetadataByPromotionStatus(
+  override fun getArtifactVersionByPromotionStatus(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifact: DeliveryArtifact,
     promotionStatus: String
-  ) = artifactRepository.getGitMetadataByPromotionStatus(
+  ) = artifactRepository.getArtifactVersionByPromotionStatus(
     deliveryConfig, environmentName, artifact, promotionStatus
   )
+
+  override fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String)
+    = artifactRepository.getPinnedVersion(deliveryConfig, targetEnvironment, reference)
 
   // END ArtifactRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -405,9 +405,10 @@ class CombinedRepository(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifact: DeliveryArtifact,
-    promotionStatus: String
+    promotionStatus: String,
+    version: String?
   ) = artifactRepository.getArtifactVersionByPromotionStatus(
-    deliveryConfig, environmentName, artifact, promotionStatus
+    deliveryConfig, environmentName, artifact, promotionStatus, version
   )
 
   override fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -204,7 +204,8 @@ interface KeelRepository : KeelReadOnlyRepository {
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifact: DeliveryArtifact,
-    promotionStatus: String
+    promotionStatus: String,
+    version: String? = null
   ): PublishedArtifact?
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -198,14 +198,19 @@ interface KeelRepository : KeelReadOnlyRepository {
   ): ArtifactSummaryInEnvironment?
 
   /**
-   * Given artifact details and promotion status, return its last deployed version git metadata, sorted by deployed_at
+   * Return the published artifact for the last deployed version that matches the promotion status
    */
-  fun getGitMetadataByPromotionStatus(
+  fun getArtifactVersionByPromotionStatus(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifact: DeliveryArtifact,
     promotionStatus: String
-  ): GitMetadata?
+  ): PublishedArtifact?
+
+  /**
+   * Return a specific artifact version if is pinned, from [targetEnvironment], by [reference], if exists.
+   */
+  fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
 
   // END ArtifactRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -420,7 +420,7 @@ class ApplicationService(
 
   private fun getUrl(version1: PublishedArtifact?, version2: PublishedArtifact?, artifact: DeliveryArtifact): String? {
     return if (version1 != null && version2 != null) {
-      return if (artifact.sortingStrategy.comparator.compare(version1, version2) < 0) {
+      return if (artifact.sortingStrategy.comparator.compare(version1, version2) > 0) { //these comparators sort in dec order, so condition is flipped
         //version2 is newer than version1
         generateCompareLink(version2.gitMetadata, version1.gitMetadata)
       } else {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -295,13 +295,13 @@ class ApplicationService(
 
   // Pinning is a special case when is coming to creating a compare link between versions.
   // If there is a pinned version, which is not the same as the current version, we need
-  // to make sure we are creating the comparable link with referance to the pinned version.
+  // to make sure we are creating the comparable link with reference to the pinned version.
   private fun getPinnedArtifact(deliveryConfig: DeliveryConfig, environmentName: String, artifact: DeliveryArtifact, version: String): PublishedArtifact? {
     val pinnedVersion = repository.getPinnedVersion(deliveryConfig, environmentName, artifact.reference)
      return if (pinnedVersion != version)
       pinnedVersion?.let { getArtifactInstance(artifact, it) }
-    else {
-       null
+    else { //if pinnedVersion == current version, fetch the version which that the pinned version replaced
+       repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, PREVIOUS.name, pinnedVersion)
      }
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -246,13 +246,13 @@ class ApplicationService(
 
     return when (status) {
       PENDING -> {
-        val olderGitMetadata = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
+        val olderArtifactVersion = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
         ArtifactSummaryInEnvironment(
           environment = environmentName,
           version = version,
           state = status.name.toLowerCase(),
           // comparing PENDING (version in question, new code) vs. CURRENT (old code)
-          compareLink = getUrl(currentArtifact, olderGitMetadata, artifact)
+          compareLink = getUrl(currentArtifact, olderArtifactVersion, artifact)
         )
       }
       SKIPPED -> {
@@ -268,25 +268,25 @@ class ApplicationService(
       }
 
       DEPLOYING, APPROVED -> {
-        val olderGitMetadata = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
+        val olderArtifactVersion = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
         potentialSummary?.copy(
           // comparing DEPLOYING/APPROVED (version in question, new code) vs. CURRENT (old code)
-          compareLink = getUrl(currentArtifact, olderGitMetadata, artifact)
+          compareLink = getUrl(currentArtifact, olderArtifactVersion, artifact)
         )
       }
       PREVIOUS -> {
-        val newerGitMetadata = potentialSummary?.replacedBy?.let { getArtifactInstance(artifact, it) }
+        val newerArtifactVersion = potentialSummary?.replacedBy?.let { getArtifactInstance(artifact, it) }
         potentialSummary?.copy(
           //comparing PREVIOUS (version in question, old code) vs. the version which replaced it (new code)
           //pinned artifact should not be consider here, as we know exactly which version replace the current one
-          compareLink = getUrl(currentArtifact, newerGitMetadata, artifact)
+          compareLink = getUrl(currentArtifact, newerArtifactVersion, artifact)
         )
       }
       CURRENT -> {
-        val olderGitMetadata = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, PREVIOUS.name)
+        val olderArtifactVersion = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, PREVIOUS.name)
         potentialSummary?.copy(
           // comparing CURRENT (version in question, new code) vs. PREVIOUS (old code)
-          compareLink = getUrl(currentArtifact, olderGitMetadata, artifact)
+          compareLink = getUrl(currentArtifact, olderArtifactVersion, artifact)
         )
       }
       else -> potentialSummary

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
 import com.netflix.spinnaker.keel.core.api.PromotionStatus
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.APPROVED
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PENDING
@@ -229,8 +230,7 @@ class ApplicationService(
   }
 
   private fun buildArtifactSummaryInEnvironment(deliveryConfig: DeliveryConfig, environmentName: String, artifact: DeliveryArtifact, version: String, status: PromotionStatus): ArtifactSummaryInEnvironment? {
-    val artifactGitMetadata = getArtifactInstance(artifact, version)?.gitMetadata
-    val baseScmUrl = artifactGitMetadata?.commitInfo?.link?.let { getScmBaseLink(it) }
+    val currentArtifact = getArtifactInstance(artifact, version)
 
     // some environments contain relevant info for skipped artifacts, so
     // try and find that summary before defaulting to less information
@@ -242,16 +242,17 @@ class ApplicationService(
         version = version
       )
 
+    val pinnedArtifact = getPinnedArtifact(deliveryConfig, environmentName, artifact, version)
+
     return when (status) {
       PENDING -> {
-        val olderGitMetadata = repository.getGitMetadataByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
-
+        val olderGitMetadata = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
         ArtifactSummaryInEnvironment(
           environment = environmentName,
           version = version,
           state = status.name.toLowerCase(),
           // comparing PENDING (version in question, new code) vs. CURRENT (old code)
-          compareLink = generateDiffLink(baseScmUrl, artifactGitMetadata, olderGitMetadata)
+          compareLink = getUrl(currentArtifact, olderGitMetadata, artifact)
         )
       }
       SKIPPED -> {
@@ -265,29 +266,43 @@ class ApplicationService(
           potentialSummary
         }
       }
-      DEPLOYING -> {
-        val olderGitMetadata = repository.getGitMetadataByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
+
+      DEPLOYING, APPROVED -> {
+        val olderGitMetadata = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
         potentialSummary?.copy(
-          // comparing DEPLOYING (version in question, new code) vs. CURRENT (old code)
-          compareLink = generateDiffLink(baseScmUrl, artifactGitMetadata, olderGitMetadata)
+          // comparing DEPLOYING/APPROVED (version in question, new code) vs. CURRENT (old code)
+          compareLink = getUrl(currentArtifact, olderGitMetadata, artifact)
         )
       }
       PREVIOUS -> {
-        val newerGitMetadata = potentialSummary?.replacedBy?.let { getArtifactInstance(artifact, it)?.gitMetadata }
+        val newerGitMetadata = potentialSummary?.replacedBy?.let { getArtifactInstance(artifact, it) }
         potentialSummary?.copy(
           //comparing PREVIOUS (version in question, old code) vs. the version which replaced it (new code)
-          compareLink = generateDiffLink(baseScmUrl, newerGitMetadata, artifactGitMetadata)
+          //pinned artifact should not be consider here, as we know exactly which version replace the current one
+          compareLink = getUrl(currentArtifact, newerGitMetadata, artifact)
         )
       }
       CURRENT -> {
-        val olderGitMetadata = repository.getGitMetadataByPromotionStatus(deliveryConfig, environmentName, artifact, PREVIOUS.name)
+        val olderGitMetadata = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, PREVIOUS.name)
         potentialSummary?.copy(
           // comparing CURRENT (version in question, new code) vs. PREVIOUS (old code)
-          compareLink = generateDiffLink(baseScmUrl, artifactGitMetadata, olderGitMetadata)
+          compareLink = getUrl(currentArtifact, olderGitMetadata, artifact)
         )
       }
       else -> potentialSummary
     }
+  }
+
+  // Pinning is a special case when is coming to creating a compare link between versions.
+  // If there is a pinned version, which is not the same as the current version, we need
+  // to make sure we are creating the comparable link with referance to the pinned version.
+  private fun getPinnedArtifact(deliveryConfig: DeliveryConfig, environmentName: String, artifact: DeliveryArtifact, version: String): PublishedArtifact? {
+    val pinnedVersion = repository.getPinnedVersion(deliveryConfig, environmentName, artifact.reference)
+     return if (pinnedVersion != version)
+      pinnedVersion?.let { getArtifactInstance(artifact, it) }
+    else {
+       null
+     }
   }
 
   /**
@@ -388,15 +403,6 @@ class ApplicationService(
     return repository.getArtifactVersion(artifact, version, releaseStatus)
   }
 
-  // Generating a SCM diff link between source and target versions (the order does matter!)
-  private fun generateDiffLink(baseUrl: String?, newerGitMetadata: GitMetadata?, olderGitMetadata: GitMetadata?): String? {
-    return if (baseUrl != null && newerGitMetadata != null && olderGitMetadata != null) {
-          "$baseUrl/projects/${newerGitMetadata.project}/repos/${newerGitMetadata.repo?.name}/compare/commits?" +
-            "targetBranch=${olderGitMetadata.commitInfo?.sha}&sourceBranch=${newerGitMetadata.commitInfo?.sha}"
-    } else {
-      null
-    }
-  }
 
   // Calling igor to fetch all base urls by SCM type, and returning the right one based on current commit link
   private fun getScmBaseLink(commitLink: String): String? {
@@ -409,6 +415,31 @@ class ApplicationService(
         return scmInfo["stash"]
       else ->
         throw UnsupportedScmType(message = "Stash is currently the only supported SCM type")
+    }
+  }
+
+  private fun getUrl(version1: PublishedArtifact?, version2: PublishedArtifact?, artifact: DeliveryArtifact): String? {
+    return if (version1 != null && version2 != null) {
+      return if (artifact.sortingStrategy.comparator.compare(version1, version2) < 0) {
+        //version2 is newer than version1
+        generateCompareLink(version2.gitMetadata, version1.gitMetadata)
+      } else {
+        //version2 is older than version1
+        generateCompareLink(version1.gitMetadata, version2.gitMetadata)
+      }
+    } else {
+      null
+    }
+  }
+
+  // Generating a SCM compare link between source (new version) and target (old version) versions (the order does matter!)
+  private fun generateCompareLink(newerGitMetadata: GitMetadata?, olderGitMetadata: GitMetadata?): String? {
+    val baseScmUrl = newerGitMetadata?.commitInfo?.link?.let { getScmBaseLink(it) }
+    return if (baseScmUrl != null && olderGitMetadata != null) {
+      "$baseScmUrl/projects/${newerGitMetadata.project}/repos/${newerGitMetadata.repo?.name}/compare/commits?" +
+        "targetBranch=${olderGitMetadata.commitInfo?.sha}&sourceBranch=${newerGitMetadata.commitInfo?.sha}"
+    } else {
+      null
     }
   }
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/CreatedAtSortingStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/CreatedAtSortingStrategyTests.kt
@@ -45,6 +45,14 @@ class CreatedAtSortingStrategyTests : JUnit5Minutests {
       )
     }
 
+    val version1 = PublishedArtifact("keeldemo", DEBIAN, "1.0.10", createdAt = clock.instant(),
+      gitMetadata = GitMetadata("commit", branch = "master")
+    )
+
+    val version2 = PublishedArtifact("keeldemo", DEBIAN, "1.0.3", createdAt = clock.instant().plusSeconds(3),
+      gitMetadata = GitMetadata("commit", branch = "master")
+    )
+
     val subject = CreatedAtSortingStrategy
   }
 
@@ -63,6 +71,12 @@ class CreatedAtSortingStrategyTests : JUnit5Minutests {
       test("artifact versions are sorted by descending order of creation timestamp") {
         expectThat(versions.shuffled().sortedWith(subject.comparator))
           .isEqualTo(versions.sortedByDescending { it.createdAt })
+      }
+
+      test("artifact versions are sorted by descending order of creation timestamp with hard coded versions") {
+        expectThat(listOf(version1, version2).sortedWith(subject.comparator))
+          .get { first().version }
+          .isEqualTo(version2.version)
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -500,7 +500,7 @@ class ApplicationServiceTests : JUnit5Minutests {
           context("compare links") {
             before {
               every {
-                repository.getArtifactVersionByPromotionStatus(singleArtifactDeliveryConfig, any(), releaseArtifact, PREVIOUS.name)
+                repository.getArtifactVersionByPromotionStatus(singleArtifactDeliveryConfig, any(), releaseArtifact, PREVIOUS.name, any())
               } answers {
                 PublishedArtifact(
                   name = arg<DeliveryArtifact>(2).name,

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
@@ -1,0 +1,415 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.ScmInfo
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
+import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
+import com.netflix.spinnaker.keel.api.artifacts.Commit
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.artifacts.Repo
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
+import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
+import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
+import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
+import com.netflix.spinnaker.keel.core.api.ArtifactSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactVersions
+import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
+import com.netflix.spinnaker.keel.core.api.PromotionStatus
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.test.DummyArtifact
+import com.netflix.spinnaker.keel.test.DummySortingStrategy
+import com.netflix.spinnaker.keel.test.artifactReferenceResource
+import com.netflix.spinnaker.keel.test.versionedArtifactResource
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import strikt.api.Assertion
+import strikt.api.DescribeableBuilder
+import strikt.api.expectThat
+import strikt.assertions.first
+import strikt.assertions.isEqualTo
+import java.time.Instant
+import java.time.ZoneId
+
+class ComparableLinksTests : JUnit5Minutests {
+
+  class Fixture {
+    val clock: MutableClock = MutableClock(
+      Instant.parse("2020-03-25T00:00:00.00Z"),
+      ZoneId.of("UTC")
+    )
+    val repository: KeelRepository = mockk()
+    val resourceStatusService: ResourceStatusService = mockk()
+
+    val application1 = "fnord1"
+
+    val releaseArtifact = DummyArtifact(reference = "release")
+    //val snapshotArtifact = DummyArtifact(reference = "snapshot")
+
+    val version0 = "fnord-1.0.0-h0.a0a0a0a"
+    val version1 = "fnord-1.0.1-h1.b1b1b1b"
+    val version2 = "fnord-1.0.2-h2.c2c2c2c"
+    val version3 = "fnord-1.0.3-h3.d3d3d3d"
+
+    val versions = listOf(version0, version1, version2, version3)
+
+    val singleArtifactEnvironments = listOf("test", "staging").associateWith { name ->
+      Environment(
+        name = name,
+        constraints = emptySet(),
+        resources = setOf(
+          // resource with new-style artifact reference
+          artifactReferenceResource(artifactReference = "release"),
+          // resource with old-style image provider
+          versionedArtifactResource()
+        )
+      )
+    }
+
+    val singleArtifactDeliveryConfig = DeliveryConfig(
+      name = "manifest_$application1",
+      application = application1,
+      serviceAccount = "keel@spinnaker",
+      artifacts = setOf(releaseArtifact),
+      environments = singleArtifactEnvironments.values.toSet()
+    )
+
+    private val artifactInstance = slot<PublishedArtifact>()
+    private val artifactSupplier = mockk<ArtifactSupplier<DummyArtifact, DummySortingStrategy>>(relaxUnitFun = true) {
+      every { supportedArtifact } returns SupportedArtifact("dummy", DummyArtifact::class.java)
+      every {
+        getVersionDisplayName(capture(artifactInstance))
+      } answers {
+        artifactInstance.captured.version
+      }
+      every { parseDefaultBuildMetadata(any(), any()) } returns null
+      every { parseDefaultGitMetadata(any(), any()) } returns null
+    }
+
+    private val scmInfo = mockk<ScmInfo>() {
+      coEvery {
+        getScmInfo()
+      } answers {
+        mapOf("stash" to "https://stash")
+      }
+    }
+
+    val dependsOnEvaluator = mockk<ConstraintEvaluator<DependsOnConstraint>>() {
+      every { isImplicit() } returns false
+      every { supportedType } returns SupportedConstraintType<DependsOnConstraint>("depends-on")
+    }
+
+    // subject
+    val applicationService = ApplicationService(
+      repository,
+      resourceStatusService,
+      listOf(dependsOnEvaluator),
+      listOf(artifactSupplier),
+      scmInfo
+    )
+
+    val buildMetadata = BuildMetadata(
+      id = 1,
+      number = "1",
+    )
+
+    val gitMetadata = GitMetadata(
+      author = "keel user",
+      commit = "1sdla",
+      commitInfo = Commit(
+        sha = "12345",
+        link = "https://stash"
+      ),
+      repo = Repo(
+        name = "keel"
+      ),
+      project = "spkr"
+    )
+
+    fun Collection<String>.toArtifactVersions(artifact: DeliveryArtifact) =
+      map { PublishedArtifact(artifact.name, artifact.type, it) }
+  }
+
+  fun comparableLinksTests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    before {
+      every { repository.getDeliveryConfigForApplication(application1) } returns singleArtifactDeliveryConfig
+
+      every {
+        repository.getArtifactVersion(any(), any(), any())
+      } answers {
+        PublishedArtifact(arg<DeliveryArtifact>(0).name, arg<DeliveryArtifact>(0).type, arg<String>(1))
+      }
+
+      every {
+        repository.getReleaseStatus(releaseArtifact, any())
+      } returns ArtifactStatus.RELEASE
+
+      every {
+        repository.getArtifactVersionByPromotionStatus(any(), any(), any(), any())
+      } returns null
+
+      every {
+        repository.getPinnedVersion(any(), any(), any())
+      } returns null
+    }
+
+    context("each environment has a current version, and previous versions") {
+      before {
+        every {
+          repository.getEnvironmentSummaries(singleArtifactDeliveryConfig)
+        } returns singleArtifactDeliveryConfig.environments.map { env ->
+          toEnvironmentSummary(env) {
+            when (env.name) {
+              "test" -> ArtifactVersionStatus(
+                previous = listOf(version0, version1),
+                current = version2,
+                deploying = version3
+              )
+              "staging" -> ArtifactVersionStatus(
+                previous = listOf(version0),
+                current = version1,
+                pending = listOf(version2)
+              )
+              else -> error("Unexpected environment ${env.name}")
+            }
+          }
+        }
+
+        // for statuses other than PENDING, we go look for the artifact summary in environment
+        every {
+          repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any())
+        } answers {
+          when (val environment = arg<String>(1)) {
+            "test" -> when (val version = arg<String>(3)) {
+              version0,
+              version1 -> ArtifactSummaryInEnvironment(environment, version, "previous", replacedBy = version2)
+              version2 -> ArtifactSummaryInEnvironment(environment, version, "current")
+              version3 -> ArtifactSummaryInEnvironment(environment, version, "deploying")
+              else -> ArtifactSummaryInEnvironment(environment, version, "pending")
+            }
+            "staging" -> when (val version = arg<String>(3)) {
+              version0 -> ArtifactSummaryInEnvironment(environment, version, "previous", replacedBy = version1)
+              version1 -> ArtifactSummaryInEnvironment(environment, version, "current")
+              else -> ArtifactSummaryInEnvironment(environment, version, "pending")
+            }
+            else -> null
+          }
+        }
+
+        every {
+          repository.constraintStateFor(singleArtifactDeliveryConfig.name, any(), any<String>())
+        } answers {
+          emptyList()
+          }
+
+
+        every { repository.artifactVersions(releaseArtifact) } returns versions.toArtifactVersions(releaseArtifact)
+
+        every {
+          repository.getArtifactVersion(any(), any(), any())
+        } answers {
+          PublishedArtifact(arg<DeliveryArtifact>(0).name, arg<DeliveryArtifact>(0).type, arg<String>(1),
+            gitMetadata = GitMetadata(commit = arg<String>(1),
+              commitInfo = Commit(sha = arg<String>(1), link = "stash"),
+              repo = Repo(name = "keel"),
+              project = "spkr"
+            )
+            , buildMetadata = buildMetadata)
+        }
+
+        every {
+            repository.getArtifactVersionByPromotionStatus(singleArtifactDeliveryConfig, any(), releaseArtifact, PromotionStatus.PREVIOUS.name, any())
+          } answers {
+            PublishedArtifact(
+              name = arg<DeliveryArtifact>(2).name,
+              type = arg<DeliveryArtifact>(2).type,
+              version = version0,
+              gitMetadata = GitMetadata(commit = arg<String>(1),
+                commitInfo = Commit(sha = "${arg<String>(1)}:$version0", link = "stash"))
+            )
+          }
+
+        every {
+          repository.getArtifactVersionByPromotionStatus(singleArtifactDeliveryConfig, any(), releaseArtifact, PromotionStatus.CURRENT.name)
+        } answers {
+          PublishedArtifact(
+            name = arg<DeliveryArtifact>(2).name,
+            type = arg<DeliveryArtifact>(2).type,
+            version = version1,
+            gitMetadata = GitMetadata(commit = arg<String>(1),
+              commitInfo = Commit(sha = "${arg<String>(1)}:$version1", link = "stash"))
+          )
+        }
+
+      }
+
+      test("compare links for previous-->current are generated as expected, in the correct env") {
+        val summaries = applicationService.getArtifactSummariesFor(application1)
+        expectThat(summaries.first())
+          .withVersionInEnvironment(version2, "test") {
+            state.isEqualTo(PromotionStatus.CURRENT.name.toLowerCase())
+            compareLink
+              .isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=test:fnord-1.0.0-h0.a0a0a0a&sourceBranch=fnord-1.0.2-h2.c2c2c2c")
+          }
+          .withVersionInEnvironment(version1, "staging") {
+            state.isEqualTo(PromotionStatus.CURRENT.name.toLowerCase())
+            compareLink.isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=staging:fnord-1.0.0-h0.a0a0a0a&sourceBranch=fnord-1.0.1-h1.b1b1b1b")
+          }
+      }
+
+      test("compare links for current --> deploying are generated as expected, in the correct env") {
+        val summaries = applicationService.getArtifactSummariesFor(application1)
+        expectThat(summaries.first())
+          .withVersionInEnvironment(version3, "test") {
+            state.isEqualTo(PromotionStatus.DEPLOYING.name.toLowerCase())
+            compareLink
+              .isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=test:fnord-1.0.1-h1.b1b1b1b&sourceBranch=fnord-1.0.3-h3.d3d3d3d")
+          }
+      }
+
+      test("compare links for previous --> current  are generated as expected, in the correct env") {
+        val summaries = applicationService.getArtifactSummariesFor(application1)
+        expectThat(summaries.first())
+          .withVersionInEnvironment(version0, "staging") {
+            state.isEqualTo(PromotionStatus.PREVIOUS.name.toLowerCase())
+            compareLink.isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=fnord-1.0.0-h0.a0a0a0a&sourceBranch=fnord-1.0.1-h1.b1b1b1b")
+          }
+      }
+
+      test("compare links for pending --> current  are generated as expected, in the correct env") {
+        val summaries = applicationService.getArtifactSummariesFor(application1)
+        expectThat(summaries.first())
+          .withVersionInEnvironment(version2, "staging") {
+            state.isEqualTo(ConstraintStatus.PENDING.name.toLowerCase())
+            compareLink.isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=staging:fnord-1.0.1-h1.b1b1b1b&sourceBranch=fnord-1.0.2-h2.c2c2c2c")
+          }
+      }
+
+      context("pinned") {
+        before {
+          every {
+            repository.getPinnedVersion(singleArtifactDeliveryConfig, "test", releaseArtifact.reference)
+          } returns version0
+
+          every {
+            repository.getPinnedVersion(singleArtifactDeliveryConfig, "staging", releaseArtifact.reference)
+          } returns version3
+
+          every {
+            repository.getArtifactVersionByPromotionStatus(singleArtifactDeliveryConfig, any(), releaseArtifact, PromotionStatus.PREVIOUS.name, version0)
+          } answers {
+            PublishedArtifact(
+              name = arg<DeliveryArtifact>(2).name,
+              type = arg<DeliveryArtifact>(2).type,
+              version = version1,
+              gitMetadata = GitMetadata(commit = arg<String>(1),
+                commitInfo = Commit(sha = "pinnedVersion", link = "stash"),
+                repo = Repo(name = "keel"),
+                project = "spkr"
+              )
+            )
+          }
+
+          every {
+            repository.getArtifactVersion(releaseArtifact, version3, ArtifactStatus.RELEASE)
+          } answers {
+            PublishedArtifact(
+              name = arg<DeliveryArtifact>(0).name,
+              type = arg<DeliveryArtifact>(0).type,
+              version = arg<String>(1),
+              gitMetadata = GitMetadata(
+                commit = "pinnedVersion",
+                commitInfo = Commit(sha = "pinnedVersion", link = "stash"),
+                repo = Repo(name = "keel"),
+                project = "spkr"
+              ),
+              buildMetadata = buildMetadata
+            )
+          }
+          every {
+            repository.getArtifactVersion(releaseArtifact, version0, ArtifactStatus.RELEASE)
+          } answers {
+            PublishedArtifact(
+              name = arg<DeliveryArtifact>(0).name,
+              type = arg<DeliveryArtifact>(0).type,
+              version = arg<String>(1),
+              gitMetadata = GitMetadata(
+                commit = "pinnedVersion",
+                commitInfo = Commit(sha = "pinnedVersion", link = "stash"),
+                repo = Repo(name = "keel"),
+                project = "spkr"
+              ),
+              buildMetadata = buildMetadata
+            )
+          }
+        }
+        test ("get the correct compare link when pinning forward") {
+          val summaries = applicationService.getArtifactSummariesFor(application1)
+          expectThat(summaries.first())
+            .withVersionInEnvironment(version1, "staging") {
+              compareLink.isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=fnord-1.0.1-h1.b1b1b1b&sourceBranch=pinnedVersion")
+            }
+        }
+
+        test ("get the correct compare link when pinning backwards") {
+          val summaries = applicationService.getArtifactSummariesFor(application1)
+          expectThat(summaries.first())
+            .withVersionInEnvironment(version2, "test") {
+              compareLink.isEqualTo("https://stash/projects/spkr/repos/keel/compare/commits?targetBranch=pinnedVersion&sourceBranch=fnord-1.0.2-h2.c2c2c2c")
+            }
+        }
+      }
+    }
+  }
+
+  private fun Assertion.Builder<ArtifactSummary>.withVersionInEnvironment(
+    version: String,
+    environment: String,
+    block: Assertion.Builder<ArtifactSummaryInEnvironment>.() -> Unit
+  ): Assertion.Builder<ArtifactSummary> =
+    with(ArtifactSummary::versions) {
+      first { it.version == version }
+        .with(ArtifactVersionSummary::environments) {
+          first { it.environment == environment }
+            .and(block)
+        }
+    }
+
+   private fun Fixture.toEnvironmentSummary(env: Environment, block: () -> ArtifactVersionStatus): EnvironmentSummary {
+    return EnvironmentSummary(
+      env,
+      setOf(
+        ArtifactVersions(
+          name = releaseArtifact.name,
+          type = releaseArtifact.type,
+          reference = releaseArtifact.reference,
+          statuses = emptySet(),
+          versions = block(),
+          pinnedVersion = null
+        )
+      )
+    )
+  }
+
+  val Assertion.Builder<ArtifactSummaryInEnvironment>.state: Assertion.Builder<String>
+    get() = get { state }
+
+  val Assertion.Builder<ArtifactSummaryInEnvironment>.compareLink: DescribeableBuilder<String?>
+    get() = get { compareLink }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -9,7 +9,6 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.supporting
@@ -247,7 +246,7 @@ class SqlArtifactRepository(
   }
 
   override fun getArtifactVersion(artifact: DeliveryArtifact, version: String, status: ArtifactStatus?): PublishedArtifact? {
-   return sqlRetry.withRetry(READ) {
+    return sqlRetry.withRetry(READ) {
       jooq
         .select(
           ARTIFACT_VERSIONS.NAME,
@@ -530,14 +529,14 @@ class SqlArtifactRepository(
         // update any past artifacts that were "APPROVED" to be "SKIPPED"
         // because the new version takes precedence
         val approved = txn.select(
-            ARTIFACT_VERSIONS.NAME,
-            ARTIFACT_VERSIONS.TYPE,
-            ARTIFACT_VERSIONS.VERSION,
-            ARTIFACT_VERSIONS.RELEASE_STATUS,
-            ARTIFACT_VERSIONS.CREATED_AT,
-            ARTIFACT_VERSIONS.GIT_METADATA,
-            ARTIFACT_VERSIONS.BUILD_METADATA
-          )
+          ARTIFACT_VERSIONS.NAME,
+          ARTIFACT_VERSIONS.TYPE,
+          ARTIFACT_VERSIONS.VERSION,
+          ARTIFACT_VERSIONS.RELEASE_STATUS,
+          ARTIFACT_VERSIONS.CREATED_AT,
+          ARTIFACT_VERSIONS.GIT_METADATA,
+          ARTIFACT_VERSIONS.BUILD_METADATA
+        )
           .from(ENVIRONMENT_ARTIFACT_VERSIONS, DELIVERY_ARTIFACT, ARTIFACT_VERSIONS)
           .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(environmentUid))
           .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
@@ -556,7 +555,7 @@ class SqlArtifactRepository(
 
         log.debug("markAsSuccessfullyDeployedTo: # of approvedButOld: ${approvedButOld.size}. ${artifact.name}. version: $version. env: $targetEnvironment")
 
-        if(approvedButOld.isNotEmpty()) {
+        if (approvedButOld.isNotEmpty()) {
           val skippedUpdates = txn
             .update(ENVIRONMENT_ARTIFACT_VERSIONS)
             .set(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS, SKIPPED.name)
@@ -1015,7 +1014,7 @@ class SqlArtifactRepository(
           .toSet()
 
         val versions = unionedVersions
-          .sortedWith(compareBy( artifact.sortingStrategy.comparator) { (artifactVersion, _) -> artifactVersion })
+          .sortedWith(compareBy(artifact.sortingStrategy.comparator) { (artifactVersion, _) -> artifactVersion })
           .groupBy(
             { (_, promotionStatus) ->
               promotionStatus
@@ -1194,43 +1193,17 @@ class SqlArtifactRepository(
         .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(environmentName)))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(artifact.uid))
         .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(promotionStatus))
-
         //special case for pinning
         .apply { if (version != null) and(ENVIRONMENT_ARTIFACT_VERSIONS.REPLACED_BY.eq(version)) }
-
         .orderBy(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.desc())
         .fetch(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION)
         .firstOrNull()
 
       if (fetchedVersion != null) {
-        jooq
-          .select(
-            ARTIFACT_VERSIONS.NAME,
-            ARTIFACT_VERSIONS.TYPE,
-            ARTIFACT_VERSIONS.VERSION,
-            ARTIFACT_VERSIONS.RELEASE_STATUS,
-            ARTIFACT_VERSIONS.CREATED_AT,
-            ARTIFACT_VERSIONS.GIT_METADATA,
-            ARTIFACT_VERSIONS.BUILD_METADATA,
-          )
-          .from(ARTIFACT_VERSIONS)
-          .where(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
-          .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type))
-          .and(ARTIFACT_VERSIONS.VERSION.eq(fetchedVersion))
-          .fetchOne { (name, type, version, status, createdAt, gitMetadata, buildMetadata) ->
-            PublishedArtifact(
-              name = name,
-              type = type,
-              version = version,
-              status = status?.let { ArtifactStatus.valueOf(it) },
-              createdAt = createdAt?.toInstant(UTC),
-              gitMetadata = gitMetadata?.let { objectMapper.readValue(it) },
-              buildMetadata = buildMetadata?.let { objectMapper.readValue(it) },
-            )
-          }
+        getArtifactVersion(artifact, fetchedVersion)
       } else {
-            null
-          }
+        null
+      }
     }
   }
 

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
@@ -25,7 +25,7 @@ class DummyArtifact(
 }
 
 object DummySortingStrategy : SortingStrategy {
-  override val comparator: Comparator<PublishedArtifact> = compareBy { it.version }
+  override val comparator: Comparator<PublishedArtifact> = compareByDescending { it.version }
   override val type = "dummy"
 }
 


### PR DESCRIPTION
We recently added a `see changes` button to compare between artifact versions.

**The current solution**
For each artifact version and status, we checked which corresponding status we need to compare against.
For example:
current --> will be compared against the latest previous version
deploying/approved --> will be compared against the current version
pending --> will be compared against the current version.

**The problem** 
We didn't take into account that if we have a pinned version, we have to include that version when making the comparison in most cases. Since we _**have**_ to provide the right order when creating the SCM compare link, we needed to handle those differently.

**The solution** 
We first check to see if there is a pinned version for that artifact, in the environment. If so, we fetch that artifact version and compare against it first.
We also added the usage of the comparator for generating the SCM link, in order to make sure we are generating the link in the right order.