### PR TITLE
fix sub-query that did not return a unique row

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -58,7 +58,12 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
           DockerArtifact(
             name = "fnord",
             deliveryConfigName = "fnord-manifest",
-            reference = "fnord-docker"
+            reference = "fnord-docker-stable"
+          ),
+          DockerArtifact(
+            name = "fnord",
+            deliveryConfigName = "fnord-manifest",
+            reference = "fnord-docker-unstable"
           )
         ),
         environments = setOf(
@@ -69,7 +74,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         )
       ),
       environmentName = "test",
-      artifactReference = "fnord-docker",
+      artifactReference = "fnord-docker-stable",
       version = "fnord-0.190.0-h378.eacb135"
     )
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.sql
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Verification
-import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
@@ -130,7 +129,7 @@ class SqlVerificationRepository(
         )
         .from(VERIFICATION_STATE)
         .where(VERIFICATION_STATE.ENVIRONMENT_UID.eq(environmentUid))
-        .and(VERIFICATION_STATE.ARTIFACT_UID.eq(artifact.uid))
+        .and(VERIFICATION_STATE.ARTIFACT_UID.eq(artifactUid))
         .and(VERIFICATION_STATE.ARTIFACT_VERSION.eq(version))
         .and(VERIFICATION_STATE.VERIFICATION_ID.eq(verification.id))
         .fetchOneInto<VerificationState>()
@@ -149,7 +148,7 @@ class SqlVerificationRepository(
         )
           .from(VERIFICATION_STATE)
           .where(VERIFICATION_STATE.ENVIRONMENT_UID.eq(environmentUid))
-          .and(VERIFICATION_STATE.ARTIFACT_UID.eq(artifact.uid))
+          .and(VERIFICATION_STATE.ARTIFACT_UID.eq(artifactUid))
           .and(VERIFICATION_STATE.ARTIFACT_VERSION.eq(version))
           .fetch()
           .associate { (id, status, started_at, ended_at, metadata) ->
@@ -171,7 +170,7 @@ class SqlVerificationRepository(
         .set(VERIFICATION_STATE.METADATA, metadata)
         .set(status.timestampColumn, currentTimestamp())
         .set(VERIFICATION_STATE.ENVIRONMENT_UID, environmentUid)
-        .set(VERIFICATION_STATE.ARTIFACT_UID, artifact.uid)
+        .set(VERIFICATION_STATE.ARTIFACT_UID, artifactUid)
         .set(VERIFICATION_STATE.ARTIFACT_VERSION, version)
         .set(VERIFICATION_STATE.VERIFICATION_ID, verification.id)
         .onDuplicateKeyUpdate()
@@ -193,9 +192,9 @@ class SqlVerificationRepository(
       .and(ENVIRONMENT.NAME.eq(environment.name))
       .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
 
-  private val DeliveryArtifact.uid: Select<Record1<String>>
+  private val VerificationContext.artifactUid: Select<Record1<String>>
     get() = select(DELIVERY_ARTIFACT.UID)
       .from(DELIVERY_ARTIFACT)
-      .where(DELIVERY_ARTIFACT.NAME.eq(name))
-      .and(DELIVERY_ARTIFACT.TYPE.eq(type))
+      .where(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
+      .and(DELIVERY_ARTIFACT.REFERENCE.eq(artifactReference))
 }

--- a/keel-sql/src/main/resources/db/changelog/20201219-add-artifact-unique-index.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201219-add-artifact-unique-index.yml
@@ -6,7 +6,12 @@ databaseChangeLog:
     - dropIndex:
         tableName: delivery_artifact
         indexName: delivery_artifact_byref_idx
-    - addUniqueConstraint:
+    - createIndex:
         tableName: delivery_artifact
-        columnNames: delivery_config_name, reference
-        constraintName: delivery_artifact_byref_idx
+        indexName: delivery_artifact_byref_idx
+        columns:
+        - column:
+            name: delivery_config_name
+        - column:
+            name: reference
+        unique: true

--- a/keel-sql/src/main/resources/db/changelog/20201219-add-artifact-unique-index.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201219-add-artifact-unique-index.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+- changeSet:
+    id: add-artifact-unique-index
+    author: fletch
+    changes:
+    - dropIndex:
+        tableName: delivery_artifact
+        indexName: delivery_artifact_byref_idx
+    - addUniqueConstraint:
+        tableName: delivery_artifact
+        columnNames: delivery_config_name, reference
+        constraintName: delivery_artifact_byref_idx

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -218,3 +218,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201218-add-environment-verify-with.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20201219-add-artifact-unique-index.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -62,7 +62,7 @@ internal class SqlVerificationRepositoryTests :
     )
 
   override fun VerificationContext.setup() {
-    artifactRepository.register(artifact)
+    deliveryConfig.artifacts.forEach(artifactRepository::register)
     deliveryConfigRepository.store(deliveryConfig)
     artifactRepository.storeArtifactVersion(
       PublishedArtifact(


### PR DESCRIPTION
I incorrectly assumed that `name` / `type` was a unique index on `delivery_artifact` but it is not. I've changed the query to use `delivery_config_name` and `reference` instead. I also upgraded that index to a unique one as it was not before, but it should be.