### PR TITLE
chore(veto): new endpoints for marking bad/good

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ApplicationController.kt
@@ -215,6 +215,38 @@ class ApplicationController(
     applicationService.markAsVetoedIn(user, application, veto, true)
   }
 
+  @PostMapping(
+    path = ["/{application}/mark/bad"]
+  )
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  @PreAuthorize(
+    """@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #application)
+    and @authorizationSupport.hasServiceAccountAccess('APPLICATION', #application)"""
+  )
+  fun markAsBad(
+    @RequestHeader("X-SPINNAKER-USER") user: String,
+    @PathVariable("application") application: String,
+    @RequestBody veto: EnvironmentArtifactVeto
+  ) {
+    applicationService.markAsVetoedIn(user, application, veto, true)
+  }
+
+  @PostMapping(
+    path = ["/{application}/mark/good"]
+  )
+  @ResponseStatus(HttpStatus.ACCEPTED)
+  @PreAuthorize(
+    """@authorizationSupport.hasApplicationPermission('WRITE', 'APPLICATION', #application)
+    and @authorizationSupport.hasServiceAccountAccess('APPLICATION', #application)"""
+  )
+  fun markAsGood(
+    @RequestHeader("X-SPINNAKER-USER") user: String,
+    @PathVariable("application") application: String,
+    @RequestBody veto: EnvironmentArtifactVeto
+  ) {
+    applicationService.deleteVeto(application, veto.targetEnvironment, veto.reference, veto.version)
+  }
+
   @DeleteMapping(
     path = ["/{application}/veto/{targetEnvironment}/{reference}/{version}"]
   )


### PR DESCRIPTION
We use "mark as bad" in the UI for the concept of vetoing an artifact. I've noticed that it's continually hard to identify the right endpoint to use. I created a "../mark/bad" endpoint to help fix this.

Also, the "un-veto" or "mark as good" endpoint currently breaks when artifact references have a slash in them. I've created a "../mark/good" endpoint with the same semantics as the "../mark/bad" endpoint to get around this (I already tried messing with the retrofit and spring configuration to allow slashes, but I couldn't get it to work). I feel like it's not technically correct REST semantic wise (we are 'deleting' a veto), but it seems reasonable and consistent with how we talk about what we are doing.