### PR TITLE
Check certificate validity against Lemur and update if expired

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ subprojects {
 
       "testImplementation"("org.junit.platform:junit-platform-runner")
       "testImplementation"("org.junit.jupiter:junit-jupiter-api")
+      "testImplementation"("org.junit.jupiter:junit-jupiter-params")
       "testImplementation"("io.mockk:mockk")
       "testImplementation"("org.jacoco:org.jacoco.ant:0.8.5")
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.keel.clouddriver
 
+import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
@@ -32,6 +33,8 @@ interface CloudDriverCache {
   fun credentialBy(name: String): Credential
   fun defaultKeyPairForAccount(account: String) =
     credentialBy(account).attributes["defaultKeyPair"] as String
+  fun certificateByName(name: String): Certificate
+  fun certificateByArn(arn: String): Certificate
 }
 
 class ResourceNotFound(message: String) : IntegrationException(message)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel.clouddriver
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.AmazonLoadBalancer
 import com.netflix.spinnaker.keel.clouddriver.model.ApplicationLoadBalancerModel
+import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.ClassicLoadBalancerModel
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
@@ -66,10 +67,11 @@ interface CloudDriverService {
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): SecurityGroupSummary
 
-  @GET("/networks")
+  @GET("/networks/{cloudProvider}")
   suspend fun listNetworks(
+    @Path("cloudProvider") cloudProvider: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
-  ): Map<String, Set<Network>>
+  ): Set<Network>
 
   @GET("/subnets/{cloudProvider}")
   suspend fun listSubnets(
@@ -196,4 +198,7 @@ interface CloudDriverService {
     @Query("entityId") entityId: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): List<EntityTags>
+
+  @GET("/certificates/aws")
+  suspend fun getCertificates() : List<Certificate>
 }

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.keel.clouddriver
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache
 import com.netflix.spinnaker.keel.caffeine.CacheFactory
+import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
@@ -56,7 +57,6 @@ class MemoryCloudDriverCache(
           }
       }
         .handleNotFound()
-        ?: notFound("Security group with id $id not found in the $account account and $region region")
     }
 
   private val securityGroupsByName: AsyncLoadingCache<Triple<String, String, String>, SecurityGroupSummary> = cacheFactory
@@ -72,34 +72,31 @@ class MemoryCloudDriverCache(
           }
       }
         .handleNotFound()
-        ?: notFound("Security group with name $name not found in the $account account and $region region")
     }
 
   private val networksById: AsyncLoadingCache<String, Network> = cacheFactory
-    .asyncLoadingCache(cacheName = "networksById") { id ->
+    .asyncBulkLoadingCache(cacheName = "networksById") {
       runCatching {
-        cloudDriver.listNetworks(DEFAULT_SERVICE_ACCOUNT)["aws"]
-          ?.firstOrNull { it.id == id }
-          ?.also {
-            networksByName.put(Triple(it.account, it.region, it.name), completedFuture(it))
-          }
+        cloudDriver.listNetworks("aws", DEFAULT_SERVICE_ACCOUNT)
+          .associateBy { it.id }
       }
-        .handleNotFound()
-        ?: notFound("VPC network with id $id not found")
+        .getOrElse { ex ->
+          throw CacheLoadingException("Error loading networksById cache", ex)
+        }
     }
 
   private val networksByName: AsyncLoadingCache<Triple<String, String, String?>, Network> = cacheFactory
-    .asyncLoadingCache(cacheName = "networksByName") { (account, region, name) ->
+    .asyncBulkLoadingCache(cacheName = "networksByName") {
       runCatching {
         cloudDriver
-          .listNetworks(DEFAULT_SERVICE_ACCOUNT)["aws"]
-          ?.firstOrNull { it.name == name && it.account == account && it.region == region }
-          ?.also {
-            networksById.put(it.id, completedFuture(it))
+          .listNetworks("aws", DEFAULT_SERVICE_ACCOUNT)
+          .associateBy {
+            Triple(it.account, it.region, it.name)
           }
       }
-        .handleNotFound()
-        ?: notFound("VPC network named $name not found in $region")
+        .getOrElse { ex ->
+          throw CacheLoadingException("Error loading networksByName cache", ex)
+        }
     }
 
   private data class AvailabilityZoneKey(
@@ -121,7 +118,7 @@ class MemoryCloudDriverCache(
           .toSet()
       }
         .getOrElse { ex ->
-          throw CacheLoadingException("Error loading cache", ex)
+          throw CacheLoadingException("Error loading availabilityZones cache", ex)
         }
     }
 
@@ -133,69 +130,98 @@ class MemoryCloudDriverCache(
         cloudDriver.getCredential(name, DEFAULT_SERVICE_ACCOUNT)
       }
         .handleNotFound()
-        ?: notFound("Credentials with name $name not found")
     }
 
   private val subnetsById: AsyncLoadingCache<String, Subnet> = cacheFactory
-    .asyncLoadingCache(cacheName = "subnetsById") { subnetId ->
+    .asyncBulkLoadingCache(cacheName = "subnetsById") {
       runCatching {
         cloudDriver
           .listSubnets("aws", DEFAULT_SERVICE_ACCOUNT)
-          .find { it.id == subnetId }
+          .associateBy { it.id }
       }
-        .handleNotFound()
-        ?: notFound("Subnet with id $subnetId not found")
+        .getOrElse { ex -> throw CacheLoadingException("Error loading subnetsById cache", ex) }
     }
 
-  private val subnetsByPurpose: AsyncLoadingCache<Triple<String, String, String>, Subnet> = cacheFactory
-    .asyncLoadingCache(cacheName = "subnetsByPurpose") { (account, region, purpose) ->
+  private val subnetsByPurpose: AsyncLoadingCache<Triple<String, String, String?>, Subnet> = cacheFactory
+    .asyncBulkLoadingCache(cacheName = "subnetsByPurpose") {
       runCatching {
         cloudDriver
           .listSubnets("aws", DEFAULT_SERVICE_ACCOUNT)
-          .find { it.account == account && it.region == region && it.purpose == purpose }
+          .associateBy { Triple(it.account, it.region, it.purpose) }
       }
-        .handleNotFound()
-        ?: notFound("Subnet with purpose \"$purpose\" not found in $account:$region")
+        .getOrElse { ex -> throw CacheLoadingException("Error loading subnetsByPurpose cache", ex) }
     }
+
+  private val certificatesByName: AsyncLoadingCache<String, Certificate> =
+    cacheFactory
+      .asyncBulkLoadingCache("certificatesByName") {
+        runCatching {
+          cloudDriver
+            .getCertificates()
+            .associateBy { it.serverCertificateName }
+        }
+          .getOrElse { ex -> throw CacheLoadingException("Error loading certificatesByName cache", ex) }
+      }
+
+  private val certificatesByArn: AsyncLoadingCache<String, Certificate> =
+    cacheFactory
+      .asyncBulkLoadingCache("certificatesByArn") {
+        runCatching {
+          cloudDriver
+            .getCertificates()
+            .associateBy { it.arn }
+        }
+          .getOrElse { ex -> throw CacheLoadingException("Error loading certificatesByArn cache", ex) }
+      }
 
   override fun credentialBy(name: String): Credential =
     runBlocking {
-      credentials.get(name).await()
+      credentials.get(name).await() ?: notFound("Credential with name $name not found")
     }
 
   override fun securityGroupById(account: String, region: String, id: String): SecurityGroupSummary =
     runBlocking {
-      securityGroupsById.get(Triple(account, region, id)).await()
+      securityGroupsById.get(Triple(account, region, id)).await()?: notFound("Security group with id $id not found in $account:$region")
     }
 
   override fun securityGroupByName(account: String, region: String, name: String): SecurityGroupSummary =
     runBlocking {
-      securityGroupsByName.get(Triple(account, region, name)).await()
+      securityGroupsByName.get(Triple(account, region, name)).await()?: notFound("Security group with name $name not found in $account:$region")
     }
 
   override fun networkBy(id: String): Network =
     runBlocking {
-      networksById.get(id).await()
+      networksById.get(id).await() ?: notFound("VPC network with id $id not found")
     }
 
   override fun networkBy(name: String?, account: String, region: String): Network =
     runBlocking {
-      networksByName.get(Triple(account, region, name)).await()
+      networksByName.get(Triple(account, region, name)).await() ?: notFound("VPC network named $name not found in $account:$region")
     }
 
   override fun availabilityZonesBy(account: String, vpcId: String, purpose: String, region: String): Set<String> =
     runBlocking {
-      availabilityZones.get(AvailabilityZoneKey(account, region, vpcId, purpose)).await()
+      availabilityZones.get(AvailabilityZoneKey(account, region, vpcId, purpose)).await() ?: notFound("Availability zone with purpose \"$purpose\" not found in $account:$region")
     }
 
   override fun subnetBy(subnetId: String): Subnet =
     runBlocking {
-      subnetsById.get(subnetId).await()
+      subnetsById.get(subnetId).await() ?: notFound("Subnet with id $subnetId not found")
     }
 
   override fun subnetBy(account: String, region: String, purpose: String): Subnet =
     runBlocking {
-      subnetsByPurpose.get(Triple(account, region, purpose)).await()
+      subnetsByPurpose.get(Triple(account, region, purpose)).await() ?: notFound("Subnet with purpose \"$purpose\" not found in $account:$region")
+    }
+
+  override fun certificateByName(name: String): Certificate =
+    runBlocking {
+      certificatesByName.get(name).await() ?: notFound("Certificate with name $name not found")
+    }
+
+  override fun certificateByArn(arn: String): Certificate =
+    runBlocking {
+      certificatesByArn.get(arn).await() ?: notFound("Certificate with ARN $arn not found")
     }
 }
 

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Certificate.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Certificate.kt
@@ -1,0 +1,3 @@
+package com.netflix.spinnaker.keel.clouddriver.model
+
+data class Certificate(val serverCertificateName: String, val arn: String)

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.clouddriver
 
 import com.netflix.spinnaker.keel.caffeine.TEST_CACHE_FACTORY
+import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
@@ -9,6 +10,8 @@ import com.netflix.spinnaker.keel.retrofit.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.retrofit.RETROFIT_SERVICE_UNAVAILABLE
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.containsExactly
@@ -49,6 +52,11 @@ internal class MemoryCloudDriverCacheTest {
     Subnet("b", "vpc-3", "prod", "us-west-2", "us-west-2b", "internal (vpc3)"),
     Subnet("c", "vpc-3", "prod", "us-west-2", "us-west-2c", "internal (vpc3)"),
     Subnet("d", "vpc-3", "prod", "us-west-2", "us-west-2d", "external (vpc3)")
+  )
+
+  val certificates = listOf(
+    Certificate("cert-1", "arn:cert-1"),
+    Certificate("cert-2", "arn:cert-2")
   )
 
   @Test
@@ -133,8 +141,8 @@ internal class MemoryCloudDriverCacheTest {
   @Test
   fun `VPC networks are looked up by id from CloudDriver`() {
     every {
-      cloudDriver.listNetworks()
-    } returns mapOf("aws" to vpcs)
+      cloudDriver.listNetworks("aws")
+    } returns vpcs
 
     subject.networkBy("vpc-2").let { vpc ->
       expectThat(vpc) {
@@ -148,8 +156,8 @@ internal class MemoryCloudDriverCacheTest {
   @Test
   fun `an invalid VPC id throws an exception`() {
     every {
-      cloudDriver.listNetworks()
-    } returns mapOf("aws" to vpcs)
+      cloudDriver.listNetworks("aws")
+    } returns vpcs
 
     expectThrows<ResourceNotFound> {
       subject.networkBy("vpc-5")
@@ -159,8 +167,8 @@ internal class MemoryCloudDriverCacheTest {
   @Test
   fun `VPC networks are looked up by name and region from CloudDriver`() {
     every {
-      cloudDriver.listNetworks()
-    } returns mapOf("aws" to vpcs)
+      cloudDriver.listNetworks("aws")
+    } returns vpcs
 
     subject.networkBy("vpcName", "test", "us-west-2").let { vpc ->
       expectThat(vpc.id).isEqualTo("vpc-2")
@@ -170,8 +178,8 @@ internal class MemoryCloudDriverCacheTest {
   @Test
   fun `an invalid VPC name and region throws an exception`() {
     every {
-      cloudDriver.listNetworks()
-    } returns mapOf("aws" to vpcs)
+      cloudDriver.listNetworks("aws")
+    } returns vpcs
 
     expectThrows<ResourceNotFound> {
       subject.networkBy("invalid", "prod", "us-west-2")
@@ -210,5 +218,77 @@ internal class MemoryCloudDriverCacheTest {
     expectThat(
       subject.availabilityZonesBy("prod", "vpc-3", "external (vpc3)", "us-west-2")
     ).containsExactly("us-west-2d")
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["cert-1", "cert-2"])
+  fun `certificates are looked up from CloudDriver when requested by name`(name: String) {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    expectThat(subject.certificateByName(name))
+      .get { serverCertificateName } isEqualTo name
+  }
+
+  @Test
+  fun `an unknown certificate name throws an exception`() {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    expectThrows<ResourceNotFound> { subject.certificateByName("does-not-exist") }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["cert-1", "cert-2"])
+  fun `subsequent requests for a certificate by name hit the cache`(name: String) {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    repeat(4) { subject.certificateByName(name) }
+
+    verify(exactly = 1) { cloudDriver.getCertificates() }
+  }
+
+  @Test
+  fun `all certs are cached at once when requested by name`() {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    listOf("cert-1", "cert-2")
+      .forEach(subject::certificateByName)
+
+    verify(exactly = 1) { cloudDriver.getCertificates() }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["arn:cert-1", "arn:cert-2"])
+  fun `certificates are looked up from CloudDriver when requested by ARN`(arn: String) {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    expectThat(subject.certificateByArn(arn))
+      .get { arn } isEqualTo arn
+  }
+
+  @Test
+  fun `an unknown certificate ARN throws an exception`() {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    expectThrows<ResourceNotFound> { subject.certificateByArn("does-not-exist") }
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = ["arn:cert-1", "arn:cert-2"])
+  fun `subsequent requests for a certificate by ARN hit the cache`(arn: String) {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    repeat(5) { subject.certificateByArn(arn) }
+
+    verify(exactly = 1) { cloudDriver.getCertificates() }
+  }
+
+  @Test
+  fun `all certs are cached at once when requested by ARN`() {
+    every { cloudDriver.getCertificates() } returns certificates
+
+    listOf("arn:cert-1", "arn:cert-2")
+      .forEach(subject::certificateByArn)
+
+    verify(exactly = 1) { cloudDriver.getCertificates() }
   }
 }

--- a/keel-core/keel-core.gradle.kts
+++ b/keel-core/keel-core.gradle.kts
@@ -47,7 +47,5 @@ dependencies {
   testImplementation("dev.minutest:minutest")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.junit.jupiter:junit-jupiter-api")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/caffeine/CacheFactory.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/caffeine/CacheFactory.kt
@@ -16,6 +16,10 @@ import kotlinx.coroutines.future.future
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executor
+import java.util.function.BiFunction
+import java.util.function.Function
 
 @Component
 @EnableConfigurationProperties(CacheProperties::class)
@@ -27,7 +31,7 @@ class CacheFactory(
    * Builds an instrumented cache configured with values from [cacheProperties] or the supplied
    * defaults that uses [dispatcher] for computing values for the cache on a miss.
    */
-  fun <K, V> asyncCache(
+  fun <K : Any, V> asyncCache(
     cacheName: String,
     defaultMaximumSize: Long = 1000,
     defaultExpireAfterWrite: Duration = Duration.ofHours(1),
@@ -41,7 +45,7 @@ class CacheFactory(
    * Builds an instrumented cache configured with values from [cacheProperties] or the supplied
    * defaults that uses [dispatcher] for computing values for the cache on a miss.
    */
-  fun <K, V> asyncLoadingCache(
+  fun <K : Any, V> asyncLoadingCache(
     cacheName: String,
     defaultMaximumSize: Long = 1000,
     defaultExpireAfterWrite: Duration = Duration.ofHours(1),
@@ -51,6 +55,24 @@ class CacheFactory(
     builder(cacheName, defaultMaximumSize, defaultExpireAfterWrite, dispatcher)
       .buildAsync(loader.toAsyncCacheLoader())
       .monitor(cacheName)
+
+  /**
+   * Builds an instrumented cache configured with values from [cacheProperties] or the supplied
+   * defaults that uses [dispatcher] for computing values for the cache on a miss.
+   *
+   * Caches created using this method load all entries at once.
+   */
+  fun <K : Any, V> asyncBulkLoadingCache(
+    cacheName: String,
+    defaultMaximumSize: Long = 1000,
+    defaultExpireAfterWrite: Duration = Duration.ofHours(1),
+    dispatcher: CoroutineDispatcher = IO,
+    loader: suspend () -> Map<K, V>
+  ): AsyncLoadingCache<K, V> =
+    builder(cacheName, defaultMaximumSize, defaultExpireAfterWrite, dispatcher)
+      .buildAsync(loader.toAsyncBulkCacheLoader())
+      .monitor(cacheName)
+      .let { AsyncBulkLoadingCache(it) }
 
   private fun builder(
     cacheName: String,
@@ -66,15 +88,49 @@ class CacheFactory(
         .recordStats()
     }
 
-  private fun <K, V, C: AsyncCache<K, V>> C.monitor(cacheName: String) =
+  private fun <K, V, C : AsyncCache<K, V>> C.monitor(cacheName: String) =
     CaffeineCacheMetrics.monitor(meterRegistry, this, cacheName)
 }
 
-fun <K, V> (suspend (K) -> V?).toAsyncCacheLoader() : AsyncCacheLoader<K, V> =
+fun <K : Any, V> (suspend (K) -> V?).toAsyncCacheLoader(): AsyncCacheLoader<K, V> =
   AsyncCacheLoader<K, V> { key, executor ->
     CoroutineScope(executor.asCoroutineDispatcher())
       .future { this@toAsyncCacheLoader.invoke(key) }
   }
+
+fun <K : Any, V> (suspend () -> Map<K, V>).toAsyncBulkCacheLoader(): AsyncCacheLoader<K, V> =
+  object : AsyncCacheLoader<K, V> {
+    override fun asyncLoad(key: K, executor: Executor): CompletableFuture<V> {
+      throw UnsupportedOperationException()
+    }
+
+    override fun asyncLoadAll(
+      keys: Iterable<K>,
+      executor: Executor
+    ): CompletableFuture<Map<K, V>> =
+      CoroutineScope(executor.asCoroutineDispatcher())
+        .future { this@toAsyncBulkCacheLoader.invoke() }
+  }
+
+/**
+ * An implementation of [AsyncLoadingCache] that _always_ uses [AsyncCacheLoader.asyncLoadAll] to
+ * populate the cache.
+ */
+private class AsyncBulkLoadingCache<K : Any, V>(delegate: AsyncLoadingCache<K, V>) :
+  AsyncLoadingCache<K, V> by delegate {
+  override fun get(key: K): CompletableFuture<V> = getAll(listOf(key)).thenApply { it[key] }
+
+  override fun get(key: K, mappingFunction: Function<in K, out V>): CompletableFuture<V> {
+    throw UnsupportedOperationException()
+  }
+
+  override fun get(
+    key: K,
+    mappingFunction: BiFunction<in K, Executor, CompletableFuture<V>>
+  ): CompletableFuture<V> {
+    throw UnsupportedOperationException()
+  }
+}
 
 /**
  * A [CacheFactory] usable in tests that uses no-op metering and default configuration.

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ApplicationLoadBalancerSpec.kt
@@ -3,9 +3,6 @@ package com.netflix.spinnaker.keel.api.ec2
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Listener
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
 import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
@@ -39,10 +36,18 @@ data class ApplicationLoadBalancerSpec(
   data class Listener(
     val port: Int,
     val protocol: String,
-    val certificateArn: String?,
+    val certificate: String? = null,
     val rules: Set<Rule> = emptySet(),
     val defaultActions: Set<Action> = emptySet()
-  )
+  ) {
+    init {
+      if (protocol == "HTTPS") {
+        requireNotNull(certificate) {
+          "HTTPS listeners must specify a certificate"
+        }
+      }
+    }
+  }
 
   data class TargetGroup(
     val name: String,

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ec2.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ec2.kt
@@ -16,6 +16,7 @@
 package com.netflix.spinnaker.keel.api.ec2
 
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.api.ec2.old.ClusterV1Spec
 import com.netflix.spinnaker.keel.api.plugins.kind
 
@@ -30,7 +31,10 @@ val EC2_SECURITY_GROUP_V1 = kind<SecurityGroupSpec>("ec2/security-group@v1")
 
 val EC2_CLASSIC_LOAD_BALANCER_V1 = kind<ClassicLoadBalancerSpec>("ec2/classic-load-balancer@v1")
 
-val EC2_APPLICATION_LOAD_BALANCER_V1_1 = kind<ApplicationLoadBalancerSpec>("ec2/application-load-balancer@v1.1")
+val EC2_APPLICATION_LOAD_BALANCER_V1_2 = kind<ApplicationLoadBalancerSpec>("ec2/application-load-balancer@v1.2")
 
-@Deprecated("Obsolete version of ALB spec", replaceWith = ReplaceWith("EC2_APPLICATION_LOAD_BALANCER_V1_1"))
+@Deprecated("Obsolete version of ALB spec", replaceWith = ReplaceWith("EC2_APPLICATION_LOAD_BALANCER_V1_2"))
+val EC2_APPLICATION_LOAD_BALANCER_V1_1 = kind<ApplicationLoadBalancerV1_1Spec>("ec2/application-load-balancer@v1.1")
+
+@Deprecated("Obsolete version of ALB spec", replaceWith = ReplaceWith("EC2_APPLICATION_LOAD_BALANCER_V1_2"))
 val EC2_APPLICATION_LOAD_BALANCER_V1 = kind<ApplicationLoadBalancerV1Spec>("ec2/application-load-balancer@v1")

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1_1Spec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/old/ApplicationLoadBalancerV1_1Spec.kt
@@ -3,24 +3,24 @@ package com.netflix.spinnaker.keel.api.ec2.old
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.UnhappyControl
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Rule
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerType.APPLICATION
-import com.netflix.spinnaker.keel.api.ec2.TargetGroupAttributes
-import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ApplicationLoadBalancerOverrideV1_1
-import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ListenerV1_1
 import com.netflix.spinnaker.keel.api.schema.Optional
 import java.time.Duration
 
-data class ApplicationLoadBalancerV1Spec(
+data class ApplicationLoadBalancerV1_1Spec(
   override val moniker: Moniker,
   @Optional override val locations: SubnetAwareLocations,
   override val internal: Boolean = true,
   override val dependencies: LoadBalancerDependencies = LoadBalancerDependencies(),
   override val idleTimeout: Duration = Duration.ofSeconds(60),
   val listeners: Set<ListenerV1_1>,
-  val targetGroups: Set<TargetGroupV1>,
+  val targetGroups: Set<TargetGroup>,
   val overrides: Map<String, ApplicationLoadBalancerOverrideV1_1> = emptyMap()
 ) : LoadBalancerSpec, UnhappyControl {
 
@@ -39,26 +39,17 @@ data class ApplicationLoadBalancerV1Spec(
 
   override val id: String = "${locations.account}:$moniker"
 
-  data class TargetGroupV1(
-    val name: String,
-    val targetType: String = "instance",
-    val protocol: String = "HTTP",
+  data class ListenerV1_1(
     val port: Int,
-    val healthCheckEnabled: Boolean = true,
-    val healthCheckTimeoutSeconds: Duration = Duration.ofSeconds(5),
-    val healthCheckPort: Int = 7001,
-    val healthCheckProtocol: String = "HTTP",
-    val healthCheckHttpCode: String = "200-299",
-    val healthCheckPath: String = "/healthcheck",
-    val healthCheckIntervalSeconds: Duration = Duration.ofSeconds(10),
-    val healthyThresholdCount: Int = 10,
-    val unhealthyThresholdCount: Int = 2,
-    val attributes: TargetGroupAttributes = TargetGroupAttributes()
-  ) {
-    init {
-      require(name.length <= 32) {
-        "targetGroup names have a 32 character limit"
-      }
-    }
-  }
+    val protocol: String,
+    val certificateArn: String?,
+    val rules: Set<Rule> = emptySet(),
+    val defaultActions: Set<Action> = emptySet()
+  )
+
+  data class ApplicationLoadBalancerOverrideV1_1(
+    val dependencies: LoadBalancerDependencies? = null,
+    val listeners: Set<ListenerV1_1>? = null,
+    val targetGroups: Set<TargetGroup>? = null
+  )
 }

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
   testImplementation("org.funktionale:funktionale-partials")
   testImplementation("org.apache.commons:commons-lang3")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
 
   // the following are needed to use keel's real(-ish) Spring configuration
   testImplementation(project(":keel-web")) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/KeelEc2ApiModule.kt
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.keel.api.ec2.StepScalingPolicy
 import com.netflix.spinnaker.keel.api.ec2.TargetGroupAttributes
 import com.netflix.spinnaker.keel.api.ec2.TargetTrackingPolicy
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.api.ec2.old.ClusterV1Spec
 import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
 import com.netflix.spinnaker.keel.ec2.jackson.mixins.ApplicationLoadBalancerSpecMixin
@@ -72,7 +73,8 @@ internal object KeelEc2ApiModule : SimpleModule("Keel EC2 API") {
   override fun setupModule(context: SetupContext) {
     with(context) {
       setMixInAnnotations<ApplicationLoadBalancerSpec, ApplicationLoadBalancerSpecMixin>()
-      // same annotations are required for this legacy model, so it can reuse the same mixin
+      // same annotations are required for these legacy models, so they can reuse the same mixin
+      setMixInAnnotations<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpecMixin>()
       setMixInAnnotations<ApplicationLoadBalancerV1Spec, ApplicationLoadBalancerSpecMixin>()
       setMixInAnnotations<BuildInfo, BuildInfoMixin>()
       setMixInAnnotations<ClassicLoadBalancerSpec, ClassicLoadBalancerSpecMixin>()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1ToV1_1Migrator.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1ToV1_1Migrator.kt
@@ -1,23 +1,24 @@
 package com.netflix.spinnaker.keel.ec2.migrators
 
-import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.TargetGroup
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.resources.SpecMigrator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty("keel.plugins.ec2.enabled")
-class ApplicationLoadBalancerV1ToV1_1Migrator : SpecMigrator<ApplicationLoadBalancerV1Spec, ApplicationLoadBalancerSpec> {
+class ApplicationLoadBalancerV1ToV1_1Migrator : SpecMigrator<ApplicationLoadBalancerV1Spec, ApplicationLoadBalancerV1_1Spec> {
   @Suppress("DEPRECATION")
   override val input = EC2_APPLICATION_LOAD_BALANCER_V1
+  @Suppress("DEPRECATION")
   override val output = EC2_APPLICATION_LOAD_BALANCER_V1_1
 
-  override fun migrate(spec: ApplicationLoadBalancerV1Spec): ApplicationLoadBalancerSpec =
-    ApplicationLoadBalancerSpec(
+  override fun migrate(spec: ApplicationLoadBalancerV1Spec): ApplicationLoadBalancerV1_1Spec =
+    ApplicationLoadBalancerV1_1Spec(
       moniker = spec.moniker,
       locations = spec.locations,
       internal = spec.internal,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2Migrator.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2Migrator.kt
@@ -7,17 +7,13 @@ import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ListenerV1_1
-import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.resources.SpecMigrator
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
 @Component
 @ConditionalOnProperty("keel.plugins.ec2.enabled")
-class ApplicationLoadBalancerV1_1ToV1_2Migrator(
-  private val cloudDriverCache: CloudDriverCache
-) :
-  SpecMigrator<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpec> {
+class ApplicationLoadBalancerV1_1ToV1_2Migrator : SpecMigrator<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpec> {
   @Suppress("DEPRECATION")
   override val input = EC2_APPLICATION_LOAD_BALANCER_V1_1
   override val output = EC2_APPLICATION_LOAD_BALANCER_V1_2
@@ -45,7 +41,7 @@ class ApplicationLoadBalancerV1_1ToV1_2Migrator(
       Listener(
         port = listener.port,
         protocol = listener.protocol,
-        certificate = listener.certificateArn?.let { cloudDriverCache.certificateByArn(it).serverCertificateName },
+        certificate = listener.certificateArn?.substringAfter(":server-certificate/"),
         rules = listener.rules,
         defaultActions = listener.defaultActions
       )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2Migrator.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2Migrator.kt
@@ -1,0 +1,53 @@
+package com.netflix.spinnaker.keel.ec2.migrators
+
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.ApplicationLoadBalancerOverride
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Listener
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ListenerV1_1
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.resources.SpecMigrator
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty("keel.plugins.ec2.enabled")
+class ApplicationLoadBalancerV1_1ToV1_2Migrator(
+  private val cloudDriverCache: CloudDriverCache
+) :
+  SpecMigrator<ApplicationLoadBalancerV1_1Spec, ApplicationLoadBalancerSpec> {
+  @Suppress("DEPRECATION")
+  override val input = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val output = EC2_APPLICATION_LOAD_BALANCER_V1_2
+
+  override fun migrate(spec: ApplicationLoadBalancerV1_1Spec): ApplicationLoadBalancerSpec =
+    ApplicationLoadBalancerSpec(
+      moniker = spec.moniker,
+      locations = spec.locations,
+      internal = spec.internal,
+      dependencies = spec.dependencies,
+      idleTimeout = spec.idleTimeout,
+      listeners = spec.listeners.migrate(),
+      targetGroups = spec.targetGroups,
+      overrides = spec.overrides.mapValues { (_, v) ->
+        ApplicationLoadBalancerOverride(
+          v.dependencies,
+          v.listeners?.migrate(),
+          v.targetGroups
+        )
+      }
+    )
+
+  private fun Set<ListenerV1_1>.migrate(): Set<Listener> =
+    mapTo(mutableSetOf()) { listener ->
+      Listener(
+        port = listener.port,
+        protocol = listener.protocol,
+        certificate = listener.certificateArn?.let { cloudDriverCache.certificateByArn(it).serverCertificateName },
+        rules = listener.rules,
+        defaultActions = listener.defaultActions
+      )
+    }
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ApplicationLoadBalancerDefaultsResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ApplicationLoadBalancerDefaultsResolver.kt
@@ -3,13 +3,13 @@ package com.netflix.spinnaker.keel.ec2.resolvers
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import org.springframework.stereotype.Component
 
 @Component
 class ApplicationLoadBalancerDefaultsResolver : Resolver<ApplicationLoadBalancerSpec> {
-  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_2
 
   override fun invoke(resource: Resource<ApplicationLoadBalancerSpec>): Resource<ApplicationLoadBalancerSpec> {
     if (resource.spec.listeners.any { it.defaultActions.isEmpty() } || resource.spec.dependencies.securityGroupNames.isEmpty()) {
@@ -31,7 +31,7 @@ class ApplicationLoadBalancerDefaultsResolver : Resolver<ApplicationLoadBalancer
           ApplicationLoadBalancerSpec.Listener(
             port = it.port,
             protocol = it.protocol,
-            certificateArn = it.certificateArn,
+            certificate = it.certificate,
             // TODO: The default rule can only be written via clouddriver as a defaultAction which seems like a bug.
             //  When an ALB is read from clouddriver, the default action appears under both defaultAction and as a rule.
             //  UpsertAmazonLoadBalancerV2Description doesn't allow setting isDefault on Rules which may be the issue.

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolver.kt
@@ -8,7 +8,7 @@ import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.plugins.Resolver
@@ -75,7 +75,7 @@ class ClassicLoadBalancerNetworkResolver(cloudDriverCache: CloudDriverCache) : N
 
 @Component
 class ApplicationLoadBalancerNetworkResolver(cloudDriverCache: CloudDriverCache) : NetworkResolver<ApplicationLoadBalancerSpec>(cloudDriverCache) {
-  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_1
+  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_2
 
   override fun invoke(resource: Resource<ApplicationLoadBalancerSpec>): Resource<ApplicationLoadBalancerSpec> =
     resource.run {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.HealthSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
-import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_1
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
@@ -291,7 +291,7 @@ internal class ApplicationLoadBalancerNetworkResolverTests : NetworkResolverTest
   override val createSubject = ::ApplicationLoadBalancerNetworkResolver
 
   override fun createResource(locations: SubnetAwareLocations): Resource<ApplicationLoadBalancerSpec> = resource(
-    kind = EC2_APPLICATION_LOAD_BALANCER_V1_1.kind,
+    kind = EC2_APPLICATION_LOAD_BALANCER_V1_2.kind,
     spec = ApplicationLoadBalancerSpec(
       moniker = Moniker(
         app = "fnord",

--- a/keel-lemur/keel-lemur.gradle.kts
+++ b/keel-lemur/keel-lemur.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  `java-library`
+  id("kotlin-spring")
+}
+
+dependencies {
+  implementation(project(":keel-retrofit"))
+  implementation(project(":keel-core"))
+  implementation(project(":keel-ec2-api"))
+  implementation("org.springframework.boot:spring-boot-autoconfigure")
+
+  testImplementation("io.strikt:strikt-core")
+  testImplementation(project(":keel-spring-test-support"))
+  testImplementation(project(":keel-test"))
+}

--- a/keel-lemur/src/main/kotlin/com/netflix/spinnaker/config/LemurConfiguration.kt
+++ b/keel-lemur/src/main/kotlin/com/netflix/spinnaker/config/LemurConfiguration.kt
@@ -1,0 +1,52 @@
+package com.netflix.spinnaker.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.lemur.LemurService
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import okhttp3.OkHttpClient
+import org.springframework.beans.factory.BeanCreationException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders.AUTHORIZATION
+import retrofit2.Retrofit
+import retrofit2.converter.jackson.JacksonConverterFactory
+
+@Configuration
+@ConditionalOnProperty("lemur.base-url")
+class LemurConfiguration {
+  @Bean
+  fun lemurEndpoint(
+    @Value("\${lemur.base-url}") lemurBaseUrl: String
+  ): HttpUrl =
+    lemurBaseUrl.toHttpUrlOrNull()
+      ?: throw BeanCreationException("Invalid URL: $lemurBaseUrl")
+
+  @Bean
+  fun lemurService(
+    objectMapper: ObjectMapper,
+    lemurEndpoint: HttpUrl,
+    @Value("\${lemur.token}") token: String
+  ): LemurService {
+    val client = OkHttpClient
+      .Builder()
+      .addInterceptor { chain ->
+        chain.proceed(
+          chain
+            .request()
+            .newBuilder()
+            .header(AUTHORIZATION, "Bearer $token")
+            .build()
+        )
+      }
+      .build()
+    return Retrofit.Builder()
+      .addConverterFactory(JacksonConverterFactory.create(objectMapper))
+      .baseUrl(lemurEndpoint)
+      .client(client)
+      .build()
+      .create(LemurService::class.java)
+  }
+}

--- a/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificate.kt
+++ b/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificate.kt
@@ -1,0 +1,17 @@
+package com.netflix.spinnaker.keel.lemur
+
+import java.time.Instant
+
+data class LemurCertificateResponse(
+  val items: List<LemurCertificate>
+)
+
+data class LemurCertificate(
+  val commonName: String,
+  val name: String,
+  val active: Boolean,
+  val validityStart: Instant,
+  val validityEnd: Instant,
+  val replacedBy: List<LemurCertificate> = emptyList(),
+  val replaces: List<LemurCertificate> = emptyList()
+)

--- a/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolver.kt
+++ b/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolver.kt
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.keel.lemur
+
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
+import com.netflix.spinnaker.keel.api.plugins.Resolver
+import kotlinx.coroutines.runBlocking
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnBean(LemurService::class)
+class LemurCertificateResolver(
+  private val lemurService: LemurService
+) : Resolver<ApplicationLoadBalancerSpec> {
+  override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_2
+
+  override fun invoke(resource: Resource<ApplicationLoadBalancerSpec>): Resource<ApplicationLoadBalancerSpec> =
+    resource.copy(
+      spec = resource.spec.copy(
+        listeners = resource.spec.listeners.mapTo(mutableSetOf()) { listener ->
+          listener.certificate?.let { name ->
+            listener.copy(
+              certificate = findCurrentCertificate(name)
+            )
+          } ?: listener
+        }
+      )
+    )
+
+  private fun findCurrentCertificate(name: String) =
+    runBlocking {
+      val certificate = lemurService.certificateByName(name).items.first()
+      if (certificate.active) {
+        certificate.name
+      } else {
+        certificate.replacedBy.first { it.active }.name
+      }
+    }
+}

--- a/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurService.kt
+++ b/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurService.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.lemur
+
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface LemurService {
+  @GET("/api/1/certificates/name/{name}")
+  suspend fun certificateByName(@Path("name") name: String) : LemurCertificateResponse
+}

--- a/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolverTests.kt
+++ b/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolverTests.kt
@@ -190,6 +190,19 @@ class LemurCertificateResolverTests {
       .get { spec.listeners.first().certificate } isEqualTo "my-certificate-v3"
   }
 
+  @Test
+  fun `an empty response from Lemur is handled`() {
+    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+      items = emptyList()
+    )
+
+    expectCatching {
+      subject.invoke(resource.withListener(httpsListener))
+    }
+      .isFailure()
+      .isA<CertificateNotFound>()
+  }
+
   private fun Resource<ApplicationLoadBalancerSpec>.withListener(listener: Listener) =
     copy(
       spec = spec.copy(

--- a/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolverTests.kt
+++ b/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolverTests.kt
@@ -1,0 +1,125 @@
+package com.netflix.spinnaker.keel.lemur
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
+import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Listener
+import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
+import com.netflix.spinnaker.keel.test.resource
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.isEqualTo
+import strikt.assertions.isSuccess
+import java.time.Instant
+import java.time.temporal.ChronoUnit.DAYS
+import io.mockk.coEvery as every
+import io.mockk.coVerify as verify
+
+class LemurCertificateResolverTests {
+
+  val httpListener = Listener(
+    port = 80,
+    protocol = "HTTP"
+  )
+
+  val httpsListener = Listener(
+    port = 443,
+    protocol = "HTTPS",
+    certificate = "my-certificate-v1"
+  )
+
+  val resource = resource(
+    kind = EC2_APPLICATION_LOAD_BALANCER_V1_2.kind,
+    spec = ApplicationLoadBalancerSpec(
+      moniker = Moniker(
+        app = "fnord"
+      ),
+      locations = SubnetAwareLocations(
+        account = "test",
+        subnet = "external",
+        regions = setOf(
+          SubnetAwareRegionSpec(
+            name = "ap-south-1"
+          )
+        )
+      ),
+      listeners = emptySet(),
+      targetGroups = emptySet()
+    )
+  )
+
+  val lemurService = mockk<LemurService>()
+  val subject = LemurCertificateResolver(lemurService)
+
+  @Test
+  fun `a listener with no certificate is not affected`() {
+    expectCatching {
+      subject.invoke(resource.withListener(httpListener))
+    }
+      .isSuccess()
+      .get { spec.listeners.first() } isEqualTo httpListener
+
+    verify(exactly = 0) { lemurService.certificateByName(any()) }
+  }
+
+  @Test
+  fun `a listener with an active certificate is not affected`() {
+    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+      items = listOf(
+        LemurCertificate(
+          commonName = "my-certificate",
+          name = httpsListener.certificate!!,
+          active = true,
+          validityStart = Instant.now().minus(28, DAYS),
+          validityEnd = Instant.now().plus(28, DAYS)
+        )
+      )
+    )
+
+    expectCatching {
+      subject.invoke(resource.withListener(httpsListener))
+    }
+      .isSuccess()
+      .get { spec.listeners.first() } isEqualTo httpsListener
+  }
+
+  @Test
+  fun `a listener with an inactive certificate is updated to the new certificate`() {
+    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+      items = listOf(
+        LemurCertificate(
+          commonName = "my-certificate",
+          name = httpsListener.certificate!!,
+          active = false,
+          validityStart = Instant.now().minus(57, DAYS),
+          validityEnd = Instant.now().minus(28, DAYS),
+          replacedBy = listOf(
+            LemurCertificate(
+              commonName = "my-certificate",
+              name = "my-certificate-v2",
+              active = true,
+              validityStart = Instant.now().minus(28, DAYS),
+              validityEnd = Instant.now().plus(28, DAYS)
+            )
+          )
+        )
+      )
+    )
+
+    expectCatching {
+      subject.invoke(resource.withListener(httpsListener))
+    }
+      .isSuccess()
+      .get { spec.listeners.first().certificate } isEqualTo "my-certificate-v2"
+  }
+
+  private fun Resource<ApplicationLoadBalancerSpec>.withListener(listener: Listener) =
+    copy(
+      spec = spec.copy(
+        listeners = setOf(listener)
+      )
+    )
+}

--- a/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateTests.kt
+++ b/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateTests.kt
@@ -1,0 +1,47 @@
+package com.netflix.spinnaker.keel.lemur
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.hasSize
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isFalse
+import strikt.assertions.isSuccess
+import strikt.assertions.isTrue
+import java.time.LocalDate
+import java.time.ZoneOffset.UTC
+
+class LemurCertificateTests {
+
+  private val certificateJson = javaClass.getResource("/lemur-certificate-response.json")
+  private val mapper = configuredObjectMapper()
+
+  @Test
+  fun `can parse a lemur certificate payload`() {
+    expectCatching {
+      mapper.readValue<LemurCertificateResponse>(certificateJson)
+    }
+      .isSuccess()
+      .and {
+        with({ items.first() }) {
+          get { active }.isFalse()
+          get { validityStart } isEqualTo LocalDate.of(2020, 1, 24).atStartOfDay(UTC).toInstant()
+          get { validityEnd } isEqualTo LocalDate.of(2021, 1, 24).atTime(12, 0).toInstant(UTC)
+          get { name } isEqualTo "fnord.illuminati.org-DigiCertSHA2SecureServerCA-20200124-20210124"
+          get { replaces }.isEmpty()
+          get { replacedBy }.hasSize(1)
+
+          with({ replacedBy.first() }) {
+            get { active }.isTrue()
+            get { validityStart } isEqualTo LocalDate.of(2020, 12, 23).atStartOfDay(UTC).toInstant()
+            get { validityEnd } isEqualTo LocalDate.of(2021, 12, 24).atTime(23, 59, 59).toInstant(UTC)
+            get { name } isEqualTo "fnord.illuminati.org-DigiCertSHA2SecureServerCA-20201223-20211224"
+            get { replaces }.isEmpty()
+            get { replacedBy }.isEmpty()
+          }
+        }
+      }
+  }
+}

--- a/keel-lemur/src/test/resources/lemur-certificate-response.json
+++ b/keel-lemur/src/test/resources/lemur-certificate-response.json
@@ -1,0 +1,32 @@
+{
+  "total": 1,
+  "items": [
+    {
+      "body": "-----BEGIN CERTIFICATE-----\nWDFnYUYwXA==\n-----END CERTIFICATE-----",
+      "active": false,
+      "validityStart": "2020-01-24T00:00:00+00:00",
+      "owner": "fzlem@netflix.com",
+      "status": "valid",
+      "replaces": [],
+      "replacedBy": [
+        {
+          "body": "-----BEGIN CERTIFICATE-----\ndEUzPzJmKlRkIw==\n-----END CERTIFICATE-----",
+          "active": true,
+          "validityStart": "2020-12-23T00:00:00+00:00",
+          "owner": "fzlem@netflix.com",
+          "status": "valid",
+          "name": "fnord.illuminati.org-DigiCertSHA2SecureServerCA-20201223-20211224",
+          "id": 3053800,
+          "validityEnd": "2021-12-24T23:59:59+00:00",
+          "commonName": "fnord.illuminati.org"
+        }
+      ],
+      "name": "fnord.illuminati.org-DigiCertSHA2SecureServerCA-20200124-20210124",
+      "id": 1763305,
+      "validityEnd": "2021-01-24T12:00:00+00:00",
+      "deleted": false,
+      "dateCreated": "2020-01-24T06:03:32.331460+00:00",
+      "commonName": "fnord.illuminati.org"
+    }
+  ]
+}

--- a/keel-orca/keel-orca.gradle.kts
+++ b/keel-orca/keel-orca.gradle.kts
@@ -39,6 +39,4 @@ dependencies {
   testImplementation("dev.minutest:minutest")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.junit.jupiter:junit-jupiter-api")
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
 }

--- a/keel-titus-plugin/keel-titus-plugin.gradle.kts
+++ b/keel-titus-plugin/keel-titus-plugin.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-autoconfigure")
   implementation("com.netflix.frigga:frigga")
 
-  testImplementation("org.junit.jupiter:junit-jupiter-params")
   testImplementation(project(":keel-test"))
   testImplementation("io.strikt:strikt-jackson")
   testImplementation("io.strikt:strikt-mockk")

--- a/keel-web/keel-web.gradle.kts
+++ b/keel-web/keel-web.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
   api(project(":keel-docker"))
   api(project(":keel-echo"))
   api(project(":keel-igor"))
+  api(project(":keel-lemur"))
   api(project(":keel-slack"))
 
   implementation(project(":keel-bakery-plugin"))

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2MigratorTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/ec2/migrators/ApplicationLoadBalancerV1_1ToV1_2MigratorTests.kt
@@ -1,0 +1,47 @@
+package com.netflix.spinnaker.keel.ec2.migrators
+
+import com.netflix.spinnaker.keel.api.Moniker
+import com.netflix.spinnaker.keel.api.SubnetAwareLocations
+import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
+import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec.ListenerV1_1
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.isEqualTo
+import strikt.assertions.isSuccess
+
+internal class ApplicationLoadBalancerV1_1ToV1_2MigratorTests {
+  val subject = ApplicationLoadBalancerV1_1ToV1_2Migrator()
+
+  @Test
+  fun `converts certificate ARN to name`() {
+    val spec = ApplicationLoadBalancerV1_1Spec(
+      moniker = Moniker(
+        app = "fnord"
+      ),
+      locations = SubnetAwareLocations(
+        account = "test",
+        subnet = "external",
+        regions = setOf(
+          SubnetAwareRegionSpec(
+            name = "ap-south-1"
+          )
+        )
+      ),
+      listeners = setOf(
+        ListenerV1_1(
+          port = 443,
+          protocol = "HTTPS",
+          certificateArn = "arn:aws:iam::179727101194:server-certificate/spinnaker.mgmt.netflix.net-DigiCertSHA2SecureServerCA-20210113-20220213"
+        )
+      ),
+      targetGroups = emptySet()
+    )
+
+    expectCatching {
+      subject.migrate(spec)
+    }
+      .isSuccess()
+      .get { listeners.first().certificate } isEqualTo "spinnaker.mgmt.netflix.net-DigiCertSHA2SecureServerCA-20210113-20220213"
+  }
+}

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -66,13 +66,13 @@ internal class AuthPropagationTests
   ) {
     val server = MockWebServer()
 
-    private var _listNetworksResults: Map<String, Set<Network>>? = null
-    val listNetworksResults: Map<String, Set<Network>>
+    private var _listNetworksResults: Set<Network>? = null
+    val listNetworksResults: Set<Network>
       get() = checkNotNull(_listNetworksResults) { "You need to actually make a call first" }
 
     fun listNetworks() {
       _listNetworksResults = runBlocking {
-        cloudDriverService.listNetworks()
+        cloudDriverService.listNetworks("aws")
       }
     }
   }
@@ -92,7 +92,7 @@ internal class AuthPropagationTests
 
     context("a call to Clouddriver") {
       before {
-        server.enqueue(MockResponse().setBody("{}"))
+        server.enqueue(MockResponse().setBody("[]"))
 
         listNetworks()
       }

--- a/keel-web/src/test/resources/examples/alb-example.yml
+++ b/keel-web/src/test/resources/examples/alb-example.yml
@@ -4,14 +4,14 @@ serviceAccount: delivery-engineering@netflix.com
 environments:
 - name: test
   resources:
-  - kind: ec2/application-load-balancer@v1.1
+  - kind: ec2/application-load-balancer@v1.2
     spec:
       moniker:
         app: fnord
       listeners:
       - port: 443
         protocol: HTTPS
-        certificateArn: arn:aws:iam::111111111111:server-certificate/fnord.prod.illuminati.org-DigiCertSHA2SecureServerCA-20200205-20210205
+        certificate: fnord.prod.illuminati.org-DigiCertSHA2SecureServerCA-20200205-20210205
         defaultActions:
         - type: forward
           order: 1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include(
   "keel-echo",
   "keel-front50",
   "keel-igor",
+  "keel-lemur",
   "keel-orca",
   "keel-retrofit",
   "keel-retrofit-test-support",


### PR DESCRIPTION
This PR restores the ALB spec v1.2 that lets users specify certificates for ALB listeners by name. It also:

- derives the name directly from the ARN when migrating older resource records on DB read, rather than querying CloudDriver. This is more resilient to error, since expired certificates may not be returned by CloudDriver and we'll get an error that potentially prevents an entire delivery config getting read.
- adds a resolver that checks certificate validity against Lemur and updates the name if the certificate has expired and a replacement exists. This means users do not need to update their delivery config when Lemur rotates certificates.
