### PR TITLE
fix(slack): fixing unactionable buttons errors

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
@@ -141,7 +141,7 @@ class NotificationEventListener(
           user = user,
           targetEnvironment = veto.targetEnvironment,
           time = clock.instant(),
-          application = config.name,
+          application = config.application,
           comment = veto.comment
         ),
         ARTIFACT_MARK_AS_BAD,

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -63,7 +63,8 @@ class GitDataGenerator(
       accessory {
         button {
           text("More...")
-          actionId("button-action")
+          // action id will be consisted by 3 sections with ":" between them to keep it consistent
+          actionId("button:url:more")
           url(artifactUrl)
         }
       }

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
@@ -84,7 +84,8 @@ class ManualJudgmentNotificationHandler(
               button {
                 text("See changes", emoji = true)
                 url(compareLink)
-                actionId("button-action")
+                // action id will be consisted by 3 sections with ":" between them to keep it consistent
+                actionId("button:url:diff")
               }
             }
           }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/SlackAppController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/SlackAppController.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.slack.callbacks.ManualJudgmentCallbackHandler
+import com.slack.api.app_backend.interactive_components.payload.BlockActionPayload
 import com.slack.api.app_backend.interactive_components.response.ActionResponse
 import com.slack.api.bolt.App
 import com.slack.api.bolt.servlet.SlackAppServlet
@@ -22,17 +23,24 @@ class SlackAppController(
     // for example, for manual judgment notifications: constraintId:OVERRIDE_PASS:MANUAL_JUDGMENT
     val actionIdPattern = "^(\\w+):(\\w+):(\\w+)".toPattern()
     slackApp.blockAction(actionIdPattern) { req, ctx ->
-      // If we want to add more handlers, we can parse here the action id type (i.e MANUAL_JUDGMENT) and use the right handler
-      if (req.payload.responseUrl != null) {
-        mjHandler.updateConstraintState(req.payload)
-        val response = ActionResponse.builder()
-          .blocks(mjHandler.updateManualJudgementNotification(req.payload))
-          .text(mjHandler.fallbackText(req.payload))
-          .replaceOriginal(true)
-          .build()
-        ctx.respond(response)
+      if (req.payload.notificationType == "MANUAL_JUDGMENT") {
+        // If we want to add more handlers, we can parse here the action id type (i.e MANUAL_JUDGMENT) and use the right handler
+        if (req.payload.responseUrl != null) {
+          mjHandler.updateConstraintState(req.payload)
+          val response = ActionResponse.builder()
+            .blocks(mjHandler.updateManualJudgementNotification(req.payload))
+            .text(mjHandler.fallbackText(req.payload))
+            .replaceOriginal(true)
+            .build()
+          ctx.respond(response)
+        }
       }
+      //acknowledge the button anyway, so we won't exceptions from slack when clicking on it
       ctx.ack()
     }
   }
+
+  //action id is consistent of 3 parts, where the last part is the type
+  val BlockActionPayload.notificationType
+    get() = actions.first().actionId.split(":").last()
 }


### PR DESCRIPTION
This PR is fixing errors coming from slack when the user is clicking on an unactionable button, like "More":
![Screen Shot 2021-02-17 at 1 20 49 PM](https://user-images.githubusercontent.com/55253849/108269649-23011680-7123-11eb-934a-5c447376b308.png)

Prior to this fix, only actionable buttons followed a convention for `actionId` (which is the button identifier), and all other buttons didn't. 
For example, when the user clicks on `approve` within the `manual_judgement` notification, the action id is set to be "{constraintId}:PASS:MANUAL_JUDGMENT". Then we parse it and act as needed.

This fix will add the right string pattern for action id (like "button:url:diff") for each button, so that keel can `ack` all action buttons and we won't show errors.