### PR TITLE
fix(builds): follow up on things we may have missed

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleMonitorRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleMonitorRepositoryTests.kt
@@ -12,6 +12,8 @@ import com.netflix.spinnaker.keel.lifecycle.StartMonitoringEvent
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import io.mockk.mockk
+import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expect
 import strikt.api.expectThat
 import strikt.assertions.hasSize
@@ -21,12 +23,13 @@ import java.time.Duration
 
 abstract class LifecycleMonitorRepositoryTests<T : LifecycleMonitorRepository, EVENT : LifecycleEventRepository> : JUnit5Minutests {
   abstract fun monitorFactory(clock: Clock): T
-  abstract fun eventFactory(clock: Clock): EVENT
+  abstract fun eventFactory(clock: Clock, publisher: ApplicationEventPublisher): EVENT
 
   open fun T.flush() {}
   open fun EVENT.flush() {}
 
   val clock = MutableClock()
+  val publisher: ApplicationEventPublisher = mockk(relaxed = true)
 
   data class Fixture<T : LifecycleMonitorRepository, EVENT : LifecycleEventRepository>(
     val subject: T,
@@ -50,7 +53,7 @@ abstract class LifecycleMonitorRepositoryTests<T : LifecycleMonitorRepository, E
 
   fun tests() = rootContext<Fixture<T, EVENT>> {
     fixture {
-      Fixture(subject = monitorFactory(clock), eventRepository = eventFactory(clock))
+      Fixture(subject = monitorFactory(clock), eventRepository = eventFactory(clock, publisher))
     }
 
     after {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -28,6 +28,7 @@ import org.jooq.DSLContext
 import org.jooq.impl.DefaultConfiguration
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -174,9 +175,10 @@ class SqlConfiguration {
     clock: Clock,
     properties: SqlProperties,
     objectMapper: ObjectMapper,
-    spectator: Registry
+    spectator: Registry,
+    publisher: ApplicationEventPublisher
   ) =
-    SqlLifecycleEventRepository(clock, jooq, SqlRetry(sqlRetryProperties), objectMapper, spectator)
+    SqlLifecycleEventRepository(clock, jooq, SqlRetry(sqlRetryProperties), objectMapper, spectator, publisher)
 
   @Bean
   fun lifecycleMonitorRepository(

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepositoryTests.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import org.junit.jupiter.api.AfterAll
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 
 internal object SqlLifecycleEventRepositoryTests : LifecycleEventRepositoryTests<SqlLifecycleEventRepository>() {
@@ -15,13 +16,14 @@ internal object SqlLifecycleEventRepositoryTests : LifecycleEventRepositoryTests
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
-  override fun factory(clock: Clock): SqlLifecycleEventRepository {
+  override fun factory(clock: Clock, publisher: ApplicationEventPublisher): SqlLifecycleEventRepository {
     return SqlLifecycleEventRepository(
       clock,
       jooq,
       sqlRetry,
       configuredTestObjectMapper(),
-      NoopRegistry()
+      NoopRegistry(),
+      publisher
     )
   }
 

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepositoryTests.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import org.junit.jupiter.api.AfterAll
+import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 
 internal object SqlLifecycleMonitorRepositoryTests
@@ -25,13 +26,14 @@ internal object SqlLifecycleMonitorRepositoryTests
     )
   }
 
-  override fun eventFactory(clock: Clock): SqlLifecycleEventRepository {
+  override fun eventFactory(clock: Clock, publisher: ApplicationEventPublisher): SqlLifecycleEventRepository {
     return SqlLifecycleEventRepository(
       clock,
       jooq,
       sqlRetry,
       configuredTestObjectMapper(),
-      NoopRegistry()
+      NoopRegistry(),
+      publisher
     )
   }
 


### PR DESCRIPTION
**Problem**
Because of my coding, we missed monitoring some events (fixed in https://github.com/spinnaker/keel/pull/1698).

**Solution**
This pr looks for single events with a non-ending status (like `NOT_STARTED` or `RUNNING`) that have asked to be monitored (`startMonitoring  == true`) and have a timestamp of more than 5 minutes ago. If found, it triggers monitoring again. This should pick out all the events we missed.

This is kicked off when a user loads the `managed/application/{application}?entities=artifacts` page. I'm going to slyly visit every app once this is rolled out so it triggers the monitoring w/o our users knowing.

Once this is done I'll watch for it to re-surface (indicating that we're missing monitoring of events for some other reason...). If it doesn't, I"ll remove this code.