### PR TITLE
fix(diff): remove description from SecurityGroupRule

### DIFF
--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/SecurityGroupRule.kt
@@ -15,7 +15,6 @@
  */
 package com.netflix.spinnaker.keel.api.ec2
 
-import com.netflix.spinnaker.keel.api.ExcludedFromDiff
 import com.netflix.spinnaker.keel.api.schema.Literal
 import com.netflix.spinnaker.keel.api.schema.Optional
 
@@ -46,9 +45,7 @@ data class CrossAccountReferenceRule(
 data class CidrRule(
   override val protocol: Protocol,
   override val portRange: IngressPorts,
-  val blockRange: String,
-  @get:ExcludedFromDiff
-  val description: String? = null
+  val blockRange: String
 ) : SecurityGroupRule()
 
 sealed class IngressPorts


### PR DESCRIPTION
Keel is still detecting diffs in security groups that haven't changed, despite the fix introduced in #1755.

This PR removes the description field that was added to a security group model in the hopes that this resolves the regression, so that we can deploy #1754. 