### PR TITLE
fix(lifecycle): only show event if it has a valid link

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
@@ -141,7 +141,11 @@ class SqlLifecycleEventRepository(
         }
         step = step.copy(status = lastEvent.status)
       }
-      steps.add(step)
+
+      // only add the step if we have a valid link
+      if (step.link?.startsWith("http") == true) {
+        steps.add(step)
+      }
     }
 
     spectator.timer(


### PR DESCRIPTION
@luispollo recently discovered that if you're exicitedly waiting for a build or bake to show up, and you click the button too fast, the link is broken. This happens because the first event we receive usually has a "link" that is malformed. the individual monitors know how to translate that into a clickable link (it's designed like this so that we don't have to inject the base spinnaker URL everywhere). This PR updates our logic so that if we end up having one of these incomplete links we don't show it to the user. 