### PR TITLE
chore(perf): speed up resource checking after new version is approved

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -275,6 +275,29 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         )
       }
 
+
+      test("resources in an environment can be rechecked") {
+        // note: this test needs to be here even though it's testing a resource repository function
+        // because we need a valid config and environment for the resources to exist in, and those can only
+        // be saved with both a delivery config repository and a resource repository.
+        storeResources()
+        store()
+
+        val firstCheck = resourceRepository.itemsDueForCheck(Duration.ofMinutes(2), 4)
+        val secondCheck = resourceRepository.itemsDueForCheck(Duration.ofMinutes(2), 4)
+        resourceRepository.triggerResourceRecheck("test", deliveryConfig.application)
+        val afterRecheck = resourceRepository.itemsDueForCheck(Duration.ofMinutes(2), 4)
+        val testResources = deliveryConfig.environments.find { it.name == "test" }?.resourceIds ?: emptySet()
+
+        expect {
+          that(firstCheck.size).isEqualTo(4)
+          that(secondCheck.size).isEqualTo(0)
+          that(afterRecheck.size).isEqualTo(2)
+          that(afterRecheck.first().application).isEqualTo(deliveryConfig.application)
+          that(afterRecheck.map { it.id }.toList()).containsExactlyInAnyOrder(testResources)
+        }
+      }
+
       context("updating an existing delivery config") {
         deriveFixture {
           storeArtifacts()

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -292,7 +292,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
         expect {
           that(firstCheck.size).isEqualTo(4)
           that(secondCheck.size).isEqualTo(0)
-          that(afterRecheck.size).isEqualTo(2)
+          that(afterRecheck.size).isEqualTo(2) //only one environment had a recheck triggered
           that(afterRecheck.first().application).isEqualTo(deliveryConfig.application)
           that(afterRecheck.map { it.id }.toList()).containsExactlyInAnyOrder(testResources)
         }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryTests.kt
@@ -50,6 +50,7 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isGreaterThanOrEqualTo
 import strikt.assertions.isNotEmpty
+import strikt.assertions.isSuccess
 import strikt.assertions.map
 import java.time.Clock
 import java.time.Duration
@@ -100,6 +101,10 @@ abstract class ResourceRepositoryTests<T : ResourceRepository> : JUnit5Minutests
         expectThrows<NoSuchResourceId> {
           subject.delete("whatever")
         }
+      }
+
+      test("recheck does not throw an exception") {
+        expectCatching { subject.triggerResourceRecheck("oh", "my") }.isSuccess()
       }
     }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -150,6 +150,9 @@ class EnvironmentPromotionChecker(
           version
         )
       )
+
+      // recheck all resources in an environment, so action can be taken right away
+      repository.triggerResourceRecheck(targetEnvironment, deliveryConfig.application)
     }
   }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -258,7 +258,7 @@ class CombinedRepository(
   override fun getApplicationSummaries(): Collection<ApplicationSummary> =
     deliveryConfigRepository.getApplicationSummaries()
 
-  override fun triggerRecheck(application: String) =
+  override fun triggerDeliveryConfigRecheck(application: String) =
     deliveryConfigRepository.triggerRecheck(application)
   // END DeliveryConfigRepository methods
 
@@ -308,8 +308,8 @@ class CombinedRepository(
   override fun resourcesDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<ResourceSpec>> =
     resourceRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
 
-  override fun artifactsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact> =
-    artifactRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
+  override fun triggerResourceRecheck(environmentName: String, application: String) =
+    resourceRepository.triggerResourceRecheck(environmentName, application)
 
   // END ResourceRepository methods
 
@@ -318,6 +318,9 @@ class CombinedRepository(
     artifactRepository.register(artifact)
     publisher.publishEvent(ArtifactRegisteredEvent(artifact))
   }
+
+  override fun artifactsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact> =
+    artifactRepository.itemsDueForCheck(minTimeSinceLastCheck, limit)
 
   override fun getArtifact(name: String, type: ArtifactType, deliveryConfigName: String): List<DeliveryArtifact> =
     artifactRepository.get(name, type, deliveryConfigName)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -120,7 +120,7 @@ interface KeelRepository : KeelReadOnlyRepository {
 
   fun getApplicationSummaries(): Collection<ApplicationSummary>
 
-  fun triggerRecheck(application: String)
+  fun triggerDeliveryConfigRecheck(application: String)
   // END DeliveryConfigRepository methods
 
   // START ResourceRepository methods
@@ -144,10 +144,12 @@ interface KeelRepository : KeelReadOnlyRepository {
 
   fun resourcesDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<ResourceSpec>>
 
-  fun artifactsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact>
+  fun triggerResourceRecheck(environmentName: String, application: String)
   // END ResourceRepository methods
 
   // START ArtifactRepository methods
+  fun artifactsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<DeliveryArtifact>
+
   fun register(artifact: DeliveryArtifact)
 
   fun getAllArtifacts(type: ArtifactType? = null, name: String? = null): List<DeliveryArtifact>

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepository.kt
@@ -15,6 +15,7 @@
  */
 package com.netflix.spinnaker.keel.persistence
 
+import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind
 import com.netflix.spinnaker.keel.api.ResourceSpec
@@ -138,6 +139,13 @@ interface ResourceRepository : PeriodicallyCheckedRepository<Resource<ResourceSp
    * different values.
    */
   override fun itemsDueForCheck(minTimeSinceLastCheck: Duration, limit: Int): Collection<Resource<ResourceSpec>>
+
+  /**
+   * Resets the last checked time for all resources in the environmet to the initial value
+   * (EPOCH + 1s) so that the resources will immediately be rechecked.
+   * This is done in response to something new happening, like a new artifact version approved.
+   */
+  fun triggerResourceRecheck(environmentName: String, application: String)
 
   companion object {
     const val DEFAULT_MAX_EVENTS: Int = 10

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/ApplicationService.kt
@@ -135,7 +135,7 @@ class ApplicationService(
   fun pin(user: String, application: String, pin: EnvironmentArtifactPin) {
     val config = repository.getDeliveryConfigForApplication(application)
     repository.pinEnvironment(config, pin.copy(pinnedBy = user))
-    repository.triggerRecheck(application) // recheck environments to reflect pin immediately
+    repository.triggerDeliveryConfigRecheck(application) // recheck environments to reflect pin immediately
     publisher.publishEvent(PinnedNotification(config, pin.copy(pinnedBy = user)))
   }
 
@@ -143,7 +143,7 @@ class ApplicationService(
     val config = repository.getDeliveryConfigForApplication(application)
     val pinnedEnvironment = repository.pinnedEnvironments(config).find { it.targetEnvironment == targetEnvironment }
     repository.deletePin(config, targetEnvironment, reference)
-    repository.triggerRecheck(application) // recheck environments to reflect pin removal immediately
+    repository.triggerDeliveryConfigRecheck(application) // recheck environments to reflect pin removal immediately
 
     publisher.publishEvent(UnpinnedNotification(config,
       pinnedEnvironment,
@@ -161,7 +161,7 @@ class ApplicationService(
     if (!succeeded) {
       throw InvalidVetoException(application, veto.targetEnvironment, veto.reference, veto.version)
     }
-    repository.triggerRecheck(application) // recheck environments to reflect veto immediately
+    repository.triggerDeliveryConfigRecheck(application) // recheck environments to reflect veto immediately
     publisher.publishEvent(MarkAsBadNotification(
       config = config,
       user = user,
@@ -179,7 +179,7 @@ class ApplicationService(
       version = version,
       targetEnvironment = targetEnvironment
     )
-    repository.triggerRecheck(application) // recheck environments to reflect removed veto immediately
+    repository.triggerDeliveryConfigRecheck(application) // recheck environments to reflect removed veto immediately
   }
 
   fun getSummariesAllEntities(application: String): Map<String, Any> {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -165,6 +165,12 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
             }
           }
 
+          test("a recheck is triggered for the environemtn") {
+            verify {
+              repository.triggerResourceRecheck(environment.name, deliveryConfig.application)
+            }
+          }
+
           test("a telemetry event is fired") {
             verify {
               publisher.publishEvent(
@@ -199,6 +205,12 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
           test("an event is not sent") {
             verify(exactly = 0) {
               publisher.publishEvent(ofType<ArtifactVersionApproved>())
+            }
+          }
+
+          test("a recheck is not triggered for the environemtn") {
+            verify(exactly = 0) {
+              repository.triggerResourceRecheck(environment.name, deliveryConfig.application)
             }
           }
         }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ApplicationServiceTests.kt
@@ -951,7 +951,7 @@ class ApplicationServiceTests : JUnit5Minutests {
           repository.pinEnvironment(singleArtifactDeliveryConfig, pin)
         } just Runs
         every {
-          repository.triggerRecheck(application1)
+          repository.triggerDeliveryConfigRecheck(application1)
         } just Runs
 
         applicationService.pin("keel@keel.io", application1, pin)
@@ -976,7 +976,7 @@ class ApplicationServiceTests : JUnit5Minutests {
         } just Runs
 
         every {
-          repository.triggerRecheck(application1)
+          repository.triggerDeliveryConfigRecheck(application1)
         } just Runs
 
         every {
@@ -1004,7 +1004,7 @@ class ApplicationServiceTests : JUnit5Minutests {
         } just Runs
 
         every {
-          repository.triggerRecheck(application1)
+          repository.triggerDeliveryConfigRecheck(application1)
         } just Runs
 
         every {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
+import org.jooq.impl.DSL
 import org.jooq.impl.DSL.coalesce
 import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.value
@@ -360,23 +361,28 @@ open class SqlResourceRepository(
   }
 
   override fun triggerResourceRecheck(environmentName: String, application: String) {
-    val resourceUids = sqlRetry.withRetry(READ) {
-      jooq.select(ENVIRONMENT_RESOURCE.RESOURCE_UID)
-        .from(ENVIRONMENT_RESOURCE)
-        .innerJoin(ENVIRONMENT)
-        .on(ENVIRONMENT.UID.eq(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID))
-        .innerJoin(DELIVERY_CONFIG)
-        .on(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
-        .where(ENVIRONMENT.NAME.eq(environmentName))
-        .and(DELIVERY_CONFIG.APPLICATION.eq(application))
-        .fetch()
-    }
-
+    log.debug("Triggering recheck for environment $environmentName in application $application")
     sqlRetry.withRetry(WRITE) {
-      jooq.update(RESOURCE_LAST_CHECKED)
-        .set(RESOURCE_LAST_CHECKED.AT, EPOCH.plusSeconds(1))
-        .where(RESOURCE_LAST_CHECKED.RESOURCE_UID.`in`(resourceUids))
-        .execute()
+      jooq.transaction { config ->
+        val txn = DSL.using(config)
+        val resourceUids =
+          txn.select(ENVIRONMENT_RESOURCE.RESOURCE_UID)
+            .from(ENVIRONMENT_RESOURCE)
+            .innerJoin(ENVIRONMENT)
+            .on(ENVIRONMENT.UID.eq(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID))
+            .innerJoin(DELIVERY_CONFIG)
+            .on(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+            .where(ENVIRONMENT.NAME.eq(environmentName))
+            .and(DELIVERY_CONFIG.APPLICATION.eq(application))
+            .fetch()
+
+          log.debug("Triggering recheck for resources $resourceUids in environment $environmentName in application $application")
+
+          txn.update(RESOURCE_LAST_CHECKED)
+            .set(RESOURCE_LAST_CHECKED.AT, EPOCH.plusSeconds(1))
+            .where(RESOURCE_LAST_CHECKED.RESOURCE_UID.`in`(resourceUids))
+            .execute()
+      }
     }
   }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -15,6 +15,7 @@ import com.netflix.spinnaker.keel.pause.PauseScope
 import com.netflix.spinnaker.keel.persistence.NoSuchResourceId
 import com.netflix.spinnaker.keel.persistence.ResourceHeader
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DIFF_FINGERPRINT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.EVENT
@@ -22,6 +23,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_LAST_CHECKED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_WITH_METADATA
+import com.netflix.spinnaker.keel.persistence.metamodel.tables.Environment.ENVIRONMENT
 import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.resources.SpecMigrator
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
@@ -354,6 +356,27 @@ open class SqlResourceRepository(
             throw e
           }
         }
+    }
+  }
+
+  override fun triggerResourceRecheck(environmentName: String, application: String) {
+    val resourceUids = sqlRetry.withRetry(READ) {
+      jooq.select(ENVIRONMENT_RESOURCE.RESOURCE_UID)
+        .from(ENVIRONMENT_RESOURCE)
+        .innerJoin(ENVIRONMENT)
+        .on(ENVIRONMENT.UID.eq(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID))
+        .innerJoin(DELIVERY_CONFIG)
+        .on(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+        .where(ENVIRONMENT.NAME.eq(environmentName))
+        .and(DELIVERY_CONFIG.APPLICATION.eq(application))
+        .fetch()
+    }
+
+    sqlRetry.withRetry(WRITE) {
+      jooq.update(RESOURCE_LAST_CHECKED)
+        .set(RESOURCE_LAST_CHECKED.AT, EPOCH.plusSeconds(1))
+        .where(RESOURCE_LAST_CHECKED.RESOURCE_UID.`in`(resourceUids))
+        .execute()
     }
   }
 


### PR DESCRIPTION
We've gotten some user reports of things feeling slow and not responsive. We've also gotten reports like "what are you waiting for??". This pr hopes to make deployment happen much faster after a new version is "approved" for an environment (pin, unpin, mark as bad, and also new versions).

This pr introduces a "recheck resources in an environment" function that clears the "last checked" time for all resources in an environment. This makes them immediately due for check. My hope is this will mean we spend almost 0 seconds in the "approved" state. (unless your application is paused, which means that versions will stay in the approved state until you un pause).

Hopefully this is a big performance-feel win for a minimal amount of effort.