### PR TITLE
add missing cascade to foreign keys on environment_last_verified table

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20201208-fix-environment-last-verified-cascade.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201208-fix-environment-last-verified-cascade.yml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+- changeSet:
+    id: fix-environment-last-verified-cascade
+    author: fletch
+    changes:
+    - dropForeignKeyConstraint:
+        baseTableName: environment_last_verified
+        constraintName: fk_environment_last_verified_environment
+    - addForeignKeyConstraint:
+        baseTableName: environment_last_verified
+        baseColumnNames: environment_uid
+        constraintName: fk_environment_last_verified_environment
+        referencedTableName: environment
+        referencedColumnNames: uid
+        referencesUniqueColumn: true
+        onDelete: CASCADE
+    - dropForeignKeyConstraint:
+        baseTableName: environment_last_verified
+        constraintName: fk_environment_last_verified_delivery_artifact
+    - addForeignKeyConstraint:
+        baseTableName: environment_last_verified
+        baseColumnNames: artifact_uid
+        constraintName: fk_environment_last_verified_delivery_artifact
+        referencedTableName: delivery_artifact
+        referencedColumnNames: uid
+        referencesUniqueColumn: true
+        onDelete: CASCADE

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -209,3 +209,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201130-environment-last-verified.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20201208-fix-environment-last-verified-cascade.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Missing cascade causes deletion of artifacts / environment elsewhere to fail.