### PR TITLE
fix(tracing): Ensure clean MDC context at top coroutine scopes

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -110,7 +110,7 @@ class ResourceActuator(
         }
 
         if (deliveryConfig.isPromotionCheckStale()) {
-          log.debug("Environments check for {} is stale, skipping checks", deliveryConfig.name)
+          log.debug("Artifact promotion check for application {} is stale, skipping resource checks", deliveryConfig.application)
           publisher.publishEvent(ResourceCheckSkipped(resource.kind, id, "PromotionCheckStale"))
           return@withTracingContext
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
@@ -15,7 +15,7 @@ class TracingSupport {
   companion object {
     const val X_SPINNAKER_RESOURCE_ID = "X-SPINNAKER-RESOURCE-ID"
 
-    val clearMDC: MDCContext = MDCContext(emptyMap())
+    val blankMDC: MDCContext = MDCContext(emptyMap())
 
     suspend fun <T : ResourceSpec, R> withTracingContext(
       resource: Resource<T>,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/logging/TracingSupport.kt
@@ -15,6 +15,8 @@ class TracingSupport {
   companion object {
     const val X_SPINNAKER_RESOURCE_ID = "X-SPINNAKER-RESOURCE-ID"
 
+    val clearMDC: MDCContext = MDCContext(emptyMap())
+
     suspend fun <T : ResourceSpec, R> withTracingContext(
       resource: Resource<T>,
       block: suspend CoroutineScope.() -> R

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
@@ -34,13 +34,13 @@ class VerificationRunner(
         }
 
       if (statuses.anyStillRunning) {
-        log.debug("Verification already running for {}", environment.name)
+        log.debug("Verification already running for environment {} of application {}", environment.name, deliveryConfig.application)
         return
       }
 
       statuses.firstOutstanding?.let { verification ->
         start(verification, imageFinder.getImages(context.deliveryConfig, context.environmentName))
-      } ?: log.debug("Verification complete for {}", environment.name)
+      } ?: log.debug("Verification complete for environment {} of application {}", environment.name, deliveryConfig.application)
     }
   }
 
@@ -56,7 +56,8 @@ class VerificationRunner(
       evaluators.evaluate(this, verification, state.metadata)
         .also { newStatus ->
           if (newStatus.complete) {
-            log.debug("Verification {} completed with status {} for {}", verification, newStatus, environment.name)
+            log.debug("Verification {} completed with status {} for environment {} of application {}",
+              verification, newStatus, environment.name, deliveryConfig.application)
             markAs(verification, newStatus)
             eventPublisher.publishEvent(VerificationCompleted(this, verification, newStatus, state.metadata))
           }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -9,6 +9,7 @@ import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import com.netflix.spinnaker.keel.core.parseMoniker
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.clearMDC
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
@@ -74,7 +75,7 @@ class ExportController(
     val handler = handlers.supporting(kind)
     val exportable = generateExportable(cloudProvider, type, account, user, name)
 
-    return runBlocking {
+    return runBlocking(clearMDC) {
       withTracingContext(exportable) {
         log.info("Exporting resource ${exportable.toResourceId()}")
         SubmittedResource(
@@ -99,7 +100,7 @@ class ExportController(
     val handler = handlers.supporting(kind)
     val exportable = generateExportable(cloudProvider, "cluster", account, user, name)
 
-    return runBlocking {
+    return runBlocking(clearMDC) {
       withTracingContext(exportable) {
         log.info("Exporting artifact from cluster ${exportable.toResourceId()}")
         handler.exportArtifact(exportable)

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ExportController.kt
@@ -2,14 +2,13 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.ResourceKind
-import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.supporting
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.core.api.SubmittedResource
 import com.netflix.spinnaker.keel.core.parseMoniker
-import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.clearMDC
+import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.blankMDC
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.withTracingContext
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
 import kotlinx.coroutines.runBlocking
@@ -75,7 +74,7 @@ class ExportController(
     val handler = handlers.supporting(kind)
     val exportable = generateExportable(cloudProvider, type, account, user, name)
 
-    return runBlocking(clearMDC) {
+    return runBlocking(blankMDC) {
       withTracingContext(exportable) {
         log.info("Exporting resource ${exportable.toResourceId()}")
         SubmittedResource(
@@ -100,7 +99,7 @@ class ExportController(
     val handler = handlers.supporting(kind)
     val exportable = generateExportable(cloudProvider, "cluster", account, user, name)
 
-    return runBlocking(clearMDC) {
+    return runBlocking(blankMDC) {
       withTracingContext(exportable) {
         log.info("Exporting artifact from cluster ${exportable.toResourceId()}")
         handler.exportArtifact(exportable)


### PR DESCRIPTION
Follow-up to #1841. Following the discussion and recommendations in https://github.com/Kotlin/kotlinx.coroutines/issues/985, this PR adds an empty `MDCContext` to all top-level coroutine scopes where `withTracingContext` is used, in an attempt to remove left-over `X-SPINNAKER-RESOURCE-ID`s when switching threads.

Hopefully fixes #1122.