### PR TITLE
pass list of certificates to Orca rather than single certificateArn

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -294,7 +294,20 @@ class ApplicationLoadBalancerHandler(
           "isInternal" to internal,
           "idleTimeout" to idleTimeout.seconds,
           "securityGroups" to dependencies.securityGroupNames,
-          "listeners" to listeners,
+          "listeners" to listeners.map {
+            mapOf(
+              "port" to it.port,
+              "protocol" to it.protocol,
+              "rules" to it.rules,
+              "defaultActions" to it.defaultActions,
+            ).run {
+              if (it.certificateArn == null) {
+                this
+              } else {
+                this + mapOf("certificates" to listOf(mapOf("certificateArn" to it.certificateArn)))
+              }
+            }
+          },
           "targetGroups" to targetGroups.map {
             mapOf(
               "name" to it.name,


### PR DESCRIPTION
This is an alternate implementation to #1736 where I'm not changing the ALB spec model, just amending how we pass the cert to Orca.