### PR TITLE
Try to speed up integration tests

### DIFF
--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/LegacySpecUpgradeTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/LegacySpecUpgradeTests.kt
@@ -13,13 +13,13 @@ import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import java.time.Clock.systemUTC
-import java.time.Instant
-import java.time.Instant.EPOCH
 import strikt.api.expectCatching
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isSuccess
+import java.time.Clock.systemUTC
+import java.time.Instant
+import java.time.Instant.EPOCH
 
 internal class LegacySpecUpgradeTests : JUnit5Minutests {
 
@@ -51,9 +51,6 @@ internal class LegacySpecUpgradeTests : JUnit5Minutests {
   }
 
   object Fixture {
-    @JvmStatic
-    val testDatabase = initTestDatabase()
-
     private val jooq = testDatabase.context
     private val retryProperties = RetryProperties(1, 0)
     private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -139,10 +136,6 @@ internal class LegacySpecUpgradeTests : JUnit5Minutests {
             }
         }
       }
-    }
-
-    afterAll {
-      Fixture.testDatabase.dataSource.close()
     }
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/MigratorErrorTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/MigratorErrorTests.kt
@@ -13,7 +13,6 @@ import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -111,15 +110,5 @@ class MigratorErrorTests {
   @AfterEach
   fun flush() {
     cleanupDb(jooq)
-  }
-
-  companion object {
-    private val testDatabase = initTestDatabase()
-
-    @JvmStatic
-    @AfterAll
-    fun shutdown() {
-      testDatabase.dataSource.close()
-    }
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlAgentLockRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlAgentLockRepositoryTests.kt
@@ -6,7 +6,6 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
-import org.junit.jupiter.api.AfterAll
 
 internal object SqlAgentLockRepositoryTests : AgentLockRepositoryTests<SqlAgentLockRepository>() {
 
@@ -14,19 +13,12 @@ internal object SqlAgentLockRepositoryTests : AgentLockRepositoryTests<SqlAgentL
     return SqlAgentLockRepository(jooq, clock, listOf(DummyScheduledAgent(1)), sqlRetry)
   }
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
 
   override fun SqlAgentLockRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }
 

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApplicationSummaryGenerationTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApplicationSummaryGenerationTests.kt
@@ -10,7 +10,6 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 
 class SqlApplicationSummaryGenerationTests : ApplicationSummaryGenerationTests<SqlArtifactRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredObjectMapper()
   private val retryProperties = RetryProperties(1, 0)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
@@ -14,7 +14,6 @@ import java.time.Clock
 
 class SqlApproveOldVersionTests : ApproveOldVersionTests<CombinedRepository>() {
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryPeriodicallyCheckedTests.kt
@@ -9,7 +9,6 @@ import java.time.Clock
 
 class SqlArtifactRepositoryPeriodicallyCheckedTests :
   ArtifactRepositoryPeriodicallyCheckedTests<SqlArtifactRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredObjectMapper()
   private val retryProperties = RetryProperties(1, 0)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepositoryTests.kt
@@ -11,7 +11,6 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
 
 class SqlArtifactRepositoryTests : ArtifactRepositoryTests<SqlArtifactRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredTestObjectMapper()
   private val retryProperties = RetryProperties(1, 0)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
@@ -7,12 +7,10 @@ import com.netflix.spinnaker.keel.test.defaultArtifactSuppliers
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import org.junit.jupiter.api.AfterAll
 import java.time.Clock
 
 internal object SqlCombinedRepositoryTests :
   CombinedRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository, SqlVerificationRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredTestObjectMapper()
   private val retryProperties = RetryProperties(1, 0)
@@ -40,11 +38,5 @@ internal object SqlCombinedRepositoryTests :
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
@@ -15,7 +15,6 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import dev.minutest.rootContext
-import org.junit.jupiter.api.AfterAll
 import strikt.api.expectThat
 import strikt.assertions.first
 import strikt.assertions.hasSize
@@ -27,7 +26,6 @@ import java.time.Duration
 internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
   DeliveryConfigRepositoryPeriodicallyCheckedTests<SqlDeliveryConfigRepository>() {
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val objectMapper = configuredTestObjectMapper()
@@ -46,12 +44,6 @@ internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
 
   override fun flush() {
     cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 
   fun pausedApplicationTests() = rootContext<Fixture<DeliveryConfig, SqlDeliveryConfigRepository>> {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryTests.kt
@@ -10,12 +10,10 @@ import com.netflix.spinnaker.keel.test.defaultArtifactSuppliers
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import java.time.Clock
 
 internal object SqlDeliveryConfigRepositoryTests : DeliveryConfigRepositoryTests<SqlDeliveryConfigRepository, SqlResourceRepository, SqlArtifactRepository, SqlPausedRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val objectMapper = configuredTestObjectMapper()
   private val retryProperties = RetryProperties(1, 0)
@@ -45,11 +43,5 @@ internal object SqlDeliveryConfigRepositoryTests : DeliveryConfigRepositoryTests
       registerSubtypes(NamedType(ManualJudgementConstraint::class.java, "manual-judgement"))
       registerSubtypes(NamedType(DummyVerification::class.java, "verification"))
     }
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDiffFingerprintRepositoryTests.kt
@@ -22,10 +22,8 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
-import org.junit.jupiter.api.AfterAll
 
 internal object SqlDiffFingerprintRepositoryTests : DiffFingerprintRepositoryTests<SqlDiffFingerprintRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -36,11 +34,5 @@ internal object SqlDiffFingerprintRepositoryTests : DiffFingerprintRepositoryTes
 
   override fun SqlDiffFingerprintRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepositoryTests.kt
@@ -5,12 +5,10 @@ import com.netflix.spinnaker.keel.persistence.LifecycleEventRepositoryTests
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import org.junit.jupiter.api.AfterAll
 import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 
 internal object SqlLifecycleEventRepositoryTests : LifecycleEventRepositoryTests<SqlLifecycleEventRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -27,11 +25,5 @@ internal object SqlLifecycleEventRepositoryTests : LifecycleEventRepositoryTests
 
   override fun SqlLifecycleEventRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleMonitorRepositoryTests.kt
@@ -6,13 +6,11 @@ import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import org.junit.jupiter.api.AfterAll
 import org.springframework.context.ApplicationEventPublisher
 import java.time.Clock
 
 internal object SqlLifecycleMonitorRepositoryTests
   : LifecycleMonitorRepositoryTests<SqlLifecycleMonitorRepository, SqlLifecycleEventRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -41,11 +39,5 @@ internal object SqlLifecycleMonitorRepositoryTests
   }
   override fun SqlLifecycleEventRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlNotificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlNotificationRepositoryTests.kt
@@ -4,12 +4,10 @@ import com.netflix.spinnaker.keel.persistence.NotificationRepositoryTests
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import org.junit.jupiter.api.AfterAll
 import java.time.Clock
 
 internal object SqlNotificationRepositoryTests : NotificationRepositoryTests<SqlNotificationRepository>() {
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -24,11 +22,5 @@ internal object SqlNotificationRepositoryTests : NotificationRepositoryTests<Sql
 
   override fun SqlNotificationRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlPausedRepositoryTests.kt
@@ -22,10 +22,8 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
-import org.junit.jupiter.api.AfterAll
 
 internal object SqlPausedRepositoryTests : PausedRepositoryTests<SqlPausedRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -35,11 +33,5 @@ internal object SqlPausedRepositoryTests : PausedRepositoryTests<SqlPausedReposi
 
   override fun SqlPausedRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -13,23 +13,21 @@ import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.rootContext
-import java.time.Clock
-import java.time.Duration
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.AfterAll
 import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isFailure
 import strikt.assertions.isSuccess
+import java.time.Clock
+import java.time.Duration
 
 internal object SqlResourceRepositoryPeriodicallyCheckedTests :
   ResourceRepositoryPeriodicallyCheckedTests<SqlResourceRepository>() {
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -40,12 +38,6 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
 
   override fun flush() {
     cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 
   fun parallelCheckingTests() = rootContext<Fixture<Resource<ResourceSpec>, SqlResourceRepository>> {

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -7,10 +7,8 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
-import org.junit.jupiter.api.AfterAll
 
 internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(5, 100)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -28,11 +26,5 @@ internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResource
 
   override fun flush() {
     cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlTaskTrackingRepositoryTests.kt
@@ -5,11 +5,9 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
-import org.junit.jupiter.api.AfterAll
 
 internal object SqlTaskTrackingRepositoryTests : TaskTrackingRepositoryTests<SqlTaskTrackingRepository>() {
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -24,11 +22,5 @@ internal object SqlTaskTrackingRepositoryTests : TaskTrackingRepositoryTests<Sql
 
   override fun SqlTaskTrackingRepository.flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepositoryTests.kt
@@ -24,13 +24,11 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import org.junit.jupiter.api.AfterAll
 import java.time.Clock
 
 internal object SqlUnhappyVetoRepositoryTests :
   UnhappyVetoRepositoryTests<SqlUnhappyVetoRepository>() {
 
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -56,11 +54,5 @@ internal object SqlUnhappyVetoRepositoryTests :
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhealthyRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhealthyRepositoryTests.kt
@@ -7,11 +7,9 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
-import org.junit.jupiter.api.AfterAll
 import java.time.Clock
 
 internal object SqlUnhealthyRepositoryTests : UnhealthyRepositoryTests<SqlUnhealthyRepository>() {
-  private val testDatabase = initTestDatabase()
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
@@ -38,11 +36,4 @@ internal object SqlUnhealthyRepositoryTests : UnhealthyRepositoryTests<SqlUnheal
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)
   }
-
-  @JvmStatic
-  @AfterAll
-  fun shutdown() {
-    testDatabase.dataSource.close()
-  }
-
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -12,7 +12,6 @@ import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import io.mockk.mockk
-import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 
 internal class SqlVerificationRepositoryTests :
@@ -92,15 +91,5 @@ internal class SqlVerificationRepositoryTests :
   @AfterEach
   fun flush() {
     SqlTestUtil.cleanupDb(jooq)
-  }
-
-  companion object {
-    private val testDatabase = initTestDatabase()
-
-    @JvmStatic
-    @AfterAll
-    fun shutdown() {
-      testDatabase.dataSource.close()
-    }
   }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/TestContainer.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/TestContainer.kt
@@ -5,16 +5,17 @@ import org.jooq.SQLDialect.MYSQL
 import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.containers.MySQLContainerProvider
 
-internal fun initTestDatabase() = initDatabase(
-  mySQLContainer.authenticatedJdbcUrl,
-  MYSQL
-)
+internal val testDatabase by lazy {
+  initDatabase(mySQLContainer.authenticatedJdbcUrl, MYSQL)
+}
 
-private val mySQLContainer = MySQLContainerProvider()
+internal val mySQLContainer = MySQLContainerProvider()
   .newInstance("5.7.22")
   .withDatabaseName("keel")
   .withUsername("keel_service")
   .withPassword("whatever")
+  .withReuse(true)
+  .withNetwork(null)
   .also { it.start() }
 
 @Suppress("UsePropertyAccessSyntax")

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/TestContainer.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/TestContainer.kt
@@ -6,7 +6,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer
 import org.testcontainers.containers.MySQLContainerProvider
 
 internal val testDatabase by lazy {
-  initDatabase(mySQLContainer.authenticatedJdbcUrl, MYSQL)
+  initDatabase(mySQLContainer.authenticatedJdbcUrl, MYSQL, "keel")
 }
 
 internal val mySQLContainer = MySQLContainerProvider()
@@ -15,7 +15,6 @@ internal val mySQLContainer = MySQLContainerProvider()
   .withUsername("keel_service")
   .withPassword("whatever")
   .withReuse(true)
-  .withNetwork(null)
   .also { it.start() }
 
 @Suppress("UsePropertyAccessSyntax")

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -19,14 +19,7 @@ import strikt.assertions.isA
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [KeelApplication::class],
-  webEnvironment = MOCK,
-  properties = [
-    "spinnaker.baseUrl=http://spinnaker",
-    "sql.enabled=true",
-    "sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
-    "sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename",
-    "spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver"
-  ]
+  webEnvironment = MOCK
 )
 internal class SpringStartupTests
 @Autowired constructor(
@@ -34,7 +27,6 @@ internal class SpringStartupTests
   val resourceRepository: ResourceRepository,
   val deliveryConfigRepository: DeliveryConfigRepository
 ) {
-
   @Test
   fun `uses SqlArtifactRepository`() {
     expectThat(artifactRepository).isA<SqlArtifactRepository>()

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/spring/SpringStartupTests.kt
@@ -8,18 +8,19 @@ import com.netflix.spinnaker.keel.sql.SqlArtifactRepository
 import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
 import com.netflix.spinnaker.keel.sql.SqlResourceRepository
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.ContextHierarchy
 import strikt.api.expectThat
 import strikt.assertions.isA
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [KeelApplication::class],
   webEnvironment = MOCK
+)
+@ContextHierarchy(
+  ContextConfiguration(classes = [KeelApplication::class])
 )
 internal class SpringStartupTests
 @Autowired constructor(

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigDeletionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigDeletionTests.kt
@@ -11,19 +11,21 @@ import org.jooq.DSLContext
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.ContextHierarchy
 import strikt.api.expectThat
 import strikt.assertions.hasSize
 import strikt.assertions.isEmpty
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
-  classes = [KeelApplication::class, TestConfiguration::class],
   webEnvironment = MOCK
+)
+@ContextHierarchy(
+  ContextConfiguration(classes = [KeelApplication::class]),
+  ContextConfiguration(classes = [TestConfiguration::class])
 )
 internal class DeliveryConfigDeletionTests
 @Autowired constructor(

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigTransactionTests.kt
@@ -23,13 +23,11 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import org.jooq.DSLContext
 import org.jooq.exception.DataAccessException
-import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.test.context.junit.jupiter.SpringExtension
 import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.isA
@@ -37,7 +35,6 @@ import strikt.assertions.isEmpty
 import strikt.assertions.isFailure
 import strikt.assertions.isFalse
 
-@ExtendWith(SpringExtension::class)
 @SpringBootTest(
   classes = [KeelApplication::class, TestConfiguration::class],
   webEnvironment = MOCK
@@ -186,5 +183,6 @@ internal class DeliveryConfigTransactionTests
 @Configuration
 internal class TestConfiguration {
   @Bean
-  fun dummyResourceHandler() = DummyResourceHandlerV1
+  fun dummyResourceHandler() =
+    DummyResourceHandlerV1
 }

--- a/keel-sql/src/test/resources/application.properties
+++ b/keel-sql/src/test/resources/application.properties
@@ -11,6 +11,6 @@ spinnaker.baseUrl=http://spinnaker
 services.fiat.baseUrl=https://fiat.net
 spring.application.name=keel
 sql.enabled=true
-sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename
-sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename
+sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
+sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/keel-sql/src/test/resources/application.properties
+++ b/keel-sql/src/test/resources/application.properties
@@ -11,6 +11,6 @@ spinnaker.baseUrl=http://spinnaker
 services.fiat.baseUrl=https://fiat.net
 spring.application.name=keel
 sql.enabled=true
-sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
-sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
+sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22:///keel&TC_REUSABLE=true
+sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22:///keel&TC_REUSABLE=true
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocCompatibilityTests.kt
@@ -24,9 +24,6 @@ import strikt.api.Assertion
 import strikt.api.expectThat
 
 @SpringBootTest(
-  properties = [
-    "keel.plugins.bakery.enabled=true"
-  ],
   webEnvironment = NONE
 )
 class ApiDocCompatibilityTests

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/apidocs/ApiDocTests.kt
@@ -52,9 +52,6 @@ import strikt.jackson.textValues
 import kotlin.reflect.KClass
 
 @SpringBootTest(
-  properties = [
-    "keel.plugins.bakery.enabled=true"
-  ],
   webEnvironment = NONE
 )
 class ApiDocTests

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/integration/AuthPropagationTests.kt
@@ -27,6 +27,8 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.ContextHierarchy
 import strikt.api.Assertion
 import strikt.api.expect
 import strikt.api.expectThat
@@ -35,8 +37,11 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 
 @SpringBootTest(
-  classes = [KeelApplication::class, MockFiat::class],
   webEnvironment = NONE
+)
+@ContextHierarchy(
+  ContextConfiguration(classes = [KeelApplication::class]),
+  ContextConfiguration(classes = [MockFiat::class])
 )
 internal class AuthPropagationTests
 @Autowired constructor(val cloudDriverService: CloudDriverService) : JUnit5Minutests {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/ApplicationEventTests.kt
@@ -21,6 +21,10 @@ import java.util.concurrent.TimeoutException
   classes = [KeelApplication::class, ThreadCapturingEventListener::class],
   webEnvironment = NONE
 )
+//@ContextHierarchy(
+//  ContextConfiguration(classes = [KeelApplication::class]),
+//  ContextConfiguration(classes = [ThreadCapturingEventListener::class])
+//)
 internal class ApplicationEventTests
 @Autowired constructor(
   val publisher: ApplicationEventPublisher,

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigYamlParsingFilterTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigYamlParsingFilterTests.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.rest
 import com.fasterxml.jackson.databind.jsontype.NamedType
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import com.netflix.spinnaker.keel.KeelApplication
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupSpec
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
@@ -30,11 +29,6 @@ import javax.servlet.ServletRequest
 import javax.servlet.http.HttpServletRequestWrapper
 
 @SpringBootTest(
-  properties = [
-    "keel.plugins.ec2.enabled = true",
-    "spring.liquibase.enabled = false" // TODO: ignored by kork's SpringLiquibaseProxy
-  ],
-  classes = [KeelApplication::class],
   webEnvironment = NONE
 )
 class DeliveryConfigYamlParsingFilterTests : JUnit5Minutests {

--- a/keel-web/src/test/resources/application.properties
+++ b/keel-web/src/test/resources/application.properties
@@ -10,8 +10,8 @@ igor.baseUrl=https://localhost:8083
 echo.baseUrl=https://localhost:8086
 services.fiat.baseUrl=https://fiat.net
 sql.enabled=true
-sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename
-sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/databasename
+sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
+sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.application.name=keel
 keel.plugins.ec2.enabled=true

--- a/keel-web/src/test/resources/application.properties
+++ b/keel-web/src/test/resources/application.properties
@@ -10,9 +10,10 @@ igor.baseUrl=https://localhost:8083
 echo.baseUrl=https://localhost:8086
 services.fiat.baseUrl=https://fiat.net
 sql.enabled=true
-sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
-sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22://somehostname:someport/keel&TC_REUSABLE=true
+sql.connection-pools.default.jdbc-url=jdbc:tc:mysql:5.7.22:///keel&TC_REUSABLE=true
+sql.migration.jdbc-url=jdbc:tc:mysql:5.7.22:///keel&TC_REUSABLE=true
 spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver
 spring.application.name=keel
 keel.plugins.ec2.enabled=true
 keel.plugins.titus.enabled=true
+keel.plugins.bakery.enabled=true


### PR DESCRIPTION
This PR

1. makes testcontainers re-use the same container across all tests

For this to work you **must have** a `~/.testcontainers.properties` file containing `testcontainers.reuse.enable=true`. This is not something you can switch on inside the project unfortunately.