### PR TITLE
Delay promotion if verifications are still running

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -27,7 +27,6 @@ interface VerificationRepository {
     context: VerificationContext,
   ) : Map<String, VerificationState>
 
-
   /**
    * Query the repository for the states of multiple contexts.
    *
@@ -55,6 +54,14 @@ interface VerificationRepository {
     status: ConstraintStatus,
     metadata: Map<String, Any?> = emptyMap()
   )
+
+  /**
+   * Returns any pending verifications for the specified environment.
+   */
+  fun pendingInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String
+  ) : Collection<PendingVerification>
 
   fun nextEnvironmentsForVerification(minTimeSinceLastCheck: Duration, limit: Int) : Collection<VerificationContext>
 }
@@ -88,3 +95,9 @@ data class VerificationContext(
 
   fun verification(id: String): Verification? = verifications.firstOrNull { it.id == id }
 }
+
+data class PendingVerification(
+  val context: VerificationContext,
+  val verification: Verification,
+  val state: VerificationState
+)

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -5,9 +5,11 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_PASS
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.api.verification.PendingVerification
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
@@ -23,6 +25,7 @@ import strikt.api.expect
 import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
+import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.containsKey
 import strikt.assertions.first
 import strikt.assertions.get
@@ -34,6 +37,7 @@ import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
+import strikt.assertions.map
 import strikt.assertions.one
 import strikt.assertions.withFirst
 import java.time.Duration
@@ -116,6 +120,24 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
       .isNotNull()
       .with(VerificationState::status) { isEqualTo(status) }
       .with(VerificationState::metadata) { isEqualTo(metadata) }
+  }
+
+  @Test
+  fun `pending verifications for an environment can be fetched`() {
+    context.setup()
+    val context2 = context.copy(version = "fnord-0.191.0-h379.0b74d6f").also { it.setup() }
+    val context3 = context.copy(version = "fnord-0.192.0-h380.9361c66").also { it.setup() }
+
+    subject.updateState(context, verification, PASS)
+    subject.updateState(context2, verification, PENDING)
+    subject.updateState(context3, verification, NOT_EVALUATED)
+
+    expectCatching {
+      subject.pendingInEnvironment(deliveryConfig, context.environmentName)
+    }
+      .isSuccess()
+      .map(PendingVerification::context)
+      .containsExactlyInAnyOrder(context2, context3)
   }
 
   @Test

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PendingVerificationsConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PendingVerificationsConstraintEvaluator.kt
@@ -1,0 +1,54 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
+import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.api.verification.VerificationRepository
+import com.netflix.spinnaker.keel.core.api.PendingVerificationsConstraint
+import org.slf4j.LoggerFactory
+
+class PendingVerificationsConstraintEvaluator(
+  private val verificationRepository: VerificationRepository,
+  override val eventPublisher: EventPublisher
+) : ConstraintEvaluator<PendingVerificationsConstraint> {
+
+  override fun isImplicit() = true
+
+  override val supportedType =
+    SupportedConstraintType<PendingVerificationsConstraint>("pending-verifications")
+
+  override fun canPromote(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment
+  ): Boolean =
+    if (targetEnvironment.verifyWith.isEmpty()) {
+      log.debug("{} / {} has no verifications", deliveryConfig.name, targetEnvironment.name)
+      true
+    } else {
+      val pendingVerifications =
+        verificationRepository.pendingInEnvironment(deliveryConfig, targetEnvironment.name)
+      if (pendingVerifications.isNotEmpty()) {
+        log.info(
+          "{} / {} is awaiting results from {} before another deployment can proceed",
+          deliveryConfig.name,
+          targetEnvironment.name,
+          pendingVerifications.map { it.verification.id }.joinToString()
+        )
+        false
+      } else {
+        log.debug(
+          "{} / {} has no pending verifications",
+          deliveryConfig.name,
+          targetEnvironment.name
+        )
+        true
+      }
+    }
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PendingVerificationsConstraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/PendingVerificationsConstraint.kt
@@ -1,0 +1,5 @@
+package com.netflix.spinnaker.keel.core.api
+
+import com.netflix.spinnaker.keel.api.Constraint
+
+class PendingVerificationsConstraint : Constraint("pending-verifications")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
@@ -91,8 +91,11 @@ class VerificationRunner(
     }
   }
 
+  /**
+   * `true` if any of the statuses is [PENDING], `false` if none are or the collection is empty.
+   */
   private val Collection<Pair<*, ConstraintStatus?>>.anyStillRunning: Boolean
-    get() = !none { (_, status) -> status == PENDING }
+    get() = any { (_, status) -> status == PENDING }
 
   private val Collection<Pair<Verification, ConstraintStatus?>>.firstOutstanding: Verification?
     get() = firstOrNull { (_, status) -> status in listOf(null, NOT_EVALUATED) }?.first

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
@@ -36,6 +36,9 @@ class VerificationRunner(
       .map {
         Triple(it.context.version, it.verification.id, it.context.latestStatus(it.verification))
       }
+      .filterNot { (_, _, status) ->
+        status?.complete ?: false
+      }
       .let {
         if (it.isNotEmpty()) {
           it.forEach { (version, id, status)->

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PendingVerificationsConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PendingVerificationsConstraintEvaluatorTests.kt
@@ -1,0 +1,93 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Verification
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.api.verification.PendingVerification
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import com.netflix.spinnaker.keel.api.verification.VerificationRepository
+import com.netflix.spinnaker.keel.api.verification.VerificationState
+import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.isFalse
+import strikt.assertions.isSuccess
+import strikt.assertions.isTrue
+import java.time.Instant.now
+
+internal class PendingVerificationsConstraintEvaluatorTests {
+
+  private val artifact = DockerArtifact(
+    name = "fnord",
+    reference = "fnord"
+  )
+
+  private val environmentWithNoVerifications = Environment(
+    name = "test"
+  )
+  private val verification = DummyVerification("1")
+  private val environmentWithVerification =
+    environmentWithNoVerifications.copy(verifyWith = listOf(verification))
+
+  private val deliveryConfig = DeliveryConfig(
+    application = "fnord",
+    name = "fnord-manifest",
+    serviceAccount = "hagbard@illuminati.org",
+    artifacts = setOf(artifact),
+    environments = setOf(environmentWithNoVerifications)
+  )
+
+  private val verificationRepository = mockk<VerificationRepository>()
+  private val eventPublisher = mockk<EventPublisher>()
+
+  private val subject = PendingVerificationsConstraintEvaluator(verificationRepository, eventPublisher)
+
+  @Test
+  fun `can promote if the environment has no verifications`() {
+    expectCatching {
+      subject.canPromote(artifact, "v1", deliveryConfig, environmentWithNoVerifications)
+    }
+      .isSuccess()
+      .isTrue()
+  }
+
+  @Test
+  fun `can promote if there are no verifications currently running`() {
+    with(deliveryConfig.copy(environments = setOf(environmentWithVerification))) {
+      every { verificationRepository.pendingInEnvironment(any(), any()) } returns emptyList()
+
+      expectCatching {
+        subject.canPromote(artifact, "v1", this, environmentWithVerification)
+      }
+        .isSuccess()
+        .isTrue()
+    }
+  }
+
+  @Test
+  fun `cannot promote if there are any verifications currently running`() {
+    with(deliveryConfig.copy(environments = setOf(environmentWithVerification))) {
+      every { verificationRepository.pendingInEnvironment(any(), any()) } returns listOf(
+        PendingVerification(
+          VerificationContext(this, environmentWithVerification.name, artifact.reference, "v1"),
+          verification,
+          VerificationState(PENDING, now(), null)
+        )
+      )
+
+      expectCatching {
+        subject.canPromote(artifact, "v1", this, environmentWithVerification)
+      }
+        .isSuccess()
+        .isFalse()
+    }
+  }
+
+  private data class DummyVerification(override val id: String) : Verification {
+    override val type: String = "dummy"
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
 import com.netflix.spinnaker.keel.api.plugins.CurrentImages
 import com.netflix.spinnaker.keel.api.plugins.ImageInRegion
 import com.netflix.spinnaker.keel.api.plugins.VerificationEvaluator
+import com.netflix.spinnaker.keel.api.verification.PendingVerification
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
@@ -106,6 +107,7 @@ internal class VerificationRunnerTests {
     )
     val metadata = mapOf("taskId" to ULID().nextULID(), "images" to images)
 
+    every { repository.pendingInEnvironment(any(), any())} returns emptyList()
     every { repository.getState(any(), any()) } returns null
     every { evaluator.start(any(), any()) } returns metadata
 
@@ -138,6 +140,7 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
+    every { repository.pendingInEnvironment(any(), any())} returns emptyList()
     every { repository.getState(any(), any()) } returns VerificationState(NOT_EVALUATED, now(), null, mapOf("tasks" to listOf(ULID().nextULID())))
     every { evaluator.start(any(), any()) } answers { mapOf("tasks" to listOf(ULID().nextULID())) }
 
@@ -170,6 +173,7 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
+    every { repository.pendingInEnvironment(any(), any())} returns emptyList()
     every { repository.getState(any(), DummyVerification("1")) } returns PENDING.toState()
     every { repository.getState(any(), DummyVerification("2")) } returns null
 
@@ -208,6 +212,9 @@ internal class VerificationRunnerTests {
       version = "fnord-0.191.0-h379.d4d9ec0"
     )
 
+    every { repository.pendingInEnvironment(any(), any())} returns listOf(
+      PendingVerification(context1, verification, VerificationState(PENDING, now(), null))
+    )
     every { repository.getState(context1, verification) } returns PENDING.toState()
     every { repository.getState(context2, verification) } returns null
 
@@ -247,6 +254,7 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
+    every { repository.pendingInEnvironment(any(), any())} returns emptyList()
     every { repository.getState(any(), DummyVerification("1")) } returns PENDING.toState()
     every { repository.getState(any(), DummyVerification("2")) } returns null
 
@@ -292,12 +300,9 @@ internal class VerificationRunnerTests {
       version = "fnord-0.190.0-h378.eacb135"
     )
 
-    every {
-      repository.getState(any(), DummyVerification("1"))
-    } returns PASS.toState()
-    every {
-      repository.getState(any(), DummyVerification("2"))
-    } returns status.toState()
+    every { repository.pendingInEnvironment(any(), any())} returns emptyList()
+    every { repository.getState(any(), DummyVerification("1")) } returns PASS.toState()
+    every { repository.getState(any(), DummyVerification("2")) } returns status.toState()
 
     subject.runVerificationsFor(context)
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -1,9 +1,11 @@
 package com.netflix.spinnaker.keel.sql
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
+import com.netflix.spinnaker.keel.api.verification.PendingVerification
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
@@ -21,8 +23,8 @@ import com.netflix.spinnaker.keel.resources.SpecMigrator
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import com.netflix.spinnaker.keel.sql.deliveryconfigs.deliveryConfigByName
 import org.jooq.*
-import org.jooq.impl.DSL.function
 import org.jooq.impl.DSL.field
+import org.jooq.impl.DSL.function
 import org.jooq.impl.DSL.inline
 import org.jooq.impl.DSL.isnull
 import org.jooq.impl.DSL.name
@@ -282,6 +284,48 @@ class SqlVerificationRepository(
         }
         .execute()
     }
+  }
+
+  override fun pendingInEnvironment(
+    deliveryConfig: DeliveryConfig,
+    environmentName: String
+  ): Collection<PendingVerification> {
+    return jooq
+      .select(
+        DELIVERY_ARTIFACT.REFERENCE,
+        VERIFICATION_STATE.ARTIFACT_VERSION,
+        VERIFICATION_STATE.VERIFICATION_ID,
+        VERIFICATION_STATE.STATUS,
+        VERIFICATION_STATE.STARTED_AT,
+        VERIFICATION_STATE.ENDED_AT,
+        VERIFICATION_STATE.METADATA,
+      )
+      .from(VERIFICATION_STATE)
+      .join(ENVIRONMENT)
+      .on(ENVIRONMENT.UID.eq(VERIFICATION_STATE.ENVIRONMENT_UID))
+      .and(ENVIRONMENT.NAME.eq(environmentName))
+      .join(DELIVERY_CONFIG)
+      .on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
+      .and(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
+      .join(DELIVERY_ARTIFACT)
+      .on(DELIVERY_ARTIFACT.UID.eq(VERIFICATION_STATE.ARTIFACT_UID))
+      .and(VERIFICATION_STATE.ENDED_AT.isNull)
+      .fetch { (artifactReference, artifactVersion, verificationId, status, startedAt, endedAt, metadata) ->
+        VerificationContext(
+          deliveryConfig,
+          environmentName,
+          artifactReference,
+          artifactVersion
+        ).let { context ->
+          PendingVerification(
+            context = context,
+            verification = checkNotNull(context.verification(verificationId)) {
+              "No verification with id $verificationId found"
+            },
+            state = VerificationState(status, startedAt, endedAt, metadata)
+          )
+        }
+      }
   }
 
   /**


### PR DESCRIPTION
If a previous deployment has verifications still running, this PR makes it so that promotion of a new version will be delayed.

Relevant to #1831