### PR TITLE
fix(verif): don't set correlation id in orca task

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/actuation/TaskLauncher.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/actuation/TaskLauncher.kt
@@ -38,7 +38,7 @@ interface TaskLauncher {
     notifications: Set<NotificationConfig>,
     subject: String,
     description: String,
-    correlationId: String,
+    correlationId: String? = null,
     stages: List<Map<String, Any?>>,
     artifacts: List<Map<String, Any?>> = emptyList(),
     parameters: Map<String, Any> = emptyMap()
@@ -62,7 +62,7 @@ interface TaskLauncher {
     notifications: Set<NotificationConfig>,
     subject: String,
     description: String,
-    correlationId: String,
+    correlationId: String? = null,
     stages: List<Map<String, Any?>>,
     type: SubjectType,
     artifacts: List<Map<String, Any?>> = emptyList(),

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrchestrationRequest.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/model/OrchestrationRequest.kt
@@ -26,7 +26,7 @@ data class OrchestrationRequest(
 class Job(type: String, m: Map<String, Any?>) : HashMap<String, Any?>(m + mapOf("type" to type, "user" to "Spinnaker"))
 
 data class OrchestrationTrigger(
-  val correlationId: String,
+  val correlationId: String?,
   val notifications: List<OrcaNotification>,
   val type: String = "keel",
   val user: String = "keel",

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskLauncher.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/orca/OrcaTaskLauncher.kt
@@ -86,7 +86,7 @@ class OrcaTaskLauncher(
     notifications: Set<NotificationConfig>,
     subject: String,
     description: String,
-    correlationId: String,
+    correlationId: String?,
     stages: List<Map<String, Any?>>,
     type: SubjectType,
     artifacts: List<Map<String, Any?>>,

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/verification/TestContainerVerificationEvaluator.kt
@@ -68,7 +68,6 @@ class TestContainerVerificationEvaluator(
           type = VERIFICATION,
           subject = "container integration test for ${context.deliveryConfig.application}.${context.environmentName}",
           description = "Verifying ${context.version} in environment ${context.environmentName} with test container ${verification.repository}:${verification.tag}",
-          correlationId = "${supportedVerification.first}:${context.deliveryConfig.application}.${context.environmentName}",
           user = context.deliveryConfig.serviceAccount,
           application = context.deliveryConfig.application,
           notifications = emptySet(),


### PR DESCRIPTION
# Background

Orca allows you to pass a correlation id when launching a task, which (I believe) is designed to support idempotently launching tasks.

Specifically, if you try to launch a task twice with the same correlation ID, orca will check to see if there is already a (not yet completed) task with the same correlation id. If so, orca will just hand back the execution ULID of the first task instead of launching a new one.

Keel uses a correlation id when launching the orca task associated with executing a verification, looks like this:

```kotlin
correlationId = "${supportedVerification.first}:${context.deliveryConfig.application}.${context.environmentName}"
```

# Problem

If a new deployment into an environment happens while a verification is
still running, when keel goes to launch a new verification, it will
instead get back the execution id associated with the earlier verification that is still running.

The particular scenario we saw looked like this:

```
13:46 v0.914.0 deployed to prestaging
      verification starts → task 01EYY449PMW8F3C5RT18CDCVDP

...

14:00 v0.916.0 deployed to prestaging
      verification starts, correlationId matches -> task 01EYY449PMW8F3C5RT18CDCVDP

14:02 verfication task 01EYY449PMW8F3C5RT18CDCVDP completes (actual duration: 16 minutes)
      keel sees task 01EYY449PMW8F3C5RT18CDCVDP completed, records duration as 2 minutes
```

# Proposed solution

Make correlation ids optional for launching orca tasks, and don't pass a correlation id when launching a test container.
This eliminates the failure mode above, since orca would unconditionally launch a new task.

We can still run into problems when users deploy new versions more quickly than the verifications run, but this at least eliminates one potential avenue for a false "correct".

# Considered alternatives

## Use artifact version to compute the correlation id

We could encode the artifact version in the correlation id, but I felt it would be safer if we *always* launch a new task, rather than risk some edge case I didn't think of where it's the same artifact version but we should still run a new test (e.g., update to the base AMI would trigger a redeploy but not a new version id).

## Don't allow multiple concurrent tests

We could enforce that we can only have one test running, either by terminating an old test, or block waiting on the new test to complete. 

I'm against blocked waiting for the old test, because I'm sure we'll hit issues where the old test hangs and the user asks "why isn't my test running?" Terminating an old test is an interesting idea, but the fix above seemed simpler and quicker to implement for now.

# Related orca code


* [checkforCorrelatedExecution][1]
* [retrieveOrchestrationForCorrelationId][2]

[1]:https://github.com/spinnaker/orca/blob/b2e18aa633f836864125c34357d2bac77ff65052/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExecutionLauncher.java#L87-L90
[2]: https://github.com/spinnaker/orca/blob/3e2d691b6884fb42ffc4a6d8994ac81eafdfab52/orca-sql/src/main/kotlin/com/netflix/spinnaker/orca/sql/pipeline/persistence/SqlExecutionRepository.kt#L520

