### PR TITLE
chore(tests): add verifyWith parsing test, use spring for plumbing

### DIFF
--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
@@ -23,9 +23,7 @@ import strikt.api.expectThat
 
 @SpringBootTest(
   properties = [
-    "keel.plugins.bakery.enabled=true",
-    "keel.plugins.ec2.enabled=true",
-    "keel.plugins.titus.enabled=true"
+    "keel.plugins.bakery.enabled=true"
   ],
   webEnvironment = NONE
 )

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -52,9 +52,7 @@ import kotlin.reflect.KClass
 
 @SpringBootTest(
   properties = [
-    "keel.plugins.bakery.enabled=true",
-    "keel.plugins.ec2.enabled=true",
-    "keel.plugins.titus.enabled=true"
+    "keel.plugins.bakery.enabled=true"
   ],
   webEnvironment = NONE
 )

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -17,47 +17,32 @@
  */
 package com.netflix.spinnaker.keel.rest
 
-import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
-import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
-import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1
-import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
-import com.netflix.spinnaker.keel.api.ec2.EC2_SECURITY_GROUP_V1
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.old.ClusterV1Spec
-import com.netflix.spinnaker.keel.api.plugins.SupportedKind
+import com.netflix.spinnaker.keel.api.titus.TestContainerVerification
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
+import com.netflix.spinnaker.keel.api.titus.TitusServerGroup.Location
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
-import com.netflix.spinnaker.keel.ec2.jackson.registerKeelEc2ApiModule
-import com.netflix.spinnaker.keel.test.configuredTestYamlMapper
-import com.netflix.spinnaker.keel.titus.TITUS_CLUSTER_V1
-import com.netflix.spinnaker.keel.titus.jackson.registerKeelTitusApiModule
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
 import strikt.api.expectCatching
 import strikt.assertions.isA
+import strikt.assertions.isEqualTo
 import strikt.assertions.isSuccess
 
+@SpringBootTest
 class ConvertExampleFilesTest : JUnit5Minutests {
-  private val mapper = configuredTestYamlMapper()
-    .registerKeelEc2ApiModule()
-    .registerKeelTitusApiModule()
+  @Autowired
+  lateinit var mapper : YAMLMapper
 
   fun tests() = rootContext<Unit> {
-    before {
-      @Suppress("DEPRECATION")
-      mapper.registerSubtypes(EC2_CLUSTER_V1.toNamedType())
-      mapper.registerSubtypes(EC2_CLUSTER_V1_1.toNamedType())
-      mapper.registerSubtypes(EC2_SECURITY_GROUP_V1.toNamedType())
-      mapper.registerSubtypes(EC2_CLASSIC_LOAD_BALANCER_V1.toNamedType())
-      mapper.registerSubtypes(EC2_APPLICATION_LOAD_BALANCER_V1_1.toNamedType())
-      mapper.registerSubtypes(TITUS_CLUSTER_V1.toNamedType())
-    }
-
     context("ec2 cluster") {
       val file = this.javaClass.getResource("/examples/cluster-example.yml").readText()
 
@@ -161,7 +146,22 @@ class ConvertExampleFilesTest : JUnit5Minutests {
           .isA<TitusClusterSpec>()
       }
     }
-  }
 
-  private fun SupportedKind<*>.toNamedType(): NamedType = NamedType(specClass, kind.toString())
+    context("titus cluster with test container") {
+      val file = this.javaClass.getResource("/examples/titus-cluster-with-test-container.yml").readText()
+
+      test("yml can be parsed") {
+        expectCatching {
+          mapper.readValue<SubmittedDeliveryConfig>(file)
+        }
+          .isSuccess()
+          .get { environments.first().verifyWith.first() }
+          .isEqualTo(TestContainerVerification(
+            repository="acme/widget",
+            tag="stable",
+            location= Location(account="test", region="us-east-1")
+          ))
+      }
+    }
+  }
 }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -39,8 +39,6 @@ import strikt.assertions.isSuccess
 
 @SpringBootTest
 class ConvertExampleFilesTest : JUnit5Minutests {
-  @Autowired
-  lateinit var mapper : YAMLMapper
 
   fun tests() = rootContext<Unit> {
     context("ec2 cluster") {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -38,7 +38,11 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isSuccess
 
 @SpringBootTest
-class ConvertExampleFilesTest : JUnit5Minutests {
+class ConvertExampleFilesTest @Autowired constructor(
+
+  private val mapper: YAMLMapper
+
+): JUnit5Minutests {
 
   fun tests() = rootContext<Unit> {
     context("ec2 cluster") {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -153,7 +153,7 @@ class ConvertExampleFilesTest @Autowired constructor(
     context("titus cluster with test container") {
       val file = this.javaClass.getResource("/examples/titus-cluster-with-test-container.yml").readText()
 
-      test("yml can be parsed") {
+      test("yaml can be parsed") {
         expectCatching {
           mapper.readValue<SubmittedDeliveryConfig>(file)
         }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ConvertExampleFilesTest.kt
@@ -32,12 +32,13 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 import strikt.api.expectCatching
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isSuccess
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = NONE)
 class ConvertExampleFilesTest @Autowired constructor(
 
   private val mapper: YAMLMapper

--- a/keel-web/src/test/resources/application.properties
+++ b/keel-web/src/test/resources/application.properties
@@ -14,3 +14,5 @@ sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:somepo
 sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.application.name=keel
+keel.plugins.ec2.enabled=true
+keel.plugins.titus.enabled=true

--- a/keel-web/src/test/resources/examples/titus-cluster-with-test-container.yml
+++ b/keel-web/src/test/resources/examples/titus-cluster-with-test-container.yml
@@ -11,7 +11,7 @@ environments:
       regions:
         - name: us-east-1
     resources:
-      - kind: ec2/cluster@v1.1
+      - kind: titus/cluster@v1
         spec:
           moniker:
              app: acme

--- a/keel-web/src/test/resources/examples/titus-cluster-with-test-container.yml
+++ b/keel-web/src/test/resources/examples/titus-cluster-with-test-container.yml
@@ -1,0 +1,26 @@
+---
+application: acme
+artifacts:
+  - name: rocketskates
+    type: docker
+    reference: rocketskates
+environments:
+  - name: test
+    locations:
+      account: test
+      regions:
+        - name: us-east-1
+    resources:
+      - kind: ec2/cluster@v1.1
+        spec:
+          moniker:
+             app: acme
+          container:
+            reference: rocketskates
+    verifyWith:
+      - type: test-container
+        repository: acme/widget
+        tag: stable
+        location:
+          account: test
+          region: us-east-1


### PR DESCRIPTION
This PR has two changes:

1. Add a test that parses delivery config with `verifyWith`
2. Use Spring framework to instantiate the beans necessary for configuring the Jackson deserialization

The motivation for 2 is to help us catch potential incorrect Spring configuration issues, by having the delivery-config-loading tests execute the same startup code as keel uses when it starts up on its own. The downside is that these tests will run a little slower.

I had to explicitly enable the ec2 and titus plugins in the application.properties used by the tests so that the ec2 and titus resource handlers and spec migrators would register the appropriate types with the Jackson object mapper.