### PR TITLE
fix(titus): add new env variable

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolver.kt
@@ -1,0 +1,38 @@
+package com.netflix.spinnaker.keel.titus
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+
+/**
+ * A resolver that adds the Spinnaker account as an evn variable
+ * because this happens already in clouddriver
+ * https://github.com/spinnaker/clouddriver/pull/5185/files
+ */
+@Component
+class EnvironmentVariablesResolver(
+  val springEnv: Environment
+) : Resolver<TitusClusterSpec> {
+
+  private val enabled: Boolean
+    get() = springEnv.getProperty("keel.titus.resolvers.environment.enabled", Boolean::class.java, true)
+
+  override val supportedKind = TITUS_CLUSTER_V1
+
+  override fun invoke(resource: Resource<TitusClusterSpec>): Resource<TitusClusterSpec> {
+    if (!enabled) {
+      return resource
+    }
+
+    val env = resource.spec.defaults.env?.toMutableMap() ?: mutableMapOf()
+    val account = resource.spec.locations.account
+    env["SPINNAKER_ACCOUNT"] = account
+
+    val resourceDefaults = resource.spec.defaults.copy(env = env)
+    val newSpec = resource.spec.copy(_defaults = resourceDefaults)
+    return resource.copy(spec = newSpec)
+  }
+}

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolverTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolverTests.kt
@@ -1,0 +1,96 @@
+package com.netflix.spinnaker.keel.titus
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.SimpleLocations
+import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
+import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
+import com.netflix.spinnaker.keel.docker.ReferenceProvider
+import com.netflix.spinnaker.keel.test.resource
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.coEvery
+import io.mockk.mockk
+import org.springframework.core.env.Environment
+import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.isTrue
+
+internal class EnvironmentVariablesResolverTests : JUnit5Minutests {
+  val account = "titus"
+  val baseSpec = TitusClusterSpec(
+    moniker = Moniker(app = "keel", stack = "test"),
+    locations = SimpleLocations(
+      account = account,
+      regions = setOf(SimpleRegionSpec("east"), SimpleRegionSpec("west"))
+    ),
+    container = ReferenceProvider("my-artifact"),
+    _defaults = TitusServerGroupSpec(),
+    overrides = emptyMap()
+  )
+
+  val specWithEnv = TitusClusterSpec(
+    moniker = Moniker(app = "keel", stack = "test"),
+    locations = SimpleLocations(
+      account = account,
+      regions = setOf(SimpleRegionSpec("east"), SimpleRegionSpec("west"))
+    ),
+    container = ReferenceProvider("my-artifact"),
+    _defaults = TitusServerGroupSpec(
+      env = mapOf("my-var" to "woah")
+    ),
+    overrides = emptyMap()
+  )
+
+  val springEnv: Environment = mockk(relaxed = true) {
+    coEvery { getProperty("keel.titus.resolvers.environment.enabled", Boolean::class.java, true) } returns true
+  }
+
+  data class Fixture(val subject: EnvironmentVariablesResolver, val spec: TitusClusterSpec) {
+    val resource = resource(
+      kind = TITUS_CLUSTER_V1.kind,
+      spec = spec
+    )
+    val resolved by lazy { subject(resource) }
+  }
+
+  fun tests() = rootContext<Fixture> {
+    context("basic test") {
+      fixture {
+        Fixture(
+          EnvironmentVariablesResolver(springEnv),
+          baseSpec
+        )
+      }
+
+      test("supports the resource kind") {
+        expectThat(listOf(subject).supporting(resource))
+          .containsExactly(subject)
+      }
+
+      context("spec has no defaults set") {
+        test("env set") {
+          val env = resolved.spec.defaults.env ?: mutableMapOf()
+          expectThat(env.containsKey("SPINNAKER_ACCOUNT")).isTrue()
+        }
+      }
+    }
+
+    context("resource with env vars defined") {
+      fixture {
+        Fixture(
+          EnvironmentVariablesResolver(springEnv),
+          specWithEnv
+        )
+      }
+
+      test("both env vars show up") {
+        val env = resolved.spec.defaults.env ?: mutableMapOf()
+        expectThat(env.containsKey("SPINNAKER_ACCOUNT")).isTrue()
+        expectThat(env.containsKey("my-var")).isTrue()
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
We now add a `SPINNAKER_ACCOUNT` env variable for titus (https://github.com/spinnaker/clouddriver/pull/5185/files). This PR introduces a resolver to add it to specs so that we don't diff forever on it.