### PR TITLE
Ensure events for all version of a resource are included in history

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -43,9 +43,11 @@ import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.api.expectThrows
 import strikt.assertions.all
+import strikt.assertions.contains
 import strikt.assertions.first
 import strikt.assertions.hasSize
 import strikt.assertions.isA
+import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isGreaterThanOrEqualTo
@@ -91,10 +93,9 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         verify { callback wasNot Called }
       }
 
-      test("getting state history throws an exception") {
-        expectThrows<NoSuchResourceId> {
-          subject.eventHistory("whatever")
-        }
+      test("getting state history returns an empty list") {
+        expectThat(subject.eventHistory("whatever"))
+          .isEmpty()
       }
 
       test("deleting a non-existent resource throws an exception") {
@@ -126,11 +127,6 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
       }
 
       test("it can be retrieved by id") {
-        val retrieved = subject.get<DummyResourceSpec>(resource.id)
-        expectThat(retrieved).isEqualTo(resource)
-      }
-
-      test("it can be retrieved by uid") {
         val retrieved = subject.get<DummyResourceSpec>(resource.id)
         expectThat(retrieved).isEqualTo(resource)
       }
@@ -174,7 +170,11 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
 
         before {
           tick()
-          subject.store(updatedResource)
+          with(subject) {
+            store(updatedResource).also {
+              appendHistory(ResourceUpdated(it, mapOf("delta" to "some-difference"), clock))
+            }
+          }
         }
 
         test("it replaces the original resource") {
@@ -186,6 +186,12 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         test("the resource version is incremented") {
           expectThat(subject.get<DummyResourceSpec>(resource.id))
             .get(Resource<*>::version) isEqualTo 2
+        }
+
+        test("history includes events for the previous version of the resource") {
+          expectThat(subject.eventHistory(resource.id) as List<ResourceEvent>)
+            .map(ResourceEvent::version)
+            .contains(1, 2)
         }
 
         context("when deleted") {
@@ -326,9 +332,8 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         }
 
         test("events for the resource are also deleted") {
-          expectThrows<NoSuchResourceException> {
-            subject.eventHistory(resource.id)
-          }
+          expectThat(subject.eventHistory(resource.id))
+            .isEmpty()
         }
 
         test("events for the resource's parent application remain") {
@@ -422,6 +427,10 @@ fun <T : List<E>, E> Assertion.Builder<T>.third(): Assertion.Builder<E> =
 
 fun <T : List<E>, E> Assertion.Builder<T>.fourth(): Assertion.Builder<E> =
   get("fourth element %s") { this[3] }
+
+@Suppress("UNCHECKED_CAST")
+inline fun <reified T> Assertion.Builder<List<*>>.areAll() : Assertion.Builder<List<T>> =
+  all { isA<T>() } as Assertion.Builder<List<T>>
 
 fun randomString(length: Int = 8) =
   randomUUID()

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -428,10 +428,6 @@ fun <T : List<E>, E> Assertion.Builder<T>.third(): Assertion.Builder<E> =
 fun <T : List<E>, E> Assertion.Builder<T>.fourth(): Assertion.Builder<E> =
   get("fourth element %s") { this[3] }
 
-@Suppress("UNCHECKED_CAST")
-inline fun <reified T> Assertion.Builder<List<*>>.areAll() : Assertion.Builder<List<T>> =
-  all { isA<T>() } as Assertion.Builder<List<T>>
-
 fun randomString(length: Int = 8) =
   randomUUID()
     .toString()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -165,11 +165,11 @@ class SqlDeliveryConfigRepository(
         // delete events
         txn.deleteFrom(EVENT)
           .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
-          .and(EVENT.REF.`in`(resourceIds))
+          .and(EVENT.REF_GEN.`in`(resourceIds))
           .execute()
         txn.deleteFrom(EVENT)
           .where(EVENT.SCOPE.eq(EventScope.APPLICATION))
-          .and(EVENT.REF.eq(application))
+          .and(EVENT.REF_GEN.eq(application))
           .execute()
         // delete pause records
         txn.deleteFrom(PAUSED)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -165,7 +165,7 @@ class SqlDeliveryConfigRepository(
         // delete events
         txn.deleteFrom(EVENT)
           .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
-          .and(EVENT.REF.`in`(resourceUids))
+          .and(EVENT.REF.`in`(resourceIds))
           .execute()
         txn.deleteFrom(EVENT)
           .where(EVENT.SCOPE.eq(EventScope.APPLICATION))

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -30,9 +30,12 @@ import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
+import org.jooq.Record1
+import org.jooq.Select
 import org.jooq.impl.DSL
 import org.jooq.impl.DSL.coalesce
 import org.jooq.impl.DSL.max
+import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.value
 import org.slf4j.LoggerFactory
 import java.time.Clock
@@ -206,8 +209,6 @@ open class SqlResourceRepository(
   override fun eventHistory(id: String, limit: Int): List<ResourceHistoryEvent> {
     require(limit > 0) { "limit must be a positive integer" }
 
-    val resource = get(id)
-
     return sqlRetry.withRetry(READ) {
       jooq
         .select(EVENT.JSON)
@@ -215,12 +216,12 @@ open class SqlResourceRepository(
         // look for resource events that match the resource...
         .where(
           EVENT.SCOPE.eq(EventScope.RESOURCE)
-            .and(EVENT.REF.eq(resource.uid))
+            .and(EVENT.REF.`in`(uidsForId(id)))
         )
         // ...or application events that match the application as they apply to all resources
         .or(
           EVENT.SCOPE.eq(EventScope.APPLICATION)
-            .and(EVENT.APPLICATION.eq(resource.application))
+            .and(EVENT.APPLICATION.eq(applicationForId(id)))
         )
         .orderBy(EVENT.TIMESTAMP.desc())
         .limit(limit)
@@ -396,6 +397,18 @@ open class SqlResourceRepository(
         .fetchOne(RESOURCE.UID)
         ?: throw IllegalStateException("Resource with id $id not found. Retrying.")
     }
+
+  private fun uidsForId(id: String): Select<Record1<String>> =
+    select(RESOURCE.UID)
+      .from(RESOURCE)
+      .where(RESOURCE.ID.eq(id))
+      .orderBy(RESOURCE.UID.desc())
+
+  private fun applicationForId(id: String): Select<Record1<String>> =
+    select(RESOURCE.APPLICATION)
+      .from(RESOURCE)
+      .where(RESOURCE.ID.eq(id))
+      .limit(1)
 
   private val Resource<*>.uid: String
     get() = getResourceUid(id, version)

--- a/keel-sql/src/main/resources/db/changelog/20210226-generate-event-columns.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210226-generate-event-columns.yml
@@ -39,13 +39,13 @@ databaseChangeLog:
           set json = json_set(
             json,
             '$.timestamp',
-            concat(substring(json_unquote(json->'$.timestamp'), 1, 19), '.000Z')
+            concat(substring(json->>'$.timestamp', 1, 19), '.000Z')
           )
           where length(json -> '$.timestamp') = 22;
     - sql:
         sql: |
           alter table event
-          add column timestamp datetime(3) generated always as (str_to_date(json_unquote(json->'$.timestamp'), '%Y-%m-%dT%T.%fZ'))
+          add column timestamp datetime(3) generated always as (str_to_date(json->>'$.timestamp', '%Y-%m-%dT%T.%fZ'))
           after application;
     - createIndex:
         tableName: event

--- a/keel-sql/src/main/resources/db/changelog/20210226-generate-event-columns.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210226-generate-event-columns.yml
@@ -1,0 +1,80 @@
+databaseChangeLog:
+- changeSet:
+    id: generate-event-timestamp
+    author: fletch
+    changes:
+    - dropIndex:
+        tableName: event
+        indexName: event_uid_timestamp_idx
+    - dropIndex:
+        tableName: event
+        indexName: event_scope_ref_timestamp_idx
+    - dropIndex:
+        tableName: event
+        indexName: event_scope_application_timestamp_idx
+    - dropColumn:
+        tableName: event
+        columnName: ref
+    - dropColumn:
+        tableName: event
+        columnName: application
+    - dropColumn:
+        tableName: event
+        columnName: timestamp
+    - sql:
+        sql: |
+          alter table event
+          add column ref varchar(255) generated always as (json ->> '$.ref')
+          not null
+          after scope;
+    - sql:
+        sql: |
+          alter table event
+          add column application varchar(255) generated always as (json ->> '$.application')
+          not null
+          after ref;
+    - sql:
+        sql: |
+          update event
+          set json = json_set(
+            json,
+            '$.timestamp',
+            concat(substring(json_unquote(json->'$.timestamp'), 1, 19), '.000Z')
+          )
+          where length(json -> '$.timestamp') = 22;
+    - sql:
+        sql: |
+          alter table event
+          add column timestamp datetime(3) generated always as (str_to_date(json_unquote(json->'$.timestamp'), '%Y-%m-%dT%T.%fZ'))
+          after application;
+    - createIndex:
+        tableName: event
+        indexName: event_uid_timestamp_idx
+        columns:
+        - column:
+            name: uid
+        - column:
+            name: timestamp
+            descending: true
+    - createIndex:
+        tableName: event
+        indexName: event_scope_ref_timestamp_idx
+        columns:
+        - column:
+            name: scope
+        - column:
+            name: ref
+        - column:
+            name: timestamp
+            descending: true
+    - createIndex:
+        tableName: event
+        indexName: event_scope_application_timestamp_idx
+        columns:
+        - column:
+            name: scope
+        - column:
+            name: application
+        - column:
+            name: timestamp
+            descending: true

--- a/keel-sql/src/main/resources/db/changelog/20210226-generate-event-columns.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210226-generate-event-columns.yml
@@ -14,17 +14,11 @@ databaseChangeLog:
         indexName: event_scope_application_timestamp_idx
     - dropColumn:
         tableName: event
-        columnName: ref
-    - dropColumn:
-        tableName: event
         columnName: application
-    - dropColumn:
-        tableName: event
-        columnName: timestamp
     - sql:
         sql: |
           alter table event
-          add column ref varchar(255) generated always as (json ->> '$.ref')
+          add column ref_gen varchar(255) generated always as (json ->> '$.ref')
           not null
           after scope;
     - sql:
@@ -32,7 +26,7 @@ databaseChangeLog:
           alter table event
           add column application varchar(255) generated always as (json ->> '$.application')
           not null
-          after ref;
+          after ref_gen;
     - sql:
         sql: |
           update event
@@ -45,7 +39,7 @@ databaseChangeLog:
     - sql:
         sql: |
           alter table event
-          add column timestamp datetime(3) generated always as (str_to_date(json->>'$.timestamp', '%Y-%m-%dT%T.%fZ'))
+          add column timestamp_gen datetime(3) generated always as (str_to_date(json->>'$.timestamp', '%Y-%m-%dT%T.%fZ'))
           after application;
     - createIndex:
         tableName: event
@@ -54,7 +48,7 @@ databaseChangeLog:
         - column:
             name: uid
         - column:
-            name: timestamp
+            name: timestamp_gen
             descending: true
     - createIndex:
         tableName: event
@@ -63,9 +57,9 @@ databaseChangeLog:
         - column:
             name: scope
         - column:
-            name: ref
+            name: ref_gen
         - column:
-            name: timestamp
+            name: timestamp_gen
             descending: true
     - createIndex:
         tableName: event
@@ -76,5 +70,5 @@ databaseChangeLog:
         - column:
             name: application
         - column:
-            name: timestamp
+            name: timestamp_gen
             descending: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -236,3 +236,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210208-versioned-resources.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210226-generate-event-columns.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/jooqConfig.xml
+++ b/keel-sql/src/main/resources/jooqConfig.xml
@@ -52,6 +52,11 @@
           <includeTypes>TIMESTAMP</includeTypes>
           <converter>com.netflix.spinnaker.jooq.LocalDateTimeToInstantConverter</converter>
         </forcedType>
+        <forcedType>
+          <userType>java.time.Instant</userType>
+          <includeTypes>DATETIME</includeTypes>
+          <converter>com.netflix.spinnaker.jooq.LocalDateTimeToInstantConverter</converter>
+        </forcedType>
         <!-- Enums -->
         <forcedType>
           <userType>com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus</userType>


### PR DESCRIPTION
Because of the poor performance of the initial attempt at this functionality, this PR includes revisions to the way the `event` table is structured. The most important is that `event.ref` will now be the `id` of a resource for rows where `scope = 'RESOURCE'`. In addition I re-ordered the columns for better indexing performance, and now derive the `ref`, `application`, and `timestamp` columns from `json` rather than requiring us to explicitly insert data. For now these are implemented as duplicate columns but I'll follow up with another PR to remove the old ones once this change is live.