### PR TITLE
allow specification of application for test container cluster

### DIFF
--- a/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/TestContainerVerification.kt
+++ b/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/TestContainerVerification.kt
@@ -10,7 +10,7 @@ data class TestContainerVerification(
   val application: String? = null
 ) : Verification {
   override val type = TYPE
-  override val id = "$repository/$tag"
+  override val id = "$repository:$tag"
 
   companion object {
     const val TYPE = "test-container"

--- a/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/TestContainerVerification.kt
+++ b/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/TestContainerVerification.kt
@@ -6,7 +6,8 @@ import com.netflix.spinnaker.keel.api.titus.TitusServerGroup.Location
 data class TestContainerVerification(
   val repository: String,
   val tag: String = "latest",
-  val location: Location
+  val location: Location,
+  val application: String? = null
 ) : Verification {
   override val type = TYPE
   override val id = "$repository/$tag"

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation(project(":keel-test"))
   testImplementation("io.strikt:strikt-jackson")
+  testImplementation("io.strikt:strikt-mockk")
   testImplementation("dev.minutest:minutest")
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   testImplementation("org.funktionale:funktionale-partials")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/batch/ContainerJobConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/batch/ContainerJobConfig.kt
@@ -25,7 +25,6 @@ data class ContainerJobConfig(
     networkMbps = 1024
   ),
   val capacity: Capacity = Capacity(min = 1, max = 1, desired = 1),
-  val serviceAccount: String,
   val credentials: String,
   val entrypoint: String = "",
   val runtimeLimit: Duration = Duration.ofSeconds(2700),

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
@@ -66,17 +66,16 @@ class TestContainerVerificationEvaluator(
         taskLauncher.submitJob(
           type = VERIFICATION,
           subject = "container integration test for ${context.deliveryConfig.application}.${context.environmentName}",
-          description = "Verifying ${context.version} in environment ${context.environmentName} with test container ${verification.repository}/${verification.tag}",
+          description = "Verifying ${context.version} in environment ${context.environmentName} with test container ${verification.repository}:${verification.tag}",
           correlationId = "${supportedVerification.first}:${context.deliveryConfig.application}.${context.environmentName}",
           user = context.deliveryConfig.serviceAccount,
           application = context.deliveryConfig.application,
           notifications = emptySet(),
           stages = listOf(
             ContainerJobConfig(
-              application = context.deliveryConfig.application,
+              application = verification.application ?: context.deliveryConfig.application,
               location = verification.location,
               repository = verification.repository,
-              serviceAccount = context.deliveryConfig.serviceAccount,
               credentials = verification.location.account,
               tag = verification.tag,
               digest = null


### PR DESCRIPTION
Our test suite fails because it runs using its own application rather than as part of keel.