### PR TITLE
chore(veto/pin): reflect new desired artifact more quickly

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -255,6 +255,9 @@ class CombinedRepository(
 
   override fun getApplicationSummaries(): Collection<ApplicationSummary> =
     deliveryConfigRepository.getApplicationSummaries()
+
+  override fun triggerRecheck(application: String) =
+    deliveryConfigRepository.triggerRecheck(application)
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepository.kt
@@ -168,6 +168,12 @@ interface DeliveryConfigRepository : PeriodicallyCheckedRepository<DeliveryConfi
   fun getApplicationSummaries(): Collection<ApplicationSummary>
 
   fun deliveryConfigLastChecked(deliveryConfig: DeliveryConfig): Instant
+
+  /**
+   * Resets the last checked time for the delivery config to the initial value
+   * (EPOCH + 1s) so that the environments will immediately be rechecked.
+   */
+  fun triggerRecheck(application: String)
 }
 
 abstract class NoSuchDeliveryConfigException(message: String) :

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -116,6 +116,8 @@ interface KeelRepository : KeelReadOnlyRepository {
   fun markDeliveryConfigCheckComplete(deliveryConfig: DeliveryConfig)
 
   fun getApplicationSummaries(): Collection<ApplicationSummary>
+
+  fun triggerRecheck(application: String)
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -958,6 +958,9 @@ class ApplicationServiceTests : JUnit5Minutests {
         every {
           repository.pinEnvironment(singleArtifactDeliveryConfig, pin)
         } just Runs
+        every {
+          repository.triggerRecheck(application1)
+        } just Runs
 
         applicationService.pin("keel@keel.io", application1, pin)
       }
@@ -978,6 +981,10 @@ class ApplicationServiceTests : JUnit5Minutests {
       before {
         every {
           repository.deletePin(singleArtifactDeliveryConfig, "production", releaseArtifact.reference)
+        } just Runs
+
+        every {
+          repository.triggerRecheck(application1)
         } just Runs
 
         every {
@@ -1002,6 +1009,10 @@ class ApplicationServiceTests : JUnit5Minutests {
       before {
         every {
           repository.deletePin(singleArtifactDeliveryConfig, "production")
+        } just Runs
+
+        every {
+          repository.triggerRecheck(application1)
         } just Runs
 
         every {


### PR DESCRIPTION
When someone vetos an artifact or pins an artifact (or deletes either of those) we want to make sure that we reflect this really quickly. It's a bad experience to have to wait a minute for that change to get picked up. This PR triggers a recheck of all the environments in a config every time one of those things happens. This means that the desired version for each resource gets reflected more quickly. 

My goal is to make the mark-as-bad -> rollback action happen as quickly as possible so the UI feels more responsive.