### PR TITLE
use existing ConstraintStatus enum for verifications

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/ConstraintStatus.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/ConstraintStatus.kt
@@ -28,4 +28,6 @@ enum class ConstraintStatus(private val passed: Boolean, private val failed: Boo
 
   fun passes() = passed
   fun failed() = failed
+
+  val complete: Boolean = passes() || failed()
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/VerificationEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/VerificationEvaluator.kt
@@ -1,8 +1,8 @@
 package com.netflix.spinnaker.keel.api.plugins
 
 import com.netflix.spinnaker.keel.api.Verification
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 
 /**
  * A component responsible for performing verification of an [com.netflix.spinnaker.keel.api.Environment].
@@ -18,7 +18,7 @@ interface VerificationEvaluator<VERIFICATION: Verification> {
     context: VerificationContext,
     verification: Verification,
     metadata: Map<String, Any?>
-  ): VerificationStatus
+  ): ConstraintStatus
 
   /**
    * Start running [verification].

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import java.time.Duration
 import java.time.Instant
 
@@ -33,7 +34,7 @@ interface VerificationRepository {
   fun updateState(
     context: VerificationContext,
     verification: Verification,
-    status: VerificationStatus,
+    status: ConstraintStatus,
     metadata: Map<String, Any?> = emptyMap()
   )
 
@@ -41,7 +42,7 @@ interface VerificationRepository {
 }
 
 data class VerificationState(
-  val status: VerificationStatus,
+  val status: ConstraintStatus,
   val startedAt: Instant,
   val endedAt: Instant?,
   /**
@@ -49,10 +50,6 @@ data class VerificationState(
    */
   val metadata: Map<String, Any?> = emptyMap()
 )
-
-enum class VerificationStatus(val complete: Boolean) {
-  RUNNING(false), PASSED(true), FAILED(true)
-}
 
 data class VerificationContext(
   val deliveryConfig: DeliveryConfig,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
@@ -3,14 +3,18 @@ package com.netflix.spinnaker.keel.constraints
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_PASS
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
 import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator.Companion.getConstraintForEnvironment
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.*
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import org.slf4j.LoggerFactory
@@ -69,13 +73,13 @@ class DependsOnConstraintEvaluator(
       .map { it.id }
       .all { id ->
         when (states[id]?.status) {
-          PASSED -> true.also {
+          PASS, OVERRIDE_PASS -> true.also {
             log.info("verification ($id) passed against version $version for app ${deliveryConfig.application}")
           }
-          FAILED -> false.also {
+          FAIL, OVERRIDE_FAIL -> false.also {
             log.info("verification ($id) failed against version $version for app ${deliveryConfig.application}")
           }
-          RUNNING -> false.also {
+          NOT_EVALUATED, PENDING -> false.also {
             log.info("verification ($id) still running against version $version for app ${deliveryConfig.application}")
           }
           null -> false.also {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -3,8 +3,8 @@ package com.netflix.spinnaker.keel.telemetry
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType
 import java.time.Duration
 
@@ -104,12 +104,12 @@ data class VerificationCompleted(
   val artifactType: ArtifactType,
   val artifactVersion: String,
   val verificationType: String,
-  val status: VerificationStatus
+  val status: ConstraintStatus
 ) : TelemetryEvent() {
   constructor(
     context: VerificationContext,
     verification: Verification,
-    status: VerificationStatus
+    status: ConstraintStatus
   ) : this(
     context.deliveryConfig.application,
     context.deliveryConfig.name,

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorTests.kt
@@ -4,8 +4,6 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
-import com.netflix.spinnaker.keel.api.verification.VerificationState
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorWithVerificationsTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorWithVerificationsTests.kt
@@ -4,10 +4,11 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.*
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
@@ -82,7 +83,7 @@ class DependsOnConstraintEvaluatorWithVerificationsTests : JUnit5Minutests {
           verificationRepository.getStates(
             verContext
           )
-        } returns mapOf("fake-id" to VerificationState(status=PASSED, startedAt=mockk(), endedAt=mockk()))
+        } returns mapOf("fake-id" to VerificationState(status= PASS, startedAt=mockk(), endedAt=mockk()))
       }
 
       test("promotion is allowed") {
@@ -97,7 +98,7 @@ class DependsOnConstraintEvaluatorWithVerificationsTests : JUnit5Minutests {
           verificationRepository.getStates(
             verContext
           )
-        } returns mapOf("fake-id" to VerificationState(status=FAILED, startedAt=mockk(), endedAt=mockk()))
+        } returns mapOf("fake-id" to VerificationState(status=FAIL, startedAt=mockk(), endedAt=mockk()))
       }
 
       test("promotion is not allowed") {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -2,11 +2,11 @@ package com.netflix.spinnaker.keel.sql
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.Verification
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.pause.PauseScope.APPLICATION
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
@@ -162,7 +162,7 @@ class SqlVerificationRepository(
   override fun updateState(
     context: VerificationContext,
     verification: Verification,
-    status: VerificationStatus,
+    status: ConstraintStatus,
     metadata: Map<String, Any?>
   ) {
     with(context) {

--- a/keel-sql/src/main/resources/db/changelog/20210111-update-verification-status-enum.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210111-update-verification-status-enum.yml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+- changeSet:
+    id: update-verification-status-enum
+    author: fletch
+    changes:
+    - update:
+        tableName: verification_state
+        columns:
+        - name: status
+          value: PASS
+        where: status = 'PASSED'
+    - update:
+        tableName: verification_state
+        columns:
+        - name: status
+          value: FAIL
+        where: status = 'FAILED'
+    - update:
+        tableName: verification_state
+        columns:
+        - name: status
+          value: PENDING
+        where: status = 'RUNNING'

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -227,3 +227,6 @@ databaseChangeLog:
   - include:
       file: changelog/20201221-shorten-environment-last-verified-pk.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210111-update-verification-status-enum.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/jooqConfig.xml
+++ b/keel-sql/src/main/resources/jooqConfig.xml
@@ -99,7 +99,7 @@
           <includeExpression>PAUSED\\.SCOPE</includeExpression>
         </forcedType>
         <forcedType>
-          <userType>com.netflix.spinnaker.keel.api.verification.VerificationStatus</userType>
+          <userType>com.netflix.spinnaker.keel.api.constraints.ConstraintStatus</userType>
           <enumConverter>true</enumConverter>
           <includeExpression>VERIFICATION_STATE\\.STATUS</includeExpression>
         </forcedType>

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
@@ -3,13 +3,13 @@ package com.netflix.spinnaker.keel.titus.verification
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.actuation.SubjectType.VERIFICATION
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
 import com.netflix.spinnaker.keel.api.plugins.VerificationEvaluator
 import com.netflix.spinnaker.keel.api.titus.TestContainerVerification
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.FAILED
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.PASSED
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.RUNNING
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.titus.batch.ContainerJobConfig
 import com.netflix.spinnaker.keel.titus.batch.createRunJobStage
@@ -35,7 +35,7 @@ class TestContainerVerificationEvaluator(
     context: VerificationContext,
     verification: Verification,
     metadata: Map<String, Any?>
-  ): VerificationStatus {
+  ): ConstraintStatus {
     val taskId = metadata[TASK_ID]
     require(taskId is String) {
       "No task id found in previous verification state"
@@ -48,9 +48,9 @@ class TestContainerVerificationEvaluator(
         .let { response ->
           log.debug("Container test task $taskId status: ${response.status.name}")
           when {
-            response.status.isSuccess() -> PASSED
-            response.status.isIncomplete() -> RUNNING
-            else -> FAILED
+            response.status.isSuccess() -> PASS
+            response.status.isIncomplete() -> PENDING
+            else -> FAIL
           }
         }
     }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluatorTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluatorTests.kt
@@ -3,13 +3,13 @@ package com.netflix.spinnaker.keel.titus.verification
 import com.netflix.spinnaker.keel.api.actuation.SubjectType.VERIFICATION
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
 import com.netflix.spinnaker.keel.api.titus.TestContainerVerification
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroup.Location
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationState
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.FAILED
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.PASSED
-import com.netflix.spinnaker.keel.api.verification.VerificationStatus.RUNNING
 import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
 import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
 import com.netflix.spinnaker.keel.orca.OrcaService
@@ -129,7 +129,7 @@ internal class TestContainerVerificationEvaluatorTests {
       status = taskStatus
     )
 
-    expectThat(subject.evaluate(context, verification, previousState.metadata)) isEqualTo RUNNING
+    expectThat(subject.evaluate(context, verification, previousState.metadata)) isEqualTo PENDING
   }
 
   @ParameterizedTest(name = "verification is considered successful if orca status is {0}")
@@ -153,7 +153,7 @@ internal class TestContainerVerificationEvaluatorTests {
       status = taskStatus
     )
 
-    expectThat(subject.evaluate(context, verification, previousState.metadata)) isEqualTo PASSED
+    expectThat(subject.evaluate(context, verification, previousState.metadata)) isEqualTo PASS
   }
 
   @ParameterizedTest(name = "verification is considered failed if orca status is {0}")
@@ -177,7 +177,7 @@ internal class TestContainerVerificationEvaluatorTests {
       status = taskStatus
     )
 
-    expectThat(subject.evaluate(context, verification, previousState.metadata)) isEqualTo FAILED
+    expectThat(subject.evaluate(context, verification, previousState.metadata)) isEqualTo FAIL
   }
 
   private fun stubTaskLaunch(): String =
@@ -217,7 +217,7 @@ internal class TestContainerVerificationEvaluatorTests {
 
   private fun runningState(taskId: String?) =
     VerificationState(
-      status = RUNNING,
+      status = PENDING,
       startedAt = now().minusSeconds(120),
       endedAt = null,
       metadata = mapOf(TASK_ID to taskId)


### PR DESCRIPTION
In the interests of keeping things small, I thought I'd break this work up. First step is to re-use the enum we already use for constraints. I'm contemplating renaming it but haven't decided to what yet.