### PR TITLE
prefer constructor autowiring to use of lateinit var in Spring tests

### DIFF
--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -30,16 +30,12 @@ import strikt.assertions.isA
   ]
 )
 @DisableSpringScheduling
-internal class SpringStartupTests {
-
-  @Autowired
-  lateinit var artifactRepository: ArtifactRepository
-
-  @Autowired
-  lateinit var resourceRepository: ResourceRepository
-
-  @Autowired
-  lateinit var deliveryConfigRepository: DeliveryConfigRepository
+internal class SpringStartupTests
+@Autowired constructor(
+  val artifactRepository: ArtifactRepository,
+  val resourceRepository: ResourceRepository,
+  val deliveryConfigRepository: DeliveryConfigRepository
+) {
 
   @Test
   fun `uses SqlArtifactRepository`() {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -51,7 +51,11 @@ import strikt.assertions.isFalse
   ]
 )
 @DisableSpringScheduling
-internal class DeliveryConfigTransactionTests : JUnit5Minutests {
+internal class DeliveryConfigTransactionTests
+@Autowired constructor(
+  val repository: KeelRepository,
+  val jooq: DSLContext
+) : JUnit5Minutests {
 
   @SpykBean
   lateinit var artifactRepository: ArtifactRepository
@@ -61,12 +65,6 @@ internal class DeliveryConfigTransactionTests : JUnit5Minutests {
 
   @SpykBean
   lateinit var deliveryConfigRepository: DeliveryConfigRepository
-
-  @Autowired
-  lateinit var repository: KeelRepository
-
-  @Autowired
-  lateinit var jooq: DSLContext
 
   private fun KeelRepository.allResourceNames(): List<String> =
     mutableListOf<String>()

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
@@ -36,9 +36,8 @@ import strikt.api.expectThat
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-class ApiDocCompatibilityTests {
-  @Autowired
-  lateinit var generator: Generator
+class ApiDocCompatibilityTests
+@Autowired constructor(val generator: Generator) {
 
   val schemaFactory: JsonSchemaFactory = JsonSchemaFactory.getInstance(V201909)
   val api by lazy {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -65,13 +65,11 @@ import kotlin.reflect.KClass
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-class ApiDocTests : JUnit5Minutests {
-
-  @Autowired
-  lateinit var generator: Generator
-
-  @Autowired
-  lateinit var extensionRegistry: ExtensionRegistry
+class ApiDocTests
+  @Autowired constructor(
+    val generator: Generator,
+    val extensionRegistry: ExtensionRegistry
+  ): JUnit5Minutests {
 
   val resourceSpecTypes
     get() = extensionRegistry.extensionsOf<ResourceSpec>()

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -40,15 +40,14 @@ import strikt.assertions.isNotNull
   webEnvironment = MOCK
 )
 @DisableSpringScheduling
-internal class AuthPropagationTests : JUnit5Minutests {
-
-  @Autowired
-  lateinit var cloudDriverService: CloudDriverService
+internal class AuthPropagationTests
+@Autowired constructor(val cloudDriverService: CloudDriverService) : JUnit5Minutests {
 
   @Configuration
   class MockFiat {
     val mockAccount = Account()
     val mockPermission = UserPermission()
+
     init {
       mockAccount.cloudProvider = "aws"
       mockAccount.name = "test"

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/SchedulingResilienceTests.kt
@@ -28,10 +28,8 @@ import java.util.concurrent.TimeUnit.SECONDS
   webEnvironment = MOCK
 )
 @DisableSpringScheduling
-internal class SchedulingResilienceTests {
-
-  @Autowired
-  lateinit var service: DummyRetrofitService
+internal class SchedulingResilienceTests
+@Autowired constructor(val service: DummyRetrofitService){
 
   @Test
   fun `retrofit call completes even if an interceptor throws an exception`() {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -22,23 +23,19 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @SpringBootTest(
   classes = [KeelApplication::class, MockEurekaConfiguration::class],
-  webEnvironment = SpringBootTest.WebEnvironment.MOCK
+  webEnvironment = MOCK
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-internal class AdminControllerTests : JUnit5Minutests {
-
-  @Autowired
-  lateinit var mvc: MockMvc
+internal class AdminControllerTests
+@Autowired constructor(
+  val mvc: MockMvc,
+  val combinedRepository: KeelRepository,
+  val actuationPauser: ActuationPauser
+) : JUnit5Minutests {
 
   @MockkBean
   lateinit var adminService: AdminService
-
-  @Autowired
-  lateinit var combinedRepository: KeelRepository
-
-  @Autowired
-  lateinit var actuationPauser: ActuationPauser
 
   companion object {
     const val application1 = "fnord"

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
@@ -23,13 +23,11 @@ import java.util.concurrent.TimeoutException
   webEnvironment = MOCK
 )
 @DisableSpringScheduling
-internal class ApplicationEventTests {
-
-  @Autowired
-  lateinit var publisher: ApplicationEventPublisher
-
-  @Autowired
-  lateinit var listener: ThreadCapturingEventListener
+internal class ApplicationEventTests
+@Autowired constructor(
+  val publisher: ApplicationEventPublisher,
+  val listener: ThreadCapturingEventListener
+) {
 
   @Test
   fun `events are dispatched on a different thread`() {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ArtifactControllerTests.kt
@@ -21,15 +21,14 @@ import org.springframework.test.web.servlet.MockMvc
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-internal class ArtifactControllerTests : JUnit5Minutests {
-  @Autowired
-  lateinit var mvc: MockMvc
+internal class ArtifactControllerTests
+@Autowired constructor(
+  val mvc: MockMvc,
+  val jsonMapper: ObjectMapper
+) : JUnit5Minutests {
 
   @MockkBean
   lateinit var repository: KeelRepository
-
-  @Autowired
-  lateinit var jsonMapper: ObjectMapper
 
   @MockkBean
   lateinit var authorizationSupport: AuthorizationSupport

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -58,10 +58,12 @@ import strikt.jackson.isMissing
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-internal class DeliveryConfigControllerTests : JUnit5Minutests {
-
-  @Autowired
-  lateinit var mvc: MockMvc
+internal class DeliveryConfigControllerTests
+@Autowired constructor(
+  val mvc: MockMvc,
+  val jsonMapper: ObjectMapper,
+  val yamlMapper: YAMLMapper
+) : JUnit5Minutests {
 
   @MockkBean
   lateinit var repository: KeelRepository
@@ -71,12 +73,6 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
 
   @MockkBean
   lateinit var importer: DeliveryConfigImporter
-
-  @Autowired
-  lateinit var jsonMapper: ObjectMapper
-
-  @Autowired
-  lateinit var yamlMapper: YAMLMapper
 
   private val deliveryConfig = SubmittedDeliveryConfig(
     name = "keel-manifest",
@@ -370,9 +366,10 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
         }
 
         test("the request is successful and the manifest persisted") {
-          val request = post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
-            .accept(APPLICATION_YAML)
-            .contentType(APPLICATION_YAML)
+          val request =
+            post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
+              .accept(APPLICATION_YAML)
+              .contentType(APPLICATION_YAML)
 
           val response = mvc.perform(request)
           response.andExpect(status().isOk)
@@ -397,9 +394,10 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
         }
 
         test("the error from the dowstream service is returned") {
-          val request = post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
-            .accept(APPLICATION_YAML)
-            .contentType(APPLICATION_YAML)
+          val request =
+            post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
+              .accept(APPLICATION_YAML)
+              .contentType(APPLICATION_YAML)
 
           val response = mvc.perform(request)
           response.andExpect(status().isNotFound)
@@ -511,9 +509,10 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
             authorizationSupport.allowServiceAccountAccess()
           }
           test("request is forbidden") {
-            val request = post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
-              .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+            val request =
+              post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("X-SPINNAKER-USER", "keel@keel.io")
 
             mvc.perform(request).andExpect(status().isForbidden)
           }
@@ -524,9 +523,10 @@ internal class DeliveryConfigControllerTests : JUnit5Minutests {
             authorizationSupport.denyServiceAccountAccess()
           }
           test("request is forbidden") {
-            val request = post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
-              .accept(MediaType.APPLICATION_JSON_VALUE)
-              .header("X-SPINNAKER-USER", "keel@keel.io")
+            val request =
+              post("/delivery-configs/import?repoType=stash&projectKey=proj&repoSlug=repo&manifestPath=spinnaker.yml")
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("X-SPINNAKER-USER", "keel@keel.io")
 
             mvc.perform(request).andExpect(status().isForbidden)
           }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ErrorSimulationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ErrorSimulationControllerTests.kt
@@ -19,9 +19,8 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-internal class ErrorSimulationControllerTests {
-  @Autowired
-  lateinit var mvc: MockMvc
+internal class ErrorSimulationControllerTests
+@Autowired constructor(val mvc: MockMvc) {
 
   @Test
   fun `error endpoint returns a 5xx server error`() {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/EventControllerTests.kt
@@ -56,9 +56,8 @@ import io.mockk.coEvery as every
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-internal class EventControllerTests : JUnit5Minutests {
-  @Autowired
-  lateinit var mvc: MockMvc
+internal class EventControllerTests
+@Autowired constructor(val mvc: MockMvc) : JUnit5Minutests {
 
   @MockkBean
   lateinit var resourceRepository: ResourceRepository

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ResourceControllerTests.kt
@@ -41,19 +41,17 @@ import strikt.assertions.isNotNull
 )
 @AutoConfigureMockMvc
 @DisableSpringScheduling
-internal class ResourceControllerTests : JUnit5Minutests {
-  @Autowired
-  lateinit var mvc: MockMvc
+internal class ResourceControllerTests
+@Autowired constructor(
+  val mvc: MockMvc,
+  @Qualifier("jsonMapper") val jsonMapper: ObjectMapper
+) : JUnit5Minutests {
 
   @MockkBean
   lateinit var repository: KeelRepository
 
   @MockkBean
   lateinit var authorizationSupport: AuthorizationSupport
-
-  @Qualifier("jsonMapper")
-  @Autowired
-  lateinit var jsonMapper: ObjectMapper
 
   @MockkBean
   lateinit var adHocDiffer: AdHocDiffer


### PR DESCRIPTION
Unfortunately this doesn't work with uses of `@MockkBean` but generally I think this is preferable.