### PR TITLE
versioned resources with some fixes

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -16,6 +16,9 @@ data class Resource<out T : ResourceSpec>(
   val id: String
     get() = metadata.getValue("id").toString()
 
+  val version: Int
+    get() = metadata.getValue("version") as Int
+
   val serviceAccount: String
     get() = metadata.getValue("serviceAccount").toString()
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -599,6 +599,29 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         }
       }
 
+      context("updating an existing delivery config with a new version of a resource") {
+        before {
+          storeArtifacts()
+          storeResources()
+          store()
+
+          val resource = deliveryConfig.environments.first().resources.first { it.kind == parseKind("ec2/cluster@v1") }
+            .run {
+              copy(spec = DummyResourceSpec(id = id, application = application))
+            }
+
+          resourceRepository.store(resource)
+        }
+
+        test("retrieving the delivery config includes the new version of the resource") {
+          getByName()
+            .isSuccess()
+            .get { resources.map(Resource<*>::version) }
+            .hasSize(deliveryConfig.resources.size)
+            .contains(2)
+        }
+      }
+
       context("notifications") {
         before {
           repository.store(deliveryConfig.copy(

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -38,10 +38,6 @@ import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyAll
-import java.time.Clock
-import java.time.Duration
-import java.time.Period
-import java.util.UUID.randomUUID
 import strikt.api.Assertion
 import strikt.api.expectCatching
 import strikt.api.expectThat
@@ -55,6 +51,10 @@ import strikt.assertions.isFailure
 import strikt.assertions.isGreaterThanOrEqualTo
 import strikt.assertions.isNotEmpty
 import strikt.assertions.map
+import java.time.Clock
+import java.time.Duration
+import java.time.Period
+import java.util.UUID.randomUUID
 
 abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests {
 
@@ -176,6 +176,25 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
           expectThat(subject.get<DummyResourceSpec>(resource.id))
             .get(Resource<*>::spec)
             .isEqualTo(updatedResource.spec)
+        }
+
+        test("the resource version is incremented") {
+          expectThat(subject.get<DummyResourceSpec>(resource.id))
+            .get(Resource<*>::version) isEqualTo 2
+        }
+
+        context("when deleted") {
+          before {
+            subject.delete(resource.id)
+          }
+
+          test("all versions of the resource are deleted") {
+            expectCatching {
+              subject.get(resource.id)
+            }
+              .isFailure()
+              .isA<NoSuchResourceException>()
+          }
         }
       }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -134,6 +134,7 @@ class ResourceActuator(
             ResourceActuationVetoed(
               resource.kind,
               resource.id,
+              resource.version,
               resource.spec.application,
               response.message,
               response.vetoName,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/ResourceMixin.kt
@@ -7,6 +7,9 @@ interface ResourceMixin {
   val id: String
 
   @get:JsonIgnore
+  val version: Int
+
+  @get:JsonIgnore
   val serviceAccount: String
 
   @get:JsonIgnore

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -281,7 +281,7 @@ class CombinedRepository(
   override fun getResourcesByApplication(application: String): List<Resource<*>> =
     resourceRepository.getResourcesByApplication(application)
 
-  override fun storeResource(resource: Resource<*>) =
+  override fun <T : ResourceSpec> storeResource(resource: Resource<T>): Resource<T> =
     resourceRepository.store(resource)
 
   override fun deleteResource(id: String) =

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -32,7 +32,7 @@ import com.netflix.spinnaker.keel.persistence.ResourceRepository.Companion.DEFAU
 import com.netflix.spinnaker.keel.services.StatusInfoForArtifactInEnvironment
 import org.slf4j.Logger
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Propagation.REQUIRED
 import org.springframework.transaction.annotation.Transactional
 import java.time.Clock
 import java.time.Duration
@@ -46,10 +46,10 @@ interface KeelRepository : KeelReadOnlyRepository {
   val publisher: ApplicationEventPublisher
   val log: Logger
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = REQUIRED)
   fun upsertDeliveryConfig(submittedDeliveryConfig: SubmittedDeliveryConfig): DeliveryConfig
 
-  @Transactional(propagation = Propagation.REQUIRED)
+  @Transactional(propagation = REQUIRED)
   fun upsertDeliveryConfig(deliveryConfig: DeliveryConfig): DeliveryConfig
 
   fun <T : ResourceSpec> upsertResource(resource: Resource<T>, deliveryConfigName: String) {
@@ -69,13 +69,15 @@ interface KeelRepository : KeelReadOnlyRepository {
       val diff = DefaultResourceDiff(resource.spec, existingResource.spec)
       if (diff.hasChanges() || resource.kind.version != existingResource.kind.version) {
         log.debug("Updating ${resource.id}")
-        storeResource(resource)
-        appendResourceHistory(ResourceUpdated(resource, diff.toDeltaJson(), clock))
+        storeResource(resource).also { updatedResource ->
+          appendResourceHistory(ResourceUpdated(updatedResource, diff.toDeltaJson(), clock))
+        }
       }
     } else {
       log.debug("Creating $resource")
-      storeResource(resource)
-      appendResourceHistory(ResourceCreated(resource, clock))
+      storeResource(resource).also { updatedResource ->
+        appendResourceHistory(ResourceCreated(updatedResource, clock))
+      }
     }
   }
 
@@ -124,7 +126,7 @@ interface KeelRepository : KeelReadOnlyRepository {
   // START ResourceRepository methods
   fun allResources(callback: (ResourceHeader) -> Unit)
 
-  fun storeResource(resource: Resource<*>)
+  fun <T : ResourceSpec> storeResource(resource: Resource<T>): Resource<T>
 
   fun deleteResource(id: String)
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -80,7 +80,7 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<ResourceSp
    *
    * @return the `uid` of the stored resource.
    */
-  fun store(resource: Resource<*>)
+  fun <T : ResourceSpec>  store(resource: Resource<T>): Resource<T>
 
   /**
    * Deletes the resource represented by [id].

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
@@ -28,6 +28,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
   private val event = ResourceValid(
     kind = parseKind("ec2/cluster@v1"),
     id = "ec2:cluster:prod:keel-main",
+    version = 1,
     application = "fnord",
     timestamp = Instant.now()
   )

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -49,6 +49,7 @@ import org.jooq.Select
 import org.jooq.SelectConditionStep
 import org.jooq.impl.DSL
 import org.jooq.impl.DSL.inline
+import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.select
 import org.jooq.util.mysql.MySQLDSL.values
 import org.slf4j.LoggerFactory
@@ -111,7 +112,7 @@ class SqlDeliveryConfigRepository(
     sqlRetry.withRetry(WRITE) {
       jooq.deleteFrom(ENVIRONMENT_RESOURCE)
         .where(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(envUid(deliveryConfigName, environmentName)))
-        .and(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(resourceId.uid))
+        .and(ENVIRONMENT_RESOURCE.RESOURCE_UID.`in`(resourceId.uids))
         .execute()
     }
   }
@@ -207,10 +208,15 @@ class SqlDeliveryConfigRepository(
       .select(RESOURCE.UID)
       .from(RESOURCE)
       .where(RESOURCE.APPLICATION.eq(application))
+      .and(RESOURCE.VERSION.eq(
+        select(max(RESOURCE.VERSION))
+          .from(RESOURCE.`as`("r2"))
+          .where(RESOURCE.ID.eq(field("r2.id")))
+      ))
 
   private fun getResourceIDs(application: String): SelectConditionStep<Record1<String>>? =
     jooq
-      .select(RESOURCE.ID)
+      .selectDistinct(RESOURCE.ID)
       .from(RESOURCE)
       .where(RESOURCE.APPLICATION.eq(application))
 
@@ -303,17 +309,22 @@ class SqlDeliveryConfigRepository(
             .set(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID, environmentUID)
             .set(
               ENVIRONMENT_RESOURCE.RESOURCE_UID,
-              select(RESOURCE.UID).from(RESOURCE).where(RESOURCE.ID.eq(resource.id))
+              select(RESOURCE.UID)
+                .from(RESOURCE)
+                .where(RESOURCE.ID.eq(resource.id))
+                .and(RESOURCE.VERSION.eq(select(max(RESOURCE.VERSION)).from(RESOURCE).where(RESOURCE.ID.eq(resource.id))))
             )
             .onDuplicateKeyIgnore()
             .execute()
-          // delete any other environment's link to this same resource (in case we are moving it
-          // from one environment to another)
+          // delete any other environment's link to any version of this same resource (in case we
+          // are moving it from one environment to another)
           jooq.deleteFrom(ENVIRONMENT_RESOURCE)
             .where(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.notEqual(environmentUID))
             .and(
-              ENVIRONMENT_RESOURCE.RESOURCE_UID.equal(
-                select(RESOURCE.UID).from(RESOURCE).where(RESOURCE.ID.eq(resource.id))
+              ENVIRONMENT_RESOURCE.RESOURCE_UID.`in`(
+                select(RESOURCE.UID)
+                  .from(RESOURCE)
+                  .where(RESOURCE.ID.eq(resource.id))
               )
             )
             .execute()
@@ -1075,7 +1086,7 @@ class SqlDeliveryConfigRepository(
     }
   }
 
-  private val String.uid: Select<Record1<String>>
+  private val String.uids: Select<Record1<String>>
     get() = select(RESOURCE.UID)
       .from(RESOURCE)
       .where(RESOURCE.ID.eq(this))

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.persistence.NoSuchResourceId
 import com.netflix.spinnaker.keel.persistence.ResourceHeader
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DIFF_FINGERPRINT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.EVENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
@@ -27,6 +28,9 @@ import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
+import org.jooq.impl.DSL.coalesce
+import org.jooq.impl.DSL.max
+import org.jooq.impl.DSL.value
 import org.slf4j.LoggerFactory
 import java.time.Clock
 import java.time.Duration
@@ -121,35 +125,50 @@ open class SqlResourceRepository(
   }
 
   // todo: this is not retryable due to overall repository structure: https://github.com/spinnaker/keel/issues/740
-  override fun store(resource: Resource<*>) {
-    val uid = jooq.select(RESOURCE.UID)
+  override fun <T : ResourceSpec> store(resource: Resource<T>): Resource<T> {
+    val version = jooq.select(
+        coalesce(
+          max(RESOURCE.VERSION),
+          value(0)
+        )
+      )
       .from(RESOURCE)
       .where(RESOURCE.ID.eq(resource.id))
-      .fetchOne(RESOURCE.UID)
-      ?: randomUID().toString()
+      .fetchOneInto(Int::class.java)
 
-    val updatePairs = mapOf(
-      RESOURCE.KIND to resource.kind,
-      RESOURCE.ID to resource.id,
-      RESOURCE.SPEC to objectMapper.writeValueAsString(resource.spec),
-      RESOURCE.APPLICATION to resource.application
-    )
-    val insertPairs = updatePairs + (RESOURCE.UID to uid)
-    jooq.insertInto(
-      RESOURCE,
-      *insertPairs.keys.toTypedArray()
-    )
-      .values(*insertPairs.values.toTypedArray())
-      .onDuplicateKeyUpdate()
-      .set(updatePairs)
+    val oldUid = if (version > 0 ) {
+      getResourceUid(resource.id, version)
+    } else {
+      null
+    }
+    val uid = randomUID().toString()
+
+    jooq.insertInto(RESOURCE)
+      .set(RESOURCE.UID, uid)
+      .set(RESOURCE.KIND, resource.kind.toString())
+      .set(RESOURCE.ID, resource.id)
+      .set(RESOURCE.VERSION, version + 1)
+      .set(RESOURCE.SPEC, objectMapper.writeValueAsString(resource.spec))
+      .set(RESOURCE.APPLICATION, resource.application)
       .execute()
+
     jooq.insertInto(RESOURCE_LAST_CHECKED)
       .set(RESOURCE_LAST_CHECKED.RESOURCE_UID, uid)
       .set(RESOURCE_LAST_CHECKED.AT, EPOCH.plusSeconds(1))
-      .onDuplicateKeyUpdate()
-      .set(RESOURCE_LAST_CHECKED.AT, EPOCH.plusSeconds(1))
-      .set(RESOURCE_LAST_CHECKED.IGNORE, false)
       .execute()
+
+    // This is somewhat temporary because eventually we'll define a new environment version
+    if (oldUid != null) {
+      jooq
+        .update(ENVIRONMENT_RESOURCE)
+        .set(ENVIRONMENT_RESOURCE.RESOURCE_UID, uid)
+        .where(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(oldUid))
+        .execute()
+    }
+
+    return resource.copy(
+      metadata = resource.metadata + mapOf("uid" to uid, "version" to version + 1)
+    )
   }
 
   override fun applicationEventHistory(application: String, limit: Int): List<ApplicationEvent> {
@@ -211,7 +230,7 @@ open class SqlResourceRepository(
   // todo: add sql retries once we've rethought repository structure: https://github.com/spinnaker/keel/issues/740
   override fun appendHistory(event: ResourceEvent) {
     // for historical reasons, we use the resource UID (not the ID) as an identifier in resource events
-    val ref = getResourceUid(event.ref)
+    val ref = getResourceUid(event.ref, event.version)
     doAppendHistory(event, ref)
   }
 
@@ -259,35 +278,41 @@ open class SqlResourceRepository(
 
   override fun delete(id: String) {
     // TODO: these should be run inside a transaction
-    val uid = sqlRetry.withRetry(READ) {
+    val uids = sqlRetry.withRetry(READ) {
       jooq.select(RESOURCE.UID)
         .from(RESOURCE)
         .where(RESOURCE.ID.eq(id))
-        .fetchOne(RESOURCE.UID)
-        ?.let(ULID::parseULID)
-        ?: throw NoSuchResourceId(id)
+        .fetch(RESOURCE.UID)
+        .map(ULID::parseULID)
     }
-    sqlRetry.withRetry(WRITE) {
-      jooq.deleteFrom(RESOURCE)
-        .where(RESOURCE.UID.eq(uid.toString()))
-        .execute()
+
+    if (uids.isEmpty()) {
+      throw NoSuchResourceId(id)
     }
-    sqlRetry.withRetry(WRITE) {
-      jooq.deleteFrom(EVENT)
-        .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
-        .and(EVENT.REF.eq(uid.toString()))
-        .execute()
-    }
-    sqlRetry.withRetry(WRITE) {
-      jooq.deleteFrom(DIFF_FINGERPRINT)
-        .where(DIFF_FINGERPRINT.ENTITY_ID.eq(id))
-        .execute()
-    }
-    sqlRetry.withRetry(WRITE) {
-      jooq.deleteFrom(PAUSED)
-        .where(PAUSED.SCOPE.eq(PauseScope.RESOURCE))
-        .and(PAUSED.NAME.eq(id))
-        .execute()
+
+    uids.forEach { uid ->
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(RESOURCE)
+          .where(RESOURCE.UID.eq(uid.toString()))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(EVENT)
+          .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
+          .and(EVENT.REF.eq(uid.toString()))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(DIFF_FINGERPRINT)
+          .where(DIFF_FINGERPRINT.ENTITY_ID.eq(id))
+          .execute()
+      }
+      sqlRetry.withRetry(WRITE) {
+        jooq.deleteFrom(PAUSED)
+          .where(PAUSED.SCOPE.eq(PauseScope.RESOURCE))
+          .and(PAUSED.NAME.eq(id))
+          .execute()
+      }
     }
   }
 
@@ -332,16 +357,17 @@ open class SqlResourceRepository(
     }
   }
 
-  fun getResourceUid(id: String) =
+  fun getResourceUid(id: String, version: Int) =
     sqlRetry.withRetry(READ) {
       jooq
         .select(RESOURCE.UID)
         .from(RESOURCE)
         .where(RESOURCE.ID.eq(id))
+        .and(RESOURCE.VERSION.eq(version))
         .fetchOne(RESOURCE.UID)
         ?: throw IllegalStateException("Resource with id $id not found. Retrying.")
     }
 
   private val Resource<*>.uid: String
-    get() = getResourceUid(this.id)
+    get() = getResourceUid(id, version)
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
@@ -96,4 +96,5 @@ class SqlUnhappyVetoRepository(
     get() = jooq.select(RESOURCE.UID)
       .from(RESOURCE)
       .where(RESOURCE.ID.eq(id))
+      .and(RESOURCE.VERSION.eq(version))
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhealthyRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhealthyRepository.kt
@@ -47,5 +47,9 @@ class SqlUnhealthyRepository(
   }
 
   private val Resource<*>.uid: Select<Record1<String>>
-    get() = jooq.select(RESOURCE.UID).from(RESOURCE).where(RESOURCE.ID.eq(id))
+    get() = jooq
+      .select(RESOURCE.UID)
+      .from(RESOURCE)
+      .where(RESOURCE.ID.eq(id))
+      .and(RESOURCE.VERSION.eq(version))
 }

--- a/keel-sql/src/main/resources/db/changelog/20210208-versioned-resources.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210208-versioned-resources.yml
@@ -1,0 +1,47 @@
+databaseChangeLog:
+- changeSet:
+    id: versioned-resources
+    author: fletch
+    changes:
+    - addColumn:
+        tableName: resource
+        columns:
+        - name: version
+          type: integer
+          defaultValueNumeric: 1
+          afterColumn: id
+          constraints:
+            nullable: false
+    - dropUniqueConstraint:
+        tableName: resource
+        constraintName: name
+    - addUniqueConstraint:
+        tableName: resource
+        constraintName: resource_id_version_idx
+        columnNames: id, version
+    - dropView:
+        viewName: resource_with_metadata
+    - createView:
+        viewName: resource_with_metadata
+        selectQuery: |
+          select
+            resource.uid,
+            resource.id,
+            resource.application,
+            resource.kind,
+            json_object(
+              'uid', resource.uid,
+              'id', resource.id,
+              'version', resource.version,
+              'application', resource.application,
+              'environment', environment.uid,
+              'environmentName', environment.name,
+              'deliveryConfig', delivery_config.uid,
+              'serviceAccount', delivery_config.service_account
+            ) as metadata,
+            resource.spec
+          from resource
+          left outer join environment_resource on resource.uid = environment_resource.resource_uid
+          left outer join environment on environment.uid = environment_resource.environment_uid
+          left outer join delivery_config on delivery_config.uid = environment.delivery_config_uid
+          where resource.version = (select max(r2.version) from resource r2 where resource.id = r2.id)

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -233,3 +233,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210114-verification-state-task-list.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210208-versioned-resources.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepositoryPeriodicallyCheckedTests.kt
@@ -23,7 +23,7 @@ import strikt.assertions.isEqualTo
 import java.time.Clock
 import java.time.Duration
 
-internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
+internal class SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
   DeliveryConfigRepositoryPeriodicallyCheckedTests<SqlDeliveryConfigRepository>() {
 
   private val jooq = testDatabase.context
@@ -143,6 +143,7 @@ internal object SqlDeliveryConfigRepositoryPeriodicallyCheckedTests :
                 kind = v1.kind,
                 metadata = mapOf(
                   "id" to spec.id,
+                  "version" to 1,
                   "application" to spec.application
                 ),
                 spec = spec

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlNotificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlNotificationRepositoryTests.kt
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
 import java.time.Clock
 
-internal object SqlNotificationRepositoryTests : NotificationRepositoryTests<SqlNotificationRepository>() {
+internal class SqlNotificationRepositoryTests : NotificationRepositoryTests<SqlNotificationRepository>() {
 
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(1, 0)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryPeriodicallyCheckedTests.kt
@@ -11,15 +11,17 @@ import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
-import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.rootContext
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectCatching
 import strikt.api.expectThat
+import strikt.assertions.first
 import strikt.assertions.hasSize
 import strikt.assertions.isA
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isSuccess
 import java.time.Clock
@@ -70,16 +72,6 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
     }
   }
 
-  class UnreadableResourceFixture(
-    val factory: (Clock) -> SqlResourceRepository
-  ) {
-    val clock = MutableClock()
-    val subject: SqlResourceRepository = factory(clock)
-
-    fun nextResults(): Collection<Resource<*>> =
-      subject.itemsDueForCheck(Duration.ofMinutes(30), 2)
-  }
-
   fun unreadableResourceTests() = rootContext<Fixture<Resource<ResourceSpec>, SqlResourceRepository>> {
     fixture {
       Fixture(
@@ -119,6 +111,29 @@ internal object SqlResourceRepositoryPeriodicallyCheckedTests :
         expectCatching { nextResults() }.isSuccess().hasSize(2)
         expectCatching { nextResults() }.isSuccess().hasSize(1)
         expectCatching { nextResults() }.isSuccess().hasSize(0)
+      }
+    }
+  }
+
+  fun versionedResourceTests() = rootContext<Fixture<Resource<ResourceSpec>, SqlResourceRepository>> {
+    fixture {
+      Fixture(factory, createAndStore, updateOne)
+    }
+
+    context("multiple versions of a resource exist") {
+      before {
+        createAndStore(1)
+        updateOne()
+      }
+
+      test("the older resource version is never checked") {
+        expectThat(nextResults())
+          .hasSize(1)
+          .first()
+          .get(Resource<*>::version) isEqualTo 2
+
+        expectThat(nextResults())
+          .isEmpty()
       }
     }
   }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -8,7 +8,7 @@ import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import java.time.Clock
 
-internal object SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
+internal class SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceRepository>() {
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(5, 100)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/Resources.kt
@@ -105,6 +105,7 @@ fun <T : ResourceSpec> resource(
     spec = spec,
     metadata = mapOf(
       "id" to generateId(kind, spec),
+      "version" to 1,
       "application" to application,
       "serviceAccount" to "keel@spinnaker"
     )

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -121,6 +121,7 @@ internal class DeliveryConfigControllerTests
             kind = it.kind,
             metadata = mapOf(
               "id" to randomUID().toString(),
+              "version" to 1,
               "serviceAccount" to serviceAccount,
               "application" to application
             ),


### PR DESCRIPTION
One of the crucial things I was missing was that version a) needed to be ignored by JSON serialization and b) would not be present when updating resources in any un-modified resources. I'm going to add some test coverage around multiple resource versions being present and then this can go back in.