### PR TITLE
feat(status): add waiting status

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -166,5 +166,6 @@ enum class ResourceStatus {
   PAUSED,
   RESUMED,
   UNKNOWN,
-  DIFF_NOT_ACTIONABLE
+  DIFF_NOT_ACTIONABLE,
+  WAITING
 }


### PR DESCRIPTION
Back end for https://github.com/spinnaker/deck/pull/8836

Introducing a new status called "waiting" for when a resource was created and then has an resource check unresolvable status. This happens primarily (maybe only) to clusters when there is no approved image. I am updating the status so new customers don't immediately see an error.

I'll re-evaluate this in the future if it turns out that other resources w/o artifacts also hit this condition.