### PR TITLE
refactor(export): Refactor security group export to facilitate customization by sub-classes

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/DefaultSecurityGroupRuleDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/DefaultSecurityGroupRuleDeserializer.kt
@@ -5,12 +5,10 @@ import com.netflix.spinnaker.keel.api.ec2.CrossAccountReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.ReferenceRule
 import com.netflix.spinnaker.keel.api.ec2.SecurityGroupRule
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.jackson.JsonComponent
 
 @JsonComponent
-//@ConditionalOnMissingBean(SecurityGroupRuleDeserializer::class)
-@ConditionalOnProperty("keel.plugins.ec2.defaultSerializers", matchIfMissing = true)
+@ConditionalOnMissingBean(name = ["securityGroupRuleDeserializer"])
 class DefaultSecurityGroupRuleDeserializer : SecurityGroupRuleDeserializer() {
   override fun identifySubType(fieldNames: Collection<String>): Class<out SecurityGroupRule> =
     when {


### PR DESCRIPTION
Problem: we want to customize the behavior of `SecurityGroupHandler.export` in Netflix's internal implementation to support IP Objects, but there's not a currently good place to hook in to the default implementation to achieve that.

This PR extracts part of the logic in the `export` method into a new `protected` method that can be overridden by sub-classes to transform the `SecurityGroup` objects as needed before the default implementation calculates the default and override properties of the `SecurityGroupSpec`.

The only behavior changes in this PR are:
1. Simplification of how to select the `SecurityGroupRuleDeserializer` bean.
2. Export now picks the security group with the fewest inbound rules as the "base" for the properties at the top-level of the spec, to account for how we merge lists in overrides.