### PR TITLE
feat(reports): Add fields to ApplicationSummary in support of reporting

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -489,13 +489,10 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
 
         test("can retrieve the manifest for the resources") {
           val resource = deliveryConfig.resources.random()
-          val persistedDeliveryConfig = repository.deliveryConfigFor(resource.id)
-            .let {
-              // disregard `createdAt` which is added when reading from the database
-              it.copy(metadata = it.metadata.filterKeys { k -> k != "createdAt" })
-            }
-          expectThat(persistedDeliveryConfig)
-            .isEqualTo(deliveryConfig)
+          getDeliveryConfig(resource)
+            .isSuccess()
+            .get { name }
+            .isEqualTo(deliveryConfig.name)
         }
       }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder
 import java.time.Instant
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(value = ["deliveryConfigName", "application", "serviceAccount", "apiVersion", "createdAt", "isPaused"])
+@JsonPropertyOrder(value = ["deliveryConfigName", "application", "serviceAccount", "apiVersion", "isPaused"])
 data class ApplicationSummary(
   val deliveryConfigName: String,
   val application: String,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ApplicationSummary.kt
@@ -2,13 +2,16 @@ package com.netflix.spinnaker.keel.core.api
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import java.time.Instant
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-@JsonPropertyOrder(value = ["deliveryConfigName", "application", "serviceAccount", "apiVersion", "isPaused"])
+@JsonPropertyOrder(value = ["deliveryConfigName", "application", "serviceAccount", "apiVersion", "createdAt", "isPaused"])
 data class ApplicationSummary(
   val deliveryConfigName: String,
   val application: String,
   val serviceAccount: String,
   val apiVersion: String,
-  val isPaused: Boolean = false
+  val createdAt: Instant,
+  val resourceCount: Int = 0,
+  val isPaused: Boolean = false,
 )

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -99,7 +99,7 @@ class SqlDeliveryConfigRepository(
             name = name,
             application = application,
             serviceAccount = serviceAccount,
-            metadata = metadata ?: emptyMap()
+            metadata = (metadata ?: emptyMap()) + mapOf("createdAt" to ULID.parseULID(uid).timestampAsInstant())
           ).let {
             attachDependents(it)
           }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -16,6 +16,7 @@ import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.core.api.parseUID
 import com.netflix.spinnaker.keel.core.api.randomUID
+import com.netflix.spinnaker.keel.core.api.timestampAsInstant
 import com.netflix.spinnaker.keel.events.PersistentEvent.EventScope
 import com.netflix.spinnaker.keel.pause.PauseScope
 import com.netflix.spinnaker.keel.pause.PauseScope.APPLICATION
@@ -43,10 +44,12 @@ import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import com.netflix.spinnaker.keel.sql.deliveryconfigs.attachDependents
 import com.netflix.spinnaker.keel.sql.deliveryconfigs.deliveryConfigByName
 import com.netflix.spinnaker.keel.sql.deliveryconfigs.resourcesForEnvironment
+import de.huxhorn.sulky.ulid.ULID
 import org.jooq.DSLContext
 import org.jooq.Record1
 import org.jooq.Select
 import org.jooq.impl.DSL
+import org.jooq.impl.DSL.count
 import org.jooq.impl.DSL.inline
 import org.jooq.impl.DSL.max
 import org.jooq.impl.DSL.select
@@ -1145,22 +1148,31 @@ class SqlDeliveryConfigRepository(
     sqlRetry.withRetry(READ) {
       jooq
         .select(
+          DELIVERY_CONFIG.UID,
           DELIVERY_CONFIG.NAME,
           DELIVERY_CONFIG.APPLICATION,
           DELIVERY_CONFIG.SERVICE_ACCOUNT,
           DELIVERY_CONFIG.API_VERSION,
+          count(RESOURCE.UID),
           PAUSED.NAME
         )
         .from(DELIVERY_CONFIG)
+        .leftOuterJoin(RESOURCE).on(
+          RESOURCE.APPLICATION.eq(DELIVERY_CONFIG.APPLICATION)
+        )
         .leftOuterJoin(PAUSED).on(
           PAUSED.NAME.eq(DELIVERY_CONFIG.APPLICATION).and(PAUSED.SCOPE.eq(APPLICATION))
         )
-        .fetch { (name, application, serviceAccount, apiVersion, paused) ->
+        .groupBy(DELIVERY_CONFIG.APPLICATION)
+        .orderBy(DELIVERY_CONFIG.APPLICATION)
+        .fetch { (uid, name, application, serviceAccount, apiVersion, resourceCount, paused) ->
           ApplicationSummary(
             deliveryConfigName = name,
             application = application,
             serviceAccount = serviceAccount,
             apiVersion = apiVersion,
+            createdAt = ULID.parseULID(uid).timestampAsInstant(),
+            resourceCount = resourceCount,
             isPaused = paused != null
           )
         }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.core.api.timestampAsInstant
 import com.netflix.spinnaker.keel.persistence.NoSuchDeliveryConfigName
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
@@ -14,6 +15,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_WITH_MET
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.SqlStorageContext
 import com.netflix.spinnaker.keel.sql.mapToArtifact
+import de.huxhorn.sulky.ulid.ULID
 import org.jooq.Record1
 import org.jooq.Select
 import org.jooq.impl.DSL.select
@@ -34,7 +36,7 @@ internal fun SqlStorageContext.deliveryConfigByName(name: String): DeliveryConfi
           name = name,
           application = application,
           serviceAccount = serviceAccount,
-          metadata = metadata as Map<String, Any?>? ?: emptyMap()
+          metadata = (metadata ?: emptyMap()) + mapOf("createdAt" to ULID.parseULID(uid).timestampAsInstant())
         )
       }
       ?.let { (_, deliveryConfig) ->

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
@@ -45,15 +45,14 @@ internal class AdminControllerTests
             application = application1,
             serviceAccount = "keel@spinnaker",
             apiVersion = "delivery.config.spinnaker.netflix.com/v1",
-            createdAt = Instant.parse("2021-02-28T21:45:00Z"),
-            resourceCount = 5,
-            isPaused = false
+            isPaused = false,
+            createdAt = Instant.now()
           )
         )
       }
 
       before {
-        every { adminService.getManagedApplications() }.returns(this)
+        every { adminService.getManagedApplications() } returns this
       }
 
       test("can get basic summary of unpaused application") {
@@ -70,8 +69,6 @@ internal class AdminControllerTests
                 "application": "fnord",
                 "serviceAccount": "keel@spinnaker",
                 "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
-                "createdAt": "2021-02-28T21:45:00Z",
-                "resourceCount": 5,
                 "isPaused":false
               }]
               """.trimIndent()
@@ -88,22 +85,22 @@ internal class AdminControllerTests
             application = application1,
             serviceAccount = "keel@spinnaker",
             apiVersion = "delivery.config.spinnaker.netflix.com/v1",
-            createdAt = Instant.now(),
-            isPaused = false
+            isPaused = false,
+            createdAt = Instant.now()
           ),
           ApplicationSummary(
             deliveryConfigName = "$application2-manifest",
             application = application2,
             serviceAccount = "keel@spinnaker",
             apiVersion = "delivery.config.spinnaker.netflix.com/v1",
-            createdAt = Instant.now(),
-            isPaused = false
+            isPaused = false,
+            createdAt = Instant.now()
           )
         )
       }
 
       before {
-        every { adminService.getManagedApplications() }.returns(this)
+        every { adminService.getManagedApplications() } returns this
       }
 
       test("can get basic summary of 2 applications") {
@@ -140,7 +137,7 @@ internal class AdminControllerTests
       fixture { emptyList() }
 
       before {
-        every { adminService.getManagedApplications() }.returns(this)
+        every { adminService.getManagedApplications() } returns this
       }
 
       test("return an empty list") {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/AdminControllerTests.kt
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.Instant
 
 @SpringBootTest(webEnvironment = MOCK)
 @AutoConfigureMockMvc
@@ -44,13 +45,15 @@ internal class AdminControllerTests
             application = application1,
             serviceAccount = "keel@spinnaker",
             apiVersion = "delivery.config.spinnaker.netflix.com/v1",
+            createdAt = Instant.parse("2021-02-28T21:45:00Z"),
+            resourceCount = 5,
             isPaused = false
           )
         )
       }
 
       before {
-        every { adminService.getManagedApplications() } returns this
+        every { adminService.getManagedApplications() }.returns(this)
       }
 
       test("can get basic summary of unpaused application") {
@@ -67,6 +70,8 @@ internal class AdminControllerTests
                 "application": "fnord",
                 "serviceAccount": "keel@spinnaker",
                 "apiVersion": "delivery.config.spinnaker.netflix.com/v1",
+                "createdAt": "2021-02-28T21:45:00Z",
+                "resourceCount": 5,
                 "isPaused":false
               }]
               """.trimIndent()
@@ -83,6 +88,7 @@ internal class AdminControllerTests
             application = application1,
             serviceAccount = "keel@spinnaker",
             apiVersion = "delivery.config.spinnaker.netflix.com/v1",
+            createdAt = Instant.now(),
             isPaused = false
           ),
           ApplicationSummary(
@@ -90,13 +96,14 @@ internal class AdminControllerTests
             application = application2,
             serviceAccount = "keel@spinnaker",
             apiVersion = "delivery.config.spinnaker.netflix.com/v1",
+            createdAt = Instant.now(),
             isPaused = false
           )
         )
       }
 
       before {
-        every { adminService.getManagedApplications() } returns this
+        every { adminService.getManagedApplications() }.returns(this)
       }
 
       test("can get basic summary of 2 applications") {
@@ -133,7 +140,7 @@ internal class AdminControllerTests
       fixture { emptyList() }
 
       before {
-        every { adminService.getManagedApplications() } returns this
+        every { adminService.getManagedApplications() }.returns(this)
       }
 
       test("return an empty list") {


### PR DESCRIPTION
Adds the following fields to `ApplicationSummary`, in support of reporting internally at Netflix:
- `createdAt`: the `Instant` at which the corresponding `DeliveryConfig` was created. This field is derived from `delivery_config.uid` (which is a ULID).
- `resourceCount`: count of resources in the `DeliveryConfig` at the time of querying.