### PR TITLE
chore(test): increase timeout

### DIFF
--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
@@ -37,7 +37,7 @@ internal class ApplicationEventTests {
 
     publisher.publishEvent(TestEvent(this))
 
-    val eventThread = listener.awaitInvoked(Duration.ofMillis(300))
+    val eventThread = listener.awaitInvoked(Duration.ofMillis(500))
 
     expectThat(eventThread)
       .isNotEqualTo(testThread)


### PR DESCRIPTION
this test failed on a pr but succeeded in a re-run. Bumping the timeout up a bit.