### PR TITLE
feat(slack): add a warning if there's a pinned version

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
@@ -273,9 +273,16 @@ class NotificationEventListener(
 
         val deliveryArtifact = configAndArtifact.first.artifacts.find {
           it.reference == currentState.artifactReference
-        }?: return
+        } ?: return
 
         val currentArtifact = repository.getArtifactVersionByPromotionStatus(configAndArtifact.first, currentState.environmentName, deliveryArtifact, PromotionStatus.CURRENT)
+
+        // fetch the pinned artifact, if exists
+        val pinnedArtifact =
+          repository.getPinnedVersion(configAndArtifact.first, currentState.environmentName, deliveryArtifact.reference)?.let {
+            repository.getArtifactVersion(deliveryArtifact, it, null)
+              ?.copy(reference = deliveryArtifact.reference)
+          }
 
         sendSlackMessage(
           configAndArtifact.first,
@@ -286,6 +293,7 @@ class NotificationEventListener(
             targetEnvironment = currentState.environmentName,
             currentArtifact = currentArtifact,
             deliveryArtifact = deliveryArtifact,
+            pinnedArtifact = pinnedArtifact,
             stateUid = currentState.uid
           ),
           MANUAL_JUDGMENT_AWAIT,

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
@@ -61,7 +61,7 @@ class NotificationEventListener(
   @EventListener(PinnedNotification::class)
   fun onPinnedNotification(notification: PinnedNotification) {
     with(notification) {
-      val configAndArtifact = getConfigAndArtifact(
+      val (_, artifact) = getConfigAndArtifact(
         application = config.application,
         artifactReference = pin.reference,
         version = pin.version,
@@ -83,7 +83,7 @@ class NotificationEventListener(
         SlackPinnedNotification(
           pin = pin,
           currentArtifact = currentArtifact,
-          pinnedArtifact = configAndArtifact.second,
+          pinnedArtifact = artifact,
           application = config.application,
           time = clock.instant()
         ),
@@ -127,7 +127,7 @@ class NotificationEventListener(
   @EventListener(MarkAsBadNotification::class)
   fun onMarkAsBadNotification(notification: MarkAsBadNotification) {
     with(notification) {
-      val configAndArtifact = getConfigAndArtifact(
+      val (_, artifact) = getConfigAndArtifact(
         application = config.application,
         artifactReference = veto.reference,
         version = veto.version,
@@ -135,7 +135,7 @@ class NotificationEventListener(
 
       sendSlackMessage(config,
         SlackMarkAsBadNotification(
-          vetoedArtifact = configAndArtifact.second,
+          vetoedArtifact = artifact,
           user = user,
           targetEnvironment = veto.targetEnvironment,
           time = clock.instant(),
@@ -181,23 +181,23 @@ class NotificationEventListener(
   @EventListener(LifecycleEvent::class)
   fun onLifecycleEvent(notification: LifecycleEvent) {
     with(notification) {
-      val configAndArtifact = getConfigAndArtifact(
+      val (config, artifact) = getConfigAndArtifact(
         deliveryConfigName = artifactRef.split(":")[0],
         artifactReference = artifactRef.split(":")[1],
         version = artifactVersion) ?: return
 
-      val deliveryArtifact = configAndArtifact.first.artifacts.find {
+      val deliveryArtifact = config.artifacts.find {
         it.reference == artifactRef.split(":")[1]
       } ?: return
 
       // we only send notifications for failures
       if (status == LifecycleEventStatus.FAILED) {
-        sendSlackMessage(configAndArtifact.first,
+        sendSlackMessage(config,
           SlackLifecycleNotification(
             time = clock.instant(),
-            artifact = configAndArtifact.second,
+            artifact = artifact,
             eventType = type,
-            application = configAndArtifact.first.application
+            application = config.application
           ),
           LIFECYCLE_EVENT,
           artifact = deliveryArtifact)
@@ -233,17 +233,16 @@ class NotificationEventListener(
   @EventListener(ArtifactVersionVetoed::class)
   fun onArtifactVersionVetoed(notification: ArtifactVersionVetoed) {
     with(notification) {
-
-      val configAndArtifact = getConfigAndArtifact(
+      val (config, artifact) = getConfigAndArtifact(
         application = application,
         artifactReference = veto.reference,
         version = veto.version) ?: return
 
-      sendSlackMessage(configAndArtifact.first,
+      sendSlackMessage(config,
         SlackArtifactDeploymentNotification(
           time = clock.instant(),
           application = application,
-          artifact = configAndArtifact.second,
+          artifact = artifact,
           targetEnvironment = veto.targetEnvironment,
           status = DeploymentStatus.FAILED
         ),
@@ -263,7 +262,7 @@ class NotificationEventListener(
         currentState.status == ConstraintStatus.PENDING
       ) {
 
-        val configAndArtifact = currentState.artifactReference?.let {
+        val (config, artifact) = currentState.artifactReference?.let {
           getConfigAndArtifact(
             deliveryConfigName = currentState.deliveryConfigName,
             artifactReference = it,
@@ -271,25 +270,25 @@ class NotificationEventListener(
           )
         } ?: return
 
-        val deliveryArtifact = configAndArtifact.first.artifacts.find {
+        val deliveryArtifact = config.artifacts.find {
           it.reference == currentState.artifactReference
         } ?: return
 
-        val currentArtifact = repository.getArtifactVersionByPromotionStatus(configAndArtifact.first, currentState.environmentName, deliveryArtifact, PromotionStatus.CURRENT)
+        val currentArtifact = repository.getArtifactVersionByPromotionStatus(config, currentState.environmentName, deliveryArtifact, PromotionStatus.CURRENT)
 
         // fetch the pinned artifact, if exists
         val pinnedArtifact =
-          repository.getPinnedVersion(configAndArtifact.first, currentState.environmentName, deliveryArtifact.reference)?.let {
+          repository.getPinnedVersion(config, currentState.environmentName, deliveryArtifact.reference)?.let {
             repository.getArtifactVersion(deliveryArtifact, it, null)
               ?.copy(reference = deliveryArtifact.reference)
           }
 
         sendSlackMessage(
-          configAndArtifact.first,
+          config,
           SlackManualJudgmentNotification(
             time = clock.instant(),
-            application = configAndArtifact.first.application,
-            artifactCandidate = configAndArtifact.second,
+            application = config.application,
+            artifactCandidate = artifact,
             targetEnvironment = currentState.environmentName,
             currentArtifact = currentArtifact,
             deliveryArtifact = deliveryArtifact,
@@ -312,9 +311,10 @@ class NotificationEventListener(
         return
       }
 
-      val configAndArtifact = getConfigAndArtifact(deliveryConfigName = deliveryConfigName,
-        artifactReference = artifactReference,
-        version = artifactVersion) ?: return
+      val (config, artifact) = getConfigAndArtifact(deliveryConfigName = deliveryConfigName,
+          artifactReference = artifactReference,
+          version = artifactVersion)
+       ?: return
 
       val type = when (status) {
         ConstraintStatus.PASS -> TEST_PASSED
@@ -324,11 +324,11 @@ class NotificationEventListener(
       }
 
       sendSlackMessage(
-        configAndArtifact.first,
+        config,
         SlackVerificationCompletedNotification(
           time = clock.instant(),
-          application = configAndArtifact.first.application,
-          artifact = configAndArtifact.second,
+          application = config.application,
+          artifact = artifact,
           targetEnvironment = environmentName,
           status = status
         ),

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackNotificationEvent.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackNotificationEvent.kt
@@ -72,6 +72,7 @@ data class SlackArtifactDeploymentNotification(
 data class SlackManualJudgmentNotification(
   val artifactCandidate: PublishedArtifact,
   val currentArtifact: PublishedArtifact? = null,
+  val pinnedArtifact: PublishedArtifact? = null,
   override val time: Instant,
   val targetEnvironment: String,
   val deliveryArtifact: DeliveryArtifact,

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -35,7 +35,7 @@ class GitDataGenerator(
   fun generateScmInfo(sectionBlockBuilder: SectionBlockBuilder, application: String, artifact: PublishedArtifact): SectionBlockBuilder {
     with(sectionBlockBuilder) {
       var details = ""
-      val artifactUrl = "$spinnakerBaseUrl/#/applications/${application}/environments/${artifact.reference}/${artifact.version}"
+      val artifactUrl = generateArtifactUrl(application, artifact.reference, artifact.version)
 
         with(artifact.gitMetadata) {
           if (this != null) {
@@ -97,7 +97,7 @@ class GitDataGenerator(
       envDetails +=  "*Where:* $env\n\n "
     }
 
-    val artifactUrl = "$spinnakerBaseUrl/#/applications/${application}/environments/${artifact.reference}/${artifact.version}"
+    val artifactUrl = generateArtifactUrl(application, artifact.reference, artifact.version)
     with(sectionBlockBuilder) {
       with(artifact) {
         if (buildMetadata != null && gitMetadata != null && gitMetadata!!.commitInfo != null) {

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -114,4 +114,7 @@ class GitDataGenerator(
     }
   }
 
+  fun generateArtifactUrl(application: String, reference: String, version: String) =
+    "$spinnakerBaseUrl/#/applications/${application}/environments/${reference}/${version}"
+
 }

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
@@ -50,6 +50,20 @@ class ManualJudgmentNotificationHandler(
           gitDataGenerator.generateScmInfo(this, application, artifactCandidate)
         }
 
+        // Add a warning section in case there's a pinned artifact
+        if (pinnedArtifact != null){
+          section {
+            markdownText(":warning: Another version is pinned here. You will need to unpin it first to promote this version.")
+            accessory {
+              button {
+                text("See pinned version", emoji = true)
+                actionId("button:url:pinned")
+                url(gitDataGenerator.generateArtifactUrl(application, pinnedArtifact.reference, pinnedArtifact.version))
+              }
+            }
+          }
+        }
+
         actions {
           elements {
             button {


### PR DESCRIPTION
This PR will add a warning to the manual judgment notification, in case there's a pinned version in the environment.
(As a reminder, if there's a pinned version, even if the user will click on `approve`, nothing will happen).
It will look like this:
![Screen Shot 2021-02-19 at 11 23 16 AM](https://user-images.githubusercontent.com/55253849/108551484-e0ffde00-72a4-11eb-9a20-360b76a00220.png)
