### PR TITLE
feat(verif): more robust handling of invalid verification id

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -86,5 +86,5 @@ data class VerificationContext(
 
   val verifications: Collection<Verification> = environment.verifyWith
 
-  fun verification(id: String): Verification = verifications.first { it.id == id }
+  fun verification(id: String): Verification? = verifications.firstOrNull { it.id == id }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -578,7 +578,7 @@ class ApplicationService(
       .mapNotNull { (vId: String, state: VerificationState) ->
         ctx.verification(vId) // Verification?
           ?.let { verification -> verification to state } // Pair<Verification, VerificationState>?
-          .also { if (it == null) { onInvalidVerificationId(vId, deliveryConfig, ctx) }}
+          .also { if (it == null) { onInvalidVerificationId(vId, deliveryConfig, ctx) } }
       }
       .toMap()
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -53,6 +53,7 @@ import com.netflix.spinnaker.keel.lifecycle.LifecycleEventRepository
 import com.netflix.spinnaker.keel.persistence.ArtifactNotFoundException
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigException
+import com.netflix.spinnaker.keel.telemetry.InvalidVerificationIdSeen
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.core.env.Environment as SpringEnvironment
@@ -499,25 +500,52 @@ class ApplicationService(
     val releaseStatus = repository.getReleaseStatus(artifact, version)
     return repository.getArtifactVersion(artifact, version, releaseStatus)
   }
+
+  /**
+   * Query the repository for all of the verification states associated with [versions]
+   *
+   * This just calls [KeelRepository.getVerificationStatesBatch] and reshapes the returned value to a map
+   */
+  fun KeelRepository.getVerificationStates(
+    deliveryConfig: DeliveryConfig,
+    versions: List<PublishedArtifact>
+  ): Map<VerificationContext, Map<Verification, VerificationState>> =
+    deliveryConfig.contexts(versions).let { contexts: List<VerificationContext> ->
+      contexts.zip(getVerificationStatesBatch(contexts)) // List<Pair<VerificationContext, Map<String, VerificationState>>
+        .associate { (ctx, vIdToState) -> ctx to vIdToState.toVerificationMap(deliveryConfig, ctx) }
+    }
+
+  /**
+   * Convert a (verification id -> verification state) map to a (verification -> verification state) map
+   *
+   * Most of the logic in this method is to deal with the case where the verification id is invalid
+   */
+  fun Map<String, VerificationState>.toVerificationMap(deliveryConfig: DeliveryConfig, ctx: VerificationContext) : Map<Verification, VerificationState> =
+    entries
+      .mapNotNull { (vId: String, state: VerificationState) ->
+        ctx.verification(vId) // Verification?
+          ?.let { verification -> verification to state } // Pair<Verification, VerificationState>?
+          .also { if (it == null) { onInvalidVerificationId(vId, deliveryConfig, ctx) }}
+      }
+      .toMap()
+
+  /**
+   * Actions to take when the verification state database table references a verification id that doesn't exist
+   * in the delivery config
+   */
+  fun onInvalidVerificationId(vId: String, deliveryConfig: DeliveryConfig, ctx: VerificationContext) {
+    publisher.publishEvent(
+      InvalidVerificationIdSeen(
+        vId,
+        deliveryConfig.application,
+        deliveryConfig.name,
+        ctx.environmentName
+      )
+    )
+    log.error("verification_state table contains invalid verification id: $vId  config: ${deliveryConfig.name} env: ${ctx.environmentName}. Valid ids in this env: ${ctx.environment.verifyWith.map { it.id }}")
+  }
 }
 
-/**
- * Query the repository for all of the verification states associated with [versions]
- *
- * This just calls [KeelRepository.getVerificationStatesBatch] and reshapes the returned value to a map
- */
-fun KeelRepository.getVerificationStates(
-  deliveryConfig: DeliveryConfig,
-  versions: List<PublishedArtifact>
-): Map<VerificationContext, Map<Verification, VerificationState>> =
-  deliveryConfig.contexts(versions).let { contexts ->
-    contexts.zip(getVerificationStatesBatch(contexts))
-      .associate { (ctx: VerificationContext, vIdToState: Map<String, VerificationState>) ->
-        ctx to (vIdToState.entries.associate { (vId, state) ->
-          ctx.verification(vId) to state
-        })
-      }
-  }
 
 /**
  * A verification context identifies an (environment, artifact version) pair.

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -564,7 +564,7 @@ class ApplicationService(
     versions: List<PublishedArtifact>
   ): Map<VerificationContext, Map<Verification, VerificationState>> =
     deliveryConfig.contexts(versions).let { contexts: List<VerificationContext> ->
-      contexts.zip(getVerificationStatesBatch(contexts)) // List<Pair<VerificationContext, Map<String, VerificationState>>
+      contexts.zip(getVerificationStatesBatch(contexts))
         .associate { (ctx, vIdToState) -> ctx to vIdToState.toVerificationMap(deliveryConfig, ctx) }
     }
 
@@ -576,8 +576,8 @@ class ApplicationService(
   fun Map<String, VerificationState>.toVerificationMap(deliveryConfig: DeliveryConfig, ctx: VerificationContext) : Map<Verification, VerificationState> =
     entries
       .mapNotNull { (vId: String, state: VerificationState) ->
-        ctx.verification(vId) // Verification?
-          ?.let { verification -> verification to state } // Pair<Verification, VerificationState>?
+        ctx.verification(vId)
+          ?.let { verification -> verification to state }
           .also { if (it == null) { onInvalidVerificationId(vId, deliveryConfig, ctx) } }
       }
       .toMap()

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryEvent.kt
@@ -165,3 +165,10 @@ data class VerificationTimedOut(
     context.version
   )
 }
+
+data class InvalidVerificationIdSeen(
+  val id: String,
+  val application: String,
+  val deliveryConfigName: String,
+  val environmentName: String,
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListener.kt
@@ -209,6 +209,18 @@ class TelemetryListener(
     )
   }
 
+  @EventListener(InvalidVerificationIdSeen::class)
+  fun onInvalidVerificationId(event: InvalidVerificationIdSeen) {
+    spectator.counter(
+      INVALID_VERIFICATION_ID_SEEN_COUNTER_ID,
+      listOf(
+        BasicTag("application", event.application),
+        BasicTag("invalidId", event.id)
+      )
+    )
+
+  }
+
   private fun createDriftGauge(name: String): AtomicReference<Instant> =
     PolledMeter
       .using(spectator)
@@ -250,6 +262,7 @@ class TelemetryListener(
     private const val VERIFICATION_STARTED_COUNTER_ID = "keel.verification.started"
     private const val VERIFICATION_CHECK_DRIFT_GAUGE = "keel.verification.check.drift"
     private const val VERIFICATION_CHECK_DURATION_ID = "keel.verification.check.duration"
+    private const val INVALID_VERIFICATION_ID_SEEN_COUNTER_ID = "keel.verification.invalid.id.seen"
     private const val AGENT_DURATION_ID = "keel.agent.duration"
   }
 }


### PR DESCRIPTION
# Problem

Environments view was blowing up for a test app in our staging environment because the `verification_state` table had an invalid verification id in one of the entries.

The invalid data looked like this: `spkr/mytest/stable` where the valid id was `spkr/mytest:stable`.

We had changed the convention for the id a while back from `/` to `:` for delimiting the tag of the container, but there was some data that hadn't been updated.

While this could have been fixed by just repairing the data in the database, having the environments view break entirely because of one invalid verificiations record is an undesirable user experience.

# Implemented solution

Explicitly detect and handle invalid verification ids.

The `VerificationContext.verification(id: String)` function now returns a null if the id doesn't exist, which forces the caller to explicitly handle it.

## Environment view

The ApplicationService, which computes the environments view, now handles this by skipping the invalid record. It also logs an error message and emits a metric: `keel.verification.invalid.id.seen`


## Verification controller

The `VerificationController` returns a meaningful error message if a client calls it with an invalid id. Here's example output

```yaml
timestamp: "2021-02-11T17:51:50.148+0000"
status: 404
error: "Not Found"
message: "Unknown verification id: spkr/fakeetest:fail. Expecting one of: [spkr/faketest:fail]"
```

