### PR TITLE
chore(ops): add missing image regions counter

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -56,6 +56,7 @@ class ImageExistsConstraintEvaluator(
           log.info("Found AMIs for all desired regions for {}", version)
         } else {
           log.warn("Missing regions {} for {}", (vmOptions.regions - it.keys).sorted().joinToString(), version)
+          eventPublisher.publishEvent(MissingRegionsDetected(version))
         }
       }
       .keys.containsAll(vmOptions.regions)
@@ -65,3 +66,6 @@ class ImageExistsConstraintEvaluator(
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 }
+
+data class MissingRegionsDetected(val version: String)
+

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
@@ -5,6 +5,7 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.keel.bakery.artifact.BakeLaunched
 import com.netflix.spinnaker.keel.bakery.artifact.ImageRegionMismatchDetected
 import com.netflix.spinnaker.keel.bakery.artifact.RecurrentBakeDetected
+import com.netflix.spinnaker.keel.bakery.constraint.MissingRegionsDetected
 import org.slf4j.LoggerFactory
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -53,11 +54,22 @@ class BakeryTelemetryListener(private val spectator: Registry) {
     )
   }
 
+  @EventListener(MissingRegionsDetected::class)
+  fun onMissingRegionsDetected(event: MissingRegionsDetected) {
+    spectator.counter(
+      MISSING_REGIONS_DETECTED,
+      listOf(
+        BasicTag("versions", event.version)
+      )
+    )
+  }
+
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   companion object {
     private const val IMAGE_REGION_MISMATCH_DETECTED_ID = "keel.bakery.image.region.mismatch"
     private const val BAKE_LAUNCHED_ID = "keel.bakery.bake.launched"
     private const val RECURRENT_BAKE_DETECTED_ID = "keel.bakery.recurrent.bake.detected"
+    private const val MISSING_REGIONS_DETECTED = "keel.bakery.missing.regions.detected"
   }
 }


### PR DESCRIPTION
We saw a period of time where this was occurring much more frequently than expected. Adding a counter so that we can alert off this.