### PR TITLE
fix(controller): reject delivery config with invalid app name

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidAppNameException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/InvalidAppNameException.kt
@@ -1,0 +1,8 @@
+package com.netflix.spinnaker.keel.exceptions
+
+class InvalidAppNameException(
+  appName: String
+) : ValidationException(
+  "'application' field in delivery config is not a valid Spinnaker app name: $appName"
+)
+


### PR DESCRIPTION
## Problem

A user submitted a delivery config with some invalid resource names, including an invalid application name: `{{application.name}}`. 

This was submitted by an app that generates delivery configs via templating, and something went wrong with this case that broke template substitution.

The invalid resource names led to clouddriver returning errors when keel queried for these resources.

## Proposed solution

Reject delivery config as invalid if the application name is not a valid Spinnaker application name according to the Frigga library.

This won't completely solve the problem of a user submitting a delivery config with invalid resource names, but it will catch the problem where there's a common mode failure with generating the app name and the resource names, as there was in the original case here with templating.

In the future, we should validate all of the resource names.

## Other changes

Changed the log level from error to warn for validation failures. This is a judgment call, but I felt that bad user input which is rejected is more of a warning case than an error case.

Pulled the `duplicates` helper method outside of the `DeliveryConfigValidator.validate` function and made it an extension function of `List<String>`.