### PR TITLE
fix(bake): unknwon is not a terminal status

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventStatus.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/lifecycle/LifecycleEventStatus.kt
@@ -15,4 +15,4 @@ enum class LifecycleEventStatus {
 }
 
 fun LifecycleEventStatus.isEndingStatus(): Boolean =
-  this in listOf(SUCCEEDED, FAILED, UNKNOWN, ABORTED)
+  this in listOf(SUCCEEDED, FAILED, ABORTED)


### PR DESCRIPTION
Unknown is not a terminal status, it can be present at any point. Removing it from the terminal status list so that generated summaries do not get "stuck" in unknown state. 