### PR TITLE
fix(artifacts): Don't nest runWithIoContext

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
@@ -69,11 +69,9 @@ class DockerArtifactSupplier(
       throw IllegalArgumentException("Only Docker artifacts are supported by this implementation.")
     }
 
-    return runWithIoContext {
-      findArtifactVersions(artifact)
+    return findArtifactVersions(artifact)
         .sortedWith(artifact.sortingStrategy.comparator)
         .firstOrNull()
-    }
   }
 
   override fun parseDefaultBuildMetadata(artifact: PublishedArtifact, sortingStrategy: SortingStrategy): BuildMetadata? {


### PR DESCRIPTION
# Problem

We're occasionally getting "stuck" instances where all 64 threads in the DefaultDispatcher-worker pool are blocked waiting. 

# Theory of the failure mode

The `DockerArtifactSupplier.getLatestArtifact` method has a `runWithIoContext` block that calls `findArtifactVersions`, which itself has another `runWithIoContext` block where it makes a call to the `CloudDriverService.findDockerImages` suspend function.

I believe the problem occurs when the coroutines/threads get scheduled a certain way:

1. The `ArtifactListener.syncArtifactVersions` scheduled method fires, running on one of the threads in the worker thread pool.
2. This method retrieves *N* Docker artifacts from the repository, where N>64 (64 being the size of the worker thread pool) .
3. This method launches a new coroutine for each artifact, which calls `DockerArtifactSupplier.getLatestArtifact`
4. These coroutines hit the `runWithIoContext` block in `getLatestArtifact`.
5. 63 threads are checked out of the thread pool to execute the `runWithIoContext` block in `getLatestArtifact`.
6. All of these threads call `findArtifactVersions`, hit another `runWithIoContext` block, and are now blocked waiting for a new thread to execute that block.
7. Meanwhile, the top-level thread gets dispatched to a coroutine that calls `DockerArtifactSupplier.getLatestArtifact`. It reaches the `runWithIoContext` block in `getLatestArtifact`, and gets returned to the pool.
8. This top-level thread gets checked out of the pool to execute the block in the previous stage. It hits calls `findArtifactVersions`, hits the `runWithIoContext` block, and now blocks waiting for another thread to be dispatched to run that block.

At this point, all 64 threads are blocked waiting for work that will never happen because there are no threads avaialble to be dispatched to run the `runWithIoContext` block inside of `findArtifactVersions`.

# Proposed solution

I think that removing the outer `runWithIoContext` block should prevent the deadlock situation from occurring. 

