### PR TITLE
Allow users to retry verification tasks

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -96,7 +96,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
   fun `after initial creation a verification state can be retrieved`(status: ConstraintStatus) {
     context.setup()
 
-    val metadata = mapOf("taskId" to ULID().nextULID())
+    val metadata = mapOf("tasks" to listOf(ULID().nextULID()))
     subject.updateState(context, verification, status, metadata)
 
     expectCatching {
@@ -113,7 +113,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
     context.setup()
 
     subject.updateState(context, verification, PENDING)
-    val metadata = mapOf("taskId" to ULID().nextULID())
+    val metadata = mapOf("tasks" to listOf(ULID().nextULID()))
     subject.updateState(context, verification, PENDING, metadata)
     subject.updateState(context, verification, PASS)
 
@@ -131,7 +131,7 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
     context.setup()
 
     subject.updateState(context, verification, PENDING)
-    val initialMetadata = mapOf("taskId" to ULID().nextULID())
+    val initialMetadata = mapOf("tasks" to listOf(ULID().nextULID()))
     subject.updateState(context, verification, FAIL, initialMetadata)
     val newMetadata = mapOf("overriddenBy" to "flzlem@netflix.com", "comment" to "flaky test!")
     subject.updateState(context, verification, OVERRIDE_PASS, newMetadata)
@@ -150,9 +150,9 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
     context.setup()
 
     subject.updateState(context, verification, PENDING)
-    val initialMetadata = mapOf("tasks" to listOf(mapOf("id" to ULID().nextULID())))
+    val initialMetadata = mapOf("tasks" to listOf(ULID().nextULID()))
     subject.updateState(context, verification, FAIL, initialMetadata)
-    val newMetadata = mapOf("tasks" to listOf(mapOf("id" to ULID().nextULID())))
+    val newMetadata = mapOf("tasks" to listOf(ULID().nextULID()))
     subject.updateState(context, verification, PASS, newMetadata)
 
     expectCatching {

--- a/keel-sql/src/main/resources/db/changelog/20210114-verification-state-task-list.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210114-verification-state-task-list.yml
@@ -7,7 +7,5 @@ databaseChangeLog:
         sql: |-
           update verification_state
           set metadata = json_object(
-            'tasks', json_array(
-              json_object('id', metadata -> '$.taskId')
-            )
+            'tasks', json_array(metadata -> '$.taskId')
           )

--- a/keel-sql/src/main/resources/db/changelog/20210114-verification-state-task-list.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210114-verification-state-task-list.yml
@@ -9,3 +9,4 @@ databaseChangeLog:
           set metadata = json_object(
             'tasks', json_array(metadata -> '$.taskId')
           )
+          where metadata -> '$.taskId' is not null

--- a/keel-sql/src/main/resources/db/changelog/20210114-verification-state-task-list.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210114-verification-state-task-list.yml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+- changeSet:
+    id: update-verification-status-enum
+    author: fletch
+    changes:
+    - sql:
+        sql: |-
+          update verification_state
+          set metadata = json_object(
+            'tasks', json_array(
+              json_object('id', metadata -> '$.taskId')
+            )
+          )

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -230,3 +230,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210111-update-verification-status-enum.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210114-verification-state-task-list.yml
+      relativeToChangelogFile: true

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
@@ -37,7 +37,7 @@ class TestContainerVerificationEvaluator(
     metadata: Map<String, Any?>
   ): ConstraintStatus {
     @Suppress("UNCHECKED_CAST")
-    val taskId = (metadata[TASKS] as List<Map<String, String>>?)?.last()?.get("id")
+    val taskId = (metadata[TASKS] as Iterable<String>?)?.last()
     require(taskId is String) {
       "No task id found in previous verification state"
     }
@@ -86,7 +86,7 @@ class TestContainerVerificationEvaluator(
       }
         .let { task ->
           log.debug("Launched container test task ${task.id} for ${context.deliveryConfig.application} environment ${context.environmentName}")
-          mapOf(TASKS to task.id)
+          mapOf(TASKS to listOf(task.id))
         }
     }
   }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
@@ -36,7 +36,8 @@ class TestContainerVerificationEvaluator(
     verification: Verification,
     metadata: Map<String, Any?>
   ): ConstraintStatus {
-    val taskId = metadata[TASK_ID]
+    @Suppress("UNCHECKED_CAST")
+    val taskId = (metadata[TASKS] as List<Map<String, String>>?)?.last()?.get("id")
     require(taskId is String) {
       "No task id found in previous verification state"
     }
@@ -85,7 +86,7 @@ class TestContainerVerificationEvaluator(
       }
         .let { task ->
           log.debug("Launched container test task ${task.id} for ${context.deliveryConfig.application} environment ${context.environmentName}")
-          mapOf(TASK_ID to task.id)
+          mapOf(TASKS to task.id)
         }
     }
   }
@@ -93,4 +94,4 @@ class TestContainerVerificationEvaluator(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }
 
-internal const val TASK_ID = "taskId"
+internal const val TASKS = "tasks"

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluatorTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluatorTests.kt
@@ -62,7 +62,7 @@ internal class TestContainerVerificationEvaluatorTests {
 
     expectCatching { subject.start(context, verification) }
       .isSuccess()
-      .get(TASK_ID) isEqualTo taskId
+      .get(TASKS) isEqualTo taskId
 
     verify {
       taskLauncher.submitJob(
@@ -220,6 +220,6 @@ internal class TestContainerVerificationEvaluatorTests {
       status = PENDING,
       startedAt = now().minusSeconds(120),
       endedAt = null,
-      metadata = mapOf(TASK_ID to taskId)
+      metadata = mapOf(TASKS to listOf(mapOf("id" to taskId)))
     )
 }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluatorTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluatorTests.kt
@@ -62,7 +62,9 @@ internal class TestContainerVerificationEvaluatorTests {
 
     expectCatching { subject.start(context, verification) }
       .isSuccess()
-      .get(TASKS) isEqualTo taskId
+      .get(TASKS)
+      .isA<Iterable<String>>()
+      .first() isEqualTo taskId
 
     verify {
       taskLauncher.submitJob(
@@ -220,6 +222,6 @@ internal class TestContainerVerificationEvaluatorTests {
       status = PENDING,
       startedAt = now().minusSeconds(120),
       endedAt = null,
-      metadata = mapOf(TASKS to listOf(mapOf("id" to taskId)))
+      metadata = mapOf(TASKS to listOf(taskId))
     )
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/VerificationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/VerificationController.kt
@@ -1,18 +1,22 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_FAIL
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_PASS
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
+import org.springframework.http.HttpStatus.CONFLICT
+import org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY
 import org.springframework.http.MediaType.APPLICATION_JSON_VALUE
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -33,31 +37,83 @@ class VerificationController(
     @RequestHeader("X-SPINNAKER-USER") user: String,
     @PathVariable("application") application: String,
     @PathVariable("environment") environment: String,
-    @RequestBody status: UpdatedVerificationStatus
+    @RequestBody payload: UpdateVerificationStatusRequest
   ) {
-    require(status.status in listOf(OVERRIDE_PASS, OVERRIDE_FAIL)) {
-      "Only override statuses may be set via this endpoint."
+    if (payload.status !in listOf(OVERRIDE_PASS, OVERRIDE_FAIL)) {
+      throw NotOverrideStatus()
     }
+
     VerificationContext(
       deliveryConfig = deliveryConfigRepository.getByApplication(application),
       environmentName = environment,
-      artifactReference = status.artifactReference,
-      version = status.artifactVersion
+      artifactReference = payload.artifactReference,
+      version = payload.artifactVersion
     ).apply {
       verificationRepository.updateState(
         context = this,
-        verification = verification(status.verificationId),
-        status = status.status,
-        mapOf("overriddenBy" to user, "comment" to status.comment)
+        verification = verification(payload.verificationId),
+        status = payload.status,
+        mapOf("overriddenBy" to user, "comment" to payload.comment)
       )
     }
   }
 
-  data class UpdatedVerificationStatus(
+  data class UpdateVerificationStatusRequest(
     val verificationId: String,
     val artifactReference: String,
     val artifactVersion: String,
     val status: ConstraintStatus,
     val comment: String?
   )
+
+  @ResponseStatus(UNPROCESSABLE_ENTITY)
+  private class NotOverrideStatus :
+    RuntimeException("Only override statuses may be set via this endpoint.")
+
+  @PostMapping(
+    path = ["/{application}/environment/{environment}/verifications/retry"],
+    consumes = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE],
+    produces = [APPLICATION_JSON_VALUE, APPLICATION_YAML_VALUE]
+  )
+  @PreAuthorize(
+    """@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #application)
+    and @authorizationSupport.hasServiceAccountAccess('APPLICATION', #application)"""
+  )
+  fun retryVerification(
+    @RequestHeader("X-SPINNAKER-USER") user: String,
+    @PathVariable("application") application: String,
+    @PathVariable("environment") environment: String,
+    @RequestBody payload: RetryVerificationRequest
+  ) {
+    VerificationContext(
+      deliveryConfig = deliveryConfigRepository.getByApplication(application),
+      environmentName = environment,
+      artifactReference = payload.artifactReference,
+      version = payload.artifactVersion
+    ).apply {
+      verificationRepository.getState(
+        context = this,
+        verification = verification(payload.verificationId)
+      )?.apply {
+        if (!status.complete) throw VerificationIncomplete()
+      }
+
+      verificationRepository.updateState(
+        context = this,
+        verification = verification(payload.verificationId),
+        status = NOT_EVALUATED,
+        mapOf("retryRequestedBy" to user)
+      )
+    }
+  }
+
+  data class RetryVerificationRequest(
+    val verificationId: String,
+    val artifactReference: String,
+    val artifactVersion: String
+  )
+
+  @ResponseStatus(CONFLICT)
+  private class VerificationIncomplete :
+    IllegalStateException("Verifications may only be retried once complete.")
 }


### PR DESCRIPTION
- support persistence of multiple task ids in verification state metadata