### PR TITLE
Scheduler for running verifications

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -42,11 +42,12 @@ enum class VerificationStatus(val complete: Boolean) {
 data class VerificationContext(
   val deliveryConfig: DeliveryConfig,
   val environmentName: String,
+  val artifactReference: String,
   val version: String
 ) {
   val environment: Environment =
     deliveryConfig.environments.first { it.name == environmentName }
 
   val artifact: DeliveryArtifact =
-    deliveryConfig.artifacts.first()
+    deliveryConfig.artifacts.first { it.reference == artifactReference }
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import java.time.Duration
 import java.time.Instant
 
 interface VerificationRepository {
@@ -24,6 +25,8 @@ interface VerificationRepository {
     verification: Verification,
     status: VerificationStatus
   )
+
+  fun nextEnvironmentsForVerification(minTimeSinceLastCheck: Duration, limit: Int) : Collection<Pair<DeliveryConfig, Environment>>
 }
 
 data class VerificationState(

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -26,7 +26,7 @@ interface VerificationRepository {
     status: VerificationStatus
   )
 
-  fun nextEnvironmentsForVerification(minTimeSinceLastCheck: Duration, limit: Int) : Collection<Pair<DeliveryConfig, Environment>>
+  fun nextEnvironmentsForVerification(minTimeSinceLastCheck: Duration, limit: Int) : Collection<VerificationContext>
 }
 
 data class VerificationState(

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -305,5 +305,43 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
           get { version } isEqualTo context2.version
         }
     }
+
+    @Test
+    fun `can return both artifacts sequentially when an environment has more than one`() {
+      val artifact1 = DockerArtifact(
+        name = "artifact1",
+        deliveryConfigName = context.deliveryConfig.name,
+        reference = "ref-1"
+      )
+      val artifact2 = DockerArtifact(
+        name = "artifact2",
+        deliveryConfigName = context.deliveryConfig.name,
+        reference = "ref-2"
+      )
+      val deliveryConfig = context.deliveryConfig.copy(
+        artifacts = setOf(artifact1, artifact2)
+      )
+      val context1 = context.copy(
+        deliveryConfig = deliveryConfig,
+        artifactReference = artifact1.reference,
+        version = "artifact1-0.254.0-h645.4ce7392"
+      )
+      val context2 = context.copy(
+        deliveryConfig = deliveryConfig,
+        artifactReference = artifact2.reference,
+          version = "artifact2-0.390.0-h584.93a3040"
+      )
+      with(context1) {
+        setup()
+        setupCurrentArtifactVersion()
+      }
+      with(context2) {
+        setup()
+        setupCurrentArtifactVersion()
+      }
+
+      next().isSuccess().hasSize(1)
+      next().isSuccess().hasSize(1)
+    }
   }
 }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import strikt.api.expectCatching
+import strikt.assertions.first
 import strikt.assertions.hasSize
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
@@ -245,6 +246,23 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
 
       next().isSuccess().isNotEmpty()
       next().isSuccess().isEmpty()
+    }
+
+    @Test
+    fun `a new artifact version will get checked right away`() {
+      with(context) {
+        setup()
+        setupCurrentArtifactVersion()
+
+        next().isSuccess().isNotEmpty().first().get { version } isEqualTo version
+      }
+
+      with(context.copy(version = "fnord-0.191.0-h379.eef6bbd")) {
+        setup()
+        setupCurrentArtifactVersion()
+
+        next().isSuccess().isNotEmpty().first().get { version } isEqualTo version
+      }
     }
 
     @Test

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -10,14 +10,20 @@ import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 import com.netflix.spinnaker.keel.api.verification.VerificationStatus.PASSED
 import com.netflix.spinnaker.keel.api.verification.VerificationStatus.RUNNING
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import strikt.api.expectCatching
+import strikt.assertions.hasSize
+import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
+import strikt.assertions.withFirst
+import java.time.Duration
 
 abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationRepository> {
 
@@ -26,6 +32,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
   val subject: IMPLEMENTATION by lazy { createSubject() }
 
   open fun VerificationContext.setup() {}
+  open fun VerificationContext.setupCurrentArtifactVersion() {}
 
   private data class DummyVerification(override val id: String) : Verification {
     override val type = "dummy"
@@ -147,5 +154,63 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
       .isSuccess()
       .isNotNull()
       .get(VerificationState::status) isEqualTo RUNNING
+  }
+
+  @DisplayName("selecting verifications to check")
+  @Nested
+  inner class NextCheckTests {
+    private val minAge = Duration.ofMinutes(1)
+    private val limit = 1
+
+    private val verification = DummyVerification("1")
+    private val context = VerificationContext(
+      deliveryConfig = DeliveryConfig(
+        application = "fnord",
+        name = "fnord-manifest",
+        serviceAccount = "jamm@illuminati.org",
+        artifacts = setOf(
+          DockerArtifact(
+            name = "fnord",
+            deliveryConfigName = "fnord-manifest"
+          )
+        ),
+        environments = setOf(
+          Environment(
+            name = "test",
+            verifyWith = setOf(verification)
+          )
+        )
+      ),
+      environmentName = "test",
+      version = "fnord-0.190.0-h378.eacb135"
+    )
+
+    @Test
+    fun `nothing is returned to check if there is no current artifact version for any environment`() {
+      context.setup()
+
+      expectCatching {
+        subject.nextEnvironmentsForVerification(minAge, limit)
+      }
+        .isSuccess()
+        .isEmpty()
+    }
+
+    @Test
+    fun `returns the current version if it has yet to be verified`() {
+      context.setup()
+      context.setupCurrentArtifactVersion()
+
+      expectCatching {
+        subject.nextEnvironmentsForVerification(minAge, limit)
+      }
+        .isSuccess()
+        .hasSize(1)
+        .withFirst {
+          get { version } isEqualTo context.version
+          get { environmentName } isEqualTo context.environmentName
+          get { deliveryConfig.name } isEqualTo context.deliveryConfig.name
+        }
+    }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.telemetry.ArtifactCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.EnvironmentsCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceCheckTimedOut
 import com.netflix.spinnaker.keel.telemetry.ResourceLoadFailed
+import com.netflix.spinnaker.keel.telemetry.VerificationTimedOut
 import com.netflix.spinnaker.keel.verification.VerificationRunner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -191,7 +192,7 @@ class CheckScheduler(
                 }
               } catch (e: TimeoutCancellationException) {
                 log.error("Timed out verifying ${it.version} in ${it.deliveryConfig.application}/${it.environmentName}", e)
-//                publisher.publishEvent(EnvironmentsCheckTimedOut(it.application, it.name))
+                publisher.publishEvent(VerificationTimedOut(it))
               }
             }
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ScheduledResourceCheckStarting.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ScheduledResourceCheckStarting.kt
@@ -4,4 +4,6 @@ object ResourceCheckCompleted
 
 object ScheduledEnvironmentCheckStarting
 
+object ScheduledEnvironmentVerificationStarting
+
 object ScheduledArtifactCheckStarting

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -13,6 +13,8 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
@@ -50,6 +52,7 @@ class CombinedRepository(
   val deliveryConfigRepository: DeliveryConfigRepository,
   val artifactRepository: ArtifactRepository,
   val resourceRepository: ResourceRepository,
+  val verificationRepository: VerificationRepository,
   override val clock: Clock,
   override val publisher: ApplicationEventPublisher,
   val objectMapper: ObjectMapper
@@ -415,4 +418,12 @@ class CombinedRepository(
     = artifactRepository.getPinnedVersion(deliveryConfig, targetEnvironment, reference)
 
   // END ArtifactRepository methods
+
+  // START VerificationRepository methods
+  override fun nextEnvironmentsForVerification(
+    minTimeSinceLastCheck: Duration,
+    limit: Int
+  ) : Collection<VerificationContext> =
+    verificationRepository.nextEnvironmentsForVerification(minTimeSinceLastCheck, limit)
+  // END VerificationRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -7,10 +7,10 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
-import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.persistence.KeelReadOnlyRepository
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
@@ -214,4 +214,11 @@ interface KeelRepository : KeelReadOnlyRepository {
   fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
 
   // END ArtifactRepository methods
+
+  // START VerificationRepository methods
+  fun nextEnvironmentsForVerification(
+    minTimeSinceLastCheck: Duration,
+    limit: Int
+  ) : Collection<VerificationContext>
+  // END VerificationRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -121,3 +121,21 @@ data class VerificationCompleted(
     status
   )
 }
+
+data class VerificationTimedOut(
+  val application: String,
+  val deliveryConfigName: String,
+  val environmentName: String,
+  val artifactName: String,
+  val artifactType: ArtifactType,
+  val artifactVersion: String
+) {
+  constructor(context: VerificationContext) : this(
+    context.deliveryConfig.application,
+    context.deliveryConfig.name,
+    context.environmentName,
+    context.artifact.name,
+    context.artifact.type,
+    context.version
+  )
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.scheduled.ScheduledAgent
 import com.netflix.spinnaker.keel.telemetry.ResourceLoadFailed
 import com.netflix.spinnaker.keel.test.resource
+import com.netflix.spinnaker.keel.verification.VerificationRunner
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.Called
@@ -18,8 +19,8 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import java.time.Duration
 import org.springframework.context.ApplicationEventPublisher
+import java.time.Duration
 
 internal object CheckSchedulerTests : JUnit5Minutests {
 
@@ -43,6 +44,8 @@ internal object CheckSchedulerTests : JUnit5Minutests {
   private var agentLockRepository = mockk<AgentLockRepository>(relaxUnitFun = true) {
     every { agents } returns listOf(dummyAgent)
   }
+
+  private val verificationRunner = mockk<VerificationRunner>()
 
   private val resources = listOf(
     resource(
@@ -77,11 +80,14 @@ internal object CheckSchedulerTests : JUnit5Minutests {
         resourceActuator = resourceActuator,
         environmentPromotionChecker = environmentPromotionChecker,
         artifactHandlers = listOf(artifactHandler),
-        resourceCheckMinAgeDuration = Duration.ofMinutes(5),
+        resourceCheckMinAge = Duration.ofMinutes(5),
         resourceCheckBatchSize = 2,
+        environmentVerificationMinAge = Duration.ofMinutes(5),
+        environmentVerificationBatchSize = 2,
         checkTimeout = Duration.ofMinutes(2),
         publisher = publisher,
-        agentLockRepository = agentLockRepository
+        agentLockRepository = agentLockRepository,
+        verificationRunner = verificationRunner
       )
     }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -48,13 +48,14 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact("fnord")
+          DockerArtifact(name = "fnord", reference = "fnord-docker")
         ),
         environments = setOf(
           Environment(name = "test")
         )
       ),
       environmentName = "test",
+      artifactReference = "fnord-docker",
       version = "fnord-0.190.0-h378.eacb135"
     )
 
@@ -72,7 +73,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact("fnord")
+          DockerArtifact(name = "fnord", reference = "fnord-docker")
         ),
         environments = setOf(
           Environment(
@@ -82,6 +83,7 @@ internal class VerificationRunnerTests {
         )
       ),
       environmentName = "test",
+      artifactReference = "fnord-docker",
       version = "fnord-0.190.0-h378.eacb135"
     )
 
@@ -102,7 +104,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact("fnord")
+          DockerArtifact(name = "fnord", reference = "fnord-docker")
         ),
         environments = setOf(
           Environment(
@@ -112,6 +114,7 @@ internal class VerificationRunnerTests {
         )
       ),
       environmentName = "test",
+      artifactReference = "fnord-docker",
       version = "fnord-0.190.0-h378.eacb135"
     )
 
@@ -141,7 +144,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact("fnord")
+          DockerArtifact(name = "fnord", reference = "fnord-docker")
         ),
         environments = setOf(
           Environment(
@@ -151,6 +154,7 @@ internal class VerificationRunnerTests {
         )
       ),
       environmentName = "test",
+      artifactReference = "fnord-docker",
       version = "fnord-0.190.0-h378.eacb135"
     )
 
@@ -183,7 +187,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact("fnord")
+          DockerArtifact(name = "fnord", reference = "fnord-docker")
         ),
         environments = setOf(
           Environment(
@@ -193,6 +197,7 @@ internal class VerificationRunnerTests {
         )
       ),
       environmentName = "test",
+      artifactReference = "fnord-docker",
       version = "fnord-0.190.0-h378.eacb135"
     )
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -2,10 +2,8 @@ package com.netflix.spinnaker.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spectator.api.Registry
-import com.netflix.spectator.api.Spectator
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.events.PersistentEvent.Companion.clock
-import com.netflix.spinnaker.keel.lifecycle.LifecycleEventRepository
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.resources.SpecMigrator
 import com.netflix.spinnaker.keel.scheduled.ScheduledAgent
@@ -64,11 +62,29 @@ class SqlConfiguration {
     specMigrators: List<SpecMigrator<*, *>>,
     objectMapper: ObjectMapper
   ) =
-    SqlResourceRepository(jooq, clock, resourceSpecIdentifier, specMigrators, objectMapper, SqlRetry(sqlRetryProperties))
+    SqlResourceRepository(
+      jooq,
+      clock,
+      resourceSpecIdentifier,
+      specMigrators,
+      objectMapper,
+      SqlRetry(sqlRetryProperties)
+    )
 
   @Bean
-  fun artifactRepository(jooq: DSLContext, clock: Clock, objectMapper: ObjectMapper, artifactSuppliers: List<ArtifactSupplier<*, *>>) =
-    SqlArtifactRepository(jooq, clock, objectMapper, SqlRetry(sqlRetryProperties), artifactSuppliers)
+  fun artifactRepository(
+    jooq: DSLContext,
+    clock: Clock,
+    objectMapper: ObjectMapper,
+    artifactSuppliers: List<ArtifactSupplier<*, *>>
+  ) =
+    SqlArtifactRepository(
+      jooq,
+      clock,
+      objectMapper,
+      SqlRetry(sqlRetryProperties),
+      artifactSuppliers
+    )
 
   @Bean
   fun deliveryConfigRepository(
@@ -83,7 +99,7 @@ class SqlConfiguration {
       jooq = jooq,
       clock = clock,
       resourceSpecIdentifier = resourceSpecIdentifier,
-      mapper = objectMapper,
+      objectMapper = objectMapper,
       sqlRetry = SqlRetry(sqlRetryProperties),
       artifactSuppliers = artifactSuppliers,
       specMigrators = specMigrators
@@ -137,8 +153,20 @@ class SqlConfiguration {
   @Bean
   fun verificationRepository(
     jooq: DSLContext,
-    clock: Clock
-  ) = SqlVerificationRepository(jooq, clock)
+    clock: Clock,
+    resourceSpecIdentifier: ResourceSpecIdentifier,
+    objectMapper: ObjectMapper,
+    artifactSuppliers: List<ArtifactSupplier<*, *>>,
+    specMigrators: List<SpecMigrator<*, *>>
+  ) = SqlVerificationRepository(
+    jooq,
+    clock,
+    resourceSpecIdentifier,
+    objectMapper,
+    SqlRetry(sqlRetryProperties),
+    artifactSuppliers,
+    specMigrators
+  )
 
   @Bean
   fun lifecycleEventRepository(
@@ -147,7 +175,8 @@ class SqlConfiguration {
     properties: SqlProperties,
     objectMapper: ObjectMapper,
     spectator: Registry
-  ) = SqlLifecycleEventRepository(clock, jooq, SqlRetry(sqlRetryProperties), objectMapper, spectator)
+  ) =
+    SqlLifecycleEventRepository(clock, jooq, SqlRetry(sqlRetryProperties), objectMapper, spectator)
 
   @Bean
   fun lifecycleMonitorRepository(

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlStorageContext.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlStorageContext.kt
@@ -1,0 +1,20 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
+import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
+import com.netflix.spinnaker.keel.resources.SpecMigrator
+import org.jooq.DSLContext
+import java.time.Clock
+
+abstract class SqlStorageContext(
+  internal val jooq: DSLContext,
+  internal val clock: Clock,
+  internal val sqlRetry: SqlRetry,
+  internal val objectMapper: ObjectMapper,
+  internal val resourceSpecIdentifier: ResourceSpecIdentifier,
+  internal val artifactSuppliers: List<ArtifactSupplier<*, *>>,
+  internal val specMigrators: List<SpecMigrator<*, *>>
+) {
+  internal val resourceFactory = ResourceFactory(objectMapper, resourceSpecIdentifier, specMigrators)
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -1,25 +1,93 @@
 package com.netflix.spinnaker.keel.sql
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.api.verification.VerificationStatus
+import com.netflix.spinnaker.keel.pause.PauseScope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_LAST_VERIFIED
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.VERIFICATION_STATE
+import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
+import com.netflix.spinnaker.keel.resources.SpecMigrator
+import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
+import com.netflix.spinnaker.keel.sql.deliveryconfigs.deliveryConfigByName
 import org.jooq.DSLContext
 import org.jooq.Record1
 import org.jooq.ResultQuery
 import org.jooq.Select
+import org.jooq.impl.DSL.select
 import java.time.Clock
+import java.time.Duration
 
 class SqlVerificationRepository(
-  private val jooq: DSLContext,
-  private val clock: Clock
-) : VerificationRepository {
+  jooq: DSLContext,
+  clock: Clock,
+  resourceSpecIdentifier: ResourceSpecIdentifier,
+  objectMapper: ObjectMapper,
+  sqlRetry: SqlRetry,
+  artifactSuppliers: List<ArtifactSupplier<*, *>> = emptyList(),
+  specMigrators: List<SpecMigrator<*, *>> = emptyList()
+) : SqlStorageContext(
+  jooq,
+  clock,
+  sqlRetry,
+  objectMapper,
+  resourceSpecIdentifier,
+  artifactSuppliers,
+  specMigrators
+), VerificationRepository {
+
+  override fun nextEnvironmentsForVerification(minTimeSinceLastCheck: Duration, limit: Int) : Collection<Pair<DeliveryConfig, Environment>> {
+    val now = clock.instant()
+    val cutoff = now.minus(minTimeSinceLastCheck).toTimestamp()
+    return sqlRetry.withRetry(WRITE) {
+      jooq.inTransaction {
+        select(
+          DELIVERY_CONFIG.UID,
+          DELIVERY_CONFIG.NAME,
+          ENVIRONMENT.UID,
+          ENVIRONMENT.NAME
+        )
+          .from(DELIVERY_CONFIG, ENVIRONMENT, ENVIRONMENT_LAST_VERIFIED)
+          .where(ENVIRONMENT.UID.eq(ENVIRONMENT_LAST_VERIFIED.ENVIRONMENT_UID))
+          .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+          // has not been checked recently
+          .and(ENVIRONMENT_LAST_VERIFIED.AT.lessOrEqual(cutoff))
+          // the application is not paused
+          .andNotExists(
+            selectOne()
+              .from(PAUSED)
+              .where(PAUSED.NAME.eq(DELIVERY_CONFIG.APPLICATION))
+              .and(PAUSED.SCOPE.eq(APPLICATION.name))
+          )
+          .orderBy(ENVIRONMENT_LAST_VERIFIED.AT)
+          .limit(limit)
+          .forUpdate()
+          .fetch()
+          .onEach { (_, _, environmentUid, _) ->
+            update(ENVIRONMENT_LAST_VERIFIED)
+              .set(ENVIRONMENT_LAST_VERIFIED.AT, now.toTimestamp())
+              .where(ENVIRONMENT_LAST_VERIFIED.ENVIRONMENT_UID.eq(environmentUid))
+              .execute()
+          }
+          .map { (_, deliveryConfigName, _, environmentName) ->
+            deliveryConfigByName(deliveryConfigName).let { deliveryConfig ->
+              deliveryConfig to deliveryConfig.environments.first { it.name == environmentName }
+            }
+          }
+      }
+    }
+  }
 
   override fun getState(
     context: VerificationContext,
@@ -70,16 +138,14 @@ class SqlVerificationRepository(
     get() = if (complete) VERIFICATION_STATE.ENDED_AT else VERIFICATION_STATE.STARTED_AT
 
   private val VerificationContext.environmentUid: Select<Record1<String>>
-    get() = jooq
-      .select(ENVIRONMENT.UID)
+    get() = select(ENVIRONMENT.UID)
       .from(DELIVERY_CONFIG, ENVIRONMENT)
       .where(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
       .and(ENVIRONMENT.NAME.eq(environment.name))
       .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
 
   private val DeliveryArtifact.uid: Select<Record1<String>>
-    get() = jooq
-      .select(DELIVERY_ARTIFACT.UID)
+    get() = select(DELIVERY_ARTIFACT.UID)
       .from(DELIVERY_ARTIFACT)
       .where(DELIVERY_ARTIFACT.NAME.eq(name))
       .and(DELIVERY_ARTIFACT.TYPE.eq(type))

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -91,16 +91,18 @@ class SqlVerificationRepository(
           .leftJoin(ENVIRONMENT_LAST_VERIFIED)
           .on(ENVIRONMENT_LAST_VERIFIED.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
           .and(ENVIRONMENT_LAST_VERIFIED.ARTIFACT_UID.eq(DELIVERY_ARTIFACT.UID))
+          .and(ENVIRONMENT_LAST_VERIFIED.ARTIFACT_VERSION.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION))
           // has not been checked recently (or has never been checked)
           .where(ENVIRONMENT_LAST_VERIFIED.AT.orEpoch().lessOrEqual(cutoff))
           // order by last time checked with things never checked coming first
           .orderBy(ENVIRONMENT_LAST_VERIFIED.AT.orEpoch())
           .limit(limit)
           .fetch()
-          .onEach { (_, _, environmentUid, _, artifactUid, _, _) ->
+          .onEach { (_, _, environmentUid, _, artifactUid, _, artifactVersion) ->
             insertInto(ENVIRONMENT_LAST_VERIFIED)
               .set(ENVIRONMENT_LAST_VERIFIED.ENVIRONMENT_UID, environmentUid)
               .set(ENVIRONMENT_LAST_VERIFIED.ARTIFACT_UID, artifactUid)
+              .set(ENVIRONMENT_LAST_VERIFIED.ARTIFACT_VERSION, artifactVersion)
               .set(ENVIRONMENT_LAST_VERIFIED.AT, now.toTimestamp())
               .onDuplicateKeyUpdate()
               .set(ENVIRONMENT_LAST_VERIFIED.AT, now.toTimestamp())

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -96,7 +96,6 @@ class SqlVerificationRepository(
           // order by last time checked with things never checked coming first
           .orderBy(ENVIRONMENT_LAST_VERIFIED.AT.orEpoch())
           .limit(limit)
-          .forUpdate()
           .fetch()
           .onEach { (_, _, environmentUid, _, artifactUid, _, _) ->
             insertInto(ENVIRONMENT_LAST_VERIFIED)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
@@ -1,0 +1,123 @@
+package com.netflix.spinnaker.keel.sql.deliveryconfigs
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG_ARTIFACT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_WITH_METADATA
+import com.netflix.spinnaker.keel.sql.RetryCategory.READ
+import com.netflix.spinnaker.keel.sql.SqlStorageContext
+import com.netflix.spinnaker.keel.sql.mapToArtifact
+import org.jooq.Record1
+import org.jooq.Select
+import org.jooq.impl.DSL.select
+
+internal fun SqlStorageContext.deliveryConfigByName(name: String): DeliveryConfig =
+  sqlRetry.withRetry(READ) {
+    jooq.select(
+      DELIVERY_CONFIG.UID,
+      DELIVERY_CONFIG.NAME,
+      DELIVERY_CONFIG.APPLICATION,
+      DELIVERY_CONFIG.SERVICE_ACCOUNT,
+      DELIVERY_CONFIG.METADATA
+    )
+      .from(DELIVERY_CONFIG)
+      .where(DELIVERY_CONFIG.NAME.eq(name))
+      .fetchOne { (uid, name, application, serviceAccount, metadata) ->
+        uid to DeliveryConfig(
+          name = name,
+          application = application,
+          serviceAccount = serviceAccount,
+          metadata = metadata?.let { objectMapper.readValue<Map<String, Any?>>(metadata) }
+            ?: emptyMap()
+        )
+      }
+      ?.let { (uid, deliveryConfig) ->
+        attachDependents(deliveryConfig)
+      }
+      ?: throw NoSuchDeliveryConfigName(name)
+  }
+
+internal fun SqlStorageContext.attachDependents(deliveryConfig: DeliveryConfig): DeliveryConfig =
+  sqlRetry.withRetry(READ) {
+    jooq
+      .select(
+        DELIVERY_ARTIFACT.NAME,
+        DELIVERY_ARTIFACT.TYPE,
+        DELIVERY_ARTIFACT.DETAILS,
+        DELIVERY_ARTIFACT.REFERENCE,
+        DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME
+      )
+      .from(DELIVERY_ARTIFACT, DELIVERY_CONFIG_ARTIFACT)
+      .where(DELIVERY_CONFIG_ARTIFACT.ARTIFACT_UID.eq(DELIVERY_ARTIFACT.UID))
+      .and(DELIVERY_CONFIG_ARTIFACT.DELIVERY_CONFIG_UID.eq(deliveryConfig.uid))
+      .fetch { (name, type, details, reference, configName) ->
+        mapToArtifact(
+          artifactSuppliers.supporting(type),
+          name,
+          type.toLowerCase(),
+          details,
+          reference,
+          configName
+        )
+      }
+      .toSet()
+      .let { artifacts ->
+        sqlRetry.withRetry(READ) {
+          jooq
+            .select(
+              ENVIRONMENT.UID,
+              ENVIRONMENT.NAME,
+              ENVIRONMENT.CONSTRAINTS,
+              ENVIRONMENT.NOTIFICATIONS
+            )
+            .from(ENVIRONMENT)
+            .where(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(deliveryConfig.uid))
+            .fetch { (environmentUid, name, constraintsJson, notificationsJson) ->
+              Environment(
+                name = name,
+                resources = resourcesForEnvironment(environmentUid),
+                constraints = objectMapper.readValue(constraintsJson),
+                notifications = objectMapper.readValue(notificationsJson ?: "[]")
+              )
+            }
+            .let { environments ->
+              deliveryConfig.copy(
+                artifacts = artifacts,
+                environments = environments.toSet()
+              )
+            }
+        }
+      }
+  }
+
+internal fun SqlStorageContext.resourcesForEnvironment(uid: String) =
+  sqlRetry.withRetry(READ) {
+    jooq
+      .select(
+        RESOURCE_WITH_METADATA.KIND,
+        RESOURCE_WITH_METADATA.METADATA,
+        RESOURCE_WITH_METADATA.SPEC
+      )
+      .from(RESOURCE_WITH_METADATA, ENVIRONMENT_RESOURCE)
+      .where(RESOURCE_WITH_METADATA.UID.eq(ENVIRONMENT_RESOURCE.RESOURCE_UID))
+      .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(uid))
+      .fetch { (kind, metadata, spec) ->
+        resourceFactory.invoke(kind, metadata, spec)
+      }
+  }
+    .toSet()
+
+/**
+ * A query that selects the UID for a [DeliveryConfig] based on its [DeliveryConfig.name].
+ */
+internal val DeliveryConfig.uid: Select<Record1<String>>
+  get() = select(DELIVERY_CONFIG.UID)
+    .from(DELIVERY_CONFIG)
+    .where(DELIVERY_CONFIG.NAME.eq(name))

--- a/keel-sql/src/main/resources/db/changelog/20201130-environment-last-verified.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201130-environment-last-verified.yml
@@ -23,6 +23,11 @@ databaseChangeLog:
               referencedTableName: delivery_artifact
               referencedColumnNames: uid
         - column:
+            name: artifact_version
+            type: varchar(255)
+            constraints:
+              primaryKey: true
+        - column:
             name: at
             type: timestamp(3)
             constraints:

--- a/keel-sql/src/main/resources/db/changelog/20201130-environment-last-verified.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201130-environment-last-verified.yml
@@ -15,6 +15,14 @@ databaseChangeLog:
               referencedTableName: environment
               referencedColumnNames: uid
         - column:
+            name: artifact_uid
+            type: char(26)
+            constraints:
+              primaryKey: true
+              foreignKeyName: fk_environment_last_verified_delivery_artifact
+              referencedTableName: delivery_artifact
+              referencedColumnNames: uid
+        - column:
             name: at
             type: timestamp(3)
             constraints:

--- a/keel-sql/src/main/resources/db/changelog/20201130-environment-last-verified.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201130-environment-last-verified.yml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+- changeSet:
+    id: environment-last-verified
+    author: fletch
+    changes:
+    - createTable:
+        tableName: environment_last_verified
+        columns:
+        - column:
+            name: environment_uid
+            type: char(26)
+            constraints:
+              primaryKey: true
+              foreignKeyName: fk_environment_last_verified_environment
+              referencedTableName: environment
+              referencedColumnNames: uid
+        - column:
+            name: at
+            type: timestamp(3)
+            constraints:
+              nullable: false

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -206,3 +206,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201203-cleanup-event-and-paused-orhpans.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20201130-environment-last-verified.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
@@ -24,10 +24,12 @@ class SqlApproveOldVersionTests : ApproveOldVersionTests<CombinedRepository>() {
     val deliveryConfigRepository = SqlDeliveryConfigRepository(jooq, clock, resourceSpecIdentifier, mapper, sqlRetry, defaultArtifactSuppliers())
     val resourceRepository = SqlResourceRepository(jooq, clock, resourceSpecIdentifier, emptyList(), mapper, sqlRetry)
     val artifactRepository = SqlArtifactRepository(jooq, clock, mapper, sqlRetry, defaultArtifactSuppliers())
+    val verificationRepository = SqlVerificationRepository(jooq, clock, resourceSpecIdentifier, mapper, sqlRetry)
     return CombinedRepository(
       deliveryConfigRepository,
       artifactRepository,
       resourceRepository,
+      verificationRepository,
       clock,
       mockk(relaxed = true),
       configuredTestObjectMapper()

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
@@ -7,10 +7,11 @@ import com.netflix.spinnaker.keel.test.defaultArtifactSuppliers
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import java.time.Clock
 import org.junit.jupiter.api.AfterAll
+import java.time.Clock
 
-internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository>() {
+internal object SqlCombinedRepositoryTests :
+  CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository, SqlVerificationRepository>() {
   private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredTestObjectMapper()
@@ -19,13 +20,23 @@ internal object SqlCombinedRepositoryTests : CombinedRepositoryTests<SqlDelivery
   private val clock = Clock.systemUTC()
 
   override fun createDeliveryConfigRepository(resourceSpecIdentifier: ResourceSpecIdentifier): SqlDeliveryConfigRepository =
-    SqlDeliveryConfigRepository(jooq, clock, resourceSpecIdentifier, objectMapper, sqlRetry, defaultArtifactSuppliers())
+    SqlDeliveryConfigRepository(
+      jooq,
+      clock,
+      resourceSpecIdentifier,
+      objectMapper,
+      sqlRetry,
+      defaultArtifactSuppliers()
+    )
 
   override fun createResourceRepository(resourceSpecIdentifier: ResourceSpecIdentifier): SqlResourceRepository =
     SqlResourceRepository(jooq, clock, resourceSpecIdentifier, emptyList(), objectMapper, sqlRetry)
 
   override fun createArtifactRepository(): SqlArtifactRepository =
     SqlArtifactRepository(jooq, clock, objectMapper, sqlRetry, defaultArtifactSuppliers())
+
+  override fun createVerificationRepository(resourceSpecIdentifier: ResourceSpecIdentifier): SqlVerificationRepository =
+    SqlVerificationRepository(jooq, clock, resourceSpecIdentifier, objectMapper, sqlRetry)
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
@@ -38,7 +38,7 @@ internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
       jooq = jooq,
       clock = clock,
       resourceSpecIdentifier = DummyResourceSpecIdentifier,
-      mapper = objectMapper,
+      objectMapper = objectMapper,
       sqlRetry = sqlRetry,
       artifactSuppliers = defaultArtifactSuppliers()
     )
@@ -134,7 +134,7 @@ internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
           jooq = jooq,
           clock = clock,
           resourceSpecIdentifier = multipleVersionsResourceSpecIdentifier,
-          mapper = objectMapper,
+          objectMapper = objectMapper,
           sqlRetry = sqlRetry,
           artifactSuppliers = defaultArtifactSuppliers(),
           specMigrators = listOf(migrator)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import io.mockk.mockk
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import java.time.Clock
@@ -21,7 +22,7 @@ internal class SqlVerificationRepositoryTests :
   private val deliveryConfigRepository = SqlDeliveryConfigRepository(jooq, Clock.systemUTC(), ResourceSpecIdentifier(), configuredObjectMapper(), sqlRetry)
   private val artifactRepository = SqlArtifactRepository(jooq, Clock.systemUTC(), configuredObjectMapper(), sqlRetry)
 
-  override fun createSubject() = SqlVerificationRepository(jooq, Clock.systemUTC())
+  override fun createSubject() = SqlVerificationRepository(jooq, Clock.systemUTC(), mockk(), configuredObjectMapper(), mockk())
 
   override fun VerificationContext.setup() {
     deliveryConfigRepository.store(deliveryConfig)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -12,7 +12,6 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import io.mockk.mockk
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
-import java.time.Clock
 
 internal class SqlVerificationRepositoryTests :
   VerificationRepositoryTests<SqlVerificationRepository>() {
@@ -23,20 +22,36 @@ internal class SqlVerificationRepositoryTests :
   private val artifactSuppliers = listOf(DockerArtifactSupplier(mockk(), mockk(), mockk()))
 
   private val deliveryConfigRepository = SqlDeliveryConfigRepository(
-    jooq,
-    Clock.systemUTC(),
-    ResourceSpecIdentifier(),
-    configuredObjectMapper(),
-    sqlRetry,
-    artifactSuppliers
+    jooq = jooq,
+    clock = clock,
+    resourceSpecIdentifier = ResourceSpecIdentifier(),
+    objectMapper = configuredObjectMapper(),
+    sqlRetry = sqlRetry,
+    artifactSuppliers = artifactSuppliers
   )
-  private val artifactRepository =
-    SqlArtifactRepository(jooq, Clock.systemUTC(), configuredObjectMapper(), sqlRetry, artifactSuppliers)
+  private val artifactRepository = SqlArtifactRepository(
+    jooq = jooq,
+    clock = clock,
+    objectMapper = configuredObjectMapper(),
+    sqlRetry = sqlRetry,
+    artifactSuppliers = artifactSuppliers
+  )
 
-  private val pausedRepository = SqlPausedRepository(jooq, sqlRetry, Clock.systemUTC())
+  private val pausedRepository = SqlPausedRepository(
+    jooq = jooq,
+    sqlRetry = sqlRetry,
+    clock = clock
+  )
 
   override fun createSubject() =
-    SqlVerificationRepository(jooq, Clock.systemUTC(), mockk(), configuredObjectMapper(), sqlRetry, artifactSuppliers)
+    SqlVerificationRepository(
+      jooq = jooq,
+      clock = clock,
+      resourceSpecIdentifier = mockk(),
+      objectMapper = configuredObjectMapper(),
+      sqlRetry = sqlRetry,
+      artifactSuppliers = artifactSuppliers
+    )
 
   override fun VerificationContext.setup() {
     artifactRepository.register(artifact)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -33,6 +33,8 @@ internal class SqlVerificationRepositoryTests :
   private val artifactRepository =
     SqlArtifactRepository(jooq, Clock.systemUTC(), configuredObjectMapper(), sqlRetry, artifactSuppliers)
 
+  private val pausedRepository = SqlPausedRepository(jooq, sqlRetry, Clock.systemUTC())
+
   override fun createSubject() =
     SqlVerificationRepository(jooq, Clock.systemUTC(), mockk(), configuredObjectMapper(), sqlRetry, artifactSuppliers)
 
@@ -54,6 +56,13 @@ internal class SqlVerificationRepositoryTests :
       artifact,
       version,
       environmentName
+    )
+  }
+
+  override fun VerificationContext.pauseApplication() {
+    pausedRepository.pauseApplication(
+      deliveryConfig.application,
+      "fzlem@netflix.com"
     )
   }
 


### PR DESCRIPTION
This adds a new `@Scheduled` function to `CheckScheduler` that invokes verifications for environment/artifact combinations using the current version deployed in the environment.