### PR TITLE
use bulk caches where appropriate

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -67,10 +67,11 @@ interface CloudDriverService {
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): SecurityGroupSummary
 
-  @GET("/networks")
+  @GET("/networks/{cloudProvider}")
   suspend fun listNetworks(
+    @Path("cloudProvider") cloudProvider: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
-  ): Map<String, Set<Network>>
+  ): Set<Network>
 
   @GET("/subnets/{cloudProvider}")
   suspend fun listSubnets(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
@@ -57,7 +57,6 @@ class MemoryCloudDriverCache(
           }
       }
         .handleNotFound()
-        ?: notFound("Security group with id $id not found in the $account account and $region region")
     }
 
   private val securityGroupsByName: AsyncLoadingCache<Triple<String, String, String>, SecurityGroupSummary> = cacheFactory
@@ -73,34 +72,31 @@ class MemoryCloudDriverCache(
           }
       }
         .handleNotFound()
-        ?: notFound("Security group with name $name not found in the $account account and $region region")
     }
 
   private val networksById: AsyncLoadingCache<String, Network> = cacheFactory
-    .asyncLoadingCache(cacheName = "networksById") { id ->
+    .asyncBulkLoadingCache(cacheName = "networksById") {
       runCatching {
-        cloudDriver.listNetworks(DEFAULT_SERVICE_ACCOUNT)["aws"]
-          ?.firstOrNull { it.id == id }
-          ?.also {
-            networksByName.put(Triple(it.account, it.region, it.name), completedFuture(it))
-          }
+        cloudDriver.listNetworks("aws", DEFAULT_SERVICE_ACCOUNT)
+          .associateBy { it.id }
       }
-        .handleNotFound()
-        ?: notFound("VPC network with id $id not found")
+        .getOrElse { ex ->
+          throw CacheLoadingException("Error loading networksById cache", ex)
+        }
     }
 
   private val networksByName: AsyncLoadingCache<Triple<String, String, String?>, Network> = cacheFactory
-    .asyncLoadingCache(cacheName = "networksByName") { (account, region, name) ->
+    .asyncBulkLoadingCache(cacheName = "networksByName") {
       runCatching {
         cloudDriver
-          .listNetworks(DEFAULT_SERVICE_ACCOUNT)["aws"]
-          ?.firstOrNull { it.name == name && it.account == account && it.region == region }
-          ?.also {
-            networksById.put(it.id, completedFuture(it))
+          .listNetworks("aws", DEFAULT_SERVICE_ACCOUNT)
+          .associateBy {
+            Triple(it.account, it.region, it.name)
           }
       }
-        .handleNotFound()
-        ?: notFound("VPC network named $name not found in $region")
+        .getOrElse { ex ->
+          throw CacheLoadingException("Error loading networksByName cache", ex)
+        }
     }
 
   private data class AvailabilityZoneKey(
@@ -122,7 +118,7 @@ class MemoryCloudDriverCache(
           .toSet()
       }
         .getOrElse { ex ->
-          throw CacheLoadingException("Error loading cache", ex)
+          throw CacheLoadingException("Error loading availabilityZones cache", ex)
         }
     }
 
@@ -134,106 +130,99 @@ class MemoryCloudDriverCache(
         cloudDriver.getCredential(name, DEFAULT_SERVICE_ACCOUNT)
       }
         .handleNotFound()
-        ?: notFound("Credentials with name $name not found")
     }
 
   private val subnetsById: AsyncLoadingCache<String, Subnet> = cacheFactory
-    .asyncLoadingCache(cacheName = "subnetsById") { subnetId ->
+    .asyncBulkLoadingCache(cacheName = "subnetsById") {
       runCatching {
         cloudDriver
           .listSubnets("aws", DEFAULT_SERVICE_ACCOUNT)
-          .find { it.id == subnetId }
+          .associateBy { it.id }
       }
-        .handleNotFound()
-        ?: notFound("Subnet with id $subnetId not found")
+        .getOrElse { ex -> throw CacheLoadingException("Error loading subnetsById cache", ex) }
     }
 
-  private val subnetsByPurpose: AsyncLoadingCache<Triple<String, String, String>, Subnet> = cacheFactory
-    .asyncLoadingCache(cacheName = "subnetsByPurpose") { (account, region, purpose) ->
+  private val subnetsByPurpose: AsyncLoadingCache<Triple<String, String, String?>, Subnet> = cacheFactory
+    .asyncBulkLoadingCache(cacheName = "subnetsByPurpose") {
       runCatching {
         cloudDriver
           .listSubnets("aws", DEFAULT_SERVICE_ACCOUNT)
-          .find { it.account == account && it.region == region && it.purpose == purpose }
+          .associateBy { Triple(it.account, it.region, it.purpose) }
       }
-        .handleNotFound()
-        ?: notFound("Subnet with purpose \"$purpose\" not found in $account:$region")
+        .getOrElse { ex -> throw CacheLoadingException("Error loading subnetsByPurpose cache", ex) }
     }
 
   private val certificatesByName: AsyncLoadingCache<String, Certificate> =
     cacheFactory
-      .asyncLoadingCache("certificatesByName") { name ->
+      .asyncBulkLoadingCache("certificatesByName") {
         runCatching {
           cloudDriver
             .getCertificates()
-            .find { it.serverCertificateName == name }
-            ?.also {
-              certificatesByArn.put(it.arn, completedFuture(it))
-            }
+            .associateBy { it.serverCertificateName }
         }
-          .handleNotFound()
-          ?: notFound("Certificate with name $name not found")
+          .getOrElse { ex -> throw CacheLoadingException("Error loading certificatesByName cache", ex) }
       }
 
   private val certificatesByArn: AsyncLoadingCache<String, Certificate> =
     cacheFactory
-      .asyncLoadingCache("certificatesByArn") { arn ->
+      .asyncBulkLoadingCache("certificatesByArn") {
         runCatching {
           cloudDriver
             .getCertificates()
-            .find { it.arn == arn }
-            ?.also {
-              certificatesByName.put(it.serverCertificateName, completedFuture(it))
-            }
+            .associateBy { it.arn }
         }
-          .handleNotFound()
-          ?: notFound("Certificate with ARN $arn not found")
+          .getOrElse { ex -> throw CacheLoadingException("Error loading certificatesByArn cache", ex) }
       }
 
   override fun credentialBy(name: String): Credential =
     runBlocking {
-      credentials.get(name).await()
+      credentials.get(name).await() ?: notFound("Credential with name $name not found")
     }
 
   override fun securityGroupById(account: String, region: String, id: String): SecurityGroupSummary =
     runBlocking {
-      securityGroupsById.get(Triple(account, region, id)).await()
+      securityGroupsById.get(Triple(account, region, id)).await()?: notFound("Security group with id $id not found in $account:$region")
     }
 
   override fun securityGroupByName(account: String, region: String, name: String): SecurityGroupSummary =
     runBlocking {
-      securityGroupsByName.get(Triple(account, region, name)).await()
+      securityGroupsByName.get(Triple(account, region, name)).await()?: notFound("Security group with name $name not found in $account:$region")
     }
 
   override fun networkBy(id: String): Network =
     runBlocking {
-      networksById.get(id).await()
+      networksById.get(id).await() ?: notFound("VPC network with id $id not found")
     }
 
   override fun networkBy(name: String?, account: String, region: String): Network =
     runBlocking {
-      networksByName.get(Triple(account, region, name)).await()
+      networksByName.get(Triple(account, region, name)).await() ?: notFound("VPC network named $name not found in $account:$region")
     }
 
   override fun availabilityZonesBy(account: String, vpcId: String, purpose: String, region: String): Set<String> =
     runBlocking {
-      availabilityZones.get(AvailabilityZoneKey(account, region, vpcId, purpose)).await()
+      availabilityZones.get(AvailabilityZoneKey(account, region, vpcId, purpose)).await() ?: notFound("Availability zone with purpose \"$purpose\" not found in $account:$region")
     }
 
   override fun subnetBy(subnetId: String): Subnet =
     runBlocking {
-      subnetsById.get(subnetId).await()
+      subnetsById.get(subnetId).await() ?: notFound("Subnet with id $subnetId not found")
     }
 
   override fun subnetBy(account: String, region: String, purpose: String): Subnet =
     runBlocking {
-      subnetsByPurpose.get(Triple(account, region, purpose)).await()
+      subnetsByPurpose.get(Triple(account, region, purpose)).await() ?: notFound("Subnet with purpose \"$purpose\" not found in $account:$region")
     }
 
   override fun certificateByName(name: String): Certificate =
-    runBlocking { certificatesByName.get(name).await() }
+    runBlocking {
+      certificatesByName.get(name).await() ?: notFound("Certificate with name $name not found")
+    }
 
   override fun certificateByArn(arn: String): Certificate =
-    runBlocking { certificatesByArn.get(arn).await() }
+    runBlocking {
+      certificatesByArn.get(arn).await() ?: notFound("Certificate with ARN $arn not found")
+    }
 }
 
 /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/caffeine/CacheFactory.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/caffeine/CacheFactory.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.future.future
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.function.BiFunction
+import java.util.function.Function
 
 @Component
 @EnableConfigurationProperties(CacheProperties::class)
@@ -27,7 +31,7 @@ class CacheFactory(
    * Builds an instrumented cache configured with values from [cacheProperties] or the supplied
    * defaults that uses [dispatcher] for computing values for the cache on a miss.
    */
-  fun <K, V> asyncCache(
+  fun <K : Any, V> asyncCache(
     cacheName: String,
     defaultMaximumSize: Long = 1000,
     defaultExpireAfterWrite: Duration = Duration.ofHours(1),
@@ -41,7 +45,7 @@ class CacheFactory(
    * Builds an instrumented cache configured with values from [cacheProperties] or the supplied
    * defaults that uses [dispatcher] for computing values for the cache on a miss.
    */
-  fun <K, V> asyncLoadingCache(
+  fun <K : Any, V> asyncLoadingCache(
     cacheName: String,
     defaultMaximumSize: Long = 1000,
     defaultExpireAfterWrite: Duration = Duration.ofHours(1),
@@ -51,6 +55,24 @@ class CacheFactory(
     builder(cacheName, defaultMaximumSize, defaultExpireAfterWrite, dispatcher)
       .buildAsync(loader.toAsyncCacheLoader())
       .monitor(cacheName)
+
+  /**
+   * Builds an instrumented cache configured with values from [cacheProperties] or the supplied
+   * defaults that uses [dispatcher] for computing values for the cache on a miss.
+   *
+   * Caches created using this method load all entries at once.
+   */
+  fun <K : Any, V> asyncBulkLoadingCache(
+    cacheName: String,
+    defaultMaximumSize: Long = 1000,
+    defaultExpireAfterWrite: Duration = Duration.ofHours(1),
+    dispatcher: CoroutineDispatcher = IO,
+    loader: suspend () -> Map<K, V>
+  ): AsyncLoadingCache<K, V> =
+    builder(cacheName, defaultMaximumSize, defaultExpireAfterWrite, dispatcher)
+      .buildAsync(loader.toAsyncBulkCacheLoader())
+      .monitor(cacheName)
+      .let { AsyncBulkLoadingCache(it) }
 
   private fun builder(
     cacheName: String,
@@ -66,15 +88,49 @@ class CacheFactory(
         .recordStats()
     }
 
-  private fun <K, V, C: AsyncCache<K, V>> C.monitor(cacheName: String) =
+  private fun <K, V, C : AsyncCache<K, V>> C.monitor(cacheName: String) =
     CaffeineCacheMetrics.monitor(meterRegistry, this, cacheName)
 }
 
-fun <K, V> (suspend (K) -> V?).toAsyncCacheLoader() : AsyncCacheLoader<K, V> =
+fun <K : Any, V> (suspend (K) -> V?).toAsyncCacheLoader(): AsyncCacheLoader<K, V> =
   AsyncCacheLoader<K, V> { key, executor ->
     CoroutineScope(executor.asCoroutineDispatcher())
       .future { this@toAsyncCacheLoader.invoke(key) }
   }
+
+fun <K : Any, V> (suspend () -> Map<K, V>).toAsyncBulkCacheLoader(): AsyncCacheLoader<K, V> =
+  object : AsyncCacheLoader<K, V> {
+    override fun asyncLoad(key: K, executor: Executor): CompletableFuture<V> {
+      throw UnsupportedOperationException()
+    }
+
+    override fun asyncLoadAll(
+      keys: Iterable<K>,
+      executor: Executor
+    ): CompletableFuture<Map<K, V>> =
+      CoroutineScope(executor.asCoroutineDispatcher())
+        .future { this@toAsyncBulkCacheLoader.invoke() }
+  }
+
+/**
+ * An implementation of [AsyncLoadingCache] that _always_ uses [AsyncCacheLoader.asyncLoadAll] to
+ * populate the cache.
+ */
+private class AsyncBulkLoadingCache<K : Any, V>(delegate: AsyncLoadingCache<K, V>) :
+  AsyncLoadingCache<K, V> by delegate {
+  override fun get(key: K): CompletableFuture<V> = getAll(listOf(key)).thenApply { it[key] }
+
+  override fun get(key: K, mappingFunction: Function<in K, out V>): CompletableFuture<V> {
+    throw UnsupportedOperationException()
+  }
+
+  override fun get(
+    key: K,
+    mappingFunction: BiFunction<in K, Executor, CompletableFuture<V>>
+  ): CompletableFuture<V> {
+    throw UnsupportedOperationException()
+  }
+}
 
 /**
  * A [CacheFactory] usable in tests that uses no-op metering and default configuration.

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -66,13 +66,13 @@ internal class AuthPropagationTests
   ) {
     val server = MockWebServer()
 
-    private var _listNetworksResults: Map<String, Set<Network>>? = null
-    val listNetworksResults: Map<String, Set<Network>>
+    private var _listNetworksResults: Set<Network>? = null
+    val listNetworksResults: Set<Network>
       get() = checkNotNull(_listNetworksResults) { "You need to actually make a call first" }
 
     fun listNetworks() {
       _listNetworksResults = runBlocking {
-        cloudDriverService.listNetworks()
+        cloudDriverService.listNetworks("aws")
       }
     }
   }
@@ -92,7 +92,7 @@ internal class AuthPropagationTests
 
     context("a call to Clouddriver") {
       before {
-        server.enqueue(MockResponse().setBody("{}"))
+        server.enqueue(MockResponse().setBody("[]"))
 
         listNetworks()
       }


### PR DESCRIPTION
Some CloudDriver endpoints return all data at once, rather than a specific item. This PR updates our CloudDriver caches to take that into account. This should result in more efficient cache utilization as we won't keep making the same CloudDriver call the first time each key is hit -- we'll make the call just once for the first key.