### PR TITLE
feat(api): show verifications in API

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Verification.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Verification.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.api
 
 import com.netflix.spinnaker.keel.api.schema.Discriminator
+import com.netflix.spinnaker.keel.api.verification.VerificationState
 
 interface Verification {
   @Discriminator
@@ -13,4 +14,9 @@ interface Verification {
    * in the database.
    */
   val id: String
+
+  /**
+   * Generate a URL that a user can be directed to in order to view the current state of a verification
+   */
+  fun link(state: VerificationState) : String? = null
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
@@ -11,6 +11,8 @@ import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import com.netflix.spinnaker.keel.api.verification.VerificationState
 
 /**
  * A read-only repository for interacting with delivery configs, artifacts, and resources.
@@ -57,6 +59,8 @@ interface KeelReadOnlyRepository {
   fun isRegistered(name: String, type: ArtifactType): Boolean
 
   fun artifactVersions(artifact: DeliveryArtifact, limit: Int = DEFAULT_MAX_ARTIFACT_VERSIONS): List<PublishedArtifact>
+
+  fun getStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>>
 
   fun latestVersionApprovedIn(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, targetEnvironment: String): String?
 

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/persistence/KeelReadOnlyRepository.kt
@@ -60,7 +60,7 @@ interface KeelReadOnlyRepository {
 
   fun artifactVersions(artifact: DeliveryArtifact, limit: Int = DEFAULT_MAX_ARTIFACT_VERSIONS): List<PublishedArtifact>
 
-  fun getStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>>
+  fun getVerificationStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>>
 
   fun latestVersionApprovedIn(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, targetEnvironment: String): String?
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.api.ActionMetadata
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionEnvironmentVerificationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
@@ -165,6 +166,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
     val version5 = "keeldemo-1.0.0-h12.4ea8a9d" // release
     val version6 = "master-h12.4ea8a9d"
     val versionOnly = "0.0.1~dev.8-h8.41595c4"
+
+    val verifications : List<ArtifactVersionEnvironmentVerificationSummary> = emptyList()
 
     val pin1 = EnvironmentArtifactPin(
       targetEnvironment = stagingEnvironment.name, // staging
@@ -481,7 +484,13 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         }
 
         test("we update the status of the old version when we mark the new one deploying") {
-          val v1summary = subject.getArtifactSummaryInEnvironment(manifest, testEnvironment.name, versionedSnapshotDebian.reference, version1)
+          val v1summary = subject.getArtifactSummaryInEnvironment(
+              manifest,
+              testEnvironment.name,
+              versionedSnapshotDebian.reference,
+              version1,
+              verifications
+          )
           expectThat(v1summary)
             .isNotNull()
             .get { state }
@@ -707,10 +716,11 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
         test("get env artifact version shows that artifact is not pinned") {
           val envArtifactSummary = subject.getArtifactSummaryInEnvironment(
-            deliveryConfig = manifest,
-            environmentName = pin1.targetEnvironment,
-            artifactReference = versionedReleaseDebian.reference,
-            version = version4
+              deliveryConfig = manifest,
+              environmentName = pin1.targetEnvironment,
+              artifactReference = versionedReleaseDebian.reference,
+              version = version4,
+              verifications = verifications
           )
           expectThat(envArtifactSummary)
             .isNotNull()
@@ -755,10 +765,11 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
           test("get env artifact version shows that artifact is pinned") {
             val envArtifactSummary = subject.getArtifactSummaryInEnvironment(
-              deliveryConfig = manifest,
-              environmentName = pin1.targetEnvironment,
-              artifactReference = versionedReleaseDebian.reference,
-              version = version4
+                deliveryConfig = manifest,
+                environmentName = pin1.targetEnvironment,
+                artifactReference = versionedReleaseDebian.reference,
+                version = version4,
+                verifications = verifications
             )
             expect {
               that(envArtifactSummary).isNotNull()
@@ -839,10 +850,11 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
 
       test("get env artifact version shows that artifact is vetoed") {
         val envArtifactSummary = subject.getArtifactSummaryInEnvironment(
-          deliveryConfig = manifest,
-          environmentName = stagingEnvironment.name,
-          artifactReference = versionedReleaseDebian.reference,
-          version = version5
+            deliveryConfig = manifest,
+            environmentName = stagingEnvironment.name,
+            artifactReference = versionedReleaseDebian.reference,
+            version = version5,
+            verifications = verifications
         )
         expect {
           that(envArtifactSummary).isNotNull()
@@ -854,10 +866,11 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         subject.deleteVeto(manifest, versionedReleaseDebian, version5, stagingEnvironment.name)
 
         val envArtifactSummary = subject.getArtifactSummaryInEnvironment(
-          deliveryConfig = manifest,
-          environmentName = stagingEnvironment.name,
-          artifactReference = versionedReleaseDebian.reference,
-          version = version5
+            deliveryConfig = manifest,
+            environmentName = stagingEnvironment.name,
+            artifactReference = versionedReleaseDebian.reference,
+            version = version5,
+            verifications = verifications
         )
 
         expectThat(subject.latestVersionApprovedIn(manifest, versionedReleaseDebian, stagingEnvironment.name))

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -51,7 +51,17 @@ data class ArtifactSummaryInEnvironment(
   val vetoed: ActionMetadata? = null,
   val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
   val statelessConstraints: List<StatelessConstraintSummary> = emptyList(),
-  val compareLink: String? = null
+  val compareLink: String? = null,
+  val verifications : List<ArtifactVersionEnvironmentVerificationSummary> = emptyList()
+)
+
+data class ArtifactVersionEnvironmentVerificationSummary(
+  val id: String,
+  val type: String,
+  val status: String,
+  val startedAt: Instant? = null,
+  val completedAt: Instant? = null,
+  val link: String? = null
 )
 
 data class ActionMetadata(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionEnvironmentVerificationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
@@ -247,7 +248,8 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactReference: String,
-    version: String
+    version: String,
+    verifications: List<ArtifactVersionEnvironmentVerificationSummary>
   ): ArtifactSummaryInEnvironment?
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -16,7 +16,9 @@ import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
+import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionEnvironmentVerificationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
@@ -404,9 +406,10 @@ class CombinedRepository(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactReference: String,
-    version: String
+    version: String,
+    verifications: List<ArtifactVersionEnvironmentVerificationSummary>
   ) = artifactRepository.getArtifactSummaryInEnvironment(
-    deliveryConfig, environmentName, artifactReference, version
+    deliveryConfig, environmentName, artifactReference, version, verifications
   )
 
   override fun getArtifactVersionByPromotionStatus(
@@ -430,5 +433,9 @@ class CombinedRepository(
     limit: Int
   ) : Collection<VerificationContext> =
     verificationRepository.nextEnvironmentsForVerification(minTimeSinceLastCheck, limit)
+
+  override fun getStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>> =
+    verificationRepository.getStatesBatch(contexts)
+
   // END VerificationRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -434,7 +434,7 @@ class CombinedRepository(
   ) : Collection<VerificationContext> =
     verificationRepository.nextEnvironmentsForVerification(minTimeSinceLastCheck, limit)
 
-  override fun getStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>> =
+  override fun getVerificationStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>> =
     verificationRepository.getStatesBatch(contexts)
 
   // END VerificationRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -11,8 +11,10 @@ import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.persistence.KeelReadOnlyRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionEnvironmentVerificationSummary
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
@@ -195,7 +197,8 @@ interface KeelRepository : KeelReadOnlyRepository {
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactReference: String,
-    version: String
+    version: String,
+    verifications: List<ArtifactVersionEnvironmentVerificationSummary>
   ): ArtifactSummaryInEnvironment?
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -237,7 +237,7 @@ class ApplicationService(
     val artifactSummaries = deliveryConfig.artifacts.map { artifact ->
       val versions = repository.artifactVersions(artifact, limit)
       val contexts : List<VerificationContext> = deliveryConfig.contexts(artifact, versions)
-      val states = repository.getStatesBatch(contexts)
+      val states = repository.getVerificationStatesBatch(contexts)
       val lookupTable = VerificationStateLookupTable(contexts, states)
 
       val artifactVersionSummaries = versions.map { artifactVersion ->

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -239,6 +239,10 @@ class ApplicationServiceTests : JUnit5Minutests {
       every {
         repository.getPinnedVersion(any(), any(), any())
       } returns null
+
+      every {
+        repository.getStatesBatch(any())
+      } returns emptyList()
     }
 
     context("artifact summaries by application") {
@@ -277,7 +281,7 @@ class ApplicationServiceTests : JUnit5Minutests {
             } returns false
 
             every {
-              repository.getArtifactSummaryInEnvironment(any(), any(), any(), any())
+              repository.getArtifactSummaryInEnvironment(any(), any(), any(), any(), any())
             } returns null
 
           }
@@ -338,7 +342,13 @@ class ApplicationServiceTests : JUnit5Minutests {
 
             // for statuses other than PENDING, we go look for the artifact summary in environment
             every {
-              repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any())
+              repository.getArtifactSummaryInEnvironment(
+                  singleArtifactDeliveryConfig,
+                  any(),
+                  any(),
+                  any(),
+                  any()
+              )
             } answers {
               when (val environment = arg<String>(1)) {
                 "test" -> when (val version = arg<String>(3)) {
@@ -586,7 +596,13 @@ class ApplicationServiceTests : JUnit5Minutests {
             before {
               // for statuses other than PENDING, we go look for the artifact summary in environment
               every {
-                repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any())
+                repository.getArtifactSummaryInEnvironment(
+                    singleArtifactDeliveryConfig,
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
               } answers {
                 val environment = arg<String>(1)
                 when (val version = arg<String>(3)) {
@@ -614,7 +630,13 @@ class ApplicationServiceTests : JUnit5Minutests {
             before {
               // for statuses other than PENDING, we go look for the artifact summary in environment
               every {
-                repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any())
+                repository.getArtifactSummaryInEnvironment(
+                    singleArtifactDeliveryConfig,
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
               } answers {
                 val environment = arg<String>(1)
                 when (val version = arg<String>(3)) {
@@ -642,7 +664,13 @@ class ApplicationServiceTests : JUnit5Minutests {
             before {
               // for statuses other than PENDING, we go look for the artifact summary in environment
               every {
-                repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any())
+                repository.getArtifactSummaryInEnvironment(
+                    singleArtifactDeliveryConfig,
+                    any(),
+                    any(),
+                    any(),
+                    any()
+                )
               } answers {
                 val environment = arg<String>(1)
                 when (val version = arg<String>(3)) {
@@ -694,7 +722,7 @@ class ApplicationServiceTests : JUnit5Minutests {
             } returns false
 
             every {
-              repository.getArtifactSummaryInEnvironment(any(), any(), any(), any())
+              repository.getArtifactSummaryInEnvironment(any(), any(), any(), any(), any())
             } returns null
           }
 
@@ -788,7 +816,7 @@ class ApplicationServiceTests : JUnit5Minutests {
 
             // for statuses other than PENDING, we go look for the artifact summary in environment
             every {
-              repository.getArtifactSummaryInEnvironment(dualArtifactDeliveryConfig, any(), any(), any())
+              repository.getArtifactSummaryInEnvironment(dualArtifactDeliveryConfig, any(), any(), any(), any())
             } answers {
               when (val environment = arg<String>(1)) {
                 "pr" -> when (val version = arg<String>(3)) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -241,7 +241,7 @@ class ApplicationServiceTests : JUnit5Minutests {
       } returns null
 
       every {
-        repository.getStatesBatch(any())
+        repository.getVerificationStatesBatch(any())
       } returns emptyList()
     }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
@@ -180,7 +180,7 @@ class ComparableLinksTests : JUnit5Minutests {
       } returns null
 
       every {
-        repository.getStatesBatch(any())
+        repository.getVerificationStatesBatch(any())
       } returns emptyList()
     }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
@@ -178,6 +178,10 @@ class ComparableLinksTests : JUnit5Minutests {
       every {
         repository.getPinnedVersion(any(), any(), any())
       } returns null
+
+      every {
+        repository.getStatesBatch(any())
+      } returns emptyList()
     }
 
     context("each environment has a current version, and previous versions") {
@@ -205,7 +209,7 @@ class ComparableLinksTests : JUnit5Minutests {
 
         // for statuses other than PENDING, we go look for the artifact summary in environment
         every {
-          repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any())
+          repository.getArtifactSummaryInEnvironment(singleArtifactDeliveryConfig, any(), any(), any(), any())
         } answers {
           when (val environment = arg<String>(1)) {
             "test" -> when (val version = arg<String>(3)) {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -14,6 +14,7 @@ import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.api.ActionMetadata
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.ArtifactVersionEnvironmentVerificationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionStatus
 import com.netflix.spinnaker.keel.core.api.ArtifactVersions
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
@@ -1210,7 +1211,8 @@ class SqlArtifactRepository(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
     artifactReference: String,
-    version: String
+    version: String,
+    verifications: List<ArtifactVersionEnvironmentVerificationSummary>
   ): ArtifactSummaryInEnvironment? {
     return sqlRetry.withRetry(READ) {
 
@@ -1262,7 +1264,8 @@ class SqlArtifactRepository(
             replacedAt = replacedAt,
             replacedBy = replacedBy,
             pinned = pinned,
-            vetoed = vetoed
+            vetoed = vetoed,
+            verifications = verifications
           )
         }
     }


### PR DESCRIPTION
# Problem

Provide the UI with information about the state of verifications for artifact versions in each environment. (For example, what verifications have been run against `keel-0.850.0-h1020.a525f99` in the `prestaging` environment)?

# Implemented solution

In the `/application/{application}` endpoint (called by deck in the environments view), add additional fields to artifact version objects which encode verification summary notification.

In *jq* notation, these verification summaries are found in: `artifacts[].versions[].environments[].verifications`.

## Example output

For the `fnord` app, the API call would be: 

http://gate/managed/application/fnord?entities=resources&entities=artifacts&entities=environments

The  output would looke like this:

```json
{
  "artifacts": [
    {
      "name": "fnord",
      "type": "deb",
      "reference": "fnord",
      "versions": [
        {
          "version": "fnord-0.850.0-h1021.b527f39",
          "environments": [
            {
              "name": "staging",
              "verifications": [
                {
                  "id": "test-container:acme/testcon:stable",
                  "type": "test-container",
                  "status": "PASSED",
                  "startedAt": "2021-01-04T22:31:12.142Z",
                  "completedAt": "2021-01-04T22:52:07.358Z",
                  "link": "http://www.example.com/test-output/abc123"
                }
              ]
            }
          ]
```

## Guide to main code changes

ApplicationService.kt - this is the meat of the change. (to be completed)

ArtifactSummary.kt - the new `ArtifactVersionEnvironmentVerificationSummary` data class maps to the payload in the `verifications` field shown above. 

Verification.kt - Verification interface now has a `link` function for generating a URL where users can learn more about the current state of a verification. This hasn't been implemented yet for test-container verifications (see future work).

The other changes are just plumbing and tests.



## Future work

[ ] Generate the `link` URL to point to the location where container output can be found.