### PR TITLE
fix(bake): use artifact version in correlation id

### DIFF
--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -108,7 +108,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
             any(),
             any(),
             any(),
-            artifact.correlationId,
+            artifact.correlationId(artifactVersion.version),
             capture(bakeTask),
             capture(bakeTaskArtifact),
             capture(bakeTaskParameters)
@@ -143,8 +143,9 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
     context("a bake is already running for the artifact") {
       before {
+        every { repository.artifactVersions(artifact, any()) } returns listOf(artifactVersion)
         every {
-          taskLauncher.correlatedTasksRunning(artifact.correlationId)
+          taskLauncher.correlatedTasksRunning(artifact.correlationId(artifactVersion.version))
         } returns true
 
         runHandler(artifact)
@@ -168,7 +169,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
     context("no bake is currently running") {
       before {
         every {
-          taskLauncher.correlatedTasksRunning(artifact.correlationId)
+          taskLauncher.correlatedTasksRunning(artifact.correlationId(artifactVersion.version))
         } returns false
       }
 


### PR DESCRIPTION
Include the version in the correlation id we send to orca so we can bake two different versions at once. This fixes the annoying situation where you push two versions in quick succession but we bake them serially instead of in parallel.