### PR TITLE
fix(titus): Fix interestingHealthProviderNames in deploy stage

### DIFF
--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterDeployStrategyTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterDeployStrategyTests.kt
@@ -2,11 +2,15 @@ package com.netflix.spinnaker.keel.orca
 
 import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.api.ClusterDeployStrategy.Companion.DEFAULT_WAIT_FOR_INSTANCES_UP
+import com.netflix.spinnaker.keel.api.DeployHealth.NONE
 import com.netflix.spinnaker.keel.api.RedBlack
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import java.time.Duration
 import strikt.api.expectThat
+import strikt.assertions.containsExactly
+import strikt.assertions.get
+import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 
 class ClusterDeployStrategyTests : JUnit5Minutests {
@@ -60,6 +64,21 @@ class ClusterDeployStrategyTests : JUnit5Minutests {
                   "interestingHealthProviderNames" to null
                 )
               )
+          }
+        }
+
+        context("with health strategy set to NONE") {
+          fixture {
+            RedBlack(health = NONE)
+          }
+
+          test("includes specified instance-only health provider") {
+            expectThat(toOrcaJobProperties("Amazon")) {
+              get("interestingHealthProviderNames").isA<List<String>>().containsExactly("Amazon")
+            }
+            expectThat(toOrcaJobProperties("Titus")) {
+              get("interestingHealthProviderNames").isA<List<String>>().containsExactly("Titus")
+            }
           }
         }
       }

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -183,7 +183,7 @@ class TitusClusterHandler(
           val job = when {
             diff.isCapacityOnly() -> diff.resizeServerGroupJob()
             diff.isEnabledOnly() -> diff.disableOtherServerGroupJob(resource, version.toString())
-            else -> diff.upsertServerGroupJob(tagToUse) + resource.spec.deployWith.toOrcaJobProperties("Amazon")
+            else -> diff.upsertServerGroupJob(tagToUse) + resource.spec.deployWith.toOrcaJobProperties("Titus")
           }
 
           val description = when {


### PR DESCRIPTION
We were passing `"Amazon"` instead of `"Titus"` for `interestingHealthProviderNames` in the Titus deploy stage. This fixes that and adds a small test.