### PR TITLE
fix(lifecycle): start monitoring kicked off after saving event

### DIFF
--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -57,11 +57,14 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
     val task = MonitoredTask(
       link = id,
-      triggeringEvent = event
+      triggeringEvent = event,
+      triggeringEventUid = "uid-i-am"
     )
 
     val subject = BakeryLifecycleMonitor(monitorRepository, publisher, lifecycleConfig, orcaService, spinnakerBaseUrl)
   }
+
+
 
   fun tests() = rootContext<Fixture> {
     fixture { Fixture() }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventHandler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventHandler.kt
@@ -1,18 +1,27 @@
 package com.netflix.spinnaker.keel.lifecycle
 
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
 /**
- * Receives lifecycle events and stores them
+ * Receives lifecycle events and stores them.
  */
 @Component
 class LifecycleEventHandler(
-  val repository: LifecycleEventRepository
+  val repository: LifecycleEventRepository,
+  val publisher: ApplicationEventPublisher
 ) {
 
+  /**
+   * Saves all lifecycle events.
+   * If they should be monitored, publish a [StartMonitoringEvent]
+   */
   @EventListener(LifecycleEvent::class)
   fun handleEvent(event: LifecycleEvent) {
-    repository.saveEvent(event)
+    val eventId = repository.saveEvent(event)
+    if (event.startMonitoring) {
+      publisher.publishEvent(StartMonitoringEvent(eventId, event))
+    }
   }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventRepository.kt
@@ -6,8 +6,10 @@ interface LifecycleEventRepository {
 
   /**
    * Adds event to list of events
+   *
+   * @return the uid of the saved event
    */
-  fun saveEvent(event: LifecycleEvent)
+  fun saveEvent(event: LifecycleEvent): String
 
   /**
    * Returns all raw events for the artifact version

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorRepository.kt
@@ -14,9 +14,9 @@ interface LifecycleMonitorRepository {
   fun tasksDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<MonitoredTask>
 
   /**
-   * Saves task to be monitored
+   * Saves a task to be monitored using the triggering event information
    */
-  fun save(task: MonitoredTask)
+  fun save(event: StartMonitoringEvent)
 
   /**
    * Removes task from list of things to be monitored

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorScheduler.kt
@@ -52,12 +52,10 @@ class LifecycleMonitorScheduler(
    * Listens for an event with monitor == true that a subclass can handle, and saves that into
    * the database for monitoring.
    */
-  @EventListener(LifecycleEvent::class)
-  fun onLifecycleEvent(event: LifecycleEvent) {
-    if (event.startMonitoring && monitors.any { it.handles(event.type) } && event.link != null) {
-      log.debug("${this.javaClass.simpleName} saving monitor event $event")
-      monitorRepository.save(MonitoredTask(event, event.link))
-    }
+  @EventListener(StartMonitoringEvent::class)
+  fun onStartMonitoringEvent(event: StartMonitoringEvent) {
+    log.debug("${this.javaClass.simpleName} saving monitor for event $event")
+    monitorRepository.save(event)
   }
 
   @Scheduled(fixedDelayString = "\${keel.lifecycle-monitor.frequency:PT1S}")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/MonitoredTask.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/MonitoredTask.kt
@@ -15,6 +15,7 @@ package com.netflix.spinnaker.keel.lifecycle
 data class MonitoredTask(
   val triggeringEvent: LifecycleEvent,
   val link: String,
+  val triggeringEventUid: String,
   val type: LifecycleEventType = triggeringEvent.type,
   val numFailures: Int = 0
 )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/StartMonitoringEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/StartMonitoringEvent.kt
@@ -1,0 +1,6 @@
+package com.netflix.spinnaker.keel.lifecycle
+
+data class StartMonitoringEvent(
+  val triggeringEventUid: String,
+  val triggeringEvent: LifecycleEvent
+)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorSchedulerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleMonitorSchedulerTests.kt
@@ -32,13 +32,17 @@ class LifecycleMonitorSchedulerTests : JUnit5Minutests {
       link = link
     )
 
+    val startMonitoringEvent = StartMonitoringEvent("im-a-uid", event)
+
     val task1 = MonitoredTask(
       triggeringEvent = event,
-      link = link + "-1"
+      link = "$link-1",
+      triggeringEventUid = "uid-1"
     )
     val task2 = MonitoredTask(
       triggeringEvent = event.copy(id = event.id + "-2"),
-      link = link + "-2"
+      link = "$link-2",
+      triggeringEventUid = "uid-2"
     )
 
     val subject = LifecycleMonitorScheduler(
@@ -72,14 +76,9 @@ class LifecycleMonitorSchedulerTests : JUnit5Minutests {
       }
 
       context("storing events for monitoring") {
-        test("monitoring enabled") {
-          subject.onLifecycleEvent(event.copy(startMonitoring = true))
+        test("saves event") {
+          subject.onStartMonitoringEvent(startMonitoringEvent)
           verify(exactly = 1) { monitorRepository.save(any()) }
-        }
-
-        test("monitoring disabled") {
-          subject.onLifecycleEvent(event)
-          verify(exactly = 0) { monitorRepository.save(any()) }
         }
       }
 

--- a/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
+++ b/keel-igor/src/test/kotlin/com/netflix/spinnaker/keel/services/BuildLifecycleMonitorTests.kt
@@ -94,7 +94,8 @@ class BuildLifecycleMonitorTests : JUnit5Minutests {
 
     val task = MonitoredTask(
       link = uid,
-      triggeringEvent = event
+      triggeringEvent = event,
+      triggeringEventUid = "uid-i-am"
     )
 
     val subject = BuildLifecycleMonitor(


### PR DESCRIPTION
**Problem**
We currently have two listeners for lifecycle events: one that saves the event (this is the "triggering event"), and one that saves the monitor instructions for that event. We're seeing some instances where the triggering event has not been saved when we try to monitor it. Because there is a foreign keys from the monitor table to the lifecycle event table, this causes problems. 

**Proposed solution**
I've changed the behavior slightly in this pr so that the lifecycle event is saved, and then a "start monitoring event" is published with that event's uid (which will be the foreign key in the monitoring table). This guarantees that the saving of the monitor event will happen only once the original event is saved. However, I've sort of 'leaked' the fact that we save the event with a uuid so that it's easier to save the monitor event. I feel this is fine but not great, and I'm happy to rethink it if anyone has suggestions.

