### PR TITLE
chore(allowed-times): consistent numeric representation

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -84,6 +84,6 @@ data class DependOnConstraintMetadata(
 ) : ConstraintMetadata()
 
 data class AllowedTimesConstraintMetadata(
-  val windows: List<TimeWindow>,
+  val windows: List<TimeWindowNumeric>,
   val timezone: String? = null
 ) : ConstraintMetadata()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStateAttributes
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.constraints.AllowedTimesConstraintEvaluator
 import com.netflix.spinnaker.keel.lifecycle.LifecycleStep
 import java.time.Instant
 
@@ -86,4 +87,9 @@ data class DependOnConstraintMetadata(
 data class AllowedTimesConstraintMetadata(
   val windows: List<TimeWindowNumeric>,
   val timezone: String? = null
-) : ConstraintMetadata()
+) : ConstraintMetadata() {
+  constructor(constraint: TimeWindowConstraint): this(
+    AllowedTimesConstraintEvaluator.toNumericTimeWindows(constraint),
+    constraint.tz
+  )
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/TimeWindowConstraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/TimeWindowConstraint.kt
@@ -31,6 +31,15 @@ data class TimeWindowConstraint(
   }
 }
 
+/**
+ * Numeric day and hour representation of a time window.
+ * This format is consistent regardless of how the window is defined in a string.
+ */
+data class TimeWindowNumeric(
+  val days: Set<Int>,
+  val hours: Set<Int>,
+)
+
 data class TimeWindow(
   val days: String? = null,
   val hours: String? = null

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -385,7 +385,7 @@ class ApplicationService(
           currentlyPassing = it.canPromote(artifact, version = version, deliveryConfig = deliveryConfig, targetEnvironment = environment),
           attributes = when (constraint) {
             is DependsOnConstraint -> DependOnConstraintMetadata(constraint.environment)
-            is TimeWindowConstraint -> translateAllowedTimesConstraint(constraint)
+            is TimeWindowConstraint -> AllowedTimesConstraintMetadata(constraint)
             else -> null
           }
         )
@@ -396,15 +396,6 @@ class ApplicationService(
       statelessConstraints = statelessConstraints
     )
   }
-
-  /**
-   * Translates the stored time window constraint format to numeric format for display
-   */
-  private fun translateAllowedTimesConstraint(constraint: TimeWindowConstraint) =
-    AllowedTimesConstraintMetadata(
-      AllowedTimesConstraintEvaluator.toNumericTimeWindows(constraint),
-      constraint.tz
-    )
 
   /**
    * Takes an artifact version, plus information about the type of artifact, and constructs a summary view.


### PR DESCRIPTION
We need a consistent representation of the allowed-times constraint (that doesn't rely on words) to power UI visualization of it. 

Before:
```
{
                  "type": "allowed-times",
                  "currentlyPassing": false,
                  "attributes": {
                    "windows": [
                      {
                        "days": "Monday-Friday",
                        "hours": "9-16"
                      }
                    ]
                  }
```

After:
```{
                  "type": "allowed-times",
                  "currentlyPassing": true,
                  "attributes": {
                    "windows": [
                      {
                        "days": [
                          1,
                          2,
                          3,
                          4,
                          5
                        ],
                        "hours": [
                          9,
                          10,
                          11,
                          12,
                          13,
                          14,
                          15,
                          16
                        ]
                      }
                    ]
                  }
                }```