### PR TITLE
feat(lifecycle): build events

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/BuildMetadata.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/BuildMetadata.kt
@@ -1,8 +1,7 @@
 package com.netflix.spinnaker.keel.api.artifacts
 
 import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneOffset.UTC
+import java.time.ZonedDateTime
 
 /**
  * The build metadata of an artifact.
@@ -18,21 +17,14 @@ data class BuildMetadata(
   val completedTs: String? = null,
   val status: String? = null
 ) {
-  fun getStartedAtInstant(): Instant? =
-    startedAt
-      ?.let {
-        LocalDateTime.parse(it.removeSuffix("Z"))
-          .atZone(UTC)
-          .toInstant()
-      }
+  val startedAtInstant: Instant?
+    get() = startedAt?.let { ZonedDateTime.parse(it).toInstant() }
 
-  fun getCompletedAtInstant(): Instant? =
-    completedAt
-      ?.let {
-        LocalDateTime.parse(it.removeSuffix("Z"))
-          .atZone(UTC)
-          .toInstant()
-      }
+  val completedAtInstant: Instant?
+    get() = completedAt?.let { ZonedDateTime.parse(it).toInstant() }
+
+  fun isComplete(): Boolean =
+    status in listOf("SUCCESS", "FAILED", "ABORTED", "UNSTABLE")
 }
 
 data class Job(

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/BuildMetadata.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/BuildMetadata.kt
@@ -1,5 +1,9 @@
 package com.netflix.spinnaker.keel.api.artifacts
 
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+
 /**
  * The build metadata of an artifact.
  */
@@ -13,7 +17,23 @@ data class BuildMetadata(
   val startedTs: String? = null,
   val completedTs: String? = null,
   val status: String? = null
-)
+) {
+  fun getStartedAtInstant(): Instant? =
+    startedAt
+      ?.let {
+        LocalDateTime.parse(it.removeSuffix("Z"))
+          .atZone(UTC)
+          .toInstant()
+      }
+
+  fun getCompletedAtInstant(): Instant? =
+    completedAt
+      ?.let {
+        LocalDateTime.parse(it.removeSuffix("Z"))
+          .atZone(UTC)
+          .toInstant()
+      }
+}
 
 data class Job(
   val link: String? = null,

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -89,6 +89,7 @@ class ArtifactListener(
         val data: MutableMap<String,String?> = mutableMapOf()
         data["buildNumber"] = artifact.metadata["buildNumber"]?.toString()
         data["commitId"] = artifact.metadata["commitId"]?.toString()
+        data["fallbackLink"] = buildMetadata.job?.link
 
         repository
           .getAllArtifacts(artifact.artifactType, artifact.name)
@@ -106,7 +107,8 @@ class ArtifactListener(
                 status = NOT_STARTED,
                 text = "Monitoring build for ${artifact.version}",
                 link = buildMetadata.uid,
-                data = data
+                data = data,
+                timestamp = buildMetadata.getStartedAtInstant()
               ))
             }
           }

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BaseArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BaseArtifactSupplier.kt
@@ -5,7 +5,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import org.slf4j.LoggerFactory
 
 abstract class BaseArtifactSupplier<A : DeliveryArtifact, V : SortingStrategy>(

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplier.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
@@ -13,8 +13,7 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedSortingStrategy
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.parseAppVersionOrNull
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
-import org.slf4j.LoggerFactory
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Component
 

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
@@ -15,7 +15,7 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedSortingStrategy
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import org.springframework.stereotype.Component
 
 /**

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplier.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
@@ -12,7 +12,7 @@ import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedSortingStrategy
 import com.netflix.spinnaker.keel.api.support.EventPublisher
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import org.springframework.stereotype.Component
 
 /**

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifactSupplierTests.kt
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.keel.artifacts
 
 import com.netflix.frigga.ami.AppVersion
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.SNAPSHOT
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedSortingStrategy
 import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplierTests.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.api.plugins.SupportedSortingStrategy
 import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifactSupplierTests.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.CANDIDATE
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
@@ -14,7 +14,7 @@ import com.netflix.spinnaker.keel.api.artifacts.Repo
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.api.plugins.SupportedSortingStrategy
 import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/config/BakeryConfiguration.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/config/BakeryConfiguration.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.config
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.bakery.BaseImageCacheProperties

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -4,6 +4,9 @@ import com.netflix.spinnaker.config.LifecycleConfig
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEvent
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.SUCCEEDED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.UNKNOWN
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType.BAKE
 import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitor
@@ -57,25 +60,15 @@ class BakeryLifecycleMonitor(
           else -> publishUnknownEvent(task, execution)
         }
 
-        if (task.numFailures > 0) {
-          // we only care about consecutive failures, and we just had a success
-          monitorRepository.clearFailuresGettingStatus(task)
-        }
-
         if (execution.status.isComplete()) {
           endMonitoringOf(task)
+        } else {
+          markSuccessFetching(task)
         }
       }
       .onFailure { exception ->
         log.error("Error fetching status for $task: ", exception)
-        if (task.numFailures >= lifecycleConfig.numFailuresAllowed - 1) {
-          log.warn("Too many consecutive errors (${lifecycleConfig.numFailuresAllowed}) " +
-            "fetching the task status for $task. Giving up.")
-          publishExceptionEvent(task)
-          monitorRepository.delete(task)
-        } else {
-          monitorRepository.markFailureGettingStatus(task)
-        }
+        handleFailureFetching(task)
       }
   }
 
@@ -97,22 +90,22 @@ class BakeryLifecycleMonitor(
   }
   private fun publishSucceededEvent(task: MonitoredTask) {
     publisher.publishEvent(task.triggeringEvent.copy(
-      status = LifecycleEventStatus.SUCCEEDED,
+      status = SUCCEEDED,
       link = orcaTaskIdToLink(task),
       text = "Bake succeeded for version ${task.triggeringEvent.artifactVersion}"
     ))
   }
   private fun publishFailedEvent(task: MonitoredTask) {
     publisher.publishEvent(task.triggeringEvent.copy(
-      status = LifecycleEventStatus.FAILED,
+      status = FAILED,
       link = orcaTaskIdToLink(task),
       text = "Bake failed for version ${task.triggeringEvent.artifactVersion}"
     ))
   }
 
-  private fun publishExceptionEvent(task: MonitoredTask) {
+  override fun publishExceptionEvent(task: MonitoredTask) {
     publisher.publishEvent(task.triggeringEvent.copy(
-      status = LifecycleEventStatus.UNKNOWN,
+      status = UNKNOWN,
       link = orcaTaskIdToLink(task),
       text = "Failed to monitor bake of version ${task.triggeringEvent.artifactVersion}" +
         " because we could not get the status ${lifecycleConfig.numFailuresAllowed} times. Status unknown."
@@ -122,7 +115,7 @@ class BakeryLifecycleMonitor(
   private fun publishUnknownEvent(task: MonitoredTask, execution: ExecutionDetailResponse) {
     log.warn("Monitored bake ${task.triggeringEvent} in an unhandled status (${execution.status}")
     publisher.publishEvent(task.triggeringEvent.copy(
-      status = LifecycleEventStatus.UNKNOWN,
+      status = UNKNOWN,
       link = orcaTaskIdToLink(task),
       text = "Bake status unknown for version ${task.triggeringEvent.artifactVersion}"
     ))

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -11,7 +11,6 @@ import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType.BAKE
 import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitor
 import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitorRepository
-import com.netflix.spinnaker.keel.lifecycle.LinkNotFound
 import com.netflix.spinnaker.keel.lifecycle.MonitoredTask
 import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
 import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus.BUFFERED
@@ -61,14 +60,14 @@ class BakeryLifecycleMonitor(
         }
 
         if (execution.status.isComplete()) {
-          endMonitoringOf(task)
+          endMonitoringOfTask(task)
         } else {
-          markSuccessFetching(task)
+          markSuccessFetchingStatus(task)
         }
       }
       .onFailure { exception ->
         log.error("Error fetching status for $task: ", exception)
-        handleFailureFetching(task)
+        handleFailureFetchingStatus(task)
       }
   }
 

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.bakery.artifact
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.actuation.ArtifactHandler
 import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.actuation.Task

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.bakery.artifact
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -178,8 +178,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       BuildMetadata(
         id = 1,
         uid = "1234",
-        startedAt = "2020-11-24T04:44:04.000",
-        completedAt = "2020-11-25T03:04:02.259",
+        startedAt = "2020-11-24T04:44:04.000Z",
+        completedAt = "2020-11-25T03:04:02.259Z",
         job = Job(
           name = "job bla bla",
           link = "enkins.com"

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -178,8 +178,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       BuildMetadata(
         id = 1,
         uid = "1234",
-        startedAt = "yesterday",
-        completedAt = "today",
+        startedAt = "2020-11-24T04:44:04.000",
+        completedAt = "2020-11-25T03:04:02.259",
         job = Job(
           name = "job bla bla",
           link = "enkins.com"

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleEventRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleEventRepositoryTests.kt
@@ -40,7 +40,7 @@ abstract class LifecycleEventRepositoryTests<T: LifecycleEventRepository> : JUni
     id = "bake-$version",
     text = "Submitting bake for version $version",
     link = "www.bake.com/$version",
-    data = mutableMapOf("hi" to "whatsup")
+    data = mapOf("hi" to "whatsup")
   )
   val anotherEvent = event.copy(id = "bake-$version-2")
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleEventRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleEventRepositoryTests.kt
@@ -14,6 +14,7 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import strikt.api.expect
 import strikt.assertions.isEqualTo
+import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import java.time.Clock
@@ -38,7 +39,8 @@ abstract class LifecycleEventRepositoryTests<T: LifecycleEventRepository> : JUni
     status = NOT_STARTED,
     id = "bake-$version",
     text = "Submitting bake for version $version",
-    link = "www.bake.com/$version"
+    link = "www.bake.com/$version",
+    data = mutableMapOf("hi" to "whatsup")
   )
   val anotherEvent = event.copy(id = "bake-$version-2")
 
@@ -60,6 +62,8 @@ abstract class LifecycleEventRepositoryTests<T: LifecycleEventRepository> : JUni
           that(events.size).isEqualTo(1)
           that(events.first().status).isEqualTo(NOT_STARTED)
           that(events.first().timestamp).isNotNull()
+          that(events.first().data).isNotEmpty()
+          that(events.first().data["hi"]).isEqualTo("whatsup")
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEvent.kt
@@ -21,6 +21,7 @@ import java.time.Instant
  *   the user.
  * [timestamp] is nullable so that the repository can insert the timestamp when
  *   the event is stored.
+ * [data] contains any extra data needed for monitoring the event
  */
 data class LifecycleEvent(
   val scope: LifecycleEventScope,
@@ -31,7 +32,8 @@ data class LifecycleEvent(
   val status: LifecycleEventStatus,
   val text: String? = null,
   val link: String? = null,
-  val timestamp: Instant? = null
+  val timestamp: Instant? = null,
+  val data: Map<String, Any?> = emptyMap()
 ) {
   fun toStep(): LifecycleStep =
     LifecycleStep(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventStatus.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.lifecycle
 
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.ABORTED
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.SUCCEEDED
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.UNKNOWN
@@ -10,8 +11,8 @@ import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.UNKNOWN
  * A [NOT_STARTED] event kicks off monitoring.
  */
 enum class LifecycleEventStatus {
-  NOT_STARTED, RUNNING, SUCCEEDED, FAILED, UNKNOWN;
+  NOT_STARTED, RUNNING, SUCCEEDED, FAILED, ABORTED, UNKNOWN;
 }
 
 fun LifecycleEventStatus.isEndingStatus(): Boolean =
-  this == SUCCEEDED || this == FAILED || this == UNKNOWN
+  this in listOf(SUCCEEDED, FAILED, UNKNOWN, ABORTED)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventType.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventType.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.lifecycle
 
 enum class LifecycleEventType {
-  BAKE
+  BAKE, BUILD
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitor.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitor.kt
@@ -11,7 +11,7 @@ import org.springframework.context.ApplicationEventPublisher
  *
  * Implementations are responsible for doing the monitoring, emitting [LifecycleEvent]s
  * as the task transitions through different stages, updating the text / link to user
- * friendly things (w/in the [LifecycleEvent]s emitted), and calling [endMonitoringOf]
+ * friendly things (w/in the [LifecycleEvent]s emitted), and calling [endMonitoringOfTask]
  * when the monitoring is finished.
  */
 @EnableConfigurationProperties(LifecycleConfig::class)
@@ -44,7 +44,7 @@ abstract class LifecycleMonitor(
    * Should be called from inside the [monitor] function when we are done
    * monitoring the task.
    */
-  fun endMonitoringOf(task: MonitoredTask) {
+  fun endMonitoringOfTask(task: MonitoredTask) {
     log.debug("${this.javaClass.simpleName} has completed monitoring for $task")
     monitorRepository.delete(task)
   }
@@ -54,11 +54,11 @@ abstract class LifecycleMonitor(
    *
    * Call when there was a failure getting status.
    */
-  fun handleFailureFetching(task: MonitoredTask) {
+  fun handleFailureFetchingStatus(task: MonitoredTask) {
     if (task.numFailures >= lifecycleConfig.numFailuresAllowed - 1) {
       log.warn("Too many consecutive errors (${lifecycleConfig.numFailuresAllowed}) " +
         "fetching the task status for $task. Giving up.")
-      endMonitoringOf(task)
+      endMonitoringOfTask(task)
       publishExceptionEvent(task)
     } else {
       monitorRepository.markFailureGettingStatus(task)
@@ -70,7 +70,7 @@ abstract class LifecycleMonitor(
    *
    * Call when status has successfully been fetched.
    */
-  fun markSuccessFetching(task: MonitoredTask) {
+  fun markSuccessFetchingStatus(task: MonitoredTask) {
     if (task.numFailures > 0) {
       // we only care about consecutive failures, and we just had a success
       monitorRepository.clearFailuresGettingStatus(task)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
@@ -51,6 +51,9 @@ class LifecycleMonitorScheduler(
   /**
    * Listens for a not started event that a subclass can handle, and saves that into
    * the database for monitoring.
+   *
+   * //todo eb: add a 'monitor' flag to lifecycle events so we don't listen for a NOT_STARTED event here,
+   *   it's kind of confusing.
    */
   @EventListener(LifecycleEvent::class)
   fun onLifecycleEvent(event: LifecycleEvent) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -33,7 +33,7 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
 
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
-  fun getAll(type: ArtifactType? = null): List<DeliveryArtifact>
+  fun getAll(type: ArtifactType? = null, name: String? = null): List<DeliveryArtifact>
 
   /**
    * Deletes an artifact from a delivery config.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -317,8 +317,8 @@ class CombinedRepository(
   override fun isRegistered(name: String, type: ArtifactType): Boolean =
     artifactRepository.isRegistered(name, type)
 
-  override fun getAllArtifacts(type: ArtifactType?): List<DeliveryArtifact> =
-    artifactRepository.getAll(type)
+  override fun getAllArtifacts(type: ArtifactType?, name: String?): List<DeliveryArtifact> =
+    artifactRepository.getAll(type, name)
 
   override fun storeArtifactVersion(artifactVersion: PublishedArtifact): Boolean =
     artifactRepository.storeArtifactVersion(artifactVersion)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -144,7 +144,7 @@ interface KeelRepository : KeelReadOnlyRepository {
   // START ArtifactRepository methods
   fun register(artifact: DeliveryArtifact)
 
-  fun getAllArtifacts(type: ArtifactType? = null): List<DeliveryArtifact>
+  fun getAllArtifacts(type: ArtifactType? = null, name: String? = null): List<DeliveryArtifact>
 
   fun storeArtifactVersion(artifactVersion: PublishedArtifact): Boolean
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -87,7 +87,7 @@ class AdminService(
     val artifactSupplier = artifactSuppliers.supporting(type)
     log.debug("Starting to back-fill old artifacts versions with artifact metadata...")
     // 1. get all registered artifacts
-    val deliveryArtifacts = repository.getAllArtifacts(type)
+    val deliveryArtifacts = repository.getAllArtifacts(type = type)
     // 2. for each artifact, fetch all versions
     deliveryArtifacts.forEach { artifact ->
       val versions = repository.artifactVersions(artifact, 10)

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -2,5 +2,14 @@ package com.netflix.spinnaker.keel.front50.model
 
 data class Application(
   val name: String,
-  val email: String
+  val email: String,
+  val dataSources: DataSources?,
+  val repoProjectKey: String? = null,
+  val repoSlug: String? = null,
+  val repoType: String? = null
+)
+
+data class DataSources(
+  val enabled: List<String>,
+  val disabled: List<String>
 )

--- a/keel-igor/keel-igor.gradle.kts
+++ b/keel-igor/keel-igor.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
   implementation(project(":keel-retrofit"))
   implementation(project(":keel-core"))
+  implementation(project(":keel-front50"))
   implementation("org.springframework.boot:spring-boot-autoconfigure")
 
   implementation ("io.github.resilience4j:resilience4j-kotlin")

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
@@ -2,10 +2,10 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
-import com.netflix.spinnaker.igor.ArtifactService
-import com.netflix.spinnaker.igor.BuildService
-import com.netflix.spinnaker.igor.ScmService
-import com.netflix.spinnaker.keel.services.DeliveryConfigImporter
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
+import com.netflix.spinnaker.keel.igor.BuildService
+import com.netflix.spinnaker.keel.igor.ScmService
+import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.springframework.beans.factory.BeanCreationException

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildLifecycleMonitor.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildLifecycleMonitor.kt
@@ -1,0 +1,156 @@
+package com.netflix.spinnaker.keel.igor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.config.LifecycleConfig
+import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.RUNNING
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.SUCCEEDED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.UNKNOWN
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType.BUILD
+import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitor
+import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitorRepository
+import com.netflix.spinnaker.keel.lifecycle.MonitoredTask
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.ABORTED
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+
+@Component
+@EnableConfigurationProperties(LifecycleConfig::class)
+class BuildLifecycleMonitor(
+  override val monitorRepository: LifecycleMonitorRepository,
+  override val publisher: ApplicationEventPublisher,
+  override val lifecycleConfig: LifecycleConfig,
+  val objectMapper: ObjectMapper,
+  val artifactMetadataService: ArtifactMetadataService,
+  @Value("\${spinnaker.baseUrl}") private val spinnakerBaseUrl: String
+) : LifecycleMonitor(monitorRepository, publisher, lifecycleConfig) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  override fun handles(type: LifecycleEventType): Boolean =
+    type == BUILD
+
+  override suspend fun monitor(task: MonitoredTask) {
+    val buildData = parseBuildData(task) ?: return
+    kotlin.runCatching {
+      artifactMetadataService.getArtifactMetadata(buildData.buildNumber, buildData.commitId)
+    }.onSuccess { metadata ->
+      val buildMetadata = metadata?.buildMetadata
+      if (buildMetadata == null) {
+        log.error("Error fetching status for $task, response was null")
+        handleFailureFetching(task)
+      } else {
+        when (buildMetadata.status) {
+          "BUILDING" -> publishRunningEvent(task)
+          "SUCCESS" -> publishSucceededEvent(task)
+          "FAILURE" -> publishFailedEvent(task)
+          "ABORTED" -> publishAbortedEvent(task)
+          "UNSTABLE" -> publishSucceededEvent(task)
+          else -> publishUnknownStatusEvent(task, buildMetadata.status)
+        }
+
+        if (buildMetadata.isComplete()) {
+          endMonitoringOf(task)
+        } else {
+          markSuccessFetching(task)
+        }
+      }
+    }
+      .onFailure { exception ->
+        log.error("Error fetching status for $task: ", exception)
+        handleFailureFetching(task)
+      }
+  }
+
+  /**
+   * Parses build data if format is correct, otherwise publish an Unknown event
+   * and end monitoring of this task.
+   */
+  private fun parseBuildData(task: MonitoredTask): BuildData? {
+    try {
+      return objectMapper.convertValue<BuildData>(task.triggeringEvent.data)
+    } catch (e: IllegalArgumentException) {
+      publishUnknownEvent(task)
+      endMonitoringOf(task)
+    }
+    return null
+  }
+
+  private fun buildIdToLink(task: MonitoredTask): String =
+    "$spinnakerBaseUrl/#/applications/${task.triggeringEvent.data["application"]}/builds/${task.link}/logs"
+
+  private fun BuildMetadata.isComplete(): Boolean =
+    status == "SUCCESS" || status == "FAILED" || status == "ABORTED"
+
+  private fun publishRunningEvent(task: MonitoredTask) {
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = RUNNING,
+      link = buildIdToLink(task),
+      text = "Build running for version ${task.triggeringEvent.artifactVersion}"
+    ))
+  }
+
+  private fun publishSucceededEvent(task: MonitoredTask) {
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = SUCCEEDED,
+      link = buildIdToLink(task),
+      text = "Build succeeded for version ${task.triggeringEvent.artifactVersion}"
+    ))
+  }
+
+  private fun publishFailedEvent(task: MonitoredTask) {
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = FAILED,
+      link = buildIdToLink(task),
+      text = "Build failed for version ${task.triggeringEvent.artifactVersion}"
+    ))
+  }
+
+  private fun publishAbortedEvent(task: MonitoredTask) {
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = ABORTED,
+      link = buildIdToLink(task),
+      text = "Build aborted for version ${task.triggeringEvent.artifactVersion}"
+    ))
+  }
+
+  private fun publishUnknownStatusEvent(task: MonitoredTask, status: String?) {
+    log.warn("Unknown status $status while monitoring ${task.triggeringEvent}")
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = UNKNOWN,
+      link = buildIdToLink(task),
+      text = "Build status unknown for version ${task.triggeringEvent.artifactVersion}"
+    ))
+  }
+
+  private fun publishUnknownEvent(task: MonitoredTask) {
+    log.warn("Unable to monitor build for ${task.triggeringEvent} because at least one required data field is missing")
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = UNKNOWN,
+      link = buildIdToLink(task),
+      text = "Build status unknown for version ${task.triggeringEvent.artifactVersion}"
+    ))
+  }
+
+  override fun publishExceptionEvent(task: MonitoredTask) {
+    publisher.publishEvent(task.triggeringEvent.copy(
+      status = UNKNOWN,
+      link = buildIdToLink(task),
+      text = "Failed to monitor build of version ${task.triggeringEvent.artifactVersion}" +
+        " because we could not get the status ${lifecycleConfig.numFailuresAllowed} times. Status unknown."
+    ))
+  }
+
+  data class BuildData(
+    val buildNumber: String,
+    val commitId: String,
+    val application: String
+  )
+}

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildLifecycleMonitor.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildLifecycleMonitor.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.config.LifecycleConfig
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
+import com.netflix.spinnaker.keel.front50.Front50Service
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.RUNNING
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.SUCCEEDED
@@ -14,13 +15,15 @@ import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitor
 import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitorRepository
 import com.netflix.spinnaker.keel.lifecycle.MonitoredTask
 import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
-import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.ABORTED
+import com.netflix.spinnaker.keel.retrofit.isNotFound
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import retrofit2.HttpException
 
 @Component
 @EnableConfigurationProperties(LifecycleConfig::class)
@@ -30,6 +33,7 @@ class BuildLifecycleMonitor(
   override val lifecycleConfig: LifecycleConfig,
   val objectMapper: ObjectMapper,
   val artifactMetadataService: ArtifactMetadataService,
+  val front50Service: Front50Service,
   @Value("\${spinnaker.baseUrl}") private val spinnakerBaseUrl: String
 ) : LifecycleMonitor(monitorRepository, publisher, lifecycleConfig) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -38,7 +42,7 @@ class BuildLifecycleMonitor(
     type == BUILD
 
   override suspend fun monitor(task: MonitoredTask) {
-    val buildData = parseBuildData(task) ?: return
+    val buildData = parseAndValidate(task) ?: return
     kotlin.runCatching {
       artifactMetadataService.getArtifactMetadata(buildData.buildNumber, buildData.commitId)
     }.onSuccess { metadata ->
@@ -49,10 +53,10 @@ class BuildLifecycleMonitor(
       } else {
         when (buildMetadata.status) {
           "BUILDING" -> publishRunningEvent(task)
-          "SUCCESS" -> publishSucceededEvent(task)
-          "FAILURE" -> publishFailedEvent(task)
-          "ABORTED" -> publishAbortedEvent(task)
-          "UNSTABLE" -> publishSucceededEvent(task)
+          "SUCCESS" -> publishSucceededEvent(task, buildMetadata)
+          "FAILURE" -> publishFailedEvent(task, buildMetadata)
+          "ABORTED" -> publishAbortedEvent(task, buildMetadata)
+          "UNSTABLE" -> publishSucceededEvent(task, buildMetadata)
           else -> publishUnknownStatusEvent(task, buildMetadata.status)
         }
 
@@ -73,18 +77,18 @@ class BuildLifecycleMonitor(
    * Parses build data if format is correct, otherwise publish an Unknown event
    * and end monitoring of this task.
    */
-  private fun parseBuildData(task: MonitoredTask): BuildData? {
+  private fun parseAndValidate(task: MonitoredTask): BuildData? =
     try {
-      return objectMapper.convertValue<BuildData>(task.triggeringEvent.data)
+      parseBuildData(task)
     } catch (e: IllegalArgumentException) {
       publishUnknownEvent(task)
       endMonitoringOf(task)
-    }
-    return null
-  }
+      null
+   }
 
-  private fun buildIdToLink(task: MonitoredTask): String =
-    "$spinnakerBaseUrl/#/applications/${task.triggeringEvent.data["application"]}/builds/${task.link}/logs"
+  private fun parseBuildData(task: MonitoredTask): BuildData =
+      objectMapper.convertValue(task.triggeringEvent.data)
+
 
   private fun BuildMetadata.isComplete(): Boolean =
     status == "SUCCESS" || status == "FAILED" || status == "ABORTED"
@@ -92,32 +96,35 @@ class BuildLifecycleMonitor(
   private fun publishRunningEvent(task: MonitoredTask) {
     publisher.publishEvent(task.triggeringEvent.copy(
       status = RUNNING,
-      link = buildIdToLink(task),
+      link = chooseLink(task),
       text = "Build running for version ${task.triggeringEvent.artifactVersion}"
     ))
   }
 
-  private fun publishSucceededEvent(task: MonitoredTask) {
+  private fun publishSucceededEvent(task: MonitoredTask, buildMetadata: BuildMetadata) {
     publisher.publishEvent(task.triggeringEvent.copy(
       status = SUCCEEDED,
-      link = buildIdToLink(task),
-      text = "Build succeeded for version ${task.triggeringEvent.artifactVersion}"
+      link = chooseLink(task),
+      text = "Build succeeded for version ${task.triggeringEvent.artifactVersion}",
+      timestamp = buildMetadata.getCompletedAtInstant()
     ))
   }
 
-  private fun publishFailedEvent(task: MonitoredTask) {
+  private fun publishFailedEvent(task: MonitoredTask, buildMetadata: BuildMetadata) {
     publisher.publishEvent(task.triggeringEvent.copy(
       status = FAILED,
-      link = buildIdToLink(task),
-      text = "Build failed for version ${task.triggeringEvent.artifactVersion}"
+      link = chooseLink(task),
+      text = "Build failed for version ${task.triggeringEvent.artifactVersion}",
+      timestamp = buildMetadata.getCompletedAtInstant()
     ))
   }
 
-  private fun publishAbortedEvent(task: MonitoredTask) {
+  private fun publishAbortedEvent(task: MonitoredTask, buildMetadata: BuildMetadata) {
     publisher.publishEvent(task.triggeringEvent.copy(
       status = ABORTED,
-      link = buildIdToLink(task),
-      text = "Build aborted for version ${task.triggeringEvent.artifactVersion}"
+      link = chooseLink(task),
+      text = "Build aborted for version ${task.triggeringEvent.artifactVersion}",
+      timestamp = buildMetadata.getCompletedAtInstant()
     ))
   }
 
@@ -125,7 +132,7 @@ class BuildLifecycleMonitor(
     log.warn("Unknown status $status while monitoring ${task.triggeringEvent}")
     publisher.publishEvent(task.triggeringEvent.copy(
       status = UNKNOWN,
-      link = buildIdToLink(task),
+      link = chooseLink(task),
       text = "Build status unknown for version ${task.triggeringEvent.artifactVersion}"
     ))
   }
@@ -134,7 +141,7 @@ class BuildLifecycleMonitor(
     log.warn("Unable to monitor build for ${task.triggeringEvent} because at least one required data field is missing")
     publisher.publishEvent(task.triggeringEvent.copy(
       status = UNKNOWN,
-      link = buildIdToLink(task),
+      link = chooseLink(task),
       text = "Build status unknown for version ${task.triggeringEvent.artifactVersion}"
     ))
   }
@@ -142,15 +149,49 @@ class BuildLifecycleMonitor(
   override fun publishExceptionEvent(task: MonitoredTask) {
     publisher.publishEvent(task.triggeringEvent.copy(
       status = UNKNOWN,
-      link = buildIdToLink(task),
+      link = chooseLink(task),
       text = "Failed to monitor build of version ${task.triggeringEvent.artifactVersion}" +
         " because we could not get the status ${lifecycleConfig.numFailuresAllowed} times. Status unknown."
     ))
   }
 
+  fun chooseLink(task: MonitoredTask): String? {
+    val buildData = parseBuildData(task)
+    val app = runBlocking {
+      try {
+        front50Service.applicationByName(buildData.application)
+      } catch (e: HttpException) {
+        if (e.isNotFound) {
+          null
+        } else {
+          throw e
+        }
+      }
+    }
+
+    if (app == null || app.dataSources?.disabled?.contains("integration") == true) {
+      // app not found or ci explicitly disabled
+      return jenkinsLink(buildData)
+    }
+
+    // ci not explicitly disabled, check and see if ci view is configured
+    return if (app.repoProjectKey != null && app.repoSlug != null && app.repoType != null) {
+      buildUidToLink(task)
+    } else {
+      jenkinsLink(buildData)
+    }
+  }
+
+  private fun buildUidToLink(task: MonitoredTask): String =
+    "$spinnakerBaseUrl/#/applications/${task.triggeringEvent.data["application"]}/builds/${task.link}/logs"
+
+  private fun jenkinsLink(buildData: BuildData): String? =
+    buildData.fallbackLink
+
   data class BuildData(
     val buildNumber: String,
     val commitId: String,
-    val application: String
+    val application: String,
+    val fallbackLink: String? // the jenkins link to use if no ci view is configured
   )
 }

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildService.kt
@@ -1,5 +1,5 @@
-package com.netflix.spinnaker.igor
-import com.netflix.spinnaker.model.Build
+package com.netflix.spinnaker.keel.igor
+import com.netflix.spinnaker.keel.igor.model.Build
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Query

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
@@ -1,7 +1,6 @@
-package com.netflix.spinnaker.keel.services
+package com.netflix.spinnaker.keel.igor
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.netflix.spinnaker.igor.ScmService
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Component
 /**
  * Provides functionality to import delivery config manifests from source control repositories (via igor).
  */
-@Component
 class DeliveryConfigImporter(
   private val jsonMapper: ObjectMapper,
   private val scmService: ScmService

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/ScmService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/ScmService.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.igor
+package com.netflix.spinnaker.keel.igor
 
 import com.netflix.spinnaker.keel.api.ScmInfo
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/artifact/ArtifactMetadataService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/artifact/ArtifactMetadataService.kt
@@ -1,6 +1,6 @@
-package com.netflix.spinnaker.keel.services
+package com.netflix.spinnaker.keel.igor.artifact
 
-import com.netflix.spinnaker.igor.BuildService
+import com.netflix.spinnaker.keel.igor.BuildService
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Commit
@@ -8,8 +8,8 @@ import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Job
 import com.netflix.spinnaker.keel.api.artifacts.PullRequest
 import com.netflix.spinnaker.keel.api.artifacts.Repo
-import com.netflix.spinnaker.model.Build
-import com.netflix.spinnaker.model.CompletionStatus
+import com.netflix.spinnaker.keel.igor.model.Build
+import com.netflix.spinnaker.keel.igor.model.CompletionStatus
 import io.github.resilience4j.kotlin.retry.executeSuspendFunction
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/artifact/ArtifactService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/artifact/ArtifactService.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.igor
+package com.netflix.spinnaker.keel.igor.artifact
 
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/model/Build.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/model/Build.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.model
+package com.netflix.spinnaker.keel.igor.model
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import java.time.Instant

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/ArtifactMetadataServiceTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/ArtifactMetadataServiceTests.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.services
 
-import com.netflix.spinnaker.igor.BuildService
+import com.netflix.spinnaker.keel.igor.BuildService
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Commit
@@ -8,10 +8,11 @@ import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Job
 import com.netflix.spinnaker.keel.api.artifacts.PullRequest
 import com.netflix.spinnaker.keel.api.artifacts.Repo
-import com.netflix.spinnaker.model.Build
-import com.netflix.spinnaker.model.CompletionStatus
-import com.netflix.spinnaker.model.GenericGitRevision
-import com.netflix.spinnaker.model.Result
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.model.Build
+import com.netflix.spinnaker.keel.igor.model.CompletionStatus
+import com.netflix.spinnaker.keel.igor.model.GenericGitRevision
+import com.netflix.spinnaker.keel.igor.model.Result
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.coEvery

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
@@ -1,0 +1,231 @@
+package com.netflix.spinnaker.keel.services
+
+import com.netflix.spinnaker.config.LifecycleConfig
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
+import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
+import com.netflix.spinnaker.keel.igor.BuildLifecycleMonitor
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEvent
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventScope.PRE_DEPLOYMENT
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.ABORTED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.NOT_STARTED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.RUNNING
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.SUCCEEDED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.UNKNOWN
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType.BUILD
+import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitorRepository
+import com.netflix.spinnaker.keel.lifecycle.MonitoredTask
+import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isTrue
+import java.time.Instant
+
+class BuildLifecycleMonitorTests : JUnit5Minutests {
+  internal class Fixture {
+    val monitorRepository: LifecycleMonitorRepository = mockk(relaxUnitFun = true)
+    val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
+    val lifecycleConfig = LifecycleConfig()
+    val artifactMetadataService: ArtifactMetadataService = mockk()
+    val spinnakerBaseUrl = "www.spin.com"
+    val id = "c9bb7369-8433-4014-bcaa-b0ef814234c3"
+    val objectMapper = configuredTestObjectMapper()
+    val buildNumber = "4"
+    val commitId = "56203b1"
+
+    val event = LifecycleEvent(
+      type = BUILD,
+      scope = PRE_DEPLOYMENT,
+      status = NOT_STARTED,
+      id = "my-build-1",
+      artifactRef = "my-config:my-artifact",
+      artifactVersion = "123.4",
+      text = "Starting build",
+      link = id,
+      timestamp = Instant.now(),
+      data = mapOf(
+        "application" to "my-app",
+        "buildNumber" to buildNumber,
+        "commitId" to commitId
+      )
+    )
+
+    val task = MonitoredTask(
+      link = id,
+      triggeringEvent = event
+    )
+
+    val subject = BuildLifecycleMonitor(
+      monitorRepository,
+      publisher,
+      lifecycleConfig,
+      objectMapper,
+      artifactMetadataService,
+      spinnakerBaseUrl
+    )
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture() }
+
+    test("handles builds") {
+      expectThat(subject.handles(BUILD)).isTrue()
+    }
+
+    context("updating status") {
+      context("building") {
+        before {
+          coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns getArtifactMetadata("BUILDING")
+          runBlocking { subject.monitor(task) }
+        }
+
+        test("emits running event") {
+          val slot = slot<LifecycleEvent>()
+          verify(exactly = 1) {
+            publisher.publishEvent(capture(slot))
+          }
+          expectThat(slot.captured.status).isEqualTo(RUNNING)
+        }
+      }
+
+      context("success") {
+        before {
+          coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns
+            getArtifactMetadata("SUCCESS")
+          runBlocking { subject.monitor(task) }
+        }
+
+        test("emits succeeded event") {
+          val slot = slot<LifecycleEvent>()
+          verify(exactly = 1) {
+            publisher.publishEvent(capture(slot))
+          }
+          expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
+        }
+      }
+
+      context("failure") {
+        before {
+          coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns
+            getArtifactMetadata("FAILURE")
+          runBlocking { subject.monitor(task) }
+        }
+
+        test("emits failed event") {
+          val slot = slot<LifecycleEvent>()
+          verify(exactly = 1) {
+            publisher.publishEvent(capture(slot))
+          }
+          expectThat(slot.captured.status).isEqualTo(FAILED)
+        }
+      }
+
+      context("aborted") {
+        before {
+          coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns
+            getArtifactMetadata("ABORTED")
+          runBlocking { subject.monitor(task) }
+        }
+
+        test("emits aborted event") {
+          val slot = slot<LifecycleEvent>()
+          verify(exactly = 1) {
+            publisher.publishEvent(capture(slot))
+          }
+          expectThat(slot.captured.status).isEqualTo(ABORTED)
+        }
+      }
+
+      context("UNSTABLE") {
+        before {
+          coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns
+            getArtifactMetadata("UNSTABLE")
+          runBlocking { subject.monitor(task) }
+        }
+
+        test("emits succeeded event") {
+          val slot = slot<LifecycleEvent>()
+          verify(exactly = 1) {
+            publisher.publishEvent(capture(slot))
+          }
+          expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
+        }
+      }
+
+      context("garbage") {
+        before {
+          coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns
+            getArtifactMetadata("BLAHHHHHH")
+          runBlocking { subject.monitor(task) }
+        }
+
+        test("emits unknown event") {
+          val slot = slot<LifecycleEvent>()
+          verify(exactly = 1) {
+            publisher.publishEvent(capture(slot))
+          }
+          expectThat(slot.captured.status).isEqualTo(UNKNOWN)
+        }
+      }
+    }
+
+    context("handle failure") {
+      before {
+        coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } throws
+          RuntimeException("this is embarrassing..")
+      }
+
+      test("failure is marked") {
+        runBlocking { subject.monitor(task) }
+        verify(exactly = 1) {
+          monitorRepository.markFailureGettingStatus(task)
+        }
+      }
+
+      test("monitoring is ended after max number is hit") {
+        val slot = slot<LifecycleEvent>()
+        val failingTask = task.copy(numFailures = 4)
+        runBlocking { subject.monitor(failingTask) }
+        verify(exactly = 1) {
+          publisher.publishEvent(capture(slot))
+          monitorRepository.delete(failingTask)
+        }
+        expectThat(slot.captured.status).isEqualTo(UNKNOWN)
+      }
+    }
+
+    context("handling intermittent failure") {
+      before {
+        coEvery { artifactMetadataService.getArtifactMetadata(buildNumber, commitId) } returns
+          getArtifactMetadata("BUILDING")
+      }
+      test("failure count is cleared after a success") {
+        val failingTask = task.copy(numFailures = 2)
+        runBlocking { subject.monitor(failingTask) }
+        verify(exactly = 1) {
+          monitorRepository.clearFailuresGettingStatus(failingTask)
+        }
+      }
+    }
+  }
+
+  private fun getArtifactMetadata(status: String): ArtifactMetadata =
+    ArtifactMetadata(
+      buildMetadata = BuildMetadata(
+        id = 4,
+        number = "4",
+        uid = "c9bb7369-8433-4014-bcaa-b0ef814234c3",
+        status = status
+      ),
+      gitMetadata = null
+    )
+}

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/DeliveryConfigImporterTests.kt
@@ -3,9 +3,10 @@ package com.netflix.spinnaker.keel.services
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.jsontype.NamedType
 import com.fasterxml.jackson.module.kotlin.convertValue
-import com.netflix.spinnaker.igor.ScmService
+import com.netflix.spinnaker.keel.igor.ScmService
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
 import com.netflix.spinnaker.keel.test.deliveryConfig

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -190,12 +190,13 @@ class SqlArtifactRepository(
         .value1()
     } > 0
 
-  override fun getAll(type: ArtifactType?): List<DeliveryArtifact> =
+  override fun getAll(type: ArtifactType?, name: String?): List<DeliveryArtifact> =
     sqlRetry.withRetry(READ) {
       jooq
         .select(DELIVERY_ARTIFACT.NAME, DELIVERY_ARTIFACT.TYPE, DELIVERY_ARTIFACT.DETAILS, DELIVERY_ARTIFACT.REFERENCE, DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME)
         .from(DELIVERY_ARTIFACT)
         .apply { if (type != null) where(DELIVERY_ARTIFACT.TYPE.eq(type.toString())) }
+        .apply { if (name != null) where(DELIVERY_ARTIFACT.NAME.eq(name)) }
         .fetch { (name, storedType, details, reference, configName) ->
           mapToArtifact(artifactSuppliers.supporting(storedType), name, storedType.toLowerCase(), details, reference, configName)
         }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
@@ -31,6 +31,7 @@ class SqlLifecycleEventRepository(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override fun saveEvent(event: LifecycleEvent) {
+    val timestamp = event.timestamp?.toTimestamp() ?: clock.timestamp()
     sqlRetry.withRetry(WRITE) {
       jooq.insertInto(LIFECYCLE_EVENT)
         .set(LIFECYCLE_EVENT.UID, ULID().nextULID(clock.millis()))
@@ -40,7 +41,7 @@ class SqlLifecycleEventRepository(
         .set(LIFECYCLE_EVENT.TYPE, event.type.name)
         .set(LIFECYCLE_EVENT.ID, event.id)
         .set(LIFECYCLE_EVENT.STATUS, event.status.name)
-        .set(LIFECYCLE_EVENT.TIMESTAMP, clock.timestamp())
+        .set(LIFECYCLE_EVENT.TIMESTAMP, timestamp)
         .set(LIFECYCLE_EVENT.JSON, objectMapper.writeValueAsString(event))
         .execute()
     }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.test
 
-import com.netflix.spinnaker.igor.ArtifactService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
@@ -11,7 +11,7 @@ import com.netflix.spinnaker.keel.artifacts.DebianArtifactSupplier
 import com.netflix.spinnaker.keel.artifacts.DockerArtifactSupplier
 import com.netflix.spinnaker.keel.artifacts.NpmArtifactSupplier
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import io.mockk.mockk
 import org.springframework.core.env.Environment
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -1,14 +1,13 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.events.ArtifactPublishedEvent
 import com.netflix.spinnaker.keel.api.events.ArtifactSyncEvent
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.UnsupportedArtifactException
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.keel.services.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigController.kt
@@ -11,7 +11,7 @@ import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.SERVICE
 import com.netflix.spinnaker.keel.schema.Generator
 import com.netflix.spinnaker.keel.schema.RootSchema
 import com.netflix.spinnaker.keel.schema.generateSchema
-import com.netflix.spinnaker.keel.services.DeliveryConfigImporter
+import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter
 import com.netflix.spinnaker.keel.validators.DeliveryConfigProcessor
 import com.netflix.spinnaker.keel.validators.DeliveryConfigValidator
 import com.netflix.spinnaker.keel.validators.applyAll

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.READ
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.Action.WRITE
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.APPLICATION
 import com.netflix.spinnaker.keel.rest.AuthorizationSupport.TargetEntity.DELIVERY_CONFIG
-import com.netflix.spinnaker.keel.services.DeliveryConfigImporter
+import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter
 import com.netflix.spinnaker.keel.spring.test.DisableSpringScheduling
 import com.netflix.spinnaker.keel.spring.test.MockEurekaConfiguration
 import com.netflix.spinnaker.keel.test.DummyResourceSpec


### PR DESCRIPTION
Adding the ability to monitor builds and have them as part of the pre-deployment steps.

The funny thing here is that the artifact is built during the build, and published before the build finishes. So, we won't "see" this build until the artifact is published. 

Also, linking to the CI view is complicated. We have to do some digging through the app config to figure out if the ci view is wired in and working.