### PR TITLE
fix(pipeline): only run if version is deployed

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -247,6 +247,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       .versions
   }
 
+  private fun Fixture<T>.currentIn(
+    environment: Environment,
+    artifact: DeliveryArtifact = versionedSnapshotDebian
+  ): String? {
+    return subject.getCurrentVersionInEnv(manifest, environment.name, artifact.reference)
+  }
+
   fun tests() = rootContext<Fixture<T>> {
     fixture { Fixture(factory(clock)) }
 
@@ -444,6 +451,10 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
           }
         }
 
+        test("current in is null") {
+          expectThat(currentIn(testEnvironment)).isNull()
+        }
+
         test("an artifact version can be vetoed even if it was not previously deployed") {
           val veto = EnvironmentArtifactVeto(
             targetEnvironment = testEnvironment.name,
@@ -574,6 +585,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
               get(ArtifactVersionStatus::deploying).isNull()
               get(ArtifactVersionStatus::previous).isEmpty()
             }
+            expectThat(currentIn(testEnvironment)).isEqualTo(version1)
           }
 
           context("a new version is promoted to the same environment") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -228,6 +228,11 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
 
   /**
+   * Returns the current version running in an environment, or null if no version is running
+   */
+  fun getCurrentVersionInEnv(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
+
+  /**
    * Return the published artifact for the last deployed version that matches the promotion status
    */
   fun getArtifactVersionByPromotionStatus(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -418,6 +418,9 @@ class CombinedRepository(
   override fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String)
     = artifactRepository.getPinnedVersion(deliveryConfig, targetEnvironment, reference)
 
+  override fun getCurrentVersionInEnv(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String? =
+    artifactRepository.getCurrentVersionInEnv(deliveryConfig, targetEnvironment, reference)
+
   // END ArtifactRepository methods
 
   // START VerificationRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -214,6 +214,11 @@ interface KeelRepository : KeelReadOnlyRepository {
    */
   fun getPinnedVersion(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
 
+  /**
+   * Returns the current version running in an environment, or null if no version is running
+   */
+  fun getCurrentVersionInEnv(deliveryConfig: DeliveryConfig, targetEnvironment: String, reference: String): String?
+
   // END ArtifactRepository methods
 
   // START VerificationRepository methods


### PR DESCRIPTION
We should only run our hacky pipeline constraint if the version it's evaluating is actually deployed. otherwise, fail the constraint.