### PR TITLE
fix(lifecycle): don't copy time forward

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -123,7 +123,8 @@ class BakeryLifecycleMonitor(
       status = status,
       link = orcaTaskIdToLink(this),
       text = text,
-      startMonitoring = false
+      startMonitoring = false,
+      timestamp = null // let repository record the current time
     ))
   }
 }

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -102,6 +102,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           }
           expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.RUNNING)
           expectThat(slot.captured.startMonitoring).isEqualTo(false)
+          expectThat(slot.captured.timestamp).isEqualTo(null)
         }
       }
 
@@ -119,6 +120,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           }
           expectThat(slot.captured.status).isEqualTo(LifecycleEventStatus.SUCCEEDED)
           expectThat(slot.captured.startMonitoring).isEqualTo(false)
+          expectThat(slot.captured.timestamp).isEqualTo(null)
         }
       }
 
@@ -136,6 +138,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           }
           expectThat(slot.captured.status).isEqualTo(FAILED)
           expectThat(slot.captured.startMonitoring).isEqualTo(false)
+          expectThat(slot.captured.timestamp).isEqualTo(null)
         }
       }
       context("unknown") {
@@ -152,6 +155,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           }
           expectThat(slot.captured.status).isEqualTo(UNKNOWN)
           expectThat(slot.captured.startMonitoring).isEqualTo(false)
+          expectThat(slot.captured.timestamp).isEqualTo(null)
         }
       }
     }


### PR DESCRIPTION
Fix for the bakery lifecycle monitor to not copy time forward.

Previously, this didn't matter, because we didn't care about the time an event added. But, when I updated that logic so the build monitor could actually pass in the correct timing I didn't realize it would cause the bakery monitor to continually pass forward the start time.