### PR TITLE
feat(delivery-config): use list instead of set for verifications

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
@@ -4,7 +4,7 @@ data class Environment(
   val name: String,
   val resources: Set<Resource<*>> = emptySet(),
   val constraints: Set<Constraint> = emptySet(),
-  val verifyWith: Set<Verification> = emptySet(),
+  val verifyWith: List<Verification> = emptyList(),
   val notifications: Set<NotificationConfig> = emptySet() // applies to each resource
 ) {
   override fun toString(): String = "Environment $name"

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -237,7 +237,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
                   ),
                   ManualJudgementConstraint()
                 ),
-                verifyWith = setOf(
+                verifyWith = listOf(
                   DummyVerification()
                 ),
                 resources = setOf(

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -69,7 +69,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(verification)
+            verifyWith = listOf(verification)
           )
         )
       ),
@@ -106,7 +106,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(verification)
+            verifyWith = listOf(verification)
           )
         )
       ),
@@ -147,7 +147,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(verification)
+            verifyWith = listOf(verification)
           )
         )
       ),
@@ -191,7 +191,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(verification1, verification2)
+            verifyWith = listOf(verification1, verification2)
           )
         )
       ),
@@ -246,7 +246,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(verification)
+            verifyWith = listOf(verification)
           )
         )
       ),

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
@@ -31,7 +31,7 @@ data class SubmittedEnvironment(
   val name: String,
   val resources: Set<SubmittedResource<*>>,
   val constraints: Set<Constraint> = emptySet(),
-  val verifyWith: Set<Verification> = emptySet(),
+  val verifyWith: List<Verification> = emptyList(),
   val notifications: Set<NotificationConfig> = emptySet(),
   @Description("Optional locations that are propagated to any [resources] where they are not specified.")
   val locations: SubnetAwareLocations? = null

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedEnvironmentDeserializer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/serialization/SubmittedEnvironmentDeserializer.kt
@@ -27,7 +27,7 @@ class SubmittedEnvironmentDeserializer : StdNodeBasedDeserializer<SubmittedEnvir
     with(context.mapper) {
       val name = root.path("name").textValue()
       val constraints: Set<Constraint> = convert(root, "constraints") ?: emptySet()
-      val verifyWith: Set<Verification> = convert(root, "verifyWith") ?: emptySet()
+      val verifyWith: List<Verification> = convert(root, "verifyWith") ?: emptyList()
       val notifications: Set<NotificationConfig> = convert(root, "notifications") ?: emptySet()
       val locations: SubnetAwareLocations? = convert(root, "locations")
       val resources: Set<SubmittedResource<*>> = copy().run {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorWithVerificationsTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorWithVerificationsTests.kt
@@ -39,7 +39,7 @@ class DependsOnConstraintEvaluatorWithVerificationsTests : JUnit5Minutests {
     )
     val previousEnvironment = Environment(
       name = "test",
-      verifyWith = setOf(verification)
+      verifyWith = listOf(verification)
     )
 
     val manifest = DeliveryConfig(

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -79,7 +79,7 @@ internal class VerificationRunnerTests {
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(DummyVerification("1"), DummyVerification("2"))
+            verifyWith = listOf(DummyVerification("1"), DummyVerification("2"))
           )
         )
       ),
@@ -112,7 +112,7 @@ internal class VerificationRunnerTests {
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(DummyVerification("1"), DummyVerification("2"))
+            verifyWith = listOf(DummyVerification("1"), DummyVerification("2"))
           )
         )
       ),
@@ -152,7 +152,7 @@ internal class VerificationRunnerTests {
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(DummyVerification("1"), DummyVerification("2"))
+            verifyWith = listOf(DummyVerification("1"), DummyVerification("2"))
           )
         )
       ),
@@ -197,7 +197,7 @@ internal class VerificationRunnerTests {
         environments = setOf(
           Environment(
             name = "test",
-            verifyWith = setOf(DummyVerification("1"), DummyVerification("2"))
+            verifyWith = listOf(DummyVerification("1"), DummyVerification("2"))
           )
         )
       ),

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -348,7 +348,7 @@ class SqlDeliveryConfigRepository(
             resources = resourcesForEnvironment(uid),
             constraints = objectMapper.readValue(constraintsJson),
             notifications = notificationsJson?.let { objectMapper.readValue(it) } ?: emptySet(),
-            verifyWith = verifyWithJson?.let { objectMapper.readValue(it) } ?: emptySet()
+            verifyWith = verifyWithJson?.let { objectMapper.readValue(it) } ?: emptyList()
           )
         }
     } ?: throw OrphanedResourceException(resourceId)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
@@ -87,7 +87,7 @@ internal fun SqlStorageContext.attachDependents(deliveryConfig: DeliveryConfig):
                 notifications = notificationsJson?.let { objectMapper.readValue(it) } ?: emptySet(),
                 verifyWith = verifyWithJson?.let {
                   objectMapper.readValue(it)
-                } ?: emptySet()
+                } ?: emptyList()
               )
             }
             .let { environments ->


### PR DESCRIPTION
## Context

The delivery config supports specifying multiple verificiations. Here's a hypothetical example with two verifications, `test-container` and `wizbang`.

```
environments:
- name: staging
  verifyWith:
  - type: test-container
    repository: acme/mytests
    tag: stable
  - type: wizbang
    power: max
```

## Problem

We expect that there will be scenarios where users will want the verifications to execute sequentially, in the order in which they are specified in the delivery config.

Currently, keel internally represents the collection of verifications as a set, so the ordering is lost.

## Proposed solution

Use a list instead of a set so the ordering in the delivery config is preserved.