### PR TITLE
feat(reports): Add Front50 API to retrieve all apps + fields in Application model

### DIFF
--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
@@ -20,4 +20,9 @@ interface Front50Service {
     @Path("name") name: String,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): Application
+
+  @GET("/v2/applications")
+  suspend fun allApplications(
+    @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
+  ): List<Application>
 }

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -9,11 +9,11 @@ import com.fasterxml.jackson.annotation.JsonAnySetter
 data class Application(
   val name: String,
   val email: String,
-  val createTs: String,
   val dataSources: DataSources?,
   val repoProjectKey: String? = null,
   val repoSlug: String? = null,
   val repoType: String? = null,
+  val createTs: String? = null,
   @get:JsonAnyGetter val details: MutableMap<String, Any?> = mutableMapOf()
 ) {
   @JsonAnySetter

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -1,13 +1,26 @@
 package com.netflix.spinnaker.keel.front50.model
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
+import com.fasterxml.jackson.annotation.JsonAnySetter
+
+/**
+ * A Spinnaker application, as represented in Front50.
+ */
 data class Application(
   val name: String,
   val email: String,
+  val createTs: String,
   val dataSources: DataSources?,
   val repoProjectKey: String? = null,
   val repoSlug: String? = null,
-  val repoType: String? = null
-)
+  val repoType: String? = null,
+  @get:JsonAnyGetter val details: MutableMap<String, Any?> = mutableMapOf()
+) {
+  @JsonAnySetter
+  fun setDetail(key: String, value: Any?) {
+    details[key] = value
+  }
+}
 
 data class DataSources(
   val enabled: List<String>,


### PR DESCRIPTION
Enablement work for an internal PR to report on Managed Delivery onboarding, which leverages metadata persisted in Front50.