### PR TITLE
clean up duplicate columns on event table

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -165,11 +165,11 @@ class SqlDeliveryConfigRepository(
         // delete events
         txn.deleteFrom(EVENT)
           .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
-          .and(EVENT.REF_GEN.`in`(resourceIds))
+          .and(EVENT.REF.`in`(resourceIds))
           .execute()
         txn.deleteFrom(EVENT)
           .where(EVENT.SCOPE.eq(EventScope.APPLICATION))
-          .and(EVENT.REF_GEN.eq(application))
+          .and(EVENT.REF.eq(application))
           .execute()
         // delete pause records
         txn.deleteFrom(PAUSED)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -184,8 +184,8 @@ open class SqlResourceRepository(
         .select(EVENT.JSON)
         .from(EVENT)
         .where(EVENT.SCOPE.eq(EventScope.APPLICATION))
-        .and(EVENT.REF_GEN.eq(application))
-        .orderBy(EVENT.TIMESTAMP_GEN.desc())
+        .and(EVENT.REF.eq(application))
+        .orderBy(EVENT.TIMESTAMP.desc())
         .limit(limit)
         .fetch(EVENT.JSON)
         .filterIsInstance<ApplicationEvent>()
@@ -198,9 +198,9 @@ open class SqlResourceRepository(
         .select(EVENT.JSON)
         .from(EVENT)
         .where(EVENT.SCOPE.eq(EventScope.APPLICATION))
-        .and(EVENT.REF_GEN.eq(application))
-        .and(EVENT.TIMESTAMP_GEN.greaterOrEqual(after))
-        .orderBy(EVENT.TIMESTAMP_GEN.desc())
+        .and(EVENT.REF.eq(application))
+        .and(EVENT.TIMESTAMP.greaterOrEqual(after))
+        .orderBy(EVENT.TIMESTAMP.desc())
         .fetch(EVENT.JSON)
         .filterIsInstance<ApplicationEvent>()
     }
@@ -216,14 +216,14 @@ open class SqlResourceRepository(
         // look for resource events that match the resource...
         .where(
           EVENT.SCOPE.eq(EventScope.RESOURCE)
-            .and(EVENT.REF_GEN.eq(id))
+            .and(EVENT.REF.eq(id))
         )
         // ...or application events that match the application as they apply to all resources
         .or(
           EVENT.SCOPE.eq(EventScope.APPLICATION)
             .and(EVENT.APPLICATION.eq(applicationForId(id)))
         )
-        .orderBy(EVENT.TIMESTAMP_GEN.desc())
+        .orderBy(EVENT.TIMESTAMP.desc())
         .limit(limit)
         .fetch(EVENT.JSON)
         // filter out application events that don't affect resource history
@@ -253,14 +253,14 @@ open class SqlResourceRepository(
           // look for resource events that match the resource...
           .where(
             EVENT.SCOPE.eq(EventScope.RESOURCE)
-              .and(EVENT.REF_GEN.eq(event.ref))
+              .and(EVENT.REF.eq(event.ref))
           )
           // ...or application events that match the application as they apply to all resources
           .or(
             EVENT.SCOPE.eq(EventScope.APPLICATION)
               .and(EVENT.APPLICATION.eq(event.application))
           )
-          .orderBy(EVENT.TIMESTAMP_GEN.desc())
+          .orderBy(EVENT.TIMESTAMP.desc())
           .limit(1)
           .fetchOne(EVENT.JSON)
       }
@@ -273,8 +273,6 @@ open class SqlResourceRepository(
         .insertInto(EVENT)
         .set(EVENT.UID, ULID().nextULID(event.timestamp.toEpochMilli()))
         .set(EVENT.SCOPE, event.scope)
-        .set(EVENT.REF, ref)
-        .set(EVENT.TIMESTAMP, event.timestamp)
         .set(EVENT.JSON, event)
         .execute()
     }
@@ -295,7 +293,7 @@ open class SqlResourceRepository(
     sqlRetry.withRetry(WRITE) {
       jooq.deleteFrom(EVENT)
         .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
-        .and(EVENT.REF_GEN.eq(id))
+        .and(EVENT.REF.eq(id))
         .execute()
     }
     sqlRetry.withRetry(WRITE) {

--- a/keel-sql/src/main/resources/db/changelog/20210302-drop-old-event-columns.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210302-drop-old-event-columns.yml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+- changeSet:
+    id: generate-event-timestamp
+    author: fletch
+    changes:
+    - dropColumn:
+        tableName: event
+        columnName: ref
+    - dropColumn:
+        tableName: event
+        columnName: timestamp
+    - sql:
+        sql: |
+          alter table event
+          change ref_gen ref varchar(255) generated always as (json ->> '$.ref')
+          not null;
+    - sql:
+        sql: |
+          alter table event
+          change timestamp_gen timestamp datetime(3) generated always as (str_to_date(json->>'$.timestamp', '%Y-%m-%dT%T.%fZ'));

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -248,3 +248,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210305-embiggen-reason-column.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210302-drop-old-event-columns.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Cleans up duplicate columns left by #1828 to enable us to roll back.