### PR TITLE
feat(compareLink): generate a comparable link in MJ slack notification

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactVersionLinks.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactVersionLinks.kt
@@ -25,7 +25,7 @@ fun generateCompareLink(scmInfo: ScmInfo, version1: PublishedArtifact?, version2
 //Generating a SCM compare link between source (new version) and target (old version) versions (the order matter!)
 private fun generateCompareLink(scmInfo: ScmInfo, newerGitMetadata: GitMetadata?, olderGitMetadata: GitMetadata?): String? {
   val baseScmUrl = newerGitMetadata?.commitInfo?.link?.let { getScmBaseLink(scmInfo, it) }
-  return if (baseScmUrl != null && olderGitMetadata != null) {
+  return if (baseScmUrl != null && olderGitMetadata != null && !(olderGitMetadata.commitInfo?.sha.isNullOrEmpty())) {
     "$baseScmUrl/projects/${newerGitMetadata.project}/repos/${newerGitMetadata.repo?.name}/compare/commits?" +
       "targetBranch=${olderGitMetadata.commitInfo?.sha}&sourceBranch=${newerGitMetadata.commitInfo?.sha}"
   } else {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactVersionLinks.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactVersionLinks.kt
@@ -1,0 +1,47 @@
+package com.netflix.spinnaker.keel.artifacts
+
+import com.netflix.spinnaker.keel.api.ScmInfo
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.exceptions.UnsupportedScmType
+import kotlinx.coroutines.runBlocking
+
+//Comparing 2 versions of a specific artifact, and generate a SCM comparable link based on old vs. new version
+fun generateCompareLink(scmInfo: ScmInfo, version1: PublishedArtifact?, version2: PublishedArtifact?, artifact: DeliveryArtifact): String? {
+  return if (version1 != null && version2 != null) {
+    return if (artifact.sortingStrategy.comparator.compare(version1, version2) > 0) { //these comparators sort in dec order, so condition is flipped
+      //version2 is newer than version1
+      generateCompareLink(scmInfo, version2.gitMetadata, version1.gitMetadata)
+    } else {
+      //version2 is older than version1
+      generateCompareLink(scmInfo, version1.gitMetadata, version2.gitMetadata)
+    }
+  } else {
+    null
+  }
+}
+
+//Generating a SCM compare link between source (new version) and target (old version) versions (the order matter!)
+private fun generateCompareLink(scmInfo: ScmInfo, newerGitMetadata: GitMetadata?, olderGitMetadata: GitMetadata?): String? {
+  val baseScmUrl = newerGitMetadata?.commitInfo?.link?.let { getScmBaseLink(scmInfo, it) }
+  return if (baseScmUrl != null && olderGitMetadata != null) {
+    "$baseScmUrl/projects/${newerGitMetadata.project}/repos/${newerGitMetadata.repo?.name}/compare/commits?" +
+      "targetBranch=${olderGitMetadata.commitInfo?.sha}&sourceBranch=${newerGitMetadata.commitInfo?.sha}"
+  } else {
+    null
+  }
+}
+
+//Calling igor to fetch all base urls by SCM type, and returning the right one based on current commit link
+private fun getScmBaseLink(scmInfo: ScmInfo, commitLink: String): String? {
+  val scmBaseURLs = runBlocking {
+    scmInfo.getScmInfo()
+  }
+  when {
+    "stash" in commitLink ->
+      return scmBaseURLs["stash"]
+    else ->
+      throw UnsupportedScmType(message = "Stash is currently the only supported SCM type")
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -8,7 +8,6 @@ import com.netflix.spinnaker.keel.api.ScmInfo
 import com.netflix.spinnaker.keel.api.StatefulConstraint
 import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
@@ -18,6 +17,7 @@ import com.netflix.spinnaker.keel.api.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.artifacts.generateCompareLink
 import com.netflix.spinnaker.keel.core.api.AllowedTimesConstraintMetadata
 import com.netflix.spinnaker.keel.core.api.ArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
@@ -47,7 +47,6 @@ import com.netflix.spinnaker.keel.lifecycle.LifecycleEventRepository
 import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.time.Instant
@@ -254,7 +253,7 @@ class ApplicationService(
           version = version,
           state = status.name.toLowerCase(),
           // comparing PENDING (version in question, new code) vs. CURRENT (old code)
-          compareLink = getUrl(currentArtifact, olderArtifactVersion, artifact)
+          compareLink = generateCompareLink(scmInfo, currentArtifact, olderArtifactVersion, artifact)
         )
       }
       SKIPPED -> {
@@ -273,7 +272,7 @@ class ApplicationService(
         val olderArtifactVersion = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, CURRENT.name)
         potentialSummary?.copy(
           // comparing DEPLOYING/APPROVED (version in question, new code) vs. CURRENT (old code)
-          compareLink = getUrl(currentArtifact, olderArtifactVersion, artifact)
+          compareLink = generateCompareLink(scmInfo, currentArtifact, olderArtifactVersion, artifact)
         )
       }
       PREVIOUS -> {
@@ -281,14 +280,14 @@ class ApplicationService(
         potentialSummary?.copy(
           //comparing PREVIOUS (version in question, old code) vs. the version which replaced it (new code)
           //pinned artifact should not be consider here, as we know exactly which version replace the current one
-          compareLink = getUrl(currentArtifact, newerArtifactVersion, artifact)
+          compareLink = generateCompareLink(scmInfo, currentArtifact, newerArtifactVersion, artifact)
         )
       }
       CURRENT -> {
         val olderArtifactVersion = pinnedArtifact?: repository.getArtifactVersionByPromotionStatus(deliveryConfig, environmentName, artifact, PREVIOUS.name)
         potentialSummary?.copy(
           // comparing CURRENT (version in question, new code) vs. PREVIOUS (old code)
-          compareLink = getUrl(currentArtifact, olderArtifactVersion, artifact)
+          compareLink = generateCompareLink(scmInfo, currentArtifact, olderArtifactVersion, artifact)
         )
       }
       else -> potentialSummary
@@ -406,43 +405,4 @@ class ApplicationService(
     return repository.getArtifactVersion(artifact, version, releaseStatus)
   }
 
-
-  // Calling igor to fetch all base urls by SCM type, and returning the right one based on current commit link
-  private fun getScmBaseLink(commitLink: String): String? {
-    val scmInfo = runBlocking {
-      scmInfo.getScmInfo()
-    }
-    //TODO[gyardeni]: replace this parsing when rocket will add scm type to gitMetadata
-    when {
-      "stash" in commitLink ->
-        return scmInfo["stash"]
-      else ->
-        throw UnsupportedScmType(message = "Stash is currently the only supported SCM type")
-    }
-  }
-
-  private fun getUrl(version1: PublishedArtifact?, version2: PublishedArtifact?, artifact: DeliveryArtifact): String? {
-    return if (version1 != null && version2 != null) {
-      return if (artifact.sortingStrategy.comparator.compare(version1, version2) > 0) { //these comparators sort in dec order, so condition is flipped
-        //version2 is newer than version1
-        generateCompareLink(version2.gitMetadata, version1.gitMetadata)
-      } else {
-        //version2 is older than version1
-        generateCompareLink(version1.gitMetadata, version2.gitMetadata)
-      }
-    } else {
-      null
-    }
-  }
-
-  // Generating a SCM compare link between source (new version) and target (old version) versions (the order does matter!)
-  private fun generateCompareLink(newerGitMetadata: GitMetadata?, olderGitMetadata: GitMetadata?): String? {
-    val baseScmUrl = newerGitMetadata?.commitInfo?.link?.let { getScmBaseLink(it) }
-    return if (baseScmUrl != null && olderGitMetadata != null) {
-      "$baseScmUrl/projects/${newerGitMetadata.project}/repos/${newerGitMetadata.repo?.name}/compare/commits?" +
-        "targetBranch=${olderGitMetadata.commitInfo?.sha}&sourceBranch=${newerGitMetadata.commitInfo?.sha}"
-    } else {
-      null
-    }
-  }
 }

--- a/keel-echo/src/main/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifier.kt
+++ b/keel-echo/src/main/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifier.kt
@@ -33,7 +33,6 @@ class ManualJudgementNotifier(
   private val echoService: EchoService,
   private val repository: KeelRepository,
   private val scmInfo: ScmInfo,
-  private val springEnv: Environment,
   @Value("\${spinnaker.baseUrl}") private val spinnakerBaseUrl: String
 ) {
   companion object {
@@ -42,9 +41,6 @@ class ManualJudgementNotifier(
   }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
-
-  private val seeChangesButton: Boolean
-    get() = springEnv.getProperty("keel.echo.seeChangesButton", Boolean::class.java, false)
 
   @EventListener(ConstraintStateChanged::class)
   fun constraintStateChanged(event: ConstraintStateChanged) {
@@ -79,7 +75,6 @@ class ManualJudgementNotifier(
     val currentArtifactInEnvironment = repository.getArtifactVersionByPromotionStatus(deliveryConfig, currentState.environmentName , artifact, PromotionStatus.CURRENT.name)
 
     var details = ""
-    var compareLink = ""
 
     if (gitMetadata != null) {
       if (!gitMetadata.commitInfo?.message.isNullOrEmpty()) {
@@ -88,7 +83,10 @@ class ManualJudgementNotifier(
 
       if (currentArtifactInEnvironment?.gitMetadata != null) {
         try {
-          compareLink += generateCompareLink(scmInfo, currentDeployableArtifact, currentArtifactInEnvironment, artifact)
+          val compareLink = generateCompareLink(scmInfo, currentDeployableArtifact, currentArtifactInEnvironment, artifact)
+          if (compareLink != null) {
+            details += "<$compareLink|*See changes*>\n"
+          }
         } catch (ex: Exception) {
           log.warn("Can't create comparable link for artifact ${currentArtifactInEnvironment.version}", ex)
         }
@@ -138,16 +136,6 @@ class ManualJudgementNotifier(
         value = ConstraintStatus.OVERRIDE_FAIL.name
       ),
     )
-
-    //if we have something to compare against, and the seeChangesButton FP is true, add this button to notification
-    if (compareLink != "" && seeChangesButton) {
-      interactiveActions.add(
-        EchoNotification.ButtonAction(
-          name = "manual-judgement",
-          label = "See changes",
-          value = compareLink
-      ))
-    }
 
     return EchoNotification(
       notificationType = EchoNotification.Type.valueOf(config.type.name.toUpperCase()),

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -37,6 +37,7 @@ import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
+import strikt.assertions.isFalse
 import strikt.assertions.isGreaterThan
 import strikt.assertions.isNull
 
@@ -64,8 +65,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
       }
     }
 
-    val springEnv: org.springframework.core.env.Environment = mockk(relaxed = true)
-    val subject = ManualJudgementNotifier(keelNotificationConfig, echoService, repository, scmInfo, springEnv, baseUrl)
+    val subject = ManualJudgementNotifier(keelNotificationConfig, echoService, repository, scmInfo, baseUrl)
   }
 
   fun tests() = rootContext<Fixture> {
@@ -122,10 +122,6 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
         every {
           repository.getArtifactVersion(artifact, "v1.0.0", any())
         } returns null
-
-        every {
-          springEnv.getProperty("keel.echo.seeChangesButton", Boolean::class.java, false)
-        } returns false
       }
 
       test("throws an exception if the constraint state uid is not present") {
@@ -276,55 +272,9 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
               commitInfo = Commit(message = "A test commit #2", link = "stash", sha = "v2.0.0")
             )
           )
-
-          every {
-            repository.getArtifactVersionByPromotionStatus(any(), any(), artifact, PromotionStatus.CURRENT.name)
-          } returns PublishedArtifact(
-            name = "mypkg",
-            type = DEBIAN,
-            version = "v1.0.0",
-            gitMetadata = GitMetadata(
-              commit = "e5f6g7h",
-              author = "joesmith",
-              project = "myproj",
-              branch = "master",
-              repo = Repo("myapp"),
-              commitInfo = Commit(message = "A test commit", link = "stash", sha = "v1.0.0")
-            )
-          )
-          every {
-            springEnv.getProperty("keel.echo.seeChangesButton", Boolean::class.java, false)
-          } returns true
         }
 
-        test("create the right comparable link") {
-          val compareLink = "https://stash/projects/myproj/repos/myapp/compare/commits?targetBranch=v1.0.0&sourceBranch=v2.0.0"
-
-          val expectedInteractiveActions = with(event) {
-            EchoNotification.InteractiveActions(
-              callbackServiceId = "keel",
-              callbackMessageId = currentState.uid!!.toString(),
-              actions = listOf(
-                EchoNotification.ButtonAction(
-                  name = "manual-judgement",
-                  label = "Approve",
-                  value = ConstraintStatus.OVERRIDE_PASS.name
-                ),
-                EchoNotification.ButtonAction(
-                  name = "manual-judgement",
-                  label = "Reject",
-                  value = ConstraintStatus.OVERRIDE_FAIL.name
-                ),
-                EchoNotification.ButtonAction(
-                  name = "manual-judgement",
-                  label = "See changes",
-                  value = compareLink
-                )
-              ),
-              color = "#fcba03"
-            )
-          }
-
+        test("when there is a single artifact in the environment, compare link is unavailable") {
           subject.constraintStateChanged(event)
 
           val notification = slot<EchoNotification>()
@@ -333,7 +283,42 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
             echoService.sendNotification(capture(notification))
           }
 
-          expectThat(notification.captured.interactiveActions).isEqualTo(expectedInteractiveActions)
+          val notificationBody = notification.captured.additionalContext!!["body"].toString()
+          expectThat(notificationBody.contains("*See full diff:*"))
+            .isFalse()
+        }
+
+        context("more artifact in an environment") {
+          before {
+            every {
+              repository.getArtifactVersionByPromotionStatus(any(), any(), artifact, PromotionStatus.CURRENT.name)
+            } returns PublishedArtifact(
+              name = "mypkg",
+              type = DEBIAN,
+              version = "v1.0.0",
+              gitMetadata = GitMetadata(
+                commit = "e5f6g7h",
+                author = "joesmith",
+                project = "myproj",
+                branch = "master",
+                repo = Repo("myapp"),
+                commitInfo = Commit(message = "A test commit", link = "stash", sha = "v1.0.0")
+              )
+            )
+          }
+          test("create the right comparable link") {
+            subject.constraintStateChanged(event)
+
+            val notification = slot<EchoNotification>()
+
+            coVerify {
+              echoService.sendNotification(capture(notification))
+            }
+
+            val notificationBody = notification.captured.additionalContext!!["body"].toString()
+            expectThat(notificationBody)
+              .contains("*See changes:* <https://stash/projects/myproj/repos/myapp/compare/commits?targetBranch=v1.0.0&sourceBranch=v2.0.0|Click for changes>")
+          }
         }
       }
     }

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -317,7 +317,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
 
             val notificationBody = notification.captured.additionalContext!!["body"].toString()
             expectThat(notificationBody)
-              .contains("*See changes:* <https://stash/projects/myproj/repos/myapp/compare/commits?targetBranch=v1.0.0&sourceBranch=v2.0.0|Click for changes>")
+              .contains("<https://stash/projects/myproj/repos/myapp/compare/commits?targetBranch=v1.0.0&sourceBranch=v2.0.0|*See changes*>")
           }
         }
       }

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.NotificationConfig
 import com.netflix.spinnaker.keel.api.NotificationFrequency
 import com.netflix.spinnaker.keel.api.NotificationType
+import com.netflix.spinnaker.keel.api.ScmInfo
 import com.netflix.spinnaker.keel.api.artifacts.BaseLabel.RELEASE
 import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
@@ -17,6 +18,7 @@ import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.events.ConstraintStateChanged
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.keel.core.api.PromotionStatus
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.echo.model.EchoNotification
 import com.netflix.spinnaker.keel.persistence.KeelRepository
@@ -37,6 +39,7 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isGreaterThan
 import strikt.assertions.isNull
+import strikt.assertions.isTrue
 
 internal class ManualJudgementNotifierTests : JUnit5Minutests {
 
@@ -54,7 +57,14 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
     val artifact = DebianArtifact("mypkg", "test", "deb",
       vmOptions = VirtualMachineOptions(RELEASE, "bionic", emptySet())
     )
-    val subject = ManualJudgementNotifier(keelNotificationConfig, echoService, repository, baseUrl)
+    val scmInfo = mockk<ScmInfo>() {
+      coEvery {
+        getScmInfo()
+      } answers {
+        mapOf("stash" to "https://stash")
+      }
+    }
+    val subject = ManualJudgementNotifier(keelNotificationConfig, echoService, repository, scmInfo, baseUrl)
   }
 
   fun tests() = rootContext<Fixture> {
@@ -102,7 +112,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
         every {
           repository.getArtifact("test", "deb")
         } returns DebianArtifact("mypkg", "test", "deb",
-            vmOptions = VirtualMachineOptions(RELEASE, "bionic", emptySet()))
+          vmOptions = VirtualMachineOptions(RELEASE, "bionic", emptySet()))
 
         every {
           repository.getDeliveryConfig("test")
@@ -241,6 +251,73 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
             .contains("*Branch:* master")
           expectThat(notificationBody)
             .contains("*Message:* A test commit")
+        }
+      }
+
+      context("compare links in notification") {
+        before {
+          every {
+            repository.getArtifactVersion(artifact, "v1.0.0", any())
+          } returns PublishedArtifact(
+            name = "mypkg",
+            type = DEBIAN,
+            version = "v2.0.0",
+            gitMetadata = GitMetadata(
+              commit = "a1b2c3d",
+              author = "joesmith",
+              project = "myproj",
+              branch = "master",
+              repo = Repo("myapp"),
+              commitInfo = Commit(message = "A test commit #2", link = "stash", sha = "v2.0.0")
+            )
+          )
+        }
+
+        test("when there is a single artifact in the environment, compare link is unavailable") {
+          subject.constraintStateChanged(event)
+
+          val notification = slot<EchoNotification>()
+
+          coVerify {
+            echoService.sendNotification(capture(notification))
+          }
+
+          val notificationBody = notification.captured.additionalContext!!["body"].toString()
+          expectThat(notificationBody.contains("*See full diff:*"))
+            .isTrue()
+        }
+
+        context("more artifact in an environment") {
+          before {
+            every {
+              repository.getArtifactVersionByPromotionStatus(any(), any(), artifact, PromotionStatus.CURRENT.name)
+            } returns PublishedArtifact(
+              name = "mypkg",
+              type = DEBIAN,
+              version = "v1.0.0",
+              gitMetadata = GitMetadata(
+                commit = "e5f6g7h",
+                author = "joesmith",
+                project = "myproj",
+                branch = "master",
+                repo = Repo("myapp"),
+                commitInfo = Commit(message = "A test commit", link = "stash", sha = "v1.0.0")
+              )
+            )
+          }
+          test("create the right comparable link") {
+            subject.constraintStateChanged(event)
+
+            val notification = slot<EchoNotification>()
+
+            coVerify {
+              echoService.sendNotification(capture(notification))
+            }
+
+            val notificationBody = notification.captured.additionalContext!!["body"].toString()
+            expectThat(notificationBody)
+              .contains("*See full diff:* <https://stash/projects/myproj/repos/myapp/compare/commits?targetBranch=v1.0.0&sourceBranch=v2.0.0>")
+          }
         }
       }
     }

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -284,7 +284,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
           }
 
           val notificationBody = notification.captured.additionalContext!!["body"].toString()
-          expectThat(notificationBody.contains("*See full diff:*"))
+          expectThat(notificationBody.contains("*See changes*"))
             .isFalse()
         }
 


### PR DESCRIPTION
Adding a "see changes" link whenever we send a manual judgment notification in slack.
Preview:
![Screen Shot 2020-11-24 at 2 00 42 PM](https://user-images.githubusercontent.com/55253849/100156511-e7c1b500-2e5d-11eb-9870-5354ee58c528.png)


Looking for feedback mainly around:
- naming (I called it "show full diff" and then the full diff, for now)
- order (where should we show it within the notification?)