### PR TITLE
fix(slack): small bug fixes + first step in deprecating notifications coming from orca

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -111,7 +111,7 @@ class ApplicationService(
   fun pin(user: String, application: String, pin: EnvironmentArtifactPin) {
     val config = repository.getDeliveryConfigForApplication(application)
     repository.pinEnvironment(config, pin.copy(pinnedBy = user))
-    publisher.publishEvent(PinnedNotification(config, pin))
+    publisher.publishEvent(PinnedNotification(config, pin.copy(pinnedBy = user)))
   }
 
   fun deletePin(user: String, application: String, targetEnvironment: String, reference: String? = null) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -139,7 +139,7 @@ class ApplicationService(
     publisher.publishEvent(MarkAsBadNotification(
       config = config,
       user = user,
-      veto = veto
+      veto = veto.copy(vetoedBy = user)
     ))
   }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -231,6 +231,10 @@ internal class ClusterExportTests : JUnit5Minutests {
       coEvery {
         clusterExportHelper.discoverDeploymentStrategy("aws", "test", "keel", any())
       } returns RedBlack()
+
+      coEvery {
+        springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+      } returns false
     }
 
     after {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -62,6 +62,7 @@ import java.time.Clock
 import java.time.Duration
 import java.util.UUID
 import com.netflix.spinnaker.keel.clouddriver.model.Capacity as ClouddriverCapacity
+import org.springframework.core.env.Environment as SpringEnv
 
 internal class ClusterExportTests : JUnit5Minutests {
 
@@ -71,11 +72,13 @@ internal class ClusterExportTests : JUnit5Minutests {
   val normalizers = emptyList<Resolver<ClusterSpec>>()
   val clock = Clock.systemUTC()
   val publisher: EventPublisher = mockk(relaxUnitFun = true)
+  val springEnv: SpringEnv = mockk(relaxUnitFun = true)
   val repository = mockk<KeelRepository>()
   val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
   val blockDeviceConfig = mockk<BlockDeviceConfig>()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -196,6 +196,10 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpc.account, vpc.region, sg1.name) } returns sg1
         every { certificateByName(cert.serverCertificateName) } returns cert
         every { certificateByArn(cert.arn) } returns cert
+
+        every {
+          springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+        } returns false
       }
 
       every { orcaService.orchestrate("keel@spinnaker", any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -50,6 +50,8 @@ import strikt.assertions.isTrue
 import java.util.UUID
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
+import org.springframework.core.env.Environment as SpringEnv
+
 
 @Suppress("UNCHECKED_CAST")
 internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
@@ -57,6 +59,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
   private val publisher: EventPublisher = mockk(relaxUnitFun = true)
+  val springEnv: SpringEnv = mockk(relaxUnitFun = true)
   private val repository = mockk<KeelRepository> {
     // we're just using this to get notifications
     every { environmentFor(any()) } returns Environment("test")
@@ -65,7 +68,8 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
   private val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
   private val yamlMapper = configuredYamlMapper()
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -56,6 +56,7 @@ import strikt.assertions.isTrue
 import java.util.UUID
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
+import org.springframework.core.env.Environment as SpringEnv
 
 @Suppress("UNCHECKED_CAST")
 internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
@@ -63,6 +64,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
   private val cloudDriverService = mockk<CloudDriverService>()
   private val cloudDriverCache = mockk<CloudDriverCache>()
   private val orcaService = mockk<OrcaService>()
+  private val springEnv: SpringEnv = mockk(relaxUnitFun = true)
 
   val repository = mockk<KeelRepository>() {
     // we're just using this to get notifications
@@ -72,7 +74,8 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
   private val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
   private val mapper = ObjectMapper().registerKotlinModule()
   private val yamlMapper = configuredYamlMapper()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -179,6 +179,10 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
         every { securityGroupByName(vpc.account, vpc.region, sg1.name) } returns sg1
         every { securityGroupByName(vpc.account, vpc.region, sg2.name) } returns sg2
         every { securityGroupByName(vpc.account, vpc.region, sg3.name) } returns sg3
+
+        every {
+          springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+        } returns false
       }
 
       every { orcaService.orchestrate("keel@spinnaker", any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -89,11 +89,15 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val clock = Clock.systemUTC()!!
   val publisher: EventPublisher = mockk(relaxUnitFun = true)
   val repository = mockk<KeelRepository>()
+  private val springEnv: org.springframework.core.env.Environment = mockk(relaxUnitFun = true)
+
   val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
+
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
   val blockDeviceConfig = BlockDeviceConfig(VolumeDefaultConfiguration())
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -243,6 +243,10 @@ internal class ClusterHandlerTests : JUnit5Minutests {
       every {
         clusterExportHelper.discoverDeploymentStrategy("aws", "test", "keel", any())
       } returns RedBlack()
+
+      every {
+        springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+      } returns false
     }
 
     after {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/OrcaTaskLauncherTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/OrcaTaskLauncherTests.kt
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import org.springframework.core.env.Environment as SpringEnv
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
@@ -49,8 +50,9 @@ class OrcaTaskLauncherTests : JUnit5Minutests {
   class Fixture {
     val orcaService: OrcaService = mockk()
     val publisher: EventPublisher = mockk(relaxUnitFun = true)
+    val springEnv: SpringEnv = mockk(relaxUnitFun = true)
     val combinedRepository = mockk<KeelRepository>()
-    val taskLauncher = OrcaTaskLauncher(orcaService, combinedRepository, publisher)
+    val taskLauncher = OrcaTaskLauncher(orcaService, combinedRepository, publisher, springEnv)
     val resource: Resource<DummyResourceSpec> = resource()
     val request = slot<OrchestrationRequest>()
   }
@@ -62,6 +64,10 @@ class OrcaTaskLauncherTests : JUnit5Minutests {
       coEvery {
         orcaService.orchestrate(any(), capture(request))
       } returns TaskRefResponse("/tasks/${randomUID()}")
+
+      coEvery {
+        springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+      } returns false
     }
 
     context("an environment exists") {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -274,6 +274,10 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
 
     before {
       setupVpc()
+
+      io.mockk.coEvery {
+        springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+      } returns false
     }
 
     context("no matching security group exists") {

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandlerTests.kt
@@ -80,6 +80,8 @@ import java.util.UUID.randomUUID
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel as ClouddriverSecurityGroup
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
+import org.springframework.core.env.Environment as SpringEnv
+
 
 @Suppress("UNCHECKED_CAST")
 internal class SecurityGroupHandlerTests : JUnit5Minutests {
@@ -92,10 +94,13 @@ internal class SecurityGroupHandlerTests : JUnit5Minutests {
   }
 
   private val publisher: EventPublisher = mockk(relaxUnitFun = true)
+  private val springEnv: SpringEnv = mockk(relaxUnitFun = true)
+
   private val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
   private val objectMapper = configuredObjectMapper()
   private val normalizers = emptyList<Resolver<SecurityGroupSpec>>()

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrcaNotification.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrcaNotification.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_COMPLETE
 import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_FAILED
 import com.netflix.spinnaker.keel.model.NotificationEvent.ORCHESTRATION_STARTING
 
+//TODO[gyardeni]: once enabling the new slack integration, delete this class
 // This gets translated into an echo notification format in orca
 data class OrcaNotification(
   val type: String,
@@ -60,7 +61,6 @@ data class NotificationMessage(
 const val RAINBOW = "\uD83C\uDF08"
 const val THUNDERCLOUD = "\u26c8\ufe0f"
 
-//TODO [gyardeni]: figure out if we want to keep it around, or deprecate it
 fun NotificationConfig.toOrcaNotification() =
   OrcaNotification(
     type = this.type.toString().toLowerCase(),

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
@@ -55,7 +55,7 @@ class NotificationEventListener(
         SlackPinnedNotification(
           pin = pin,
           currentArtifact = currentArtifact,
-          pinnedArtifact = pinnedArtifact,
+          pinnedArtifact = pinnedArtifact.copy(reference = pin.reference),
           application = config.application,
           time = clock.instant()
         ),
@@ -85,7 +85,7 @@ class NotificationEventListener(
 
       sendSlackMessage(config,
         SlackUnpinnedNotification(
-          latestArtifact = latestArtifact,
+          latestArtifact = latestArtifact?.copy(reference = pinnedEnvironment!!.artifact.reference),
           pinnedArtifact = pinnedArtifact,
           application = config.application,
           time = clock.instant(),
@@ -115,7 +115,7 @@ class NotificationEventListener(
 
       sendSlackMessage(config,
         SlackMarkAsBadNotification(
-          vetoedArtifact = vetoedArtifact,
+          vetoedArtifact = vetoedArtifact.copy(reference = deliveryArtifact.reference),
           user = user,
           targetEnvironment = veto.targetEnvironment,
           time = clock.instant(),
@@ -177,7 +177,7 @@ class NotificationEventListener(
         sendSlackMessage(config,
           SlackLifecycleNotification(
             time = clock.instant(),
-            artifact = artifact,
+            artifact = artifact.copy(reference = deliveryArtifact.reference),
             eventType = type,
             application = config.application
           ),
@@ -202,7 +202,7 @@ class NotificationEventListener(
         SlackArtifactDeploymentNotification(
           time = clock.instant(),
           application = config.application,
-          artifact = artifact,
+          artifact = artifact.copy(reference = deliveryArtifact.reference),
           targetEnvironment = targetEnvironment,
           priorVersion = priorVersion,
           status = DeploymentStatus.SUCCEEDED
@@ -231,7 +231,7 @@ class NotificationEventListener(
         SlackArtifactDeploymentNotification(
           time = clock.instant(),
           application = config.application,
-          artifact = artifact,
+          artifact = artifact.copy(reference = deliveryArtifact.reference),
           targetEnvironment = veto.targetEnvironment,
           status = DeploymentStatus.FAILED
         ),

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -62,10 +62,13 @@ internal class TitusClusterExportTests : JUnit5Minutests {
   val resolvers = emptyList<Resolver<TitusClusterSpec>>()
   val repository = mockk<KeelRepository>()
   val publisher: EventPublisher = mockk(relaxUnitFun = true)
+  val springEnv: org.springframework.core.env.Environment = mockk(relaxUnitFun = true)
+
   val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
   val clock = Clock.systemUTC()
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
@@ -179,6 +182,10 @@ internal class TitusClusterExportTests : JUnit5Minutests {
       coEvery {
         clusterExportHelper.discoverDeploymentStrategy("titus", "titustest", "keel", any())
       } returns RedBlack()
+
+      every {
+        springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+      } returns false
     }
 
     after {

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -97,10 +97,13 @@ class TitusClusterHandlerTests : JUnit5Minutests {
   val resolvers = emptyList<Resolver<TitusClusterSpec>>()
   val repository = mockk<KeelRepository>()
   val publisher: EventPublisher = mockk(relaxUnitFun = true)
+  val springEnv: org.springframework.core.env.Environment = mockk(relaxUnitFun = true)
+
   val taskLauncher = OrcaTaskLauncher(
     orcaService,
     repository,
-    publisher
+    publisher,
+    springEnv
   )
   val clock = Clock.systemUTC()
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
@@ -214,6 +217,10 @@ class TitusClusterHandlerTests : JUnit5Minutests {
       every {
         clusterExportHelper.discoverDeploymentStrategy("titus", "titustest", "keel", any())
       } returns RedBlack()
+
+      every {
+        springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
+      } returns false
     }
 
     after {


### PR DESCRIPTION
1. fixed broken links and empty usernames.
2. wrapping orca notifications with a fast property, so we can finish working on + testing out the new integration and then remove it completely. The missing piece in the puzzle is interactive notifications (aka manual judgments).