### PR TITLE
docs(api): Re-enable Swagger UI

### DIFF
--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     exclude(mapOf("group" to "com.netflix.spinnaker.kork", "module" to "kork-secrets-aws"))
     exclude(mapOf("group" to "com.netflix.spinnaker.kork", "module" to "kork-secrets-gcp"))
   }
+  runtimeOnly("io.springfox:springfox-boot-starter:3.0.0")
 
   testImplementation("io.strikt:strikt-jackson")
   testImplementation(project(":keel-test"))


### PR DESCRIPTION
Re-enable the Swagger UI by adding a dependency to springfox.