### PR TITLE
fix(verification): you can't have a path variable with a slash

### DIFF
--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/VerificationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/VerificationControllerTests.kt
@@ -77,13 +77,14 @@ internal class VerificationControllerTests
   @EnumSource(ConstraintStatus::class, names = ["OVERRIDE_PASS", "OVERRIDE_FAIL"])
   fun `verification status can be overridden by user request`(status: ConstraintStatus) {
     val payload = UpdateVerificationStatusRequest(
+      verificationId = verification.id,
       artifactReference = artifact.reference,
       artifactVersion = "1.0.0",
       status = status,
       comment = "I swear this is fine"
     )
     val user = "fzlem@netflix.com"
-    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications/${verification.id}")
+    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications")
       .header("X-SPINNAKER-USER", user)
       .contentType(APPLICATION_JSON)
       .accept(APPLICATION_JSON)
@@ -107,13 +108,14 @@ internal class VerificationControllerTests
   @EnumSource(ConstraintStatus::class, names = ["OVERRIDE_PASS", "OVERRIDE_FAIL"], mode = EXCLUDE)
   fun `only override statuses are accepted`(status: ConstraintStatus) {
     val payload = UpdateVerificationStatusRequest(
+      verificationId = verification.id,
       artifactReference = artifact.reference,
       artifactVersion = "1.0.0",
       status = status,
       comment = "I swear this is fine"
     )
     val user = "fzlem@netflix.com"
-    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications/${verification.id}")
+    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications")
       .header("X-SPINNAKER-USER", user)
       .contentType(APPLICATION_JSON)
       .accept(APPLICATION_JSON)
@@ -131,11 +133,12 @@ internal class VerificationControllerTests
   @NullSource
   fun `verification can be retried if not currently running`(currentStatus: ConstraintStatus?) {
     val payload = RetryVerificationRequest(
+      verificationId = verification.id,
       artifactReference = artifact.reference,
       artifactVersion = "1.0.0"
     )
     val user = "fzlem@netflix.com"
-    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications/${verification.id}/retry")
+    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications/retry")
       .header("X-SPINNAKER-USER", user)
       .contentType(APPLICATION_JSON)
       .accept(APPLICATION_JSON)
@@ -163,11 +166,12 @@ internal class VerificationControllerTests
   @EnumSource(ConstraintStatus::class, names = ["NOT_EVALUATED", "PENDING"])
   fun `verification cannot be retried if running`(currentStatus: ConstraintStatus) {
     val payload = RetryVerificationRequest(
+      verificationId = verification.id,
       artifactReference = artifact.reference,
       artifactVersion = "1.0.0"
     )
     val user = "fzlem@netflix.com"
-    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications/${verification.id}/retry")
+    val request = post("/application/${deliveryConfig.application}/environment/${environment.name}/verifications/retry")
       .header("X-SPINNAKER-USER", user)
       .contentType(APPLICATION_JSON)
       .accept(APPLICATION_JSON)


### PR DESCRIPTION
I have also done this, accidentally. And it is no bueno. If the URL value might have a slash it needs to go into the request body.