### PR TITLE
reference certificate by name in ALB spec

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ subprojects {
 
       "testImplementation"("org.junit.platform:junit-platform-runner")
       "testImplementation"("org.junit.jupiter:junit-jupiter-api")
+      "testImplementation"("org.junit.jupiter:junit-jupiter-params")
       "testImplementation"("io.mockk:mockk")
       "testImplementation"("org.jacoco:org.jacoco.ant:0.8.5")
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.keel.clouddriver
 
+import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
@@ -32,6 +33,8 @@ interface CloudDriverCache {
   fun credentialBy(name: String): Credential
   fun defaultKeyPairForAccount(account: String) =
     credentialBy(account).attributes["defaultKeyPair"] as String
+  fun certificateByName(name: String): Certificate
+  fun certificateByArn(arn: String): Certificate
 }
 
 class ResourceNotFound(message: String) : IntegrationException(message)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel.clouddriver
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.AmazonLoadBalancer
 import com.netflix.spinnaker.keel.clouddriver.model.ApplicationLoadBalancerModel
+import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.ClassicLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
@@ -196,4 +197,7 @@ interface CloudDriverService {
     @Query("entityId") entityId: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): List<EntityTags>
+
+  @GET("/certificates/aws")
+  suspend fun getCertificates() : List<Certificate>
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Certificate.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Certificate.kt
@@ -1,0 +1,3 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+data class Certificate(val serverCertificateName: String, val arn: String)

--- a/keel-core/keel-core.gradle.kts
+++ b/keel-core/keel-core.gradle.kts
@@ -47,7 +47,5 @@ dependencies {
   testImplementation("dev.minutest:minutest")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.junit.jupiter:junit-jupiter-api")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
 }

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
@@ -3,9 +3,6 @@ package com.netflix.spinnaker.keel.api.ec2
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Listener
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
 import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
@@ -39,10 +36,18 @@ data class ApplicationLoadBalancerSpec(
   data class Listener(
     val port: Int,
     val protocol: String,
-    val certificateArn: String?,
+    val certificate: String? = null,
     val rules: Set<Rule> = emptySet(),
     val defaultActions: Set<Action> = emptySet()
-  )
+  ) {
+    init {
+      if (protocol == "HTTPS") {
+        requireNotNull(certificate) {
+          "HTTPS listeners must specify a certificate"
+        }
+      }
+    }
+  }
 
   data class TargetGroup(
     val name: String,

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ec2.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ec2.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.api.ec2.old.ClusterV1Spec
 import com.netflix.spinnaker.keel.api.plugins.kind
 
@@ -30,7 +31,10 @@ val EC2_SECURITY_GROUP_V1 = kind<SecurityGroupSpec>("ec2/security-group@v1")
 
 val EC2_CLASSIC_LOAD_BALANCER_V1 = kind<ClassicLoadBalancerSpec>("ec2/classic-load-balancer@v1")
 
-val EC2_APPLICATION_LOAD_BALANCER_V1_1 = kind<ApplicationLoadBalancerSpec>("ec2/application-load-balancer@v1.1")
+val EC2_APPLICATION_LOAD_BALANCER_V1_2 = kind<ApplicationLoadBalancerSpec>("ec2/application-load-balancer@v1.2")
 
-@Deprecated("Obsolete version of ALB spec", replaceWith = ReplaceWith("EC2_APPLICATION_LOAD_BALANCER_V1_1"))
+@Deprecated("Obsolete version of ALB spec", replaceWith = ReplaceWith("EC2_APPLICATION_LOAD_BALANCER_V1_2"))
+val EC2_APPLICATION_LOAD_BALANCER_V1_1 = kind<ApplicationLoadBalancerV1_1Spec>("ec2/application-load-balancer@v1.1")
+
+@Deprecated("Obsolete version of ALB spec", replaceWith = ReplaceWith("EC2_APPLICATION_LOAD_BALANCER_V1_2"))
 val EC2_APPLICATION_LOAD_BALANCER_V1 = kind<ApplicationLoadBalancerV1Spec>("ec2/application-load-balancer@v1")

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1Spec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1Spec.kt
@@ -3,12 +3,12 @@ package com.netflix.spinnaker.keel.api.ec2.old
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.ApplicationLoadBalancerOverride
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
 import com.netflix.spinnaker.keel.api.ec2.TargetGroupAttributes
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ApplicationLoadBalancerOverrideV1_1
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ListenerV1_1
 import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
@@ -21,7 +21,7 @@ data class ApplicationLoadBalancerV1Spec(
   override val idleTimeout: Duration = Duration.ofSeconds(60),
   val listeners: Set<ListenerV1_1>,
   val targetGroups: Set<TargetGroupV1>,
-  val overrides: Map<String, ApplicationLoadBalancerOverride> = emptyMap()
+  val overrides: Map<String, ApplicationLoadBalancerOverrideV1_1> = emptyMap()
 ) : LoadBalancerSpec, UnhappyControl {
 
   init {

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1_1Spec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1_1Spec.kt
@@ -3,24 +3,25 @@ package com.netflix.spinnaker.keel.api.ec2.old
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.ApplicationLoadBalancerOverride
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Rule
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
-import com.netflix.spinnaker.keel.api.ec2.TargetGroupAttributes
-import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ListenerV1_1
 import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
 
-data class ApplicationLoadBalancerV1Spec(
+data class ApplicationLoadBalancerV1_1Spec(
   override val moniker: Moniker,
   @Optional override val locations: SubnetAwareLocations,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),
   val listeners: Set<ListenerV1_1>,
-  val targetGroups: Set<TargetGroupV1>,
+  val targetGroups: Set<TargetGroup>,
   val overrides: Map<String, ApplicationLoadBalancerOverride> = emptyMap()
 ) : LoadBalancerSpec, UnhappyControl {
 
@@ -39,26 +40,11 @@ data class ApplicationLoadBalancerV1Spec(
 
   override val id: String = "${locations.account}:$moniker"
 
-  data class TargetGroupV1(
-    val name: String,
-    val targetType: String = "instance",
-    val protocol: String = "HTTP",
+  data class ListenerV1_1(
     val port: Int,
-    val healthCheckEnabled: Boolean = true,
-    val healthCheckTimeoutSeconds: Duration = Duration.ofSeconds(5),
-    val healthCheckPort: Int = 7001,
-    val healthCheckProtocol: String = "HTTP",
-    val healthCheckHttpCode: String = "200-299",
-    val healthCheckPath: String = "/healthcheck",
-    val healthCheckIntervalSeconds: Duration = Duration.ofSeconds(10),
-    val healthyThresholdCount: Int = 10,
-    val unhealthyThresholdCount: Int = 2,
-    val attributes: TargetGroupAttributes = TargetGroupAttributes()
-  ) {
-    init {
-      require(name.length <= 32) {
-        "targetGroup names have a 32 character limit"
-      }
-    }
-  }
+    val protocol: String,
+    val certificateArn: String?,
+    val rules: Set<Rule> = emptySet(),
+    val defaultActions: Set<Action> = emptySet()
+  )
 }

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1_1Spec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1_1Spec.kt
@@ -4,7 +4,6 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.ApplicationLoadBalancerOverride
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Rule
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
@@ -22,7 +21,7 @@ data class ApplicationLoadBalancerV1_1Spec(
   override val idleTimeout: Duration = Duration.ofSeconds(60),
   val listeners: Set<ListenerV1_1>,
   val targetGroups: Set<TargetGroup>,
-  val overrides: Map<String, ApplicationLoadBalancerOverride> = emptyMap()
+  val overrides: Map<String, ApplicationLoadBalancerOverrideV1_1> = emptyMap()
 ) : LoadBalancerSpec, UnhappyControl {
 
   init {
@@ -46,5 +45,11 @@ data class ApplicationLoadBalancerV1_1Spec(
     val certificateArn: String?,
     val rules: Set<Rule> = emptySet(),
     val defaultActions: Set<Action> = emptySet()
+  )
+
+  data class ApplicationLoadBalancerOverrideV1_1(
+    val dependencies: LoadBalancerDependencies? = null,
+    val listeners: Set<ListenerV1_1>? = null,
+    val targetGroups: Set<TargetGroup>? = null
   )
 }

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   testImplementation("org.funktionale:funktionale-partials")
   testImplementation("org.apache.commons:commons-lang3")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
 
   // the following are needed to use keel's real(-ish) Spring configuration
   testImplementation(project(":keel-web")) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.api.ec2.StepScalingPolicy
 import com.netflix.spinnaker.keel.api.ec2.TargetGroupAttributes
 import com.netflix.spinnaker.keel.api.ec2.TargetTrackingPolicy
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.api.ec2.old.ClusterV1Spec
 import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.ApplicationLoadBalancerSpecMixin
@@ -72,7 +73,8 @@ internal object KeelEc2ApiModule : SimpleModule("Keel EC2 API") {
   override fun setupModule(context: SetupContext) {
     with(context) {
       setMixInAnnotations<ApplicationLoadBalancerSpec, ApplicationLoadBalancerSpecMixin>()
-      // same annotations are required for this legacy model, so it can reuse the same mixin
+      // same annotations are required for this legacy models, so they can reuse the same mixin
+      setMixInAnnotations<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpecMixin>()
       setMixInAnnotations<ApplicationLoadBalancerV1Spec, ApplicationLoadBalancerSpecMixin>()
       setMixInAnnotations<BuildInfo, BuildInfoMixin>()
       setMixInAnnotations<ClassicLoadBalancerSpec, ClassicLoadBalancerSpecMixin>()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
@@ -73,7 +73,7 @@ internal object KeelEc2ApiModule : SimpleModule("Keel EC2 API") {
   override fun setupModule(context: SetupContext) {
     with(context) {
       setMixInAnnotations<ApplicationLoadBalancerSpec, ApplicationLoadBalancerSpecMixin>()
-      // same annotations are required for this legacy models, so they can reuse the same mixin
+      // same annotations are required for these legacy models, so they can reuse the same mixin
       setMixInAnnotations<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpecMixin>()
       setMixInAnnotations<ApplicationLoadBalancerV1Spec, ApplicationLoadBalancerSpecMixin>()
       setMixInAnnotations<BuildInfo, BuildInfoMixin>()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2Migrator.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2Migrator.kt
@@ -1,48 +1,59 @@
 package com.netflix.spinnaker.keel.ec2.migrators
 
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
-import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1Spec
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.resources.SpecMigrator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty("keel.plugins.ec2.enabled")
-class ApplicationLoadBalancerV1ToV1_1Migrator : SpecMigrator<ApplicationLoadBalancerV1Spec, ApplicationLoadBalancerV1_1Spec> {
+class ApplicationLoadBalancerV1_1ToV1_2Migrator(
+  private val cloudDriverCache: CloudDriverCache
+) :
+  SpecMigrator<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpec> {
   @Suppress("DEPRECATION")
-  override val input = EC2_APPLICATION_LOAD_BALANCER_V1
-  @Suppress("DEPRECATION")
-  override val output = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val input = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val output = EC2_APPLICATION_LOAD_BALANCER_V1_2
 
-  override fun migrate(spec: ApplicationLoadBalancerV1Spec): ApplicationLoadBalancerV1_1Spec =
-    ApplicationLoadBalancerV1_1Spec(
+  override fun migrate(spec: ApplicationLoadBalancerV1_1Spec): ApplicationLoadBalancerSpec =
+    ApplicationLoadBalancerSpec(
       moniker = spec.moniker,
       locations = spec.locations,
       internal = spec.internal,
       dependencies = spec.dependencies,
       idleTimeout = spec.idleTimeout,
-      listeners = spec.listeners,
-      targetGroups = spec.targetGroups.map {
+      listeners = spec.listeners.mapTo(mutableSetOf()) {
+        ApplicationLoadBalancerSpec.Listener(
+          port = it.port,
+          protocol = it.protocol,
+          certificate = it.certificateArn?.let { cloudDriverCache.certificateByArn(it).serverCertificateName },
+          rules = it.rules,
+          defaultActions = it.defaultActions
+        )
+      },
+      targetGroups = spec.targetGroups.mapTo(mutableSetOf()) {
         TargetGroup(
           name = it.name,
           targetType = it.targetType,
           protocol = it.protocol,
           port = it.port,
           healthCheckEnabled = it.healthCheckEnabled,
-          healthCheckTimeout = it.healthCheckTimeoutSeconds,
+          healthCheckTimeout = it.healthCheckTimeout,
           healthCheckPort = it.healthCheckPort,
           healthCheckProtocol = it.healthCheckProtocol,
           healthCheckHttpCode = it.healthCheckHttpCode,
           healthCheckPath = it.healthCheckPath,
-          healthCheckInterval = it.healthCheckIntervalSeconds,
+          healthCheckInterval = it.healthCheckInterval,
           healthyThresholdCount = it.healthyThresholdCount,
           unhealthyThresholdCount = it.unhealthyThresholdCount,
           attributes = it.attributes
         )
-      }.toSet(),
+      },
       overrides = spec.overrides
     )
 }

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ApplicationLoadBalancerDefaultsResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ApplicationLoadBalancerDefaultsResolver.kt
@@ -3,13 +3,13 @@ package com.netflix.spinnaker.keel.ec2.resolvers
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import org.springframework.stereotype.Component
 
 @Component
 class ApplicationLoadBalancerDefaultsResolver : Resolver<ApplicationLoadBalancerSpec> {
-  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_2
 
   override fun invoke(resource: Resource<ApplicationLoadBalancerSpec>): Resource<ApplicationLoadBalancerSpec> {
     if (resource.spec.listeners.any { it.defaultActions.isEmpty() } || resource.spec.dependencies.securityGroupNames.isEmpty()) {
@@ -31,7 +31,7 @@ class ApplicationLoadBalancerDefaultsResolver : Resolver<ApplicationLoadBalancer
           ApplicationLoadBalancerSpec.Listener(
             port = it.port,
             protocol = it.protocol,
-            certificateArn = it.certificateArn,
+            certificate = it.certificate,
             // TODO: The default rule can only be written via clouddriver as a defaultAction which seems like a bug.
             //  When an ALB is read from clouddriver, the default action appears under both defaultAction and as a rule.
             //  UpsertAmazonLoadBalancerV2Description doesn't allow setting isDefault on Rules which may be the issue.

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
@@ -8,7 +8,7 @@ import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.plugins.Resolver
@@ -75,7 +75,7 @@ class ClassicLoadBalancerNetworkResolver(cloudDriverCache: CloudDriverCache) : N
 
 @Component
 class ApplicationLoadBalancerNetworkResolver(cloudDriverCache: CloudDriverCache) : NetworkResolver<ApplicationLoadBalancerSpec>(cloudDriverCache) {
-  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_2
 
   override fun invoke(resource: Resource<ApplicationLoadBalancerSpec>): Resource<ApplicationLoadBalancerSpec> =
     resource.run {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.HealthSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
@@ -291,7 +291,7 @@ internal class ApplicationLoadBalancerNetworkResolverTests : NetworkResolverTest
   override val createSubject = ::ApplicationLoadBalancerNetworkResolver
 
   override fun createResource(locations: SubnetAwareLocations): Resource<ApplicationLoadBalancerSpec> = resource(
-    kind = EC2_APPLICATION_LOAD_BALANCER_V1_1.kind,
+    kind = EC2_APPLICATION_LOAD_BALANCER_V1_2.kind,
     spec = ApplicationLoadBalancerSpec(
       moniker = Moniker(
         app = "fnord",

--- a/keel-orca/keel-orca.gradle.kts
+++ b/keel-orca/keel-orca.gradle.kts
@@ -39,6 +39,4 @@ dependencies {
   testImplementation("dev.minutest:minutest")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.junit.jupiter:junit-jupiter-api")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
 
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation(project(":keel-test"))
   testImplementation("io.strikt:strikt-jackson")
   testImplementation("io.strikt:strikt-mockk")

--- a/keel-web/src/test/resources/examples/alb-example.yml
+++ b/keel-web/src/test/resources/examples/alb-example.yml
@@ -4,14 +4,14 @@ serviceAccount: delivery-engineering@netflix.com
 environments:
 - name: test
   resources:
-  - kind: ec2/application-load-balancer@v1.1
+  - kind: ec2/application-load-balancer@v1.2
     spec:
       moniker:
         app: fnord
       listeners:
       - port: 443
         protocol: HTTPS
-        certificateArn: arn:aws:iam::111111111111:server-certificate/fnord.prod.illuminati.org-DigiCertSHA2SecureServerCA-20200205-20210205
+        certificate: fnord.prod.illuminati.org-DigiCertSHA2SecureServerCA-20200205-20210205
         defaultActions:
         - type: forward
           order: 1


### PR DESCRIPTION
Instead of requiring users to specify the certificate ARN, we can resolve that from Clouddriver so users can reference the cert by name. This PR adds a new ALB spec version.