### PR TITLE
fix(view): don't summarize artifact when unused

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.keel.api.artifacts
 
+import com.netflix.spinnaker.keel.api.ArtifactReferenceProvider
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.schema.Discriminator
 import java.time.Instant
 
@@ -92,6 +94,15 @@ abstract class DeliveryArtifact {
         "createdAt" to createdAt
       )
     ).normalized()
+
+  /**
+   * @return `true` if this artifact is used by any resource in [environment], `false` otherwise.
+   */
+  fun isUsedIn(environment: Environment) =
+    environment
+      .resources
+      .map { (it.spec as? ArtifactReferenceProvider)?.artifactReference }
+      .contains(reference)
 
   fun toLifecycleRef() = "$deliveryConfigName:$reference"
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -120,15 +120,6 @@ class EnvironmentPromotionChecker(
     }
   }
 
-  /**
-   * @return `true` if this artifact is used by any resource in [environment], `false` otherwise.
-   */
-  private fun DeliveryArtifact.isUsedIn(environment: Environment) =
-    environment
-      .resources
-      .map { (it.spec as? ArtifactReferenceProvider)?.artifactReference }
-      .contains(reference)
-
   private fun approveVersion(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -75,13 +75,17 @@ class ApplicationController(
       if (includeDetails && !entities.contains("resources")) {
         entities.add("resources")
       }
-      entities.forEach { entity ->
-        results[entity] = when (entity) {
-          "resources" -> applicationService.getResourceSummariesFor(application)
-          "environments" -> applicationService.getEnvironmentSummariesFor(application)
-          "artifacts" -> applicationService.getArtifactSummariesFor(application,
-            maxArtifactVersions ?: DEFAULT_MAX_ARTIFACT_VERSIONS)
-          else -> throw InvalidRequestException("Unknown entity type: $entity")
+      if (entities.size == 3) { // requesting everything, can optimize
+        results.putAll(applicationService.getSummariesAllEntities(application))
+      } else {
+        entities.forEach { entity ->
+          results[entity] = when (entity) {
+            "resources" -> applicationService.getResourceSummariesFor(application)
+            "environments" -> applicationService.getEnvironmentSummariesFor(application)
+            "artifacts" -> applicationService.getArtifactSummariesFor(application,
+              maxArtifactVersions ?: DEFAULT_MAX_ARTIFACT_VERSIONS)
+            else -> throw InvalidRequestException("Unknown entity type: $entity")
+          }
         }
       }
     }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationControllerTests.kt
@@ -11,9 +11,12 @@ import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_PASS
 import com.netflix.spinnaker.keel.api.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
+import com.netflix.spinnaker.keel.core.api.EnvironmentSummary
+import com.netflix.spinnaker.keel.core.api.ResourceSummary
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
@@ -41,6 +44,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
+import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotEmpty
@@ -96,8 +100,12 @@ internal class ApplicationControllerTests : JUnit5Minutests {
         every { applicationService.getResourceSummariesFor(application) } returns emptyList()
         every { applicationService.getEnvironmentSummariesFor(application) } returns emptyList()
         every { applicationService.getArtifactSummariesFor(application) } returns emptyList()
-        every { applicationService.getArtifactSummariesFor(application, any()) } returns emptyList()
+        every { applicationService.getArtifactSummariesFor(application, ofType<Int>()) } returns emptyList()
         every { applicationService.getDeliveryConfig(application) } returns deliveryConfig
+        every { applicationService.getSummariesAllEntities(application) } returns
+          mapOf("environments" to emptyList<EnvironmentSummary>(),
+                "resources" to emptyList<ResourceSummary>(),
+                "artifacts" to emptyList<ArtifactSummary>())
       }
 
       test("can get delivery config") {
@@ -152,7 +160,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             .andReturn()
           val response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
           expectThat(response.keys)
-            .containsExactly(
+            .containsExactlyInAnyOrder(
               "applicationPaused",
               "hasManagedResources",
               "currentEnvironmentConstraints",
@@ -172,7 +180,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             .andReturn()
           val response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
           expectThat(response.keys)
-            .containsExactly(
+            .containsExactlyInAnyOrder(
               "applicationPaused",
               "hasManagedResources",
               "currentEnvironmentConstraints",
@@ -214,7 +222,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             .andReturn()
           var response = jsonMapper.readValue<Map<String, Any>>(result.response.contentAsString)
           expectThat(response.keys)
-            .containsExactly(
+            .containsExactlyInAnyOrder(
               "applicationPaused",
               "hasManagedResources",
               "currentEnvironmentConstraints"
@@ -229,7 +237,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
             .andReturn()
           response = jsonMapper.readValue(result.response.contentAsString)
           expectThat(response.keys)
-            .containsExactly(
+            .containsExactlyInAnyOrder(
               "applicationPaused",
               "hasManagedResources",
               "currentEnvironmentConstraints",
@@ -287,7 +295,7 @@ internal class ApplicationControllerTests : JUnit5Minutests {
               actuationPauser.applicationIsPaused(application)
             } returns false
 
-            every { applicationService.getArtifactSummariesFor(application, any()) } returns listOf(
+            every { applicationService.getArtifactSummariesFor(application, ofType<Int>()) } returns listOf(
               ArtifactSummary(
                 name = "test",
                 type = DEBIAN,


### PR DESCRIPTION
This PR fixes the issue where we create summaries for environments where an artifact will never go. that is distracting and confusing in the UI. it does not spark joy.