### PR TITLE
fix(test): Bump testcontainers version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,16 +108,16 @@ subprojects {
     exclude("javax.servlet", "servlet-api")
 
     resolutionStrategy {
-      var okHttpVersion = "4.5.0"
-      var resilience4jVersion = "1.5.0"
       force(
-        "com.squareup.okhttp3:okhttp:$okHttpVersion",
-        "com.squareup.okhttp3:okhttp-urlconnection:$okHttpVersion",
-        "com.squareup.okhttp3:okhttp-sse:$okHttpVersion",
-        "com.squareup.okhttp3:mockwebserver:$okHttpVersion",
-        "com.squareup.okhttp3:logging-interceptor:$okHttpVersion",
-        "io.github.resilience4j:resilience4j-kotlin:$resilience4jVersion",
-        "io.github.resilience4j:resilience4j-retry:$resilience4jVersion")
+        "com.squareup.okhttp3:okhttp:${property("okHttpVersion")}",
+        "com.squareup.okhttp3:okhttp-urlconnection:${property("okHttpVersion")}",
+        "com.squareup.okhttp3:okhttp-sse:${property("okHttpVersion")}",
+        "com.squareup.okhttp3:mockwebserver:${property("okHttpVersion")}",
+        "com.squareup.okhttp3:logging-interceptor:${property("okHttpVersion")}",
+        "io.github.resilience4j:resilience4j-kotlin:${property("resilience4jVersion")}",
+        "io.github.resilience4j:resilience4j-retry:${property("resilience4jVersion")}",
+        "org.testcontainers:mysql:${property("testContainersVersion")}"
+      )
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,9 @@ org.gradle.parallel=true
 spinnakerGradleVersion=8.10.1
 buildingInDocker=false
 targetJava11=true
-testContainersVersion=1.15.0
+testContainersVersion=1.15.1
+okHttpVersion=4.5.0
+resilience4jVersion=1.5.0
 
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.

--- a/keel-sql/src/test/resources/testcontainers.properties
+++ b/keel-sql/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+ryuk.container.image = public.ecr.aws/s4w6t4b6/testcontainers/ryuk:0.3.0 


### PR DESCRIPTION
Upgrades `testcontainers` to 1.15.1 to fix the following error in the builds:
```
com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"No such image: testcontainers/ryuk:0.3.0"}
    at org.testcontainers.shaded.com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:241)
```