### PR TITLE
chore(release): Setup weekly releases for the benefit of OSS users

### DIFF
--- a/.github/workflows/periodic_release.yml
+++ b/.github/workflows/periodic_release.yml
@@ -1,0 +1,60 @@
+name: Weekly Release
+
+on:
+  schedule:
+    # Every Tuesday at 6 PM UTC (10 AM PST)
+    - cron: "0 18 * * 2"
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git fetch --prune --unshallow
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - uses: actions/cache@v1
+        with:
+          path: ~/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Write current version
+        run: |
+          export CURRENT_TAG=`curl --silent "https://api.github.com/repos/spinnaker/keel/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'`
+          echo "version: $CURRENT_TAG" > version.yml
+
+      - name: Prepare changelog
+        id: changelog
+        uses: TriPSs/conventional-changelog-action@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version-file: "./version.yml"
+          output-file: "false"
+          skip-version-file: "true"
+          skip-commit: "true"
+
+      - name: Release build
+        env:
+          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+          BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+          RELEASE_VERSION: ${{ steps.changelog.outputs.version }}
+        run: |
+          ./gradlew --info -Pversion="${RELEASE_VERSION}" -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" -PbintrayPublishDebEnabled=false publish
+
+      - name: Create release
+        uses: actions/create-release@v1
+        if: ${{ steps.changelog.outputs.skipped == 'false' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.changelog.outputs.tag }}
+          release_name: ${{ steps.changelog.outputs.tag }}
+          body: ${{ steps.changelog.outputs.clean_changelog }}
+          draft: false
+          prerelease: true


### PR DESCRIPTION
Adds a new GitHub Action triggered on a cron schedule to create a weekly release, so that OSS users can pull in the latest changes as a dependency during installation.

I couldn't think of a way to test this locally. If you have any ideas, please let me know.

Cc: @nimakaviani 