### PR TITLE
fix(perf): eliminate caching delay between bake and deploy

### DIFF
--- a/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
+++ b/keel-bakery-plugin/keel-bakery-plugin.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation("com.netflix.frigga:frigga")
 
   testImplementation(project(":keel-test"))
+  testImplementation(project(":keel-core-test"))
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-mockk")
   testImplementation(project(":keel-spring-test-support"))

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
@@ -12,5 +12,12 @@ interface BaseImageCache {
    */
   fun getBaseAmiVersion(os: String, label: BaseLabel): String
 
+  /**
+   * @param the image of the base id
+   * @return the base AMI version (i.e. the "appversion" of the base AMI) of the requested base
+   * @throws UnknownBaseImageId if there is no base image know with that id
+   */
+  fun getVersionByImageId(imageId: String, region: String): String
+
   val allVersions: Map<String, Map<String, String>>
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
@@ -12,12 +12,5 @@ interface BaseImageCache {
    */
   fun getBaseAmiVersion(os: String, label: BaseLabel): String
 
-  /**
-   * @param the image of the base id
-   * @return the base AMI version (i.e. the "appversion" of the base AMI) of the requested base
-   * @throws UnknownBaseImageId if there is no base image know with that id
-   */
-  fun getVersionByImageId(imageId: String, region: String): String
-
   val allVersions: Map<String, Map<String, String>>
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
@@ -20,6 +20,10 @@ class DefaultBaseImageCache(
   override fun getBaseAmiVersion(os: String, label: BaseLabel) =
     baseImages[os]?.get(label.name.toLowerCase()) ?: throw UnknownBaseImage(os, label)
 
+  override fun getVersionByImageId(imageId: String, region: String): String {
+    TODO("not implemented")
+  }
+
   override val allVersions: Map<String, Map<String, String>>
     get() = baseImages
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
@@ -20,10 +20,6 @@ class DefaultBaseImageCache(
   override fun getBaseAmiVersion(os: String, label: BaseLabel) =
     baseImages[os]?.get(label.name.toLowerCase()) ?: throw UnknownBaseImage(os, label)
 
-  override fun getVersionByImageId(imageId: String, region: String): String {
-    TODO("not implemented")
-  }
-
   override val allVersions: Map<String, Map<String, String>>
     get() = baseImages
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/UnknownBaseImage.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/UnknownBaseImage.kt
@@ -5,3 +5,6 @@ import com.netflix.spinnaker.kork.exceptions.SystemException
 
 class UnknownBaseImage(os: String, label: BaseLabel) :
   SystemException("Could not identify base image for os $os and label $label")
+
+class UnknownBaseImageId(id: String):
+  SystemException("Could not identify base image for id $id")

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeStage.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeStage.kt
@@ -1,0 +1,26 @@
+package com.netflix.spinnaker.keel.bakery.artifact
+
+import com.netflix.spinnaker.keel.api.artifacts.BaseLabel
+
+data class BakeStage(
+  val type: String,
+  val outputs: Outputs
+)
+
+data class Outputs(
+  val deploymentDetails: List<DeploymentDetail>
+)
+
+data class DeploymentDetail(
+  val ami: String,
+  val imageId: String,
+  val imageName: String,
+  val baseLabel: BaseLabel,
+  val baseOs: String,
+  val storeType: String,
+  val vmType: String,
+  val region: String,
+  val `package`: String,
+  val cloudProviderType: String,
+  val baseAmiId: String
+)

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -1,6 +1,11 @@
 package com.netflix.spinnaker.keel.bakery.artifact
 
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
 import com.netflix.spinnaker.config.LifecycleConfig
+import com.netflix.spinnaker.keel.artifacts.BakedImage
+import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEvent
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventStatus
@@ -16,11 +21,13 @@ import com.netflix.spinnaker.keel.orca.ExecutionDetailResponse
 import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus.BUFFERED
 import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus.RUNNING
 import com.netflix.spinnaker.keel.orca.OrcaService
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Component
+import java.time.Clock
 
 /**
  * A monitor for bake tasks.
@@ -39,7 +46,11 @@ class BakeryLifecycleMonitor(
   override val publisher: ApplicationEventPublisher,
   override val lifecycleConfig: LifecycleConfig,
   private val orcaService: OrcaService,
-  @Value("\${spinnaker.baseUrl}") private val spinnakerBaseUrl: String
+  @Value("\${spinnaker.baseUrl}") private val spinnakerBaseUrl: String,
+  private val bakedImageRepository: BakedImageRepository,
+  private val baseImageCache: BaseImageCache,
+  private val objectMapper: ObjectMapper,
+  private val clock: Clock
 ): LifecycleMonitor(monitorRepository, publisher, lifecycleConfig) {
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
@@ -54,7 +65,10 @@ class BakeryLifecycleMonitor(
         when {
           execution.status == BUFFERED -> publishCorrectLink(task)
           execution.status == RUNNING -> publishRunningEvent(task)
-          execution.status.isSuccess() -> publishSucceededEvent(task)
+          execution.status.isSuccess() -> {
+            publishSucceededEvent(task)
+            storeBakedImage(execution)
+          }
           execution.status.isFailure() -> publishFailedEvent(task)
           else -> publishUnknownEvent(task, execution)
         }
@@ -69,6 +83,51 @@ class BakeryLifecycleMonitor(
         log.error("Error fetching status for $task: ", exception)
         handleFailureFetchingStatus(task)
       }
+  }
+
+  /**
+   * Stores the ami details from a successful bake task so we don't have to wait for those
+   * details to appear in the clouddriver cache (~5 minute delay every time).
+   *
+   * If there's a problem parsing we log an error and move on, because we will see
+   * the image in clouddriver eventually.
+   */
+  fun storeBakedImage(execution: ExecutionDetailResponse) {
+    // we know we launch a bake task with a stage called "bake".
+    val bakeStageRaw = execution.execution.stages?.find { it["type"] == "bake" }
+    if (bakeStageRaw == null) {
+      log.error("Trying to find baked ami information, but can't find a bake stage in execution ${execution.id}")
+      return
+    }
+    try {
+      val bakeStage = objectMapper.convertValue<BakeStage>(bakeStageRaw)
+      val details = bakeStage.outputs.deploymentDetails
+      if (details.isEmpty()) {
+        log.error("No bake details in the bake stage in execution ${execution.id}")
+      }
+
+      // use the first region present because the only difference should be in ami id and region name
+      // even the base ami app version will be the same across regions
+      val bakedImage = BakedImage(
+        name = details.first().imageName,
+        baseLabel = details.first().baseLabel,
+        baseOs = details.first().baseOs,
+        vmType = details.first().vmType,
+        cloudProvider = details.first().cloudProviderType,
+        appVersion = details.first().`package`.substringBefore("_all.deb").replaceFirst("_", "-"),
+        baseAmiVersion = baseImageCache.getVersionByImageId(details.first().baseAmiId, details.first().region),
+        timestamp = execution.endTime ?: clock.instant(),
+        amiIdsByRegion = details.associate { regionDetail -> regionDetail.region to regionDetail.imageId }
+      )
+      bakedImageRepository.store(bakedImage)
+    } catch (e: JsonMappingException) {
+      log.error("Error converting bake stage to kotlin object in execution ${execution.id}", e)
+      return
+    } catch (e: Exception) {
+      // if there's an error that's fine, we will move on.
+      log.error("Error finding baked image information in execution ${execution.id}", e)
+      return
+    }
   }
 
   private fun orcaTaskIdToLink(task: MonitoredTask): String =

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -13,6 +13,7 @@ import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.keel.parseAppVersion
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -28,7 +29,8 @@ import org.springframework.stereotype.Component
 class ImageExistsConstraintEvaluator(
   private val imageService: ImageService,
   private val dynamicConfigService: DynamicConfigService,
-  override val eventPublisher: EventPublisher
+  override val eventPublisher: EventPublisher,
+  private val bakedImageRepository: BakedImageRepository
 ) : ConstraintEvaluator<ImageExistsConstraint> {
 
   override fun isImplicit(): Boolean = true
@@ -41,25 +43,38 @@ class ImageExistsConstraintEvaluator(
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment
   ): Boolean =
-    artifact !is DebianArtifact || imagesExistInAllRegions(version, artifact.vmOptions)
+    artifact !is DebianArtifact || imagesExistInAllRegions(version, artifact.vmOptions, artifact)
 
-  private fun imagesExistInAllRegions(version: String, vmOptions: VirtualMachineOptions): Boolean =
-    runBlocking {
+  /**
+   * Check both clouddriver cached images and the images we've baked that haven't been
+   * cached yet.
+   */
+  private fun imagesExistInAllRegions(version: String, vmOptions: VirtualMachineOptions, artifact: DebianArtifact): Boolean {
+    val clouddriverImages = runBlocking {
       imageService.getLatestNamedImages(
         appVersion = version.parseAppVersion(),
         account = defaultImageAccount,
         regions = vmOptions.regions
       )
     }
-      .also {
-        if (it.keys.containsAll(vmOptions.regions)) {
-          log.info("Found AMIs for all desired regions for {}", version)
-        } else {
-          log.warn("Missing regions {} for {}", (vmOptions.regions - it.keys).sorted().joinToString(), version)
-          eventPublisher.publishEvent(MissingRegionsDetected(version))
-        }
-      }
-      .keys.containsAll(vmOptions.regions)
+
+    val bakedImage = bakedImageRepository.getLatestByArtfiactVerstion(version, artifact)
+
+    if (clouddriverImages.keys.containsAll(vmOptions.regions)) {
+      log.info("Found AMIs for all desired regions in clouddriver cache for {}", version)
+    } else {
+      log.warn("Missing regions {} clouddriver cache for {}", (vmOptions.regions - clouddriverImages.keys).sorted().joinToString(), version)
+      eventPublisher.publishEvent(MissingRegionsDetected(version))
+    }
+
+    if (!clouddriverImages.keys.containsAll(vmOptions.regions) && bakedImage != null) {
+      log.debug("Found AMIs for regions {} in baked image list for {}", bakedImage.amiIdsByRegion.keys, version)
+      // if we can see them from the bake, we know they exist, so we can approve the version.
+      return bakedImage.amiIdsByRegion.keys.containsAll(vmOptions.regions)
+    }
+
+    return clouddriverImages.keys.containsAll(vmOptions.regions)
+  }
 
   private val defaultImageAccount: String
     get() = dynamicConfigService.getConfig("images.default-account", "test")

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -58,19 +58,19 @@ class ImageExistsConstraintEvaluator(
       )
     }
 
-    val bakedImage = bakedImageRepository.getLatestByArtfiactVerstion(version, artifact)
+    val bakedImage = bakedImageRepository.getByArtifactVersion(version, artifact)
 
     if (clouddriverImages.keys.containsAll(vmOptions.regions)) {
       log.info("Found AMIs for all desired regions in clouddriver cache for {}", version)
     } else {
       log.warn("Missing regions {} clouddriver cache for {}", (vmOptions.regions - clouddriverImages.keys).sorted().joinToString(), version)
       eventPublisher.publishEvent(MissingRegionsDetected(version))
-    }
 
-    if (!clouddriverImages.keys.containsAll(vmOptions.regions) && bakedImage != null) {
-      log.debug("Found AMIs for regions {} in baked image list for {}", bakedImage.amiIdsByRegion.keys, version)
-      // if we can see them from the bake, we know they exist, so we can approve the version.
-      return bakedImage.amiIdsByRegion.keys.containsAll(vmOptions.regions)
+      if (bakedImage != null) {
+        log.debug("Found AMIs for regions {} in baked image list for {}", bakedImage.amiIdsByRegion.keys, version)
+        // if we can see them from the bake, we know they exist, so we can approve the version.
+        return bakedImage.presentInAllRegions(vmOptions.regions)
+      }
     }
 
     return clouddriverImages.keys.containsAll(vmOptions.regions)

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -6,14 +6,17 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.BaseLabel.RELEASE
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.artifacts.BakedImage
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.bakery.api.ImageExistsConstraint
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import com.netflix.spinnaker.keel.test.locatableResource
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService.NoopDynamicConfig
@@ -25,6 +28,7 @@ import org.slf4j.LoggerFactory
 import strikt.api.expectThat
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
+import java.time.Instant
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
 
@@ -61,10 +65,14 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
     val imageService = mockk<ImageService>(relaxUnitFun = true) {
       every { log } returns LoggerFactory.getLogger(ImageService::class.java)
     }
+    val bakedImageRepository: BakedImageRepository = mockk(relaxUnitFun = true) {
+      every { getLatestByArtfiactVerstion(any(), any()) } returns null
+    }
     val evaluator = ImageExistsConstraintEvaluator(
       imageService,
       NoopDynamicConfig(),
-      eventPublisher
+      eventPublisher,
+      bakedImageRepository
     )
     val appVersion = "fnord-1.0.0-123456"
     var promotionResult: Boolean? = null
@@ -109,14 +117,69 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
         every {
           imageService.getLatestNamedImage(any(), any(), any())
         } returns null
-
-        canPromote()
       }
 
       test("the constraint does not pass (yet)") {
+        canPromote()
+
         expectThat(promotionResult)
           .describedAs("promotion decision")
           .isFalse()
+      }
+
+      context("we know of an image for this artifact version, we know of all regions") {
+        before {
+          every { bakedImageRepository.getLatestByArtfiactVerstion(appVersion, artifact as DebianArtifact) } returns
+            BakedImage(
+              name = appVersion,
+              baseLabel = RELEASE,
+              baseOs = "bionic-classic",
+              vmType = "hvm",
+              cloudProvider = "aws",
+              appVersion = appVersion,
+              baseAmiVersion = "base-ami-1",
+              amiIdsByRegion = mapOf(
+                "us-east-1" to "ami-11110",
+                "us-west-2" to "ami-22228"
+              ),
+              timestamp = Instant.ofEpochMilli(1614893256845)
+            )
+        }
+
+        test("the constraint passes") {
+          canPromote()
+
+          expectThat(promotionResult)
+            .describedAs("promotion decision")
+            .isTrue()
+        }
+      }
+
+      context("we know of an image for this artifact version, we know of only one region") {
+        before {
+          every { bakedImageRepository.getLatestByArtfiactVerstion(appVersion, artifact as DebianArtifact) } returns
+            BakedImage(
+              name = appVersion,
+              baseLabel = RELEASE,
+              baseOs = "bionic-classic",
+              vmType = "hvm",
+              cloudProvider = "aws",
+              appVersion = appVersion,
+              baseAmiVersion = "base-ami-1",
+              amiIdsByRegion = mapOf(
+                "us-east-1" to "ami-11110"
+              ),
+              timestamp = Instant.ofEpochMilli(1614893256845)
+            )
+        }
+
+        test("the constraint does not pass (yet)") {
+          canPromote()
+
+          expectThat(promotionResult)
+            .describedAs("promotion decision")
+            .isFalse()
+        }
       }
     }
 

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -66,7 +66,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
       every { log } returns LoggerFactory.getLogger(ImageService::class.java)
     }
     val bakedImageRepository: BakedImageRepository = mockk(relaxUnitFun = true) {
-      every { getLatestByArtfiactVerstion(any(), any()) } returns null
+      every { getByArtifactVersion(any(), any()) } returns null
     }
     val evaluator = ImageExistsConstraintEvaluator(
       imageService,
@@ -129,7 +129,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
 
       context("we know of an image for this artifact version, we know of all regions") {
         before {
-          every { bakedImageRepository.getLatestByArtfiactVerstion(appVersion, artifact as DebianArtifact) } returns
+          every { bakedImageRepository.getByArtifactVersion(appVersion, artifact as DebianArtifact) } returns
             BakedImage(
               name = appVersion,
               baseLabel = RELEASE,
@@ -157,7 +157,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
 
       context("we know of an image for this artifact version, we know of only one region") {
         before {
-          every { bakedImageRepository.getLatestByArtfiactVerstion(appVersion, artifact as DebianArtifact) } returns
+          every { bakedImageRepository.getByArtifactVersion(appVersion, artifact as DebianArtifact) } returns
             BakedImage(
               name = appVersion,
               baseLabel = RELEASE,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -170,7 +170,7 @@ class ImageService(
   }
 
   /**
-   * Extracts the base ami version from the tages of a named image
+   * Extracts the base ami version from the tags of a named image
    */
   private fun findBaseAmiVersion(image: NamedImage): String? =
     image

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -157,14 +157,29 @@ class ImageService(
     return cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, baseImageName, "test")
       .lastOrNull()
       ?.let { namedImage ->
-        namedImage
-          .tagsByImageId
-          .values
-          .filterNotNull()
-          .find { it.containsKey("base_ami_version") }
-          ?.getValue("base_ami_version")
+        findBaseAmiVersion(namedImage)
       } ?: throw BaseAmiNotFound(baseImageName)
   }
+
+  suspend fun findBaseAmiVersion(baseImageId: String, region: String): String {
+    return cloudDriverService.getImage("test", region, baseImageId)
+      .lastOrNull()
+      ?.let { namedImage ->
+        findBaseAmiVersion(namedImage)
+      } ?: throw BaseAmiNotFound(baseImageId)
+  }
+
+  /**
+   * Extracts the base ami version from the tages of a named image
+   */
+  private fun findBaseAmiVersion(image: NamedImage): String? =
+    image
+      .tagsByImageId
+      .values
+      .filterNotNull()
+      .find { it.containsKey("base_ami_version") }
+      ?.getValue("base_ami_version")
+
 
   private fun tagsExistForAllAmis(tagsByImageId: Map<String, Map<String, String?>?>): Boolean {
     tagsByImageId.keys.forEach { key ->
@@ -214,7 +229,7 @@ suspend fun ImageService.getLatestNamedImages(
     }
 }
 
-private fun AppVersion.toImageName() = "$packageName-$version-h$buildNumber.$commit"
+fun AppVersion.toImageName() = "$packageName-$version-h$buildNumber.$commit"
 
 class BaseAmiNotFound(baseImage: String) :
   IntegrationException("Could not find a base AMI for base image $baseImage")

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepositoryTests.kt
@@ -65,7 +65,7 @@ abstract class BakedImageRepositoryTests<T : BakedImageRepository> : JUnit5Minut
 
       test("can retrieve stored image"){
         subject.store(bakedImage)
-        val image = subject.getLatestByArtfiactVerstion(version, artifact)
+        val image = subject.getByArtifactVersion(version, artifact)
         expect {
           that(image).isNotNull()
           that(image?.amiIdsByRegion).isEqualTo(amisByRegion)
@@ -75,12 +75,12 @@ abstract class BakedImageRepositoryTests<T : BakedImageRepository> : JUnit5Minut
 
     context("no baked image exists") {
       test("getting latest by version does not throw an exception") {
-        expectCatching { subject.getLatestByArtfiactVerstion(version, artifact) }
+        expectCatching { subject.getByArtifactVersion(version, artifact) }
           .isSuccess()
       }
 
       test("getting latest by version returns null") {
-        expectThat(subject.getLatestByArtfiactVerstion(version, artifact)).isNull()
+        expectThat(subject.getByArtifactVersion(version, artifact)).isNull()
       }
     }
   }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepositoryTests.kt
@@ -1,0 +1,88 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.artifacts.BaseLabel.RELEASE
+import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.artifacts.BakedImage
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
+import com.netflix.spinnaker.time.MutableClock
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import strikt.api.expect
+import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+import strikt.assertions.isNotNull
+import strikt.assertions.isNull
+import strikt.assertions.isSuccess
+import java.time.Clock
+
+abstract class BakedImageRepositoryTests<T : BakedImageRepository> : JUnit5Minutests {
+  abstract fun factory(clock: Clock): T
+
+  val clock = MutableClock()
+
+  open fun T.flush() {}
+
+  val version = "keel-1-h1.9808f2e"
+  val amisByRegion = mapOf(
+    "us-east-1" to "ami-1",
+    "us-west-1" to "ami-2"
+  )
+
+  val bakedImage = BakedImage(
+    name = "$version-x86_64-20210302221913-bionic-classic-hvm-sriov-ebs",
+    baseLabel = RELEASE,
+    baseOs = "bionic-classic",
+    vmType = "hvm",
+    cloudProvider = "aws",
+    appVersion = version,
+    baseAmiVersion = "base-ami-123",
+    timestamp = clock.instant(),
+    amiIdsByRegion = amisByRegion
+  )
+
+  val artifact = DebianArtifact(
+    name = "keel",
+    deliveryConfigName = "keel-config",
+    vmOptions = VirtualMachineOptions(baseOs = "bionic-classic", regions = setOf("us-west-1", "us-east-1")))
+
+  data class Fixture<T: BakedImageRepository>(
+    val subject: T
+  )
+
+  fun tests() = rootContext<Fixture<T>> {
+    fixture { Fixture(factory(clock)) }
+
+    after {
+      subject.flush()
+    }
+
+    context("can store a baked image") {
+      test("storing works") {
+        expectCatching { subject.store(bakedImage) }
+          .isSuccess()
+      }
+
+      test("can retrieve stored image"){
+        subject.store(bakedImage)
+        val image = subject.getLatestByArtfiactVerstion(version, artifact)
+        expect {
+          that(image).isNotNull()
+          that(image?.amiIdsByRegion).isEqualTo(amisByRegion)
+        }
+      }
+    }
+
+    context("no baked image exists") {
+      test("getting latest by version does not throw an exception") {
+        expectCatching { subject.getLatestByArtfiactVerstion(version, artifact) }
+          .isSuccess()
+      }
+
+      test("getting latest by version returns null") {
+        expectThat(subject.getLatestByArtfiactVerstion(version, artifact)).isNull()
+      }
+    }
+  }
+
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BakedImage.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BakedImage.kt
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.keel.artifacts
+
+import com.netflix.spinnaker.keel.api.artifacts.BaseLabel
+import java.time.Instant
+
+data class BakedImage(
+  val name: String,
+  val baseLabel: BaseLabel,
+  val baseOs: String,
+  val vmType: String,
+  val cloudProvider: String,
+  val appVersion: String,
+  val baseAmiVersion: String,
+  val amiIdsByRegion: Map<String, String>,
+  val timestamp: Instant
+)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BakedImage.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BakedImage.kt
@@ -13,4 +13,7 @@ data class BakedImage(
   val baseAmiVersion: String,
   val amiIdsByRegion: Map<String, String>,
   val timestamp: Instant
-)
+) {
+  fun presentInAllRegions(regions: Set<String>) =
+    amiIdsByRegion.keys.containsAll(regions)
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepository.kt
@@ -17,5 +17,5 @@ interface BakedImageRepository {
    * Retrieves the information we have about baked images for an artifact versions,
    * or null.
    */
-  fun getLatestByArtfiactVerstion(version: String, artifact: DebianArtifact): BakedImage?
+  fun getByArtifactVersion(version: String, artifact: DebianArtifact): BakedImage?
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepository.kt
@@ -1,0 +1,21 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.artifacts.BakedImage
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
+
+/**
+ * A repository used for storing details about amis that keel bakes so that we can circumvent
+ * the aws + clouddriver caching and immediately know about amis that we created.
+ */
+interface BakedImageRepository {
+  /**
+   * Stores information about an image that keel successfully baked
+   */
+  fun store(image: BakedImage)
+
+  /**
+   * Retrieves the information we have about baked images for an artifact versions,
+   * or null.
+   */
+  fun getLatestByArtfiactVerstion(version: String, artifact: DebianArtifact): BakedImage?
+}

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/NoImageFound.kt
@@ -27,3 +27,6 @@ class NoImageFoundForRegions(artifactName: String, regions: Collection<String>) 
 
 class NoImageSatisfiesConstraints(artifactName: String, environment: String) :
   ResourceCurrentlyUnresolvable("No image found for artifact $artifactName that satisfies constraints in environment $environment")
+
+class NoArtifactVersionHasBeenApproved(artifactName: String, environment: String) :
+  ResourceCurrentlyUnresolvable("No versions have been approved for deployment for $artifactName in environment $environment")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -12,14 +12,14 @@ import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
-import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
 import com.netflix.spinnaker.keel.clouddriver.model.baseImageVersion
+import com.netflix.spinnaker.keel.ec2.NoArtifactVersionHasBeenApproved
 import com.netflix.spinnaker.keel.ec2.NoImageFoundForRegions
-import com.netflix.spinnaker.keel.ec2.NoImageSatisfiesConstraints
 import com.netflix.spinnaker.keel.filterNotNullValues
 import com.netflix.spinnaker.keel.getConfig
 import com.netflix.spinnaker.keel.parseAppVersion
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoMatchingArtifactException
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -31,7 +31,8 @@ import org.springframework.stereotype.Component
 class ImageResolver(
   private val dynamicConfigService: DynamicConfigService,
   private val repository: KeelRepository,
-  private val imageService: ImageService
+  private val imageService: ImageService,
+  private val bakedImageRepository: BakedImageRepository
 ) : Resolver<ClusterSpec> {
 
   override val supportedKind = EC2_CLUSTER_V1_1
@@ -39,14 +40,14 @@ class ImageResolver(
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   data class VersionedNamedImage(
-    val namedImages: Map<String, NamedImage>,
+    val bakedVmImages: Map<String, VirtualMachineImage>, // from our store of what we baked
+    val vmImages: Map<String, VirtualMachineImage>, // from clouddriver
     val artifact: DeliveryArtifact,
     val version: String
   )
 
   override fun invoke(resource: Resource<ClusterSpec>): Resource<ClusterSpec> {
-    val ref = resource.spec.artifactReference
-    if (ref == null) return resource
+    val ref = resource.spec.artifactReference ?: return resource
 
     val image = runBlocking {
       resource.resolveFromReference(ref)
@@ -79,7 +80,7 @@ class ImageResolver(
       deliveryConfig,
       artifact,
       environment.name
-    ) ?: throw NoImageSatisfiesConstraints(artifact.name, environment.name)
+    ) ?: throw NoArtifactVersionHasBeenApproved(artifact.name, environment.name)
 
     val images = imageService.getLatestNamedImages(
       appVersion = artifactVersion.parseAppVersion(),
@@ -87,36 +88,58 @@ class ImageResolver(
       regions = regions
     )
 
-    return VersionedNamedImage(images, artifact, artifactVersion)
+    val imageIdByRegion: Map<String, String> = images
+      .mapValues { (region, image) -> image.amis[region]?.first() }
+      .filterNotNullValues()
+
+     val vmImages = images.mapValues { (region, namedImage) ->
+      VirtualMachineImage(
+        id = imageIdByRegion.getValue(region),
+        appVersion = namedImage.appVersion,
+        baseImageVersion = namedImage.baseImageVersion
+      )
+    }
+
+    val bakedVmImages = mutableMapOf<String, VirtualMachineImage>()
+    // we might have pre-knowledge of baked images here, so let's load that.
+    bakedImageRepository
+      .getLatestByArtfiactVerstion(artifactVersion, artifact)
+      ?.let { bakedImage ->
+        bakedImage.amiIdsByRegion.forEach{ (region, amiId) ->
+          bakedVmImages[region] = VirtualMachineImage(
+            id = amiId,
+            appVersion = bakedImage.appVersion,
+            baseImageVersion = bakedImage.baseAmiVersion
+          )
+        }
+      }
+
+    return VersionedNamedImage(
+      bakedVmImages = bakedVmImages,
+      vmImages = vmImages,
+      artifact = artifact,
+      version = artifactVersion
+    )
   }
 
   private fun Resource<ClusterSpec>.withVirtualMachineImages(image: VersionedNamedImage): Resource<ClusterSpec> {
     val requiredRegions = spec.locations.regions.map { it.name }
 
-    val missingRegions = requiredRegions - image.namedImages.keys
-    if (missingRegions.isNotEmpty()) {
-      throw NoImageFoundForRegions(image.version, missingRegions)
+    val missingRegions = requiredRegions - image.vmImages.keys
+    val missingBakedRegions = requiredRegions - image.bakedVmImages.keys
+    if (missingRegions.isNotEmpty() && missingBakedRegions.isNotEmpty()) {
+      log.warn("Missing regions for ${image.version}. Clouddriver has {}, we have {}", missingRegions, missingBakedRegions)
+      throw NoImageFoundForRegions(image.version, missingRegions.intersect(missingBakedRegions))
     }
-
-    val imageIdByRegion = image
-      .namedImages
-      .mapValues { (region, image) -> image.amis[region]?.first() }
-      .filterNotNullValues()
 
     val overrides = mutableMapOf<String, ServerGroupSpec>()
     overrides.putAll(spec.overrides)
 
     requiredRegions.forEach { region ->
-      val amiId = imageIdByRegion.getValue(region)
-      val namedImage = image.namedImages.getValue(region)
+      // fall back to looking at our data about baked images
+      val vmImage = image.vmImages[region] ?: image.bakedVmImages.getValue(region)
       overrides[region] = overrides[region]
-        .withVirtualMachineImage(
-          VirtualMachineImage(
-            amiId,
-            namedImage.appVersion,
-            namedImage.baseImageVersion
-          )
-        )
+        .withVirtualMachineImage(vmImage)
     }
 
     return copy(

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -100,19 +100,18 @@ class ImageResolver(
       )
     }
 
-    val bakedVmImages = mutableMapOf<String, VirtualMachineImage>()
     // we might have pre-knowledge of baked images here, so let's load that.
-    bakedImageRepository
-      .getLatestByArtfiactVerstion(artifactVersion, artifact)
+    val bakedVmImages: Map<String, VirtualMachineImage> = bakedImageRepository
+      .getByArtifactVersion(artifactVersion, artifact)
       ?.let { bakedImage ->
-        bakedImage.amiIdsByRegion.forEach{ (region, amiId) ->
-          bakedVmImages[region] = VirtualMachineImage(
+        bakedImage.amiIdsByRegion.mapValues { (region, amiId) ->
+          VirtualMachineImage(
             id = amiId,
             appVersion = bakedImage.appVersion,
             baseImageVersion = bakedImage.baseAmiVersion
           )
-        }
-      }
+        }.toMap()
+      } ?: emptyMap()
 
     return VersionedNamedImage(
       bakedVmImages = bakedVmImages,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -8,17 +8,20 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
+import com.netflix.spinnaker.keel.api.artifacts.BaseLabel
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
+import com.netflix.spinnaker.keel.artifacts.BakedImage
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
+import com.netflix.spinnaker.keel.ec2.NoArtifactVersionHasBeenApproved
 import com.netflix.spinnaker.keel.ec2.NoImageFoundForRegions
-import com.netflix.spinnaker.keel.ec2.NoImageSatisfiesConstraints
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
@@ -34,6 +37,7 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isNotNull
 import strikt.java.propertiesAreEqualTo
+import java.time.Instant
 import io.mockk.coEvery as every
 
 internal class ImageResolverTests : JUnit5Minutests {
@@ -63,10 +67,14 @@ internal class ImageResolverTests : JUnit5Minutests {
     val imageService = mockk<ImageService>() {
       every { log } returns LoggerFactory.getLogger(ImageService::class.java)
     }
+    val bakedImageRepository: BakedImageRepository = mockk(relaxUnitFun = true) {
+      every { getLatestByArtfiactVerstion(any(), any()) } returns null
+    }
     private val subject = ImageResolver(
       dynamicConfigService,
       repository,
-      imageService
+      imageService,
+      bakedImageRepository
     )
     val images = listOf(
       NamedImage(
@@ -108,6 +116,20 @@ internal class ImageResolverTests : JUnit5Minutests {
           imageRegion to listOf("ami-3")
         )
       )
+    )
+
+    val bakedImage = BakedImage(
+      name = "fnord-$version2",
+      baseLabel = BaseLabel.RELEASE,
+      baseOs = "bionic-classic",
+      vmType = "hvm",
+      cloudProvider = "aws",
+      appVersion = "fnord-$version2",
+      baseAmiVersion = "nflx-base-5.464.0-h1473.31178a8",
+      amiIdsByRegion = mapOf(
+        imageRegion to "ami-2"
+      ),
+      timestamp = Instant.ofEpochMilli(1614893256845)
     )
 
     val resource = resource(
@@ -201,11 +223,11 @@ internal class ImageResolverTests : JUnit5Minutests {
           test("throws an exception") {
             expectCatching { resolve() }
               .isFailure()
-              .isA<NoImageSatisfiesConstraints>()
+              .isA<NoArtifactVersionHasBeenApproved>()
           }
         }
 
-        context("no image is found for the artifact version") {
+        context("no image is found for the artifact version in clouddriver") {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
@@ -217,6 +239,24 @@ internal class ImageResolverTests : JUnit5Minutests {
             expectCatching { resolve() }
               .isFailure()
               .isA<NoImageFoundForRegions>()
+          }
+
+          context("an image is found in our list of images") {
+            before {
+              every {
+                bakedImageRepository.getLatestByArtfiactVerstion("${artifact.name}-$version2", artifact)
+              } returns bakedImage
+            }
+
+            test("returns the ami of the image") {
+              val resolved = resolve()
+              expectThat(resolved.spec.overrides[imageRegion]?.launchConfiguration?.image)
+                .isNotNull()
+                .and {
+                  get { appVersion }.isEqualTo("fnord-$version2")
+                  get { id }.isEqualTo("ami-2")
+                }
+            }
           }
         }
 
@@ -248,6 +288,24 @@ internal class ImageResolverTests : JUnit5Minutests {
             expectCatching { resolve() }
               .isFailure()
               .isA<NoImageFoundForRegions>()
+          }
+
+          context("all regions are found in our list of images") {
+            before {
+              every {
+                bakedImageRepository.getLatestByArtfiactVerstion("${artifact.name}-$version2", artifact)
+              } returns bakedImage.copy(amiIdsByRegion = bakedImage.amiIdsByRegion + mapOf("cn-north-1" to "ami-2"))
+            }
+
+            test("returns the ami of the image") {
+              val resolved = resolve()
+              expectThat(resolved.spec.overrides["cn-north-1"]?.launchConfiguration?.image)
+                .isNotNull()
+                .and {
+                  get { appVersion }.isEqualTo("fnord-$version2")
+                  get { id }.isEqualTo("ami-2")
+                }
+            }
           }
         }
       }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -68,7 +68,7 @@ internal class ImageResolverTests : JUnit5Minutests {
       every { log } returns LoggerFactory.getLogger(ImageService::class.java)
     }
     val bakedImageRepository: BakedImageRepository = mockk(relaxUnitFun = true) {
-      every { getLatestByArtfiactVerstion(any(), any()) } returns null
+      every { getByArtifactVersion(any(), any()) } returns null
     }
     private val subject = ImageResolver(
       dynamicConfigService,
@@ -244,7 +244,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           context("an image is found in our list of images") {
             before {
               every {
-                bakedImageRepository.getLatestByArtfiactVerstion("${artifact.name}-$version2", artifact)
+                bakedImageRepository.getByArtifactVersion("${artifact.name}-$version2", artifact)
               } returns bakedImage
             }
 
@@ -293,7 +293,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           context("all regions are found in our list of images") {
             before {
               every {
-                bakedImageRepository.getLatestByArtfiactVerstion("${artifact.name}-$version2", artifact)
+                bakedImageRepository.getByArtifactVersion("${artifact.name}-$version2", artifact)
               } returns bakedImage.copy(amiIdsByRegion = bakedImage.amiIdsByRegion + mapOf("cn-north-1" to "ami-2"))
             }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.resources.SpecMigrator
 import com.netflix.spinnaker.keel.scheduled.ScheduledAgent
 import com.netflix.spinnaker.keel.sql.SqlAgentLockRepository
 import com.netflix.spinnaker.keel.sql.SqlArtifactRepository
+import com.netflix.spinnaker.keel.sql.SqlBakedImageRepository
 import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
 import com.netflix.spinnaker.keel.sql.SqlDiffFingerprintRepository
 import com.netflix.spinnaker.keel.sql.SqlLifecycleEventRepository
@@ -190,4 +191,12 @@ class SqlConfiguration {
     properties: SqlProperties,
     objectMapper: ObjectMapper
   ) = SqlLifecycleMonitorRepository(jooq, clock, objectMapper, SqlRetry(sqlRetryProperties))
+
+  @Bean
+  fun bakedImageRepository(
+    jooq: DSLContext,
+    clock: Clock,
+    properties: SqlProperties,
+    objectMapper: ObjectMapper
+  ) = SqlBakedImageRepository(jooq, clock, objectMapper, SqlRetry(sqlRetryProperties))
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepository.kt
@@ -25,18 +25,13 @@ class SqlBakedImageRepository(
     sqlRetry.withRetry(WRITE) {
       jooq
         .insertInto(BAKED_IMAGES)
-        .set(BAKED_IMAGES.PACKAGE_VERSION, image.appVersion)
-        .set(BAKED_IMAGES.CLOUD_PROVIDER, image.cloudProvider)
-        .set(BAKED_IMAGES.BASE_OS, image.baseOs)
-        .set(BAKED_IMAGES.BASE_LABEL, image.baseLabel.name)
-        .set(BAKED_IMAGES.TIME_DETECTED, clock.instant())
         .set(BAKED_IMAGES.IMAGE, objectMapper.writeValueAsString(image))
         .onDuplicateKeyIgnore()
         .execute()
     }
   }
 
-  override fun getLatestByArtfiactVerstion(version: String, artifact: DebianArtifact): BakedImage? {
+  override fun getByArtifactVersion(version: String, artifact: DebianArtifact): BakedImage? {
      return sqlRetry.withRetry(READ) {
       jooq
         .select(BAKED_IMAGES.IMAGE)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepository.kt
@@ -1,0 +1,54 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.keel.artifacts.BakedImage
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.BAKED_IMAGES
+import com.netflix.spinnaker.keel.sql.RetryCategory.READ
+import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
+import org.jooq.DSLContext
+import org.slf4j.LoggerFactory
+import java.time.Clock
+
+class SqlBakedImageRepository(
+  private val jooq: DSLContext,
+  private val clock: Clock,
+  private val objectMapper: ObjectMapper,
+  private val sqlRetry: SqlRetry,
+) : BakedImageRepository {
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  override fun store(image: BakedImage) {
+    log.debug("Storing baked image $image")
+    sqlRetry.withRetry(WRITE) {
+      jooq
+        .insertInto(BAKED_IMAGES)
+        .set(BAKED_IMAGES.PACKAGE_VERSION, image.appVersion)
+        .set(BAKED_IMAGES.CLOUD_PROVIDER, image.cloudProvider)
+        .set(BAKED_IMAGES.BASE_OS, image.baseOs)
+        .set(BAKED_IMAGES.BASE_LABEL, image.baseLabel.name)
+        .set(BAKED_IMAGES.TIME_DETECTED, clock.instant())
+        .set(BAKED_IMAGES.IMAGE, objectMapper.writeValueAsString(image))
+        .onDuplicateKeyIgnore()
+        .execute()
+    }
+  }
+
+  override fun getLatestByArtfiactVerstion(version: String, artifact: DebianArtifact): BakedImage? {
+     return sqlRetry.withRetry(READ) {
+      jooq
+        .select(BAKED_IMAGES.IMAGE)
+        .from(BAKED_IMAGES)
+        .where(BAKED_IMAGES.PACKAGE_VERSION.eq(version))
+        .and(BAKED_IMAGES.CLOUD_PROVIDER.eq("aws"))
+        .and(BAKED_IMAGES.BASE_OS.eq(artifact.vmOptions.baseOs))
+        .and(BAKED_IMAGES.BASE_LABEL.eq(artifact.vmOptions.baseLabel.name))
+        .fetch { (image) ->
+          objectMapper.readValue(image, BakedImage::class.java)
+        }
+        .firstOrNull()
+    }
+  }
+}

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepository.kt
@@ -26,6 +26,7 @@ class SqlBakedImageRepository(
       jooq
         .insertInto(BAKED_IMAGES)
         .set(BAKED_IMAGES.IMAGE, objectMapper.writeValueAsString(image))
+        .set(BAKED_IMAGES.TIME_DETECTED, clock.instant())
         .onDuplicateKeyIgnore()
         .execute()
     }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlLifecycleEventRepository.kt
@@ -161,7 +161,7 @@ class SqlLifecycleEventRepository(
    * an id and if the event is older than 5 minutes
    * because we dropped a fair amount of monitoring of events.
    *
-   * todo eb: remove once we backfill the events.
+   * Update 3/2020: This is extremely useful for local testing, so it stays.
    */
   private fun retriggerMonitoring(events: List<LifecycleEvent>) {
     if (events.size != 1) {

--- a/keel-sql/src/main/resources/db/changelog/202010303-baked-images.yml
+++ b/keel-sql/src/main/resources/db/changelog/202010303-baked-images.yml
@@ -1,0 +1,46 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-baked-images
+      author: emjburns
+      changes:
+        - createTable:
+            tableName: baked_images
+            columns:
+              - column:
+                  name: package_version
+                  type: varchar(150)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: cloud_provider
+                  type: varchar(50)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: base_os
+                  type: varchar(50)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: base_label
+                  type: varchar(50)
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: time_detected
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
+                  name: image
+                  type: json
+                  constraints:
+                    nullable: true
+        - modifySql:
+            dbms: mysql
+            append:
+              value: " engine innodb"

--- a/keel-sql/src/main/resources/db/changelog/202010303-baked-images.yml
+++ b/keel-sql/src/main/resources/db/changelog/202010303-baked-images.yml
@@ -7,40 +7,61 @@ databaseChangeLog:
             tableName: baked_images
             columns:
               - column:
-                  name: package_version
-                  type: varchar(150)
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: cloud_provider
-                  type: varchar(50)
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: base_os
-                  type: varchar(50)
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: base_label
-                  type: varchar(50)
-                  constraints:
-                    primaryKey: true
-                    nullable: false
-              - column:
-                  name: time_detected
-                  type: timestamp
-                  constraints:
-                    nullable: false
-              - column:
                   name: image
                   type: json
                   constraints:
-                    nullable: true
+                    nullable: false
         - modifySql:
             dbms: mysql
             append:
               value: " engine innodb"
+  - changeSet:
+      id: add-baked-images-generated-columns
+      author: emjburns
+      changes:
+        - sql:
+            sql: |
+              alter table baked_images
+              add column package_version varchar(150) generated always as (image ->> '$.packageVersion')
+              not null
+              first;
+        - sql:
+            sql: |
+              alter table baked_images
+              add column cloud_provider varchar(150) generated always as (image ->> '$.cloudProvider')
+              not null
+              after package_version;
+        - sql:
+            sql: |
+              alter table baked_images
+              add column base_label varchar(150) generated always as (image ->> '$.baseLabel')
+              not null
+              after cloud_provider;
+        - sql:
+            sql: |
+              alter table baked_images
+              add column base_os varchar(150) generated always as (image ->> '$.baseOs')
+              not null
+              after base_label;
+        - sql:
+            sql: |
+              alter table baked_images
+              add column time_detected datetime(3) generated always as (str_to_date(image->>'$.timestamp', '%Y-%m-%dT%T.%fZ'))
+              after base_os;
+  - changeSet:
+      id: create-baked-image-indicies
+      author: emjburns
+      changes:
+        - createIndex:
+            tableName: baked_images
+            indexName: baked_images_primary_idx
+            unique: true
+            columns:
+              - column:
+                  name: package_version
+              - column:
+                  name: cloud_provider
+              - column:
+                  name: base_os
+              - column:
+                  name: base_label

--- a/keel-sql/src/main/resources/db/changelog/202010303-baked-images.yml
+++ b/keel-sql/src/main/resources/db/changelog/202010303-baked-images.yml
@@ -7,6 +7,11 @@ databaseChangeLog:
             tableName: baked_images
             columns:
               - column:
+                  name: time_detected
+                  type: timestamp
+                  constraints:
+                    nullable: false
+              - column:
                   name: image
                   type: json
                   constraints:
@@ -22,32 +27,27 @@ databaseChangeLog:
         - sql:
             sql: |
               alter table baked_images
-              add column package_version varchar(150) generated always as (image ->> '$.packageVersion')
+              add column package_version varchar(150) generated always as (image ->> '$.appVersion')
               not null
               first;
         - sql:
             sql: |
               alter table baked_images
-              add column cloud_provider varchar(150) generated always as (image ->> '$.cloudProvider')
+              add column cloud_provider varchar(50) generated always as (image ->> '$.cloudProvider')
               not null
               after package_version;
         - sql:
             sql: |
               alter table baked_images
-              add column base_label varchar(150) generated always as (image ->> '$.baseLabel')
+              add column base_label varchar(50) generated always as (image ->> '$.baseLabel')
               not null
               after cloud_provider;
         - sql:
             sql: |
               alter table baked_images
-              add column base_os varchar(150) generated always as (image ->> '$.baseOs')
+              add column base_os varchar(50) generated always as (image ->> '$.baseOs')
               not null
               after base_label;
-        - sql:
-            sql: |
-              alter table baked_images
-              add column time_detected datetime(3) generated always as (str_to_date(image->>'$.timestamp', '%Y-%m-%dT%T.%fZ'))
-              after base_os;
   - changeSet:
       id: create-baked-image-indicies
       author: emjburns

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -239,3 +239,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210226-generate-event-columns.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/202010303-baked-images.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlBakedImageRepositoryTests.kt
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.persistence.BakedImageRepositoryTests
+import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import java.time.Clock
+
+class SqlBakedImageRepositoryTests : BakedImageRepositoryTests<SqlBakedImageRepository>() {
+
+  private val jooq = testDatabase.context
+  private val objectMapper = configuredTestObjectMapper()
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+
+  override fun factory(clock: Clock): SqlBakedImageRepository =
+    SqlBakedImageRepository(jooq, clock, objectMapper, sqlRetry)
+
+
+  override fun SqlBakedImageRepository.flush() {
+    SqlTestUtil.cleanupDb(jooq)
+  }
+}


### PR DESCRIPTION
*Summary*
Currently, there is a delay between baking and deploying because we wait for the baked image to appear in the clouddriver cache (this is where we get all our data about what exists in the world). Bake and deploy pipelines don't have this delay because the deploy stage grabs the ami id from the bake stage.

In order to bring this lightning fast speed to keel, we need to store the ami information from the bake task we launch in order to use it right away. This allows us to deploy before the ami is seen in clouddriver's cache.

*Background knowledge*
We have an implicit constraint `ImageExistsConstraint` that prevents a debian artifact version from being approved in an environment before an image exists for that version. This is the thing that ultimately makes the delay. I modified this constraint to read from the new store of ami information.

We have an `ImageResolver` that takes the desired state (version + base ami version) and calculates the ami that matches that. I modified this to also read from the new store of ami information.

*New things*
We already monitor the bake task (to produce lifecycle events, the underlying date for the cute cake bubble that appears while a version is baking). I am using this mechanism to store ami information from _successful_ bake tasks. This data is stored in a new repository called `BakedImageRepository`.

*Resiliency*
What happens if the data is malformed, or we can't get information about the ami from the bake stage? That's fine, we just ignore this optimization and we will wait for clouddriver information. We also default to the information clouddriver has, and only use our stored information if the information is not present in the clouddriver response.
