### PR TITLE
fix(db): add read lock to avoid phantom read

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -32,6 +32,7 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
+import org.springframework.core.env.Environment
 import java.time.Clock
 import javax.annotation.PostConstruct
 
@@ -158,7 +159,8 @@ class SqlConfiguration {
     resourceSpecIdentifier: ResourceSpecIdentifier,
     objectMapper: ObjectMapper,
     artifactSuppliers: List<ArtifactSupplier<*, *>>,
-    specMigrators: List<SpecMigrator<*, *>>
+    specMigrators: List<SpecMigrator<*, *>>,
+    environment: Environment
   ) = SqlVerificationRepository(
     jooq,
     clock,
@@ -166,7 +168,8 @@ class SqlConfiguration {
     objectMapper,
     SqlRetry(sqlRetryProperties),
     artifactSuppliers,
-    specMigrators
+    specMigrators,
+    environment
   )
 
   @Bean

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt
@@ -20,20 +20,15 @@ import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
 import com.netflix.spinnaker.keel.resources.SpecMigrator
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import com.netflix.spinnaker.keel.sql.deliveryconfigs.deliveryConfigByName
-import org.jooq.DSLContext
-import org.jooq.Field
-import org.jooq.Record1
-import org.jooq.Record4
-import org.jooq.Select
-import org.jooq.SelectOrderByStep
+import org.jooq.*
 import org.jooq.impl.DSL.function
-import org.jooq.Table
 import org.jooq.impl.DSL.field
 import org.jooq.impl.DSL.inline
 import org.jooq.impl.DSL.isnull
 import org.jooq.impl.DSL.name
 import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.value
+import org.springframework.core.env.Environment
 import java.time.Clock
 import java.time.Duration
 import java.time.Instant.EPOCH
@@ -45,7 +40,8 @@ class SqlVerificationRepository(
   objectMapper: ObjectMapper,
   sqlRetry: SqlRetry,
   artifactSuppliers: List<ArtifactSupplier<*, *>> = emptyList(),
-  specMigrators: List<SpecMigrator<*, *>> = emptyList()
+  specMigrators: List<SpecMigrator<*, *>> = emptyList(),
+  private val environment: Environment
 ) : SqlStorageContext(
   jooq,
   clock,
@@ -55,6 +51,9 @@ class SqlVerificationRepository(
   artifactSuppliers,
   specMigrators
 ), VerificationRepository {
+
+  private val useLockingRead : Boolean
+    get() = environment.getProperty("keel.verifications.db.lock.reads.enabled", Boolean::class.java, true)
 
   override fun nextEnvironmentsForVerification(
     minTimeSinceLastCheck: Duration,
@@ -102,6 +101,7 @@ class SqlVerificationRepository(
           // order by last time checked with things never checked coming first
           .orderBy(isnull(ENVIRONMENT_LAST_VERIFIED.AT, EPOCH))
           .limit(limit)
+          .lockInShareMode()
           .fetch()
           .onEach { (_, _, environmentUid, _, artifactUid, _, artifactVersion) ->
             insertInto(ENVIRONMENT_LAST_VERIFIED)
@@ -386,4 +386,16 @@ class SqlVerificationRepository(
           ?.asTable(alias, ind, environmentName, artifactReference, artifactVersion)
   }
 
+  /**
+   * Set a share mode lock on a select query to prevent phantom reads in a transaction.
+   *
+   * In MySQL 5.7, this is `LOCK IN SHARE MODE`
+   * See https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
+   */
+  private fun <R : Record?> SelectForUpdateStep<R>.lockInShareMode(): SelectOptionStep<R> =
+    if(useLockingRead) {
+      this.forShare()
+    } else {
+      this
+    }
 }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlApproveOldVersionTests.kt
@@ -23,7 +23,7 @@ class SqlApproveOldVersionTests : ApproveOldVersionTests<CombinedRepository>() {
     val deliveryConfigRepository = SqlDeliveryConfigRepository(jooq, clock, resourceSpecIdentifier, mapper, sqlRetry, defaultArtifactSuppliers())
     val resourceRepository = SqlResourceRepository(jooq, clock, resourceSpecIdentifier, emptyList(), mapper, sqlRetry)
     val artifactRepository = SqlArtifactRepository(jooq, clock, mapper, sqlRetry, defaultArtifactSuppliers())
-    val verificationRepository = SqlVerificationRepository(jooq, clock, resourceSpecIdentifier, mapper, sqlRetry)
+    val verificationRepository = SqlVerificationRepository(jooq, clock, resourceSpecIdentifier, mapper, sqlRetry, environment = mockk())
     return CombinedRepository(
       deliveryConfigRepository,
       artifactRepository,

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlCombinedRepositoryTests.kt
@@ -7,6 +7,7 @@ import com.netflix.spinnaker.keel.test.defaultArtifactSuppliers
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import io.mockk.mockk
 import java.time.Clock
 
 internal object SqlCombinedRepositoryTests :
@@ -34,7 +35,7 @@ internal object SqlCombinedRepositoryTests :
     SqlArtifactRepository(jooq, clock, objectMapper, sqlRetry, defaultArtifactSuppliers())
 
   override fun createVerificationRepository(resourceSpecIdentifier: ResourceSpecIdentifier): SqlVerificationRepository =
-    SqlVerificationRepository(jooq, clock, resourceSpecIdentifier, objectMapper, sqlRetry)
+    SqlVerificationRepository(jooq, clock, resourceSpecIdentifier, objectMapper, sqlRetry, environment = mockk())
 
   override fun flush() {
     SqlTestUtil.cleanupDb(jooq)

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -11,8 +11,11 @@ import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
 import com.netflix.spinnaker.kork.sql.config.RetryProperties
 import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
 import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import org.junit.jupiter.api.AfterEach
+import org.springframework.core.env.Environment
 
 internal class SqlVerificationRepositoryTests :
   VerificationRepositoryTests<SqlVerificationRepository>() {
@@ -50,6 +53,22 @@ internal class SqlVerificationRepositoryTests :
     clock = clock
   )
 
+  /**
+   * Generate a mock Spring environment that returns the default value for all boolean properties
+   */
+  private fun mockEnvironment() : Environment {
+    val defaultValue = slot<Boolean>()
+    val environment: Environment = mockk()
+
+    every {
+      environment.getProperty(any(), Boolean::class.java, capture(defaultValue))
+    } answers {
+      defaultValue.captured
+    }
+
+    return environment
+  }
+
   override fun createSubject() =
     SqlVerificationRepository(
       jooq = jooq,
@@ -57,7 +76,8 @@ internal class SqlVerificationRepositoryTests :
       resourceSpecIdentifier = mockk(),
       objectMapper = mapper,
       sqlRetry = sqlRetry,
-      artifactSuppliers = artifactSuppliers
+      artifactSuppliers = artifactSuppliers,
+      environment = mockEnvironment()
     )
 
   override fun VerificationContext.setup() {


### PR DESCRIPTION
## Summary

Use a locking read to eliminate a race condition in a database transaction related to checking verifications.

## Problem

We've seen cases where two nodes check the same environments for verification within about the same second, even though verification checks are only supposed to have for an environment once a minute.

Here's an example of timestamps from two keel instances checking the same environments:

```
02/23/2021 12:46:35.613 -0800
02/23/2021 12:46:35.869 -0800
```

### Hypothesis: phantom reads

I belive the problem is related to the database consistency level used in the [SqlVerificationRepository.nextEnvironmentsForVerification][1] check. This is a databasde anomaly known as *phantom reads*.

See #1832 for details.

## Implemented solution: locking reads

This PR adds a [`LOCK IN SHARE MODE`][2] directive to the relevant select statement to ensure that phantom reads can't happen.

## Concerns: performance impact

I don't know how this lock will impact database performance. As a precaution, I put in a feature toggle so we can turn it off quickly: `keel.verifications.db.lock.reads.enabled`

I set it to be on by default, so we can see what effect it has as soon as it rolls out.

[1]: https://github.com/spinnaker/keel/blob/d87062779779c383685a2f495c1ce2dc719dbf6f/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepository.kt#L59-L127
[2]: https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html


