### PR TITLE
fix(builds): calculate steps more correctly

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
@@ -30,20 +31,56 @@ class SqlLifecycleEventRepository(
 ) : LifecycleEventRepository {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
+  /**
+   * Only saves event if a field other than the timestamp changes.
+   * If only the timestamp changed, update the timestamp on the existing row.
+   */
   override fun saveEvent(event: LifecycleEvent) {
     val timestamp = event.timestamp?.toTimestamp() ?: clock.timestamp()
     sqlRetry.withRetry(WRITE) {
-      jooq.insertInto(LIFECYCLE_EVENT)
-        .set(LIFECYCLE_EVENT.UID, ULID().nextULID(clock.millis()))
-        .set(LIFECYCLE_EVENT.SCOPE, event.scope.name)
-        .set(LIFECYCLE_EVENT.REF, event.artifactRef)
-        .set(LIFECYCLE_EVENT.ARTIFACT_VERSION, event.artifactVersion)
-        .set(LIFECYCLE_EVENT.TYPE, event.type.name)
-        .set(LIFECYCLE_EVENT.ID, event.id)
-        .set(LIFECYCLE_EVENT.STATUS, event.status.name)
-        .set(LIFECYCLE_EVENT.TIMESTAMP, timestamp)
-        .set(LIFECYCLE_EVENT.JSON, objectMapper.writeValueAsString(event))
-        .execute()
+      jooq.transaction { config ->
+        val txn = DSL.using(config)
+        // if event exists, only update timestamp
+        var uid: String? = null
+        txn.select(LIFECYCLE_EVENT.UID, LIFECYCLE_EVENT.JSON)
+          .from(LIFECYCLE_EVENT)
+          .where(LIFECYCLE_EVENT.SCOPE.eq(event.scope.name))
+          .and(LIFECYCLE_EVENT.REF.eq(event.artifactRef))
+          .and(LIFECYCLE_EVENT.ARTIFACT_VERSION.eq(event.artifactVersion))
+          .and(LIFECYCLE_EVENT.TYPE.eq(event.type.name))
+          .and(LIFECYCLE_EVENT.ID.eq(event.id))
+          .and(LIFECYCLE_EVENT.STATUS.eq(event.status.name))
+          .limit(1)
+          .fetch()
+          .map { (savedUid: String, savedEvent: String) ->
+            uid = savedUid
+            objectMapper.readValue<LifecycleEvent>(savedEvent)
+          }
+          .firstOrNull()
+          ?.let { existingEvent: LifecycleEvent ->
+            if (existingEvent.copy(timestamp = null) == event.copy(timestamp = null)) {
+              // events are the same except time
+              txn.update(LIFECYCLE_EVENT)
+                .set(LIFECYCLE_EVENT.TIMESTAMP, timestamp)
+                .where(LIFECYCLE_EVENT.UID.eq(uid))
+                .execute()
+            }
+          }
+
+        if (uid == null) {
+          txn.insertInto(LIFECYCLE_EVENT)
+            .set(LIFECYCLE_EVENT.UID, ULID().nextULID(clock.millis()))
+            .set(LIFECYCLE_EVENT.SCOPE, event.scope.name)
+            .set(LIFECYCLE_EVENT.REF, event.artifactRef)
+            .set(LIFECYCLE_EVENT.ARTIFACT_VERSION, event.artifactVersion)
+            .set(LIFECYCLE_EVENT.TYPE, event.type.name)
+            .set(LIFECYCLE_EVENT.ID, event.id)
+            .set(LIFECYCLE_EVENT.STATUS, event.status.name)
+            .set(LIFECYCLE_EVENT.TIMESTAMP, timestamp)
+            .set(LIFECYCLE_EVENT.JSON, objectMapper.writeValueAsString(event))
+            .execute()
+        }
+      }
     }
   }
 
@@ -85,14 +122,10 @@ class SqlLifecycleEventRepository(
     val events = getEvents(artifact, artifactVersion)
     val steps: MutableList<LifecycleStep> = mutableListOf()
 
-    val firstEventById = events.filter { it.status == NOT_STARTED }.associateBy { it.id }
+    // associateBy overwrites values when presented with duplicate keys
+    // get first and last event by sorting both ways
+    val firstEventById = events.sortedByDescending { it.timestamp }.associateBy { it.id }
     val lastEventById = events.associateBy { it.id }
-
-    if (firstEventById.size != lastEventById.size) {
-      log.error("Missing a NOT_STARTED event for artifact ${artifact.toLifecycleRef()} with version $artifactVersion. " +
-        "This may lead to some wonky steps or no monitoring. " +
-        "firstEvents: $firstEventById, lastEvents: $lastEventById")
-    }
 
     firstEventById.forEach { (id, event) ->
       var step = event.toStep()
@@ -109,7 +142,7 @@ class SqlLifecycleEventRepository(
         }
         step = step.copy(status = lastEvent.status)
       } else {
-        log.error("Somehow we have a NOT_STARTED event but no last event for $event. Not sure how this could happen.")
+        log.error("Somehow we have a starting event but no last event for $event. Not sure how this could happen.")
       }
       steps.add(step)
     }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepository.kt
@@ -77,7 +77,7 @@ class SqlLifecycleMonitorRepository(
         }
     }
 
-  fun LifecycleEvent.getUid(jooq: DSLContext): String {
+  fun LifecycleEvent.getUid(): String {
     return sqlRetry.withRetry(READ) {
       jooq.select(LIFECYCLE_EVENT.UID)
         .from(LIFECYCLE_EVENT)
@@ -94,8 +94,7 @@ class SqlLifecycleMonitorRepository(
 
   override fun save(task: MonitoredTask) {
     sqlRetry.withRetry(WRITE) {
-      //todo eb: don't add new one if triggering uid is the same!
-      val triggeringEventUid = task.triggeringEvent.getUid(jooq)
+      val triggeringEventUid = task.triggeringEvent.getUid()
       jooq.insertInto(LIFECYCLE_MONITOR)
         .set(LIFECYCLE_MONITOR.UID, ULID().nextULID(clock.millis()))
         .set(LIFECYCLE_MONITOR.TYPE, task.type.name)
@@ -108,7 +107,7 @@ class SqlLifecycleMonitorRepository(
 
   override fun delete(task: MonitoredTask) {
     sqlRetry.withRetry(WRITE) {
-      val triggeringEventUid = task.triggeringEvent.getUid(jooq)
+      val triggeringEventUid = task.triggeringEvent.getUid()
       jooq.deleteFrom(LIFECYCLE_MONITOR)
         .where(LIFECYCLE_MONITOR.TYPE.eq(task.type.name))
         .and(LIFECYCLE_MONITOR.TRIGGERING_EVENT_UID.eq(triggeringEventUid))
@@ -118,7 +117,7 @@ class SqlLifecycleMonitorRepository(
 
   override fun markFailureGettingStatus(task: MonitoredTask) {
     sqlRetry.withRetry(WRITE) {
-      val triggeringEventUid = task.triggeringEvent.getUid(jooq)
+      val triggeringEventUid = task.triggeringEvent.getUid()
       jooq.update(LIFECYCLE_MONITOR)
         .set(LIFECYCLE_MONITOR.NUM_FAILURES,LIFECYCLE_MONITOR.NUM_FAILURES.plus(1))
         .where(LIFECYCLE_MONITOR.TYPE.eq(task.type.name))
@@ -129,7 +128,7 @@ class SqlLifecycleMonitorRepository(
 
   override fun clearFailuresGettingStatus(task: MonitoredTask) {
     sqlRetry.withRetry(WRITE) {
-      val triggeringEventUid = task.triggeringEvent.getUid(jooq)
+      val triggeringEventUid = task.triggeringEvent.getUid()
       jooq.update(LIFECYCLE_MONITOR)
         .set(LIFECYCLE_MONITOR.NUM_FAILURES, 0)
         .where(LIFECYCLE_MONITOR.TYPE.eq(task.type.name))


### PR DESCRIPTION
(1) correctly calculates build steps: I changed the requirement to have the first event be NOT_STARTED, then I forgot to actually make that true. This PR fixes that.

(2) changes duplicate events to update the timestamp instead of saving a new event. Why? Last week I had a bug in my code where we never stopped monitoring failed builds. We got a LOT of events saved about this. It seems useless. Really, I just want to know the last seen time for the status. So, I made the saving this way.

(3) I put a retry around grabbing the event uuid for the foreign key.