### PR TITLE
fix(api): don't blow up the api if can't query for verifications

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -306,7 +306,7 @@ class ApplicationService(
       // This map associates a context with this collection of verifications and their states
       val verificationStateMap = try {
         getVerificationStates(deliveryConfig, artifactVersions)
-      }catch(e: Exception) {
+      } catch(e: Exception) {
         log.error("error getting verification states for application ${deliveryConfig.application}", e)
         emptyMap()
       }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -304,7 +304,12 @@ class ApplicationService(
       // For each context, there may be multiple verifications (e.g., test-container, canary)
       //
       // This map associates a context with this collection of verifications and their states
-      val verificationStateMap = getVerificationStates(deliveryConfig, artifactVersions)
+      val verificationStateMap = try {
+        getVerificationStates(deliveryConfig, artifactVersions)
+      }catch(e: Exception) {
+        log.error("error getting verification states for application ${deliveryConfig.application}", e)
+        emptyMap()
+      }
 
       val artifactVersionSummaries = artifactVersions.map { artifactVersion ->
         // For each version of the artifact

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -68,6 +68,7 @@ import strikt.assertions.all
 import strikt.assertions.containsExactly
 import strikt.assertions.first
 import strikt.assertions.hasSize
+import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
@@ -1136,6 +1137,23 @@ class ApplicationServiceTests : JUnit5Minutests {
           that(v(version4, "test")).containsExactly("smoke" to "PASS", "fuzz" to "PASS")
           that(v(version4, "staging")).containsExactly("end-to-end" to "PASS", "canary" to "PASS")
           that(v(version5, "test")).containsExactly("smoke" to "PENDING")
+        }
+      }
+
+      context("getVerificationStates throws an exception") {
+        before {
+          every {
+            repository.getVerificationStatesBatch(any())
+          }.throws(java.sql.SQLSyntaxErrorException("bad syntax"))
+        }
+
+        test("artifact summaries succeeds, with no verification info") {
+          val versions = applicationService.getArtifactSummariesFor(application1)[0].versions
+          versions.forEach {
+            expectThat(it.environments).all {
+              this.get { verifications }.isEmpty()
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
# Problem

We hit an issue (documented as as #1821) where the batch verification query was throwing an exception, which broke the view.

# Implemented solution

Degrade gracefully by catching the exception, logging the error, and continuing on as if there is no verification info to display.

This ensures that the UI remains functional even if that particular query breaks.