### PR TITLE
fix(bake monitor): fail only for consecutive failures

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorRepository.kt
@@ -29,6 +29,11 @@ interface LifecycleMonitorRepository {
   fun markFailureGettingStatus(task: MonitoredTask)
 
   /**
+   * Clears the counter for failed get status attempts
+   */
+  fun clearFailuresGettingStatus(task: MonitoredTask)
+
+  /**
    * @return the number of tasks currently being monitored
    */
   fun numTasksMonitoring(): Int

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepository.kt
@@ -124,6 +124,17 @@ class SqlLifecycleMonitorRepository(
     }
   }
 
+  override fun clearFailuresGettingStatus(task: MonitoredTask) {
+    sqlRetry.withRetry(WRITE) {
+      val triggeringEventUid = task.triggeringEvent.getUid(jooq)
+      jooq.update(LIFECYCLE_MONITOR)
+        .set(LIFECYCLE_MONITOR.NUM_FAILURES, 0)
+        .where(LIFECYCLE_MONITOR.TYPE.eq(task.type.name))
+        .and(LIFECYCLE_MONITOR.TRIGGERING_EVENT_UID.eq(triggeringEventUid))
+        .execute()
+    }
+  }
+
   override fun numTasksMonitoring(): Int =
     sqlRetry.withRetry(READ) {
       jooq.selectCount()


### PR DESCRIPTION
We only want to fail for consecutive failures, it's ok if something fails intermittently.

Also, the status of something we failed to monitor should be unknown, not failed. failed is misleading. 