### PR TITLE
feat(lifecycle): refactor start monitoring events

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -89,7 +89,7 @@ class ArtifactListener(
         val data = mutableMapOf(
           "buildNumber" to artifact.metadata["buildNumber"]?.toString(),
           "commitId" to artifact.metadata["commitId"]?.toString(),
-          "fallbackLink" to buildMetadata.job?.link
+          "buildMetadata" to buildMetadata
         )
 
         repository

--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -113,7 +113,7 @@ class ArtifactListener(
                 link = buildMetadata.uid,
                 data = data,
                 timestamp = buildMetadata.startedAtInstant,
-                monitor = true
+                startMonitoring = true
               ))
             }
           }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -465,7 +465,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
           val slot = slot<LifecycleEvent>()
           verify(exactly = 1) { publisher.publishEvent(capture(slot)) }
           expectThat(slot.captured.status).isEqualTo(RUNNING)
-          expectThat(slot.captured.monitor).isEqualTo(true)
+          expectThat(slot.captured.startMonitoring).isEqualTo(true)
         }
       }
     }

--- a/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
+++ b/keel-artifact/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListenerTests.kt
@@ -15,7 +15,7 @@ import com.netflix.spinnaker.keel.api.events.ArtifactPublishedEvent
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.api.plugins.SupportedArtifact
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEvent
-import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.NOT_STARTED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.RUNNING
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactVersionUpdated
 import dev.minutest.junit.JUnit5Minutests
@@ -446,7 +446,7 @@ internal class ArtifactListenerTests : JUnit5Minutests {
               debianArtifact,
               debianArtifact.copy(reference = "blah-blay", deliveryConfigName = "another-config")
             )
-          listener.createBuildLifecycleEvent(publishedDeb)
+          listener.publishBuildLifecycleEvent(publishedDeb)
         }
 
         test("publishes event for each artifact") {
@@ -458,13 +458,14 @@ internal class ArtifactListenerTests : JUnit5Minutests {
         before {
           every { repository.getAllArtifacts(DEBIAN, any())} returns
             listOf(debianArtifact)
-          listener.createBuildLifecycleEvent(publishedDeb)
+          listener.publishBuildLifecycleEvent(publishedDeb)
         }
 
-        test("publishes event with status NOT STARTED") {
+        test("publishes event with monitor = true") {
           val slot = slot<LifecycleEvent>()
           verify(exactly = 1) { publisher.publishEvent(capture(slot)) }
-          expectThat(slot.captured.status).isEqualTo(NOT_STARTED)
+          expectThat(slot.captured.status).isEqualTo(RUNNING)
+          expectThat(slot.captured.monitor).isEqualTo(true)
         }
       }
     }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -75,48 +75,55 @@ class BakeryLifecycleMonitor(
     "$spinnakerBaseUrl/#/tasks/${task.link}"
 
   private fun publishCorrectLink(task: MonitoredTask) {
-    publisher.publishEvent(task.triggeringEvent.copy(
-      link = orcaTaskIdToLink(task)
-    ))
+    task.publishEvent(
+      task.triggeringEvent.status,
+      task.triggeringEvent.text,
+    )
   }
 
   private fun publishRunningEvent(task: MonitoredTask) {
-    publisher.publishEvent(task.triggeringEvent.copy(
-      status = LifecycleEventStatus.RUNNING,
-      link = orcaTaskIdToLink(task),
-      text = "Bake running for version ${task.triggeringEvent.artifactVersion}"
-    ))
+    task.publishEvent(
+      LifecycleEventStatus.RUNNING,
+      "Bake running for version ${task.triggeringEvent.artifactVersion}",
+    )
   }
+
   private fun publishSucceededEvent(task: MonitoredTask) {
-    publisher.publishEvent(task.triggeringEvent.copy(
-      status = SUCCEEDED,
-      link = orcaTaskIdToLink(task),
-      text = "Bake succeeded for version ${task.triggeringEvent.artifactVersion}"
-    ))
+    task.publishEvent(
+      SUCCEEDED,
+      "Bake succeeded for version ${task.triggeringEvent.artifactVersion}",
+    )
   }
+
   private fun publishFailedEvent(task: MonitoredTask) {
-    publisher.publishEvent(task.triggeringEvent.copy(
-      status = FAILED,
-      link = orcaTaskIdToLink(task),
-      text = "Bake failed for version ${task.triggeringEvent.artifactVersion}"
-    ))
+    task.publishEvent(
+      FAILED,
+      "Bake failed for version ${task.triggeringEvent.artifactVersion}"
+    )
   }
 
   override fun publishExceptionEvent(task: MonitoredTask) {
-    publisher.publishEvent(task.triggeringEvent.copy(
-      status = UNKNOWN,
-      link = orcaTaskIdToLink(task),
-      text = "Failed to monitor bake of version ${task.triggeringEvent.artifactVersion}" +
-        " because we could not get the status ${lifecycleConfig.numFailuresAllowed} times. Status unknown."
-    ))
+    task.publishEvent(
+      UNKNOWN,
+      "Failed to monitor bake of version ${task.triggeringEvent.artifactVersion}" +
+        " because we could not get the status ${lifecycleConfig.numFailuresAllowed} times. Status unknown.",
+    )
   }
 
   private fun publishUnknownEvent(task: MonitoredTask, execution: ExecutionDetailResponse) {
     log.warn("Monitored bake ${task.triggeringEvent} in an unhandled status (${execution.status}")
-    publisher.publishEvent(task.triggeringEvent.copy(
-      status = UNKNOWN,
-      link = orcaTaskIdToLink(task),
-      text = "Bake status unknown for version ${task.triggeringEvent.artifactVersion}"
+    task.publishEvent(
+      UNKNOWN,
+      "Bake status unknown for version ${task.triggeringEvent.artifactVersion}"
+    )
+  }
+
+  fun MonitoredTask.publishEvent(status: LifecycleEventStatus, text: String?) {
+    publisher.publishEvent(triggeringEvent.copy(
+      status = status,
+      link = orcaTaskIdToLink(this),
+      text = text,
+      monitor = false
     ))
   }
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -123,7 +123,7 @@ class BakeryLifecycleMonitor(
       status = status,
       link = orcaTaskIdToLink(this),
       text = text,
-      monitor = false
+      startMonitoring = false
     ))
   }
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -181,7 +181,8 @@ class ImageHandler(
         id = "bake-$desiredVersion",
         status = NOT_STARTED,
         text = "Launching bake for $version",
-        link = taskRef.id
+        link = taskRef.id,
+        monitor = true
       ))
       return listOf(Task(id = taskRef.id, name = description))
     } catch (e: Exception) {

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -182,7 +182,7 @@ class ImageHandler(
         status = NOT_STARTED,
         text = "Launching bake for $version",
         link = taskRef.id,
-        monitor = true
+        startMonitoring = true
       ))
       return listOf(Task(id = taskRef.id, name = description))
     } catch (e: Exception) {

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -84,7 +84,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(NOT_STARTED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -101,7 +101,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.RUNNING)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -118,7 +118,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.SUCCEEDED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -135,7 +135,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(FAILED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
       context("unknown") {
@@ -151,7 +151,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(UNKNOWN)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
     }
@@ -178,7 +178,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           monitorRepository.delete(failingTask)
         }
         expectThat(slot.captured.status).isEqualTo(UNKNOWN)
-        expectThat(slot.captured.monitor).isEqualTo(false)
+        expectThat(slot.captured.startMonitoring).isEqualTo(false)
       }
     }
 

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -5,7 +5,9 @@ import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEvent
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventScope.PRE_DEPLOYMENT
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.NOT_STARTED
+import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.UNKNOWN
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType.BAKE
 import com.netflix.spinnaker.keel.lifecycle.LifecycleMonitorRepository
 import com.netflix.spinnaker.keel.lifecycle.MonitoredTask
@@ -82,6 +84,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(NOT_STARTED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -98,6 +101,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.RUNNING)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -114,6 +118,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.SUCCEEDED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -129,7 +134,8 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           verify(exactly = 1) {
             publisher.publishEvent(capture(slot))
           }
-          expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.FAILED)
+          expectThat(slot.captured.status).isEqualTo(FAILED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
       context("unknown") {
@@ -144,7 +150,8 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           verify(exactly = 1) {
             publisher.publishEvent(capture(slot))
           }
-          expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.UNKNOWN)
+          expectThat(slot.captured.status).isEqualTo(UNKNOWN)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
     }
@@ -170,7 +177,8 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           publisher.publishEvent(capture(slot))
           monitorRepository.delete(failingTask)
         }
-        expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.UNKNOWN)
+        expectThat(slot.captured.status).isEqualTo(UNKNOWN)
+        expectThat(slot.captured.monitor).isEqualTo(false)
       }
     }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEvent.kt
@@ -21,7 +21,7 @@ import java.time.Instant
  *   the user.
  * [timestamp] is nullable so that the repository can insert the timestamp when
  *   the event is stored.
- * [monitor] true if this event is the first in the chain and needs to be monitored.
+ * [startMonitoring] true if this event is the first in the chain and needs to be monitored.
  *    Follow up events should leave it set to false.
  * [data] contains any extra data needed for monitoring the event
  */
@@ -35,7 +35,7 @@ data class LifecycleEvent(
   val text: String? = null,
   val link: String? = null,
   val timestamp: Instant? = null,
-  val monitor: Boolean = false,
+  val startMonitoring: Boolean = false,
   val data: Map<String, Any?> = emptyMap()
 ) {
   fun toStep(): LifecycleStep =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEvent.kt
@@ -21,6 +21,8 @@ import java.time.Instant
  *   the user.
  * [timestamp] is nullable so that the repository can insert the timestamp when
  *   the event is stored.
+ * [monitor] true if this event is the first in the chain and needs to be monitored.
+ *    Follow up events should leave it set to false.
  * [data] contains any extra data needed for monitoring the event
  */
 data class LifecycleEvent(
@@ -33,6 +35,7 @@ data class LifecycleEvent(
   val text: String? = null,
   val link: String? = null,
   val timestamp: Instant? = null,
+  val monitor: Boolean = false,
   val data: Map<String, Any?> = emptyMap()
 ) {
   fun toStep(): LifecycleStep =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
@@ -54,7 +54,7 @@ class LifecycleMonitorScheduler(
    */
   @EventListener(LifecycleEvent::class)
   fun onLifecycleEvent(event: LifecycleEvent) {
-    if (event.monitor && monitors.any { it.handles(event.type) } && event.link != null) {
+    if (event.startMonitoring && monitors.any { it.handles(event.type) } && event.link != null) {
       log.debug("${this.javaClass.simpleName} saving monitor event $event")
       monitorRepository.save(MonitoredTask(event, event.link))
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
@@ -49,17 +49,12 @@ class LifecycleMonitorScheduler(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   /**
-   * Listens for a not started event that a subclass can handle, and saves that into
+   * Listens for an event with monitor == true that a subclass can handle, and saves that into
    * the database for monitoring.
-   *
-   * //todo eb: add a 'monitor' flag to lifecycle events so we don't listen for a NOT_STARTED event here,
-   *   it's kind of confusing.
    */
   @EventListener(LifecycleEvent::class)
   fun onLifecycleEvent(event: LifecycleEvent) {
-    if (event.status == LifecycleEventStatus.NOT_STARTED
-      && monitors.any { it.handles(event.type) }
-      && event.link != null) {
+    if (event.monitor && monitors.any { it.handles(event.type) } && event.link != null) {
       log.debug("${this.javaClass.simpleName} saving monitor event $event")
       monitorRepository.save(MonitoredTask(event, event.link))
     }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorSchedulerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorSchedulerTests.kt
@@ -1,10 +1,6 @@
 package com.netflix.spinnaker.keel.lifecycle
 
 import com.netflix.spinnaker.config.LifecycleConfig
-import com.netflix.spinnaker.keel.artifacts.DockerArtifact
-import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.FAILED
-import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.RUNNING
-import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus.SUCCEEDED
 import com.netflix.spinnaker.keel.telemetry.LifecycleMonitorLoadFailed
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -77,7 +73,7 @@ class LifecycleMonitorSchedulerTests : JUnit5Minutests {
 
       context("storing events for monitoring") {
         test("monitoring enabled") {
-          subject.onLifecycleEvent(event.copy(monitor = true))
+          subject.onLifecycleEvent(event.copy(startMonitoring = true))
           verify(exactly = 1) { monitorRepository.save(any()) }
         }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorSchedulerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorSchedulerTests.kt
@@ -76,23 +76,13 @@ class LifecycleMonitorSchedulerTests : JUnit5Minutests {
       }
 
       context("storing events for monitoring") {
-        test("not started event") {
-          subject.onLifecycleEvent(event)
+        test("monitoring enabled") {
+          subject.onLifecycleEvent(event.copy(monitor = true))
           verify(exactly = 1) { monitorRepository.save(any()) }
         }
 
-        test("running event") {
-          subject.onLifecycleEvent(event.copy(status = RUNNING))
-          verify(exactly = 0) { monitorRepository.save(any()) }
-        }
-
-        test("failed event") {
-          subject.onLifecycleEvent(event.copy(status = FAILED))
-          verify(exactly = 0) { monitorRepository.save(any()) }
-        }
-
-        test("succeeded event") {
-          subject.onLifecycleEvent(event.copy(status = SUCCEEDED))
+        test("monitoring disabled") {
+          subject.onLifecycleEvent(event)
           verify(exactly = 0) { monitorRepository.save(any()) }
         }
       }

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildLifecycleMonitor.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildLifecycleMonitor.kt
@@ -161,7 +161,7 @@ class BuildLifecycleMonitor(
       link = chooseLink(this),
       text = text,
       timestamp = timestamp,
-      monitor = false
+      startMonitoring = false
     ))
   }
 

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
@@ -111,6 +111,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(RUNNING)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -127,6 +128,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -143,6 +145,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(FAILED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -159,6 +162,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(ABORTED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -175,6 +179,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
 
@@ -191,6 +196,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(UNKNOWN)
+          expectThat(slot.captured.monitor).isEqualTo(false)
         }
       }
     }
@@ -218,6 +224,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
           monitorRepository.delete(failingTask)
         }
         expectThat(slot.captured.status).isEqualTo(UNKNOWN)
+        expectThat(slot.captured.monitor).isEqualTo(false)
       }
     }
 

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
@@ -131,7 +131,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(RUNNING)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -148,7 +148,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -165,7 +165,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(FAILED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -182,7 +182,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(ABORTED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -199,7 +199,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -216,7 +216,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(UNKNOWN)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
 
@@ -235,7 +235,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
             publisher.publishEvent(capture(slot))
           }
           expectThat(slot.captured.status).isEqualTo(SUCCEEDED)
-          expectThat(slot.captured.monitor).isEqualTo(false)
+          expectThat(slot.captured.startMonitoring).isEqualTo(false)
         }
       }
     }
@@ -263,7 +263,7 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
           monitorRepository.delete(failingTask)
         }
         expectThat(slot.captured.status).isEqualTo(UNKNOWN)
-        expectThat(slot.captured.monitor).isEqualTo(false)
+        expectThat(slot.captured.startMonitoring).isEqualTo(false)
       }
     }
 


### PR DESCRIPTION
After adding a second type of event I realized that it is a lot easier to use if the event can indicate whether it kicks off monitoring. I added a `monitor: Boolean` field to indicate whether or not the event should kick off a monitoring cycle. Follow-up events need to set this to `false`. 

I also refactored the publishing event functions in each monitor so that it was easy to enforce setting `monitor = false`.

No change in behavior except that the first `build` event is now of status `RUNNING`.