### PR TITLE
fix(api): Include metadata when retrieving delivery config by application

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -30,6 +30,7 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
+import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
@@ -51,7 +52,8 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
     val deliveryConfig: DeliveryConfig = DeliveryConfig(
       name = "keel",
       application = "keel",
-      serviceAccount = "keel@spinnaker"
+      serviceAccount = "keel@spinnaker",
+      metadata = mapOf("some" to "meta")
     )
   ) {
     private val resourceSpecIdentifier: ResourceSpecIdentifier =
@@ -181,14 +183,18 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
           .and {
             get { name }.isEqualTo(deliveryConfig.name)
             get { application }.isEqualTo(deliveryConfig.application)
+            get { metadata }.isNotEmpty()
           }
       }
 
       test("the config can be retrieved by application") {
         getByApplication()
           .isSuccess()
-          .get(DeliveryConfig::name)
-          .isEqualTo(deliveryConfig.name)
+          .and {
+            get { name }.isEqualTo(deliveryConfig.name)
+            get { application }.isEqualTo(deliveryConfig.application)
+            get { metadata }.isNotEmpty()
+          }
       }
     }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -73,12 +73,18 @@ class SqlDeliveryConfigRepository(
           DELIVERY_CONFIG.UID,
           DELIVERY_CONFIG.NAME,
           DELIVERY_CONFIG.APPLICATION,
-          DELIVERY_CONFIG.SERVICE_ACCOUNT
+          DELIVERY_CONFIG.SERVICE_ACCOUNT,
+          DELIVERY_CONFIG.METADATA
         )
         .from(DELIVERY_CONFIG)
         .where(DELIVERY_CONFIG.APPLICATION.eq(application))
-        .fetchOne { (uid, name, application, serviceAccount) ->
-          DeliveryConfig(name = name, application = application, serviceAccount = serviceAccount)
+        .fetchOne { (uid, name, application, serviceAccount, metadata) ->
+          DeliveryConfig(
+            name = name,
+            application = application,
+            serviceAccount = serviceAccount,
+            metadata = metadata?.let { mapper.readValue<Map<String, Any?>>(metadata) } ?: emptyMap()
+          )
             .attachDependents(uid)
         }
     } ?: throw NoDeliveryConfigForApplication(application)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
@@ -21,7 +21,8 @@ fun deliveryConfig(
     application = "fnord",
     serviceAccount = "keel@spinnaker",
     artifacts = setOf(artifact),
-    environments = setOf(env)
+    environments = setOf(env),
+    metadata = mapOf("some" to "meta")
   )
 ): DeliveryConfig {
   return deliveryConfig


### PR DESCRIPTION
I found out by accident that, when retrieving a delivery config via `GET /application/{application}/config`, the `metadata` field was always coming back empty, even when there was data in the database. Turns out we were not reading that column. This fixes that and adds a couple tests.