### PR TITLE
fix(diff): Ignore CidrRule description when diffing

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
@@ -15,13 +15,13 @@
  */
 package com.netflix.spinnaker.keel.api.ec2
 
+import com.netflix.spinnaker.keel.api.ExcludedFromDiff
 import com.netflix.spinnaker.keel.api.schema.Literal
 import com.netflix.spinnaker.keel.api.schema.Optional
 
 abstract class SecurityGroupRule {
   abstract val protocol: Protocol
   abstract val portRange: IngressPorts
-  open val description: String? = null
 
   enum class Protocol {
     ALL, TCP, UDP, ICMP
@@ -47,7 +47,8 @@ data class CidrRule(
   override val protocol: Protocol,
   override val portRange: IngressPorts,
   val blockRange: String,
-  override val description: String? = null
+  @get:ExcludedFromDiff
+  val description: String? = null
 ) : SecurityGroupRule()
 
 sealed class IngressPorts


### PR DESCRIPTION
In #1739, I added a `description` property to `SecurityGroupRule`, which was needed to identify security groups reported by CloudDriver associated with a Netflix IP Object in the internal implementation. However, it looks like several of our applications had managed security group rules that were managed by Keel (probably migrated apps), but because there's no such property in the corresponding delivery configs, we could never resolve the delta and kept trying indefinitely.

The fix in this PR is to ignore that property when diffing. I've also moved the property out of the base abstract class and into the `CidrRule` sub-class, which is the only one we care about in the internal implementation.

I've tested this change against the following delivery config and Keel behaves as expected:
```yaml
name: luistest
application: luistest
serviceAccount: managed-delivery-team@netflix.com
artifacts: []
environments:
- name: local
  locations:
    account: test
    regions:
      - name: us-west-2
  resources:
    - kind: "netflix.ec2/security-group@v1"
      spec:
        moniker:
          app: luistest
          stack: local
          detail: keel_local
        description: test
        inboundRules:
        - ipObject: awstest/us-west-2/private
          portRange:
            startPort: 8080
            endPort: 8080
          protocol: tcp
        - ipObject: awstest/us-west-2/private
          portRange:
            startPort: 7070
            endPort: 7070
          protocol: tcp
    - kind: "ec2/security-group@v1"
      spec:
        moniker:
          app: luistest
          stack: local
          detail: reftest
        description: test
        inboundRules:
        - name: luistest-local-keel_local
          portRange:
            startPort: 8080
            endPort: 8080
          protocol: tcp
    - kind: "ec2/security-group@v1"
      spec:
        moniker:
          app: luistest
          stack: local
          detail: cidrtest
        description: test
        inboundRules:
        - blockRange: "100.78.0.0/16"
          portRange:
            startPort: 8080
            endPort: 8080
          protocol: tcp
```