### PR TITLE
use a cache to reduce repetitive Lemur calls

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverCache.kt
@@ -38,4 +38,3 @@ interface CloudDriverCache {
 }
 
 class ResourceNotFound(message: String) : IntegrationException(message)
-class CacheLoadingException(message: String, cause: Throwable) : IntegrationException(message, cause)

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCache.kt
@@ -18,12 +18,14 @@ package com.netflix.spinnaker.keel.clouddriver
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache
 import com.netflix.spinnaker.keel.caffeine.CacheFactory
+import com.netflix.spinnaker.keel.caffeine.CacheLoadingException
 import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.Credential
 import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
+import com.netflix.spinnaker.keel.retrofit.isNotFound
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.runBlocking
 import retrofit2.HttpException
@@ -231,7 +233,7 @@ class MemoryCloudDriverCache(
  */
 private fun <V> Result<V>.handleNotFound(): V? =
   getOrElse { ex ->
-    if (ex is HttpException && ex.code() == 404) {
+    if (ex.isNotFound) {
       null
     } else {
       throw CacheLoadingException("Error loading cache", ex)

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/MemoryCloudDriverCacheTest.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.clouddriver
 
+import com.netflix.spinnaker.keel.caffeine.CacheLoadingException
 import com.netflix.spinnaker.keel.caffeine.TEST_CACHE_FACTORY
 import com.netflix.spinnaker.keel.clouddriver.model.Certificate
 import com.netflix.spinnaker.keel.clouddriver.model.Credential

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/caffeine/CacheLoadingException.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/caffeine/CacheLoadingException.kt
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.keel.caffeine
+
+import com.netflix.spinnaker.kork.exceptions.IntegrationException
+
+class CacheLoadingException(message: String, cause: Throwable) : IntegrationException(message, cause)

--- a/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolver.kt
+++ b/keel-lemur/src/main/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolver.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component
 @Component
 @ConditionalOnBean(LemurService::class)
 class LemurCertificateResolver(
-  private val lemurService: LemurService
+  private val lemurCertificateByName: suspend (String) -> LemurCertificateResponse
 ) : Resolver<ApplicationLoadBalancerSpec> {
   override val supportedKind = EC2_APPLICATION_LOAD_BALANCER_V1_2
 
@@ -30,7 +30,7 @@ class LemurCertificateResolver(
     )
 
   private suspend fun findCurrentCertificate(name: String): String {
-    val certificate = lemurService.certificateByName(name).items.firstOrNull()
+    val certificate = lemurCertificateByName(name).items.firstOrNull()
     return when {
       certificate == null -> throw CertificateNotFound(name)
       certificate.active -> certificate.name

--- a/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolverTests.kt
+++ b/keel-lemur/src/test/kotlin/com/netflix/spinnaker/keel/lemur/LemurCertificateResolverTests.kt
@@ -53,8 +53,8 @@ class LemurCertificateResolverTests {
     )
   )
 
-  val lemurService = mockk<LemurService>()
-  val subject = LemurCertificateResolver(lemurService)
+  val lemurCertificateByName = mockk<suspend (String) -> LemurCertificateResponse>()
+  val subject = LemurCertificateResolver(lemurCertificateByName)
 
   @Test
   fun `a listener with no certificate is not affected`() {
@@ -64,12 +64,12 @@ class LemurCertificateResolverTests {
       .isSuccess()
       .get { spec.listeners.first() } isEqualTo httpListener
 
-    verify(exactly = 0) { lemurService.certificateByName(any()) }
+    verify(exactly = 0) { lemurCertificateByName.invoke(any()) }
   }
 
   @Test
   fun `a listener with an active certificate is not affected`() {
-    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+    every { lemurCertificateByName.invoke(httpsListener.certificate!!)} returns LemurCertificateResponse(
       items = listOf(
         LemurCertificate(
           commonName = "my-certificate",
@@ -90,7 +90,7 @@ class LemurCertificateResolverTests {
 
   @Test
   fun `an expires certificate with a replacement is updated to the new certificate`() {
-    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+    every { lemurCertificateByName.invoke(httpsListener.certificate!!)} returns LemurCertificateResponse(
       items = listOf(
         LemurCertificate(
           commonName = "my-certificate",
@@ -120,7 +120,7 @@ class LemurCertificateResolverTests {
 
   @Test
   fun `an expired certificate with no replacement results in an exception being thrown`() {
-    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+    every { lemurCertificateByName.invoke(httpsListener.certificate!!)} returns LemurCertificateResponse(
       items = listOf(
         LemurCertificate(
           commonName = "my-certificate",
@@ -141,7 +141,7 @@ class LemurCertificateResolverTests {
 
   @Test
   fun `an expired certificate with an expired replacement results in looking further up the chain`() {
-    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+    every { lemurCertificateByName.invoke(httpsListener.certificate!!)} returns LemurCertificateResponse(
       items = listOf(
         LemurCertificate(
           commonName = "my-certificate",
@@ -162,7 +162,7 @@ class LemurCertificateResolverTests {
       )
     )
 
-    every { lemurService.certificateByName("my-certificate-v2")} returns LemurCertificateResponse(
+    every { lemurCertificateByName.invoke("my-certificate-v2")} returns LemurCertificateResponse(
       items = listOf(
         LemurCertificate(
           commonName = "my-certificate",
@@ -192,7 +192,7 @@ class LemurCertificateResolverTests {
 
   @Test
   fun `an empty response from Lemur is handled`() {
-    every { lemurService.certificateByName(httpsListener.certificate!!)} returns LemurCertificateResponse(
+    every { lemurCertificateByName.invoke(httpsListener.certificate!!)} returns LemurCertificateResponse(
       items = emptyList()
     )
 

--- a/keel-retrofit/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/Exceptions.kt
+++ b/keel-retrofit/src/main/kotlin/com/netflix/spinnaker/keel/retrofit/Exceptions.kt
@@ -6,5 +6,5 @@ import retrofit2.HttpException
 /**
  * Is this exception an HTTP 404?
  */
-val HttpException.isNotFound: Boolean
-  get() = code() == NOT_FOUND.value()
+val Throwable.isNotFound: Boolean
+  get() = this is HttpException && code() == NOT_FOUND.value()


### PR DESCRIPTION
Just wraps a cache around the calls to Lemur added in #1767