### PR TITLE
fix(api): remove 3 sql queries per artifact version

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -240,6 +240,19 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   ): PublishedArtifact?
 
   /**
+   * Given information about a delivery config, environment, artifact and a list of versions
+   * returns a list of summaries for all versions that can be
+   * used by the UI.
+   */
+  fun getArtifactSummariesInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String,
+    artifactReference: String,
+    versions: List<String>
+  ): List<ArtifactSummaryInEnvironment>
+
+  @Deprecated("Replace with the bulk call `getArtifactSummariesInEnvironment(...)` above")
+  /**
    * Given information about a delivery config, environment, artifact and version, returns a summary that can be
    * used by the UI.
    */

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -18,6 +18,7 @@ import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
+import com.netflix.spinnaker.keel.core.api.ArtifactSummaryInEnvironment
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVetoes
@@ -404,6 +405,16 @@ class CombinedRepository(
   override fun markAsSkipped(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String, supersededByVersion: String) {
     artifactRepository.markAsSkipped(deliveryConfig, artifact, version, targetEnvironment, supersededByVersion)
   }
+
+  override fun getArtifactSummariesInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String,
+    artifactReference: String,
+    versions: List<String>
+  ): List<ArtifactSummaryInEnvironment> =
+    artifactRepository.getArtifactSummariesInEnvironment(
+      deliveryConfig, environmentName, artifactReference, versions
+    )
 
   override fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -191,9 +191,22 @@ interface KeelRepository : KeelReadOnlyRepository {
   )
 
   /**
+   * Given information about a delivery config, environment, artifact and a list of versions
+   * returns a list of summaries for all versions that can be
+   * used by the UI.
+   */
+  fun getArtifactSummariesInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String,
+    artifactReference: String,
+    versions: List<String>
+  ): List<ArtifactSummaryInEnvironment>
+  
+  /**
    * Given information about a delivery config, environment, artifact and version, returns a summary that can be
    * used by the UI, or null if the artifact version is not applicable to the environment.
    */
+  @Deprecated("Replace with the bulk call `getArtifactSummariesInEnvironment(...)` above")
   fun getArtifactSummaryInEnvironment(
     deliveryConfig: DeliveryConfig,
     environmentName: String,


### PR DESCRIPTION
This pr batch loads artifact evironment version data which was previously loaded by doing 3 SQL queries per artifact version requested. So, if we have 1 artifact in one environment and we load 30 versions for the environments UI, this takes 30*3 = 90 SQL queries and reduces it to 3.

I could further optimize this API by bulk loading constraints data (we are also making 1 SQL query per version and environment also) but I decided not to do that in this PR.

I also created a context object for the data loaded (like Luis had previously suggested) because I was adding even more data to each function.

