### PR TITLE
fix(events): Fix race condition persisting resource events

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -69,12 +69,12 @@ interface KeelRepository : KeelReadOnlyRepository {
       if (diff.hasChanges() || resource.kind.version != existingResource.kind.version) {
         log.debug("Updating ${resource.id}")
         storeResource(resource)
-        publisher.publishEvent(ResourceUpdated(resource, diff.toDeltaJson(), clock))
+        appendResourceHistory(ResourceUpdated(resource, diff.toDeltaJson(), clock))
       }
     } else {
       log.debug("Creating $resource")
       storeResource(resource)
-      publisher.publishEvent(ResourceCreated(resource, clock))
+      appendResourceHistory(ResourceCreated(resource, clock))
     }
   }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -27,11 +27,7 @@ import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
-import org.jooq.impl.DSL
 import org.slf4j.LoggerFactory
-import org.springframework.transaction.annotation.Propagation.NESTED
-import org.springframework.transaction.annotation.Propagation.SUPPORTS
-import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant
@@ -247,17 +243,17 @@ open class SqlResourceRepository(
       }
 
       if (event.javaClass == previousEvent?.javaClass) return
+    }
 
-      sqlRetry.withRetry(WRITE) {
-        jooq
-          .insertInto(EVENT)
-          .set(EVENT.UID, ULID().nextULID(event.timestamp.toEpochMilli()))
-          .set(EVENT.SCOPE, event.scope)
-          .set(EVENT.REF, ref)
-          .set(EVENT.TIMESTAMP, event.timestamp)
-          .set(EVENT.JSON, event)
-          .execute()
-      }
+    sqlRetry.withRetry(WRITE) {
+      jooq
+        .insertInto(EVENT)
+        .set(EVENT.UID, ULID().nextULID(event.timestamp.toEpochMilli()))
+        .set(EVENT.SCOPE, event.scope)
+        .set(EVENT.REF, ref)
+        .set(EVENT.TIMESTAMP, event.timestamp)
+        .set(EVENT.JSON, event)
+        .execute()
     }
   }
 


### PR DESCRIPTION
**Problem**
We're consistently seeing resources being created when upserting a delivery config and the matching `ResourceCreated` events failing to persist. There's a race condition between those two flows because the first runs a transaction to persist all the records associated with the delivery config, while the second is triggered asynchronously and attempts to read the UID of the resource to create the event record.

**Proposed solution**
This PR replaces the asynchronous events published in `CombinedRepository.upsertResource` (which is only used in this particular code path) with repository calls to persist the event records as part of the transaction in `CombinedRepository.upsertDeliveryConfig`.

**Other alternatives considered**
I've considered:
* Doubling the number of read retries in that second flow. This is pretty flaky.
* Refactoring the call to `upsertResource` to return any events that need publishing, and publishing the events as the very last thing in `upsertDeliveryConfig`, which would decrease the time window of the race condition, but it seemed ugly.
* Same as above, but bubbling up the events one call higher in the stack to publish the events outside of `upsertDeliveryConfig`. This was even uglier.