### PR TITLE
feat(api): add displayName and level to events history

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -32,7 +32,9 @@ abstract class ApplicationEvent(
 data class ApplicationActuationPaused(
   override val application: String,
   override val timestamp: Instant,
-  override val triggeredBy: String?
+  override val triggeredBy: String?,
+  override val level: EventLevel = EventLevel.WARNING,
+  override val displayName: String = "Application management paused",
 ) : ApplicationEvent(), ResourceHistoryEvent {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -50,7 +52,9 @@ data class ApplicationActuationPaused(
 data class ApplicationActuationResumed(
   override val application: String,
   override val triggeredBy: String?,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Application management resumed",
 ) : ApplicationEvent(), ResourceHistoryEvent {
   @JsonIgnore override val ignoreRepeatedInHistory = true
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ApplicationEvent.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Clock
 import java.time.Instant
+import com.netflix.spinnaker.keel.events.EventLevel.WARNING
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -33,7 +34,7 @@ data class ApplicationActuationPaused(
   override val application: String,
   override val timestamp: Instant,
   override val triggeredBy: String?,
-  override val level: EventLevel = EventLevel.WARNING,
+  override val level: EventLevel = WARNING,
   override val displayName: String = "Application management paused",
 ) : ApplicationEvent(), ResourceHistoryEvent {
   @JsonIgnore
@@ -53,7 +54,6 @@ data class ApplicationActuationResumed(
   override val application: String,
   override val triggeredBy: String?,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Application management resumed",
 ) : ApplicationEvent(), ResourceHistoryEvent {
   @JsonIgnore override val ignoreRepeatedInHistory = true

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/PersistentEvent.kt
@@ -7,6 +7,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import java.time.Clock
 import java.time.Instant
 
+enum class EventLevel {
+  SUCCESS, INFO, WARNING, ERROR
+}
+
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
   property = "type",
@@ -22,6 +26,8 @@ abstract class PersistentEvent {
   abstract val ref: String // The unique ID of the thing associated with the scope. Defined in sub-classes.
   abstract val timestamp: Instant
   abstract val triggeredBy: String?
+  abstract val displayName: String
+  open val level: EventLevel = EventLevel.INFO
   @JsonIgnore
   open val ignoreRepeatedInHistory: Boolean = false
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -85,7 +85,9 @@ data class ResourceCreated(
   override val id: String,
   override val version: Int,
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Created",
 ) : ResourceEvent() {
 
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
@@ -109,7 +111,9 @@ data class ResourceUpdated(
   override val version: Int,
   override val application: String,
   val delta: Map<String, Any?>,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Config updated",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, delta: Map<String, Any?>, clock: Clock = Companion.clock) : this(
     resource.kind,
@@ -126,7 +130,9 @@ data class ResourceDeleted(
   override val id: String,
   override val version: Int,
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Deleted",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
     resource.kind,
@@ -154,7 +160,9 @@ data class ResourceMissing(
   override val id: String,
   override val version: Int,
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Missing",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Missing
@@ -179,7 +187,9 @@ data class ResourceDeltaDetected(
   override val version: Int,
   override val application: String,
   val delta: Map<String, Any?>,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Difference detected",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Diff
@@ -205,7 +215,9 @@ data class ResourceActuationLaunched(
   override val application: String,
   val plugin: String,
   val tasks: List<Task>,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Updating resource state",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, plugin: String, tasks: List<Task>, clock: Clock = Companion.clock) :
     this(
@@ -228,7 +240,9 @@ data class ResourceActuationPaused(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val triggeredBy: String?
+  override val triggeredBy: String?,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Update paused",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -263,7 +277,9 @@ data class ResourceActuationVetoed(
   val reason: String?,
   val veto: String? = null,
   val suggestedStatus: ResourceStatus? = null,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.WARNING,
+  override val displayName: String = "Update terminated",
 ) : ResourceEvent(message = reason) {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -289,7 +305,9 @@ data class ResourceActuationResumed(
   override val version: Int,
   override val application: String,
   override val triggeredBy: String?,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.INFO,
+  override val displayName: String = "Update continued",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -316,7 +334,9 @@ data class ResourceTaskFailed(
   override val application: String,
   val reason: String?,
   val tasks: List<Task> = emptyList(),
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.ERROR,
+  override val displayName: String = "Update failed",
 ) : ResourceEvent() {
 
   constructor(resource: Resource<*>, reason: String?, tasks: List<Task>, clock: Clock = Companion.clock) : this(
@@ -339,7 +359,9 @@ data class ResourceTaskSucceeded(
   override val version: Int,
   override val application: String,
   val tasks: List<Task> = emptyList(),
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.SUCCESS,
+  override val displayName: String = "Update succeeded",
 ) : ResourceEvent() {
 
   constructor(resource: Resource<*>, tasks: List<Task>, clock: Clock = Companion.clock) : this(
@@ -361,7 +383,9 @@ data class ResourceDeltaResolved(
   override val id: String,
   override val version: Int,
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.SUCCESS,
+  override val displayName: String = "Difference resolved",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Ok
@@ -380,7 +404,9 @@ data class ResourceValid(
   override val id: String,
   override val version: Int,
   override val application: String,
-  override val timestamp: Instant
+  override val timestamp: Instant,
+  override val level: EventLevel = EventLevel.SUCCESS,
+  override val displayName: String = "Valid",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Ok
@@ -404,7 +430,9 @@ data class ResourceCheckUnresolvable(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val message: String?
+  override val message: String?,
+  override val level: EventLevel = EventLevel.WARNING,
+  override val displayName: String = "Failed to resolved state diff",
 ) : ResourceCheckResult(message = message) {
   @JsonIgnore
   override val state = Unresolvable
@@ -456,7 +484,9 @@ data class ResourceCheckError(
   override val application: String,
   override val timestamp: Instant,
   val exceptionType: Class<out SpinnakerException>,
-  val exceptionMessage: String?
+  val exceptionMessage: String?,
+  override val displayName: String = "State check error",
+  override val level: EventLevel = EventLevel.ERROR,
 ) : ResourceCheckResult(message = exceptionMessage) {
   @JsonIgnore
   override val state = Error
@@ -481,7 +511,9 @@ data class ResourceDiffNotActionable(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val message: String?
+  override val message: String?,
+  override val level: EventLevel = EventLevel.WARNING,
+  override val displayName: String = "Unable to resolve state diff",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -32,6 +32,9 @@ import com.netflix.spinnaker.keel.events.ResourceState.Error
 import com.netflix.spinnaker.keel.events.ResourceState.Missing
 import com.netflix.spinnaker.keel.events.ResourceState.Ok
 import com.netflix.spinnaker.keel.events.ResourceState.Unresolvable
+import com.netflix.spinnaker.keel.events.EventLevel.WARNING
+import com.netflix.spinnaker.keel.events.EventLevel.ERROR
+import com.netflix.spinnaker.keel.events.EventLevel.SUCCESS
 import com.netflix.spinnaker.keel.persistence.ResourceStatus
 import com.netflix.spinnaker.kork.exceptions.SpinnakerException
 import com.netflix.spinnaker.kork.exceptions.SystemException
@@ -86,7 +89,6 @@ data class ResourceCreated(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Created",
 ) : ResourceEvent() {
 
@@ -112,7 +114,6 @@ data class ResourceUpdated(
   override val application: String,
   val delta: Map<String, Any?>,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Config updated",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, delta: Map<String, Any?>, clock: Clock = Companion.clock) : this(
@@ -131,7 +132,6 @@ data class ResourceDeleted(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Deleted",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
@@ -161,7 +161,6 @@ data class ResourceMissing(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Missing",
 ) : ResourceCheckResult() {
   @JsonIgnore
@@ -188,7 +187,6 @@ data class ResourceDeltaDetected(
   override val application: String,
   val delta: Map<String, Any?>,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Difference detected",
 ) : ResourceCheckResult() {
   @JsonIgnore
@@ -216,8 +214,8 @@ data class ResourceActuationLaunched(
   val plugin: String,
   val tasks: List<Task>,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
-  override val displayName: String = "Updating resource state",
+
+  override val displayName: String = "Update started",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, plugin: String, tasks: List<Task>, clock: Clock = Companion.clock) :
     this(
@@ -241,7 +239,6 @@ data class ResourceActuationPaused(
   override val application: String,
   override val timestamp: Instant,
   override val triggeredBy: String?,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Update paused",
 ) : ResourceEvent() {
   @JsonIgnore
@@ -278,7 +275,7 @@ data class ResourceActuationVetoed(
   val veto: String? = null,
   val suggestedStatus: ResourceStatus? = null,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.WARNING,
+  override val level: EventLevel = WARNING,
   override val displayName: String = "Update terminated",
 ) : ResourceEvent(message = reason) {
   @JsonIgnore
@@ -306,7 +303,6 @@ data class ResourceActuationResumed(
   override val application: String,
   override val triggeredBy: String?,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.INFO,
   override val displayName: String = "Update continued",
 ) : ResourceEvent() {
   @JsonIgnore
@@ -335,7 +331,7 @@ data class ResourceTaskFailed(
   val reason: String?,
   val tasks: List<Task> = emptyList(),
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.ERROR,
+  override val level: EventLevel = ERROR,
   override val displayName: String = "Update failed",
 ) : ResourceEvent() {
 
@@ -360,7 +356,7 @@ data class ResourceTaskSucceeded(
   override val application: String,
   val tasks: List<Task> = emptyList(),
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.SUCCESS,
+  override val level: EventLevel = SUCCESS,
   override val displayName: String = "Update succeeded",
 ) : ResourceEvent() {
 
@@ -384,7 +380,7 @@ data class ResourceDeltaResolved(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.SUCCESS,
+  override val level: EventLevel = SUCCESS,
   override val displayName: String = "Difference resolved",
 ) : ResourceCheckResult() {
   @JsonIgnore
@@ -405,7 +401,7 @@ data class ResourceValid(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val level: EventLevel = EventLevel.SUCCESS,
+  override val level: EventLevel = SUCCESS,
   override val displayName: String = "Valid",
 ) : ResourceCheckResult() {
   @JsonIgnore
@@ -431,8 +427,8 @@ data class ResourceCheckUnresolvable(
   override val application: String,
   override val timestamp: Instant,
   override val message: String?,
-  override val level: EventLevel = EventLevel.WARNING,
-  override val displayName: String = "Failed to resolve state diff",
+  override val level: EventLevel = WARNING,
+  override val displayName: String = "Failed to resolve state difference",
 ) : ResourceCheckResult(message = message) {
   @JsonIgnore
   override val state = Unresolvable
@@ -486,7 +482,7 @@ data class ResourceCheckError(
   val exceptionType: Class<out SpinnakerException>,
   val exceptionMessage: String?,
   override val displayName: String = "State check error",
-  override val level: EventLevel = EventLevel.ERROR,
+  override val level: EventLevel = ERROR,
 ) : ResourceCheckResult(message = exceptionMessage) {
   @JsonIgnore
   override val state = Error
@@ -512,8 +508,8 @@ data class ResourceDiffNotActionable(
   override val application: String,
   override val timestamp: Instant,
   override val message: String?,
-  override val level: EventLevel = EventLevel.WARNING,
-  override val displayName: String = "Unable to resolve state diff",
+  override val level: EventLevel = WARNING,
+  override val displayName: String = "Unable to resolve state difference",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -432,7 +432,7 @@ data class ResourceCheckUnresolvable(
   override val timestamp: Instant,
   override val message: String?,
   override val level: EventLevel = EventLevel.WARNING,
-  override val displayName: String = "Failed to resolved state diff",
+  override val displayName: String = "Failed to resolve state diff",
 ) : ResourceCheckResult(message = message) {
   @JsonIgnore
   override val state = Unresolvable

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -89,7 +89,7 @@ data class ResourceCreated(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val displayName: String = "Created",
+  override val displayName: String = "Resource definition created",
 ) : ResourceEvent() {
 
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
@@ -114,7 +114,7 @@ data class ResourceUpdated(
   override val application: String,
   val delta: Map<String, Any?>,
   override val timestamp: Instant,
-  override val displayName: String = "Config updated",
+  override val displayName: String = "Resource definition updated",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, delta: Map<String, Any?>, clock: Clock = Companion.clock) : this(
     resource.kind,
@@ -132,7 +132,7 @@ data class ResourceDeleted(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val displayName: String = "Deleted",
+  override val displayName: String = "Resource definition deleted",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, clock: Clock = Companion.clock) : this(
     resource.kind,
@@ -161,7 +161,7 @@ data class ResourceMissing(
   override val version: Int,
   override val application: String,
   override val timestamp: Instant,
-  override val displayName: String = "Missing",
+  override val displayName: String = "Resource not found",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Missing
@@ -187,7 +187,7 @@ data class ResourceDeltaDetected(
   override val application: String,
   val delta: Map<String, Any?>,
   override val timestamp: Instant,
-  override val displayName: String = "Difference detected",
+  override val displayName: String = "Resource does not match current definition",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Diff
@@ -215,7 +215,7 @@ data class ResourceActuationLaunched(
   val tasks: List<Task>,
   override val timestamp: Instant,
 
-  override val displayName: String = "Update started",
+  override val displayName: String = "Updating resource to match current definition",
 ) : ResourceEvent() {
   constructor(resource: Resource<*>, plugin: String, tasks: List<Task>, clock: Clock = Companion.clock) :
     this(
@@ -239,7 +239,7 @@ data class ResourceActuationPaused(
   override val application: String,
   override val timestamp: Instant,
   override val triggeredBy: String?,
-  override val displayName: String = "Update paused",
+  override val displayName: String = "Resource management paused",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -276,7 +276,7 @@ data class ResourceActuationVetoed(
   val suggestedStatus: ResourceStatus? = null,
   override val timestamp: Instant,
   override val level: EventLevel = WARNING,
-  override val displayName: String = "Update terminated",
+  override val displayName: String = "Unable to update resource to match current definition${if (reason != null) " - $reason" else ""}",
 ) : ResourceEvent(message = reason) {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -303,7 +303,7 @@ data class ResourceActuationResumed(
   override val application: String,
   override val triggeredBy: String?,
   override val timestamp: Instant,
-  override val displayName: String = "Update continued",
+  override val displayName: String = "Resource management resumed",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true
@@ -332,7 +332,7 @@ data class ResourceTaskFailed(
   val tasks: List<Task> = emptyList(),
   override val timestamp: Instant,
   override val level: EventLevel = ERROR,
-  override val displayName: String = "Update failed",
+  override val displayName: String = "Failed to update resource to match definition${if (reason != null) " - $reason" else ""}",
 ) : ResourceEvent() {
 
   constructor(resource: Resource<*>, reason: String?, tasks: List<Task>, clock: Clock = Companion.clock) : this(
@@ -357,7 +357,7 @@ data class ResourceTaskSucceeded(
   val tasks: List<Task> = emptyList(),
   override val timestamp: Instant,
   override val level: EventLevel = SUCCESS,
-  override val displayName: String = "Update succeeded",
+  override val displayName: String = "Resource update task succeeded",
 ) : ResourceEvent() {
 
   constructor(resource: Resource<*>, tasks: List<Task>, clock: Clock = Companion.clock) : this(
@@ -381,7 +381,7 @@ data class ResourceDeltaResolved(
   override val application: String,
   override val timestamp: Instant,
   override val level: EventLevel = SUCCESS,
-  override val displayName: String = "Difference resolved",
+  override val displayName: String = "Resource was matched to its definition successfully",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Ok
@@ -402,7 +402,7 @@ data class ResourceValid(
   override val application: String,
   override val timestamp: Instant,
   override val level: EventLevel = SUCCESS,
-  override val displayName: String = "Valid",
+  override val displayName: String = "Resource matches its definition",
 ) : ResourceCheckResult() {
   @JsonIgnore
   override val state = Ok
@@ -428,7 +428,7 @@ data class ResourceCheckUnresolvable(
   override val timestamp: Instant,
   override val message: String?,
   override val level: EventLevel = WARNING,
-  override val displayName: String = "Failed to resolve state difference",
+  override val displayName: String = "Unable to compare resource to its definition${if (message != null) " - $message" else ""}",
 ) : ResourceCheckResult(message = message) {
   @JsonIgnore
   override val state = Unresolvable
@@ -481,7 +481,7 @@ data class ResourceCheckError(
   override val timestamp: Instant,
   val exceptionType: Class<out SpinnakerException>,
   val exceptionMessage: String?,
-  override val displayName: String = "State check error",
+  override val displayName: String = "Failed to check resource status",
   override val level: EventLevel = ERROR,
 ) : ResourceCheckResult(message = exceptionMessage) {
   @JsonIgnore
@@ -509,7 +509,7 @@ data class ResourceDiffNotActionable(
   override val timestamp: Instant,
   override val message: String?,
   override val level: EventLevel = WARNING,
-  override val displayName: String = "Unable to resolve state difference",
+  override val displayName: String = "Unable to update resource to match current definition${if (message != null) " - $message" else ""}",
 ) : ResourceEvent() {
   @JsonIgnore
   override val ignoreRepeatedInHistory = true


### PR DESCRIPTION
The goal is to remove the allow-list from the frontend, and allow backend changes without the need to update the frontend.

https://github.com/spinnaker/deck/blob/5a9768bc6db2f527a73d6b1f5fb3120c101e094b/app/scripts/modules/core/src/managed/resourceHistory/ManagedResourceHistoryModal.tsx#L34