### PR TITLE
fix(baking): Handle no versions gracefully in ImageHandler

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -45,7 +45,12 @@ class ImageHandler(
           ArtifactCheckSkipped(artifact.type, artifact.name, "ActuationInProgress")
         )
       } else {
-        val latestArtifactVersion = artifact.findLatestArtifactVersion()
+        val latestArtifactVersion = try {
+          artifact.findLatestArtifactVersion()
+        } catch (e: NoKnownArtifactVersions) {
+          log.debug("Cannot resolve AMI for artifact $artifact: $e")
+          return
+        }
         val latestBaseAmiVersion = artifact.findLatestBaseAmiVersion()
 
         val desired = Image(latestBaseAmiVersion, latestArtifactVersion, artifact.vmOptions.regions)

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -48,7 +48,7 @@ class ImageHandler(
         val latestArtifactVersion = try {
           artifact.findLatestArtifactVersion()
         } catch (e: NoKnownArtifactVersions) {
-          log.debug("Cannot resolve AMI for artifact $artifact: $e")
+          log.debug(e.message)
           return
         }
         val latestBaseAmiVersion = artifact.findLatestBaseAmiVersion()

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -38,6 +38,7 @@ import strikt.assertions.hasSize
 import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
+import strikt.assertions.isSuccess
 import strikt.mockk.captured
 import strikt.mockk.isCaptured
 import java.util.UUID.randomUUID
@@ -213,8 +214,12 @@ internal class ImageHandlerTests : JUnit5Minutests {
             }
           }
 
-          test("the handler throws an exception") {
-            handlerResult.isFailure().isA<NoKnownArtifactVersions>()
+          test("the handler completes successfully") {
+            handlerResult.isSuccess()
+          }
+
+          test("no bake is launched") {
+            expectThat(bakeTask).isNotCaptured()
           }
         }
 


### PR DESCRIPTION
We've been getting alerts for `NoKnownArtifactVersions` exceptions bubbling up all the way to the root exception handler from `ImageHandler`. This PR modifies the behavior to handle the exception gracefully by logging it and returning early.