### PR TITLE
fix(api): verification summary issues

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -473,4 +473,13 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         }
     }
   }
+
+  @Test
+  fun `zero states`() {
+    context.setup()
+
+    val stateMaps = subject.getStatesBatch(emptyList())
+
+    expectThat(stateMaps).isEmpty()
+  }
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -221,7 +221,7 @@ class SqlArtifactRepository(
         .where(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
         .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type))
         .fetchSortedArtifactVersions(artifact, limit)
-        .map { it.copy(reference=artifact.reference) }
+        .map { it.copy(reference = artifact.reference) }
     }
   }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -221,6 +221,7 @@ class SqlArtifactRepository(
         .where(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
         .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type))
         .fetchSortedArtifactVersions(artifact, limit)
+        .map { it.copy(reference=artifact.reference) }
     }
   }
 


### PR DESCRIPTION
This fixes two bugs in the API used by the environments view that displays verifications data.

## Problems

Two separate cases weren't being handled properly

* when the artifact reference does not match artifact name
* when the list of verification contexts is empty in the `getStatesBatch` call.

## Implemented solutions

### Copy objects to add artifact reference

When querying the artifact repository for a list of published artifact versions, we now add the artifact references by copying each element of the list. 

This isn't the most efficient way of doing this, but code-wise it was the smallest change.

### Use reduceOrNull instead of reduce

Kotlin's `reduce` throws an exception if you give it an empty list. Change to using `reduceOrNull` and then do null handling.


Note: You'll want to hide whitespace when looking at the diff.