### PR TITLE
fix(db): handle verif query when artifact ref and env name are the same

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -69,6 +69,11 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
         name = "fnord",
         deliveryConfigName = "fnord-manifest",
         reference = "fnord-docker-unstable"
+      ),
+      DockerArtifact(
+        name = "fnord",
+        deliveryConfigName = "fnord-manifest",
+        reference = "test" // an artifact that has a reference name the same as an environment name
       )
     ),
     environments = setOf(
@@ -472,6 +477,15 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
             .get(VerificationState::status) isEqualTo PENDING
         }
     }
+  }
+
+  @Test
+  fun `environment name and artifact reference name are the same`() {
+    val contexts = listOf(context, context.copy(artifactReference="test"))
+      .onEach { it.setup() }
+
+    // verify it doesn't explode with a SQLSyntaxErrorException
+    expectCatching { subject.getStatesBatch(contexts) }.isSuccess()
   }
 
   @Test

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -378,7 +378,10 @@ class SqlVerificationRepository(
         contexts // List<VerificationContext>
           // Creates a SELECT statement from each element of [contexts], where every column is a constant. e.g.:
           // SELECT 0, "staging", "myapp", "myapp-h123-v23.4" FROM dual
-          .mapIndexed { idx, v -> jooq.select(inline(idx), inline(v.environmentName), inline(v.artifactReference), inline(v.version)) as SelectOrderByStep<Record4<Int, String, String, String>> } // List<SelectOrderByStep<Record4<Int, String, String, String>>>
+          .mapIndexed { idx, v -> jooq.select(inline(idx).`as`(ind),
+                                              inline(v.environmentName).`as`(environmentName),
+                                              inline(v.artifactReference).`as`(artifactReference),
+                                              inline(v.version).`as`(artifactVersion)) as SelectOrderByStep<Record4<Int, String, String, String>> }
 
           // Apply UNION ALL to the list of SELECT statements so they form a single query
           .reduceOrNull { s1, s2 -> s1.unionAll(s2) } // SelectOrderByStep<Record4<Int, String, String, String>>?


### PR DESCRIPTION

## Problem

If a delivery config contains an artifact reference and environment that both happen to have the same name (e.g., an artifact reference named `"dev"` and an environment named `"dev"`), then the [`SqlVerificationRepository.getStatesBatch`][1] method throws a SQLSyntaxErrorException.

For details, see #1821

## Implemented solution

Add field aliases to prevent the name collision.

[1]: https://github.com/spinnaker/keel/blob/d87062779779c383685a2f495c1ce2dc719dbf6f/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt#L183-L241
