### PR TITLE
feat(ec2): tag image after verification

### DIFF
--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -160,6 +160,14 @@ interface CloudDriverService {
     @Query("region") region: String? = null
   ): List<NamedImage>
 
+  @GET("/aws/images/{account}/{region}/{id}")
+  suspend fun getImage(
+    @Path("account") account: String,
+    @Path("region") region: String,
+    @Path("id") amiId: String,
+    @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
+  ): List<NamedImage>
+
   @GET("/images/find")
   suspend fun images(
     @Query("provider") provider: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/BaseClusterHandler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/BaseClusterHandler.kt
@@ -59,4 +59,9 @@ abstract class BaseClusterHandler<SPEC: ResourceSpec, RESOLVED: Any>(
     }
     return ActionDecision(willAct = true)
   }
+
+  /**
+   * gets current state of the resource and returns the current image, by region.
+   */
+  abstract suspend fun getImage(resource: Resource<SPEC>): CurrentImages
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/CurrentImages.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/CurrentImages.kt
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.keel.api.plugins
+
+import com.netflix.spinnaker.keel.api.ResourceKind
+
+data class CurrentImages(
+  val kind: ResourceKind,
+  val images: List<ImageInRegion>,
+  val resourceId: String
+)
+
+data class ImageInRegion(
+  val region: String,
+  val imageName: String,
+  val account: String
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -125,6 +125,7 @@ data class VerificationCompleted(
   val artifactType: ArtifactType,
   val artifactVersion: String,
   val verificationType: String,
+  val verificationId: String,
   val status: ConstraintStatus,
   val metadata: Map<String,Any?>
 ) : TelemetryEvent() {
@@ -141,6 +142,7 @@ data class VerificationCompleted(
     context.artifact.type,
     context.version,
     verification.type,
+    verification.id,
     status,
     metadata
   )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -121,25 +121,28 @@ data class VerificationCompleted(
   val application: String,
   val deliveryConfigName: String,
   val environmentName: String,
-  val artifactName: String,
+  val artifactReference: String,
   val artifactType: ArtifactType,
   val artifactVersion: String,
   val verificationType: String,
-  val status: ConstraintStatus
+  val status: ConstraintStatus,
+  val metadata: Map<String,Any?>
 ) : TelemetryEvent() {
   constructor(
     context: VerificationContext,
     verification: Verification,
-    status: ConstraintStatus
+    status: ConstraintStatus,
+    metadata: Map<String, Any?>
   ) : this(
     context.deliveryConfig.application,
     context.deliveryConfig.name,
     context.environmentName,
-    context.artifact.name,
+    context.artifact.reference,
     context.artifact.type,
     context.version,
     verification.type,
-    status
+    status,
+    metadata
   )
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/ImageFinder.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/ImageFinder.kt
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.keel.verification
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.plugins.BaseClusterHandler
+import com.netflix.spinnaker.keel.api.plugins.CurrentImages
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+@Component
+class ImageFinder(
+  val clusterHandlers: List<BaseClusterHandler<*,*>>
+) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  /**
+   * Find images that are currently running in an environment and returns them
+   */
+  fun getImages(deliveryConfig: DeliveryConfig, envName: String): List<CurrentImages> {
+    val env = checkNotNull(deliveryConfig.environments.find { it.name == envName }) {
+      "Failed to find environment $envName in deliveryConfig ${deliveryConfig.name}"
+    }
+    return env.resources.mapNotNull { resource ->
+        runBlocking { getImages(resource) }
+      }
+  }
+
+  private suspend fun getImages(resource: Resource<*>): CurrentImages? =
+    clusterHandlers
+      .find { it.supportedKind.kind == resource.kind }
+      ?.getImages(resource)
+
+  @Suppress("UNCHECKED_CAST")
+  private suspend fun <S : ResourceSpec, R : Any> BaseClusterHandler<S, R>.getImages(
+    resource: Resource<*>
+  ): CurrentImages =
+    getImage(resource as Resource<S>)
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/ImageTagger.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/ImageTagger.kt
@@ -1,0 +1,90 @@
+package com.netflix.spinnaker.keel.ec2
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spectator.api.BasicTag
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.plugins.CurrentImages
+import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
+import com.netflix.spinnaker.keel.telemetry.VerificationCompleted
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.context.event.EventListener
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+
+/**
+ * This class tags images after they've been verified.
+ *
+ * This is meant to provide a hook to transition from managed
+ * delivery back to pipelines. Images will be tagged when they have
+ * successfully been verified with `latest tested = true`. This allows
+ * a pipeline to find the latest tested image and deploy that.
+ *
+ * This runs for all images that have passed verification.
+ */
+@Component
+class ImageTagger(
+  private val mapper: ObjectMapper,
+  private val taskLauncher: TaskLauncher,
+  private val springEnv: Environment,
+  private val spectator: Registry
+) {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val TAG_AMI_JOB_LAUNCHED = "keel.image.tag"
+
+  private val shouldTagImages: Boolean
+    get() = springEnv.getProperty("keel.image.tagging.enabled", Boolean::class.java, true)
+
+  @EventListener(VerificationCompleted::class)
+  fun onVerificationCompleted(event: VerificationCompleted) {
+    if (event.status.failed() || !shouldTagImages) {
+      return
+    }
+
+    val imagesString: Any = event.metadata["images"] ?: emptyList<CurrentImages>()
+    val images: List<CurrentImages> = try {
+      mapper.convertValue(imagesString)
+    } catch (e: IllegalArgumentException) {
+      log.error("Malformed metadata in 'images' key: $imagesString")
+      emptyList()
+    }
+
+    val jobs = images
+      .filter { it.kind.group == "ec2" } // spinnaker only supports tagging amis
+      .map { it.toJob(event.environmentName) }
+
+    jobs.forEach { job ->
+      val names = job["imageNames"].toString()
+      val task = runBlocking {
+        taskLauncher.submitJob(
+          user = DEFAULT_SERVICE_ACCOUNT,
+          application = event.application,
+          notifications = emptySet(),
+          subject = names,
+          description = "Automatically tagging image(s) as verified $names",
+          correlationId = names,
+          stages = listOf(job)
+        )
+      }
+      log.debug("Launching task ${task.id} to tag image(s) $names")
+      spectator.counter(
+        TAG_AMI_JOB_LAUNCHED,
+        listOf(BasicTag("application", event.application))
+      )
+    }
+  }
+
+  fun CurrentImages.toJob(env: String): Map<String, Any?> =
+    mapOf(
+      "type" to "upsertImageTags",
+      "imageNames" to images.map { it.imageName },
+      "regions" to images.map { it.region }.toSet(),
+      "tags" to mapOf(
+        "latest tested" to true,
+        "environment" to env
+      )
+    )
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/ImageTaggerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/ImageTaggerTests.kt
@@ -1,0 +1,132 @@
+package com.netflix.spinnaker.keel.ec2
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spectator.api.Registry
+import com.netflix.spinnaker.keel.api.ResourceKind
+import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
+import com.netflix.spinnaker.keel.api.plugins.CurrentImages
+import com.netflix.spinnaker.keel.api.plugins.ImageInRegion
+import com.netflix.spinnaker.keel.telemetry.VerificationCompleted
+import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.Called
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.springframework.core.env.Environment
+import strikt.api.expect
+import strikt.assertions.isA
+import strikt.assertions.isEqualTo
+
+class ImageTaggerTests : JUnit5Minutests {
+  object Fixture {
+    private val mapper = configuredTestObjectMapper()
+    val taskLauncher: TaskLauncher = mockk() {
+      coEvery { submitJob(user = any(), application = "waffles", notifications = emptySet(), subject = any(), description = any(), correlationId = any(), stages = any())
+      } returns Task("123", "blah")
+    }
+    private val springEnv: Environment = mockk {
+      every { getProperty("keel.image.tagging.enabled", Boolean::class.java, any()) } returns true
+    }
+    val spectator: Registry = NoopRegistry()
+    val tagger: ImageTagger = ImageTagger(mapper, taskLauncher, springEnv, spectator)
+
+    val ec2images = listOf(CurrentImages(
+      ResourceKind.parseKind("ec2/cluster@v1.1"),
+      listOf(ImageInRegion("us-east-1", "my-waffles-are-great", "kitchen")),
+      "my-resource"
+    ))
+    val titusImages = listOf(CurrentImages(
+      ResourceKind.parseKind("titus/cluster@v1.1"),
+      listOf(ImageInRegion("us-east-1", "my-waffles-are-great", "kitchen")),
+      "my-resource"
+    ))
+
+    val eventWithImages = VerificationCompleted(
+      application = "waffles",
+      deliveryConfigName = "waffles-manifest",
+      environmentName = "breakfast",
+      artifactReference = "waffle",
+      artifactType = DEBIAN,
+      artifactVersion = "waffle-buttermilk-2.0",
+      verificationType = "taste-test",
+      status = PASS,
+      metadata = mapOf(
+        "taste" to "excellent",
+        "task" to "eater=emily",
+        "images" to ec2images
+      )
+    )
+    val eventWithoutImages = eventWithImages.copy(metadata = emptyMap())
+    val failedEvent = eventWithImages.copy(status = FAIL)
+    val notEc2Event = eventWithoutImages.copy(
+      metadata = mapOf(
+        "taste" to "excellent",
+        "task" to "eater=emily",
+        "images" to titusImages
+      )
+    )
+    val malformedImagesEvent = eventWithImages.copy(metadata = mapOf("images" to "pictures"))
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture { Fixture }
+
+    context("ignored events") {
+      test("failed verification") {
+        tagger.onVerificationCompleted(failedEvent)
+        verify { taskLauncher wasNot Called}
+      }
+
+      test("not ec2 cluster") {
+        tagger.onVerificationCompleted(notEc2Event)
+        verify { taskLauncher wasNot Called}
+      }
+
+      test("no images") {
+        tagger.onVerificationCompleted(eventWithoutImages)
+        verify { taskLauncher wasNot Called}
+      }
+
+      test("malformed images") {
+        tagger.onVerificationCompleted(malformedImagesEvent)
+        verify { taskLauncher wasNot Called}
+      }
+    }
+
+    context("ec2 events") {
+      test("task launched to tag") {
+        tagger.onVerificationCompleted(eventWithImages)
+        val jobSlot = slot<List<Map<String,Any?>>>()
+        coVerify(exactly = 1) {
+          taskLauncher.submitJob(
+            user = any(),
+            application = "waffles",
+            notifications = emptySet(),
+            subject = any(),
+            description = any(),
+            correlationId = any(),
+            stages = capture(jobSlot)
+          )
+        }
+        expect {
+          with(jobSlot.captured) {
+            that(size).isEqualTo(1)
+            that(first()["type"]).isEqualTo("upsertImageTags")
+            that(first()["tags"]).isA<Map<String,Any?>>().isEqualTo(
+              mapOf("latest tested" to true, "environment" to "breakfast")
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/ImageTaggerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/ImageTaggerTests.kt
@@ -58,6 +58,7 @@ class ImageTaggerTests : JUnit5Minutests {
       artifactType = DEBIAN,
       artifactVersion = "waffle-buttermilk-2.0",
       verificationType = "taste-test",
+      verificationId = "my/docker:tag",
       status = PASS,
       metadata = mapOf(
         "taste" to "excellent",
@@ -122,7 +123,7 @@ class ImageTaggerTests : JUnit5Minutests {
             that(size).isEqualTo(1)
             that(first()["type"]).isEqualTo("upsertImageTags")
             that(first()["tags"]).isA<Map<String,Any?>>().isEqualTo(
-              mapOf("latest tested" to true, "environment" to "breakfast")
+              mapOf("latest tested" to true, "breakfast" to "environment:passed", "my/docker:tag" to "passed")
             )
           }
         }


### PR DESCRIPTION
This pr supports an experiment: a hook point that allows managed delivery to hand off to pipelines. 

Right before a verification starts the verification runner finds all the images that are currently in an environment. This is done by calling the cluster handlers (we ignore other resources) and getting the image that's running in that cluster (using the `current` function). We save that in the verification metadata.

If the verification passes, we dig into that metadata and issue a "tag image" job for each ami.
![Screen Shot 2021-02-04 at 3 59 45 PM](https://user-images.githubusercontent.com/8454927/107092850-1bec1700-67b9-11eb-9af0-569ceef8a412.png)

This is meant to be a quick and dirty experiment to allow our partners (danny) to test out some new templates. If it turns out that handing off between md and pipelines is useful, I might implement v2 of this in a different way.


