### PR TITLE
fix incorrect column type in verification_state

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20201220-fix-verification-state-columns.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201220-fix-verification-state-columns.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+- changeSet:
+    id: fix-verification-state-columns
+    author: fletch
+    changes:
+    - modifyDataType:
+        tableName: verification_state
+        columnName: artifact_version
+        newDataType: varchar(255)

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -221,3 +221,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201219-add-artifact-unique-index.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20201220-fix-verification-state-columns.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Dumb copy 'n paste error. The `artifact_version` column is not a ULID.