### PR TITLE
Versioned resources

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -16,6 +16,9 @@ data class Resource<out T : ResourceSpec>(
   val id: String
     get() = metadata.getValue("id").toString()
 
+  val version: Int
+    get() = metadata.getValue("version") as Int
+
   val serviceAccount: String
     get() = metadata.getValue("serviceAccount").toString()
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -599,6 +599,29 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         }
       }
 
+      context("updating an existing delivery config with a new version of a resource") {
+        before {
+          storeArtifacts()
+          storeResources()
+          store()
+
+          val resource = deliveryConfig.environments.first().resources.first { it.kind == parseKind("ec2/cluster@v1") }
+            .run {
+              copy(spec = DummyResourceSpec(id = id, application = application))
+            }
+
+          resourceRepository.store(resource)
+        }
+
+        test("retrieving the delivery config includes the new version of the resource") {
+          getByName()
+            .isSuccess()
+            .get { resources.map(Resource<*>::version) }
+            .hasSize(deliveryConfig.resources.size)
+            .contains(2)
+        }
+      }
+
       context("notifications") {
         before {
           repository.store(deliveryConfig.copy(

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -17,6 +17,7 @@ package com.netflix.spinnaker.keel.persistence
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.events.ApplicationActuationPaused
 import com.netflix.spinnaker.keel.events.ApplicationActuationResumed
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
@@ -181,6 +182,20 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         test("the resource version is incremented") {
           expectThat(subject.get<DummyResourceSpec>(resource.id))
             .get(Resource<*>::version) isEqualTo 2
+        }
+
+        context("when deleted") {
+          before {
+            subject.delete(resource.id)
+          }
+
+          test("all versions of the resource are deleted") {
+            expectCatching {
+              subject.get(resource.id)
+            }
+              .isFailure()
+              .isA<NoSuchResourceException>()
+          }
         }
       }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -38,10 +38,6 @@ import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
-import java.time.Clock
-import java.time.Duration
-import java.time.Period
-import java.util.UUID.randomUUID
 import strikt.api.Assertion
 import strikt.api.expectCatching
 import strikt.api.expectThat
@@ -55,6 +51,10 @@ import strikt.assertions.isFailure
 import strikt.assertions.isGreaterThanOrEqualTo
 import strikt.assertions.isNotEmpty
 import strikt.assertions.map
+import java.time.Clock
+import java.time.Duration
+import java.time.Period
+import java.util.UUID.randomUUID
 
 abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests {
 
@@ -176,6 +176,11 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
           expectThat(subject.get<DummyResourceSpec>(resource.id))
             .get(Resource<*>::spec)
             .isEqualTo(updatedResource.spec)
+        }
+
+        test("the resource version is incremented") {
+          expectThat(subject.get<DummyResourceSpec>(resource.id))
+            .get(Resource<*>::version) isEqualTo 2
         }
       }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -134,6 +134,7 @@ class ResourceActuator(
             ResourceActuationVetoed(
               resource.kind,
               resource.id,
+              resource.version,
               resource.spec.application,
               response.message,
               response.vetoName,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -279,7 +279,7 @@ class CombinedRepository(
   override fun getResourcesByApplication(application: String): List<Resource<*>> =
     resourceRepository.getResourcesByApplication(application)
 
-  override fun storeResource(resource: Resource<*>) =
+  override fun storeResource(resource: Resource<*>): Resource<*> =
     resourceRepository.store(resource)
 
   override fun deleteResource(id: String) =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -68,13 +68,15 @@ interface KeelRepository : KeelReadOnlyRepository {
       val diff = DefaultResourceDiff(resource.spec, existingResource.spec)
       if (diff.hasChanges() || resource.kind.version != existingResource.kind.version) {
         log.debug("Updating ${resource.id}")
-        storeResource(resource)
-        appendResourceHistory(ResourceUpdated(resource, diff.toDeltaJson(), clock))
+        storeResource(resource).also { updatedResource ->
+          appendResourceHistory(ResourceUpdated(updatedResource, diff.toDeltaJson(), clock))
+        }
       }
     } else {
       log.debug("Creating $resource")
-      storeResource(resource)
-      appendResourceHistory(ResourceCreated(resource, clock))
+      storeResource(resource).also { updatedResource ->
+        appendResourceHistory(ResourceCreated(updatedResource, clock))
+      }
     }
   }
 
@@ -123,7 +125,7 @@ interface KeelRepository : KeelReadOnlyRepository {
   // START ResourceRepository methods
   fun allResources(callback: (ResourceHeader) -> Unit)
 
-  fun storeResource(resource: Resource<*>)
+  fun storeResource(resource: Resource<*>): Resource<*>
 
   fun deleteResource(id: String)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -31,7 +31,7 @@ import com.netflix.spinnaker.keel.exceptions.DuplicateManagedResourceException
 import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAULT_MAX_EVENTS
 import org.slf4j.Logger
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Propagation.REQUIRED
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Duration
@@ -45,10 +45,10 @@ interface KeelRepository : KeelReadOnlyRepository {
   val publisher: ApplicationEventPublisher
   val log: Logger
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = REQUIRED)
   fun upsertDeliveryConfig(submittedDeliveryConfig: SubmittedDeliveryConfig): DeliveryConfig
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = REQUIRED)
   fun upsertDeliveryConfig(deliveryConfig: DeliveryConfig): DeliveryConfig
 
   fun <T : ResourceSpec> upsertResource(resource: Resource<T>, deliveryConfigName: String) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -80,7 +80,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<ResourceSp
    *
    * @return the `uid` of the stored resource.
    */
-  fun store(resource: Resource<*>)
+  fun store(resource: Resource<*>): Resource<*>
 
   /**
    * Deletes the resource represented by [id].

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
@@ -28,6 +28,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
   private val event = ResourceValid(
     kind = parseKind("ec2/cluster@v1"),
     id = "ec2:cluster:prod:keel-main",
+    version = 1,
     application = "fnord",
     timestamp = Instant.now()
   )

--- a/keel-sql/src/main/resources/db/changelog/20210208-versioned-resources.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210208-versioned-resources.yml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+- changeSet:
+    id: versioned-resources
+    author: fletch
+    changes:
+    - addColumn:
+        tableName: resource
+        columns:
+        - name: version
+          type: integer
+          defaultValueNumeric: 1
+          afterColumn: id
+          constraints:
+            nullable: false
+    - dropUniqueConstraint:
+        tableName: resource
+        constraintName: name
+    - addUniqueConstraint:
+        tableName: resource
+        constraintName: resource_id_version_idx
+        columnNames: id, version
+    - dropView:
+        viewName: resource_with_metadata
+    - createView:
+        viewName: resource_with_metadata
+        selectQuery: |
+          select
+            resource.uid,
+            resource.id,
+            resource.application,
+            resource.kind,
+            json_object(
+              'uid', resource.uid,
+              'id', resource.id,
+              'version', resource.version,
+              'application', resource.application,
+              'environment', environment.uid,
+              'environmentName', environment.name,
+              'deliveryConfig', delivery_config.uid,
+              'serviceAccount', delivery_config.service_account
+            ) as metadata,
+            resource.spec
+          from resource
+          left outer join environment_resource on resource.uid = environment_resource.resource_uid
+          left outer join environment on environment.uid = environment_resource.environment_uid
+          left outer join delivery_config on delivery_config.uid = environment.delivery_config_uid
+          where resource.version = (select max(r2.version) from resource r2 where resource.id = r2.id)

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -233,3 +233,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210114-verification-state-task-list.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210208-versioned-resources.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -73,16 +73,6 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
     }
   }
 
-  class UnreadableResourceFixture(
-    val factory: (Clock) -> SqlResourceRepository
-  ) {
-    val clock = MutableClock()
-    val subject: SqlResourceRepository = factory(clock)
-
-    fun nextResults(): Collection<Resource<*>> =
-      subject.itemsDueForCheck(Duration.ofMinutes(30), 2)
-  }
-
   fun unreadableResourceTests() = rootContext<Fixture<Resource<ResourceSpec>, SqlResourceRepository>> {
     fixture {
       Fixture(

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -18,8 +18,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.assertions.first
 import strikt.assertions.hasSize
 import strikt.assertions.isA
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isSuccess
 import java.time.Clock
@@ -119,6 +122,29 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
         expectCatching { nextResults() }.isSuccess().hasSize(2)
         expectCatching { nextResults() }.isSuccess().hasSize(1)
         expectCatching { nextResults() }.isSuccess().hasSize(0)
+      }
+    }
+  }
+
+  fun versionedResourceTests() = rootContext<Fixture<Resource<ResourceSpec>, SqlResourceRepository>> {
+    fixture {
+      Fixture(factory, createAndStore, updateOne)
+    }
+
+    context("multiple versions of a resource exist") {
+      before {
+        createAndStore(1)
+        updateOne()
+      }
+
+      test("the older resource version is never checked") {
+        expectThat(nextResults())
+          .hasSize(1)
+          .first()
+          .get(Resource<*>::version) isEqualTo 2
+
+        expectThat(nextResults())
+          .isEmpty()
       }
     }
   }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -8,7 +8,7 @@ import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
 
-internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
+internal class SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(5, 100)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -105,6 +105,7 @@ fun <T : ResourceSpec> resource(
     spec = spec,
     metadata = mapOf(
       "id" to generateId(kind, spec),
+      "version" to 1,
       "application" to application,
       "serviceAccount" to "keel@spinnaker"
     )

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -121,6 +121,7 @@ internal class DeliveryConfigControllerTests
             kind = it.kind,
             metadata = mapOf(
               "id" to randomUID().toString(),
+              "version" to 1,
               "serviceAccount" to serviceAccount,
               "application" to application
             ),


### PR DESCRIPTION
The aim of this PR is to start the implementation of versioned environments by making resources versioned.

* Each resource `id` may have 1..n versions
* The combination of `id` and `version` is unique
* Each version has a unique `uid`
* The resource with the highest `version` for a given `id` is the newest
* For now we will always deal with the newest version, but in future an environment version will reference particular resource versions

To-do
- [x] Test that old resource versions are no longer checked
- [x] Change resource deletion so that it deletes _all_ versions
- [x] Re-link environment to new resource version