### PR TITLE
feat(api): show verifications in api

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import java.time.Duration
 import java.time.Instant
@@ -74,6 +75,9 @@ data class VerificationContext(
   val artifactReference: String,
   val version: String
 ) {
+  constructor(deliveryConfig: DeliveryConfig, environment: Environment, artifact: PublishedArtifact) :
+    this(deliveryConfig, environment.name, artifact.reference, artifact.version)
+
   val environment: Environment =
     deliveryConfig.environments.first { it.name == environmentName }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStateAttributes
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.constraints.AllowedTimesConstraintEvaluator
 import com.netflix.spinnaker.keel.lifecycle.LifecycleStep
 import java.time.Instant
@@ -62,7 +64,10 @@ data class VerificationSummary(
   val startedAt: Instant? = null,
   val completedAt: Instant? = null,
   val link: String? = null
-)
+) {
+  constructor(v: Verification, s: VerificationState) :
+    this(v.id, v.type, s.status.toString(), s.startedAt, s.endedAt, v.getLink(s))
+}
 
 data class ActionMetadata(
   val at: Instant,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -259,7 +259,7 @@ class ApplicationService(
 
           environmentSummary.getArtifactPromotionStatus(artifact, artifactVersion.version)
             ?.let { status ->
-              if ( artifact.isUsedIn(environment)) { // only add a summary if the artifact is used in the environment
+              if (artifact.isUsedIn(environment)) { // only add a summary if the artifact is used in the environment
                 buildArtifactSummaryInEnvironment(
                   deliveryConfig,
                   environment.name,
@@ -295,7 +295,7 @@ class ApplicationService(
       deliveryConfig: DeliveryConfig,
       artifactVersions: List<PublishedArtifact>
   ) =
-    if(verificationsEnabled) {
+    if (verificationsEnabled) {
       repository.getVerificationStates(deliveryConfig, artifactVersions)
     } else {
       emptyMap()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -55,6 +55,7 @@ import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.core.env.Environment as SpringEnvironment
 import org.springframework.stereotype.Component
 import java.time.Instant
 
@@ -70,7 +71,7 @@ class ApplicationService(
   private val scmInfo: ScmInfo,
   private val lifecycleEventRepository: LifecycleEventRepository,
   private val publisher: ApplicationEventPublisher,
-  private val springEnv: org.springframework.core.env.Environment
+  private val springEnv: SpringEnvironment
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ScmInfo
 import com.netflix.spinnaker.keel.api.StatefulConstraint
+import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.DEFAULT_MAX_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
@@ -17,11 +18,13 @@ import com.netflix.spinnaker.keel.api.constraints.UpdatedConstraintStatus
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.artifacts.generateCompareLink
-import com.netflix.spinnaker.keel.constraints.AllowedTimesConstraintEvaluator
 import com.netflix.spinnaker.keel.core.api.AllowedTimesConstraintMetadata
 import com.netflix.spinnaker.keel.core.api.ArtifactSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
+import com.netflix.spinnaker.keel.core.api.VerificationSummary
 import com.netflix.spinnaker.keel.core.api.ArtifactVersionSummary
 import com.netflix.spinnaker.keel.core.api.DependOnConstraintMetadata
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
@@ -66,9 +69,13 @@ class ApplicationService(
   private val artifactSuppliers: List<ArtifactSupplier<*, *>>,
   private val scmInfo: ScmInfo,
   private val lifecycleEventRepository: LifecycleEventRepository,
-  private val publisher: ApplicationEventPublisher
+  private val publisher: ApplicationEventPublisher,
+  private val springEnv: org.springframework.core.env.Environment
 ) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val verificationsEnabled: Boolean
+    get() = springEnv.getProperty("keel.verifications.summary.enabled", Boolean::class.java, false)
 
   private val statelessEvaluators: List<ConstraintEvaluator<*>> =
     constraintEvaluators.filter { !it.isImplicit() && it !is StatefulConstraintEvaluator<*, *> }
@@ -231,15 +238,34 @@ class ApplicationService(
     }
 
     val artifactSummaries = deliveryConfig.artifacts.map { artifact ->
-      val artifactVersionSummaries = repository.artifactVersions(artifact, limit).map { artifactVersion ->
+      val artifactVersions = repository.artifactVersions(artifact, limit)
+
+      // A verification context identifies an artifact version in an environment
+      // For each context, there may be multiple verifications (e.g., test-container, canary)
+      //
+      // This map associates a context with this collection of verifications and their states
+      val vStateMap = getVerificationStates(deliveryConfig, artifactVersions)
+
+      val artifactVersionSummaries = artifactVersions.map { artifactVersion ->
         val artifactSummariesInEnvironments = mutableSetOf<ArtifactSummaryInEnvironment>()
 
         envSummaries.forEach { environmentSummary ->
           val environment = deliveryConfig.environments.find { it.name == environmentSummary.name }!!
+          val verifications = vStateMap[VerificationContext(deliveryConfig, environment, artifactVersion)]
+              ?.map { (verification, state) -> VerificationSummary(verification, state) }
+              ?: emptyList()
+
           environmentSummary.getArtifactPromotionStatus(artifact, artifactVersion.version)
             ?.let { status ->
               if ( artifact.isUsedIn(environment)) { // only add a summary if the artifact is used in the environment
-                buildArtifactSummaryInEnvironment(deliveryConfig, environment.name, artifact, artifactVersion.version, status)
+                buildArtifactSummaryInEnvironment(
+                  deliveryConfig,
+                  environment.name,
+                  artifact,
+                  artifactVersion.version,
+                  status,
+                  verifications
+                )
                   ?.also {
                     artifactSummariesInEnvironments.add(
                       it.addStatefulConstraintSummaries(deliveryConfig, environment, artifactVersion.version)
@@ -262,6 +288,26 @@ class ApplicationService(
 
     return artifactSummaries
   }
+
+  private fun getVerificationStates(
+      deliveryConfig: DeliveryConfig,
+      artifactVersions: List<PublishedArtifact>
+  ) =
+    if(verificationsEnabled) {
+      repository.getVerificationStates(deliveryConfig, artifactVersions)
+    } else {
+      emptyMap()
+    }
+
+  private fun buildArtifactSummaryInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String,
+    artifact: DeliveryArtifact,
+    version: String,
+    status: PromotionStatus,
+    verifications: List<VerificationSummary>) =
+    buildArtifactSummaryInEnvironment(deliveryConfig, environmentName, artifact, version, status)
+      ?.copy(verifications = verifications)
 
   private fun buildArtifactSummaryInEnvironment(deliveryConfig: DeliveryConfig, environmentName: String, artifact: DeliveryArtifact, version: String, status: PromotionStatus): ArtifactSummaryInEnvironment? {
     val currentArtifact = getArtifactInstance(artifact, version)
@@ -437,5 +483,34 @@ class ApplicationService(
     val releaseStatus = repository.getReleaseStatus(artifact, version)
     return repository.getArtifactVersion(artifact, version, releaseStatus)
   }
-
 }
+
+/**
+ * Query the repository for all of the verification states associated with [versions]
+ *
+ * This just calls [KeelRepository.getVerificationStatesBatch] and reshapes the returned value to a map
+ */
+fun KeelRepository.getVerificationStates(
+  deliveryConfig: DeliveryConfig,
+  versions: List<PublishedArtifact>
+): Map<VerificationContext, Map<Verification, VerificationState>> =
+  deliveryConfig.contexts(versions).let { contexts ->
+    contexts.zip(getVerificationStatesBatch(contexts))
+      .associate { (ctx: VerificationContext, vIdToState: Map<String, VerificationState>) ->
+        ctx to (vIdToState.entries.associate { (vId, state) ->
+          ctx.verification(vId) to state
+        })
+      }
+  }
+
+/**
+ * A verification context identifies an (environment, artifact version) pair.
+ *
+ * This takes a list of [PublishedArtifact] (artifact versions) and returns the corresponding contexts
+ */
+fun DeliveryConfig.contexts(
+  versions: List<PublishedArtifact>
+): List<VerificationContext> =
+  versions.flatMap { version ->
+    environments.map { env -> VerificationContext(this, env, version) }
+  }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -245,14 +245,14 @@ class ApplicationService(
       // For each context, there may be multiple verifications (e.g., test-container, canary)
       //
       // This map associates a context with this collection of verifications and their states
-      val vStateMap = getVerificationStates(deliveryConfig, artifactVersions)
+      val verificationStateMap = getVerificationStates(deliveryConfig, artifactVersions)
 
       val artifactVersionSummaries = artifactVersions.map { artifactVersion ->
         val artifactSummariesInEnvironments = mutableSetOf<ArtifactSummaryInEnvironment>()
 
         envSummaries.forEach { environmentSummary ->
           val environment = deliveryConfig.environments.find { it.name == environmentSummary.name }!!
-          val verifications = vStateMap[VerificationContext(deliveryConfig, environment, artifactVersion)]
+          val verifications = verificationStateMap[VerificationContext(deliveryConfig, environment, artifactVersion)]
               ?.map { (verification, state) -> VerificationSummary(verification, state) }
               ?: emptyList()
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -252,7 +252,8 @@ class ApplicationService(
 
         envSummaries.forEach { environmentSummary ->
           val environment = deliveryConfig.environments.find { it.name == environmentSummary.name }!!
-          val verifications = verificationStateMap[VerificationContext(deliveryConfig, environment, artifactVersion)]
+          val verificationContext = VerificationContext(deliveryConfig, environment, artifactVersion)
+          val verifications = verificationStateMap[verificationContext]
               ?.map { (verification, state) -> VerificationSummary(verification, state) }
               ?: emptyList()
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
@@ -120,6 +120,12 @@ class ComparableLinksTests : JUnit5Minutests {
 
     val publisher: ApplicationEventPublisher = mockk(relaxed = true)
 
+    val springEnv: org.springframework.core.env.Environment = mockk() {
+      every {
+        getProperty("keel.verifications.summary.enabled", Boolean::class.java, any())
+      } returns true
+    }
+
     // subject
     val applicationService = ApplicationService(
       repository,
@@ -128,7 +134,8 @@ class ComparableLinksTests : JUnit5Minutests {
       listOf(artifactSupplier),
       scmInfo,
       lifecycleEventRepository,
-      publisher
+      publisher,
+      springEnv
     )
 
     val buildMetadata = BuildMetadata(
@@ -150,7 +157,7 @@ class ComparableLinksTests : JUnit5Minutests {
     )
 
     fun Collection<String>.toArtifactVersions(artifact: DeliveryArtifact) =
-      map { PublishedArtifact(artifact.name, artifact.type, it) }
+      map { PublishedArtifact(artifact.name, artifact.type, artifact.reference, it) }
   }
 
   fun comparableLinksTests() = rootContext<Fixture> {
@@ -178,6 +185,10 @@ class ComparableLinksTests : JUnit5Minutests {
       every {
         repository.getPinnedVersion(any(), any(), any())
       } returns null
+
+      every {
+        repository.getVerificationStatesBatch(any())
+      } returns emptyList()
     }
 
     context("each environment has a current version, and previous versions") {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
@@ -37,6 +37,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.core.env.Environment as SpringEnvironment
 import strikt.api.Assertion
 import strikt.api.DescribeableBuilder
 import strikt.api.expectThat
@@ -120,7 +121,7 @@ class ComparableLinksTests : JUnit5Minutests {
 
     val publisher: ApplicationEventPublisher = mockk(relaxed = true)
 
-    val springEnv: org.springframework.core.env.Environment = mockk() {
+    val springEnv: SpringEnvironment = mockk() {
       every {
         getProperty("keel.verifications.summary.enabled", Boolean::class.java, any())
       } returns true


### PR DESCRIPTION
Provide the UI with information about the state of verifications for artifact versions in each environment. (For example, what verifications have been run against keel-0.850.0-h1020.a525f99 in the prestaging environment)?

Note: follow-up to PR #1777. Much of the description is copied from there.

# Proposed solution

In the `/application/{application}` endpoint (called by deck in the environments view), add additional fields to artifact version objects which encode verification summary notification.

In *jq* notation, these verification summaries are found in: `artifacts[].versions[].environments[].verifications`.

## Example output

For the `fnord` app, the API call would be:

http://gate/managed/application/fnord?entities=resources&entities=artifacts&entities=environments

The  output would looke like this:

```json
{
  "artifacts": [
    {
      "name": "fnord",
      "type": "deb",
      "reference": "fnord",
      "versions": [
        {
          "version": "fnord-0.850.0-h1021.b527f39",
          "environments": [
            {
              "name": "staging",
              "verifications": [
                {
                  "id": "test-container:acme/testcon:stable",
                  "type": "test-container",
                  "status": "PASSED",
                  "startedAt": "2021-01-04T22:31:12.142Z",
                  "completedAt": "2021-01-04T22:52:07.358Z",
                  "link": "http://www.example.com/test-output/abc123"
                }
              ]
            }
          ]
```

# Work in this PR

With this PR, the verification info actually shows up in the API! All of the logic is in the ApplicationService class.

I put this functionality behind a feature toggle , so we can switch it off quickly if it breaks the environment view.

Property name: `keel.verifications.summary.enabled`

It's off by default, will test by enabling via our internal dynamic property system. Will turn it on by default, or zap it entirely, in a future PR.

# Future work

* Populate the `link` for test-container verification strategy (currently it is always null).