### PR TITLE
chore(test): rename test label so 'failed' doesn't appear

### DIFF
--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -134,7 +134,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
           runBlocking { subject.monitor(task) }
         }
 
-        test("publishes failed event and marks failure") {
+        test("publishes fail(ed) event and marks failure") {
           val slot = slot<LifecycleEvent>()
           verify(exactly = 1) {
             publisher.publishEvent(capture(slot))


### PR DESCRIPTION
## Problem

When tests fail on GitHub Actions, I search for the string `" failed"` to jump to the failing test lines.

When I do that, the first search hit is a successful test that has the string `"failed"` in its description.
```
BakeryLifecycleMonitorTests publishes failed event and marks failure PASSED
```

## Implemented solution

Change the test description text from `failed` to `fail(ed)` so it doesn't match a `failed` string search.
