### PR TITLE
still update environment_last_verified if delivery config load fails

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20201221-shorten-environment-last-verified-pk.yml
+++ b/keel-sql/src/main/resources/db/changelog/20201221-shorten-environment-last-verified-pk.yml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+- changeSet:
+    id: shorten-environment-last-verified-pk
+    author: fletch
+    changes:
+    - dropAllForeignKeyConstraints:
+        baseTableName: environment_last_verified
+    - delete:
+        tableName: environment_last_verified
+    - dropPrimaryKey:
+        tableName: environment_last_verified
+    - addForeignKeyConstraint:
+        baseTableName: environment_last_verified
+        baseColumnNames: environment_uid
+        constraintName: fk_environment_last_verified_environment
+        referencedTableName: environment
+        referencedColumnNames: uid
+        referencesUniqueColumn: true
+        onDelete: CASCADE
+    - addForeignKeyConstraint:
+        baseTableName: environment_last_verified
+        baseColumnNames: artifact_uid
+        constraintName: fk_environment_last_verified_delivery_artifact
+        referencedTableName: delivery_artifact
+        referencedColumnNames: uid
+        referencesUniqueColumn: true
+        onDelete: CASCADE
+    - addPrimaryKey:
+        tableName: environment_last_verified
+        columnNames: environment_uid, artifact_uid

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -224,3 +224,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201220-fix-verification-state-columns.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20201221-shorten-environment-last-verified-pk.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
If the delivery config failed to load it would roll back the transaction and cause the verification loop to get stuck.