### PR TITLE
feat(export): Add support for branch-based artifacts

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -26,7 +26,7 @@ enum class ArtifactStatus {
  * @param startsWith Match branches starting with this string.
  * @param regex A regular expression to match against (e.g. "feature-.*").
  */
-data class BranchFilterSpec(
+data class BranchFilter(
   val name: String? = null,
   val startsWith: String? = null,
   val regex: String? = null
@@ -45,11 +45,11 @@ data class BranchFilterSpec(
 /**
  * Filters for the origin of an artifact in source control.
  *
- * @param branch A [BranchFilterSpec] with branch filters.
+ * @param branch A [BranchFilter] with branch filters.
  * @param pullRequestOnly Whether to include only artifacts built from pull requests.
  */
-data class ArtifactOriginFilterSpec(
-  val branch: BranchFilterSpec? = null,
+data class ArtifactOriginFilter(
+  val branch: BranchFilter? = null,
   val pullRequestOnly: Boolean? = false
 )
 
@@ -72,7 +72,7 @@ abstract class DeliveryArtifact {
   /** A set of release statuses to filter by. Mutually exclusive with [from] filters. */
   open val statuses: Set<ArtifactStatus> = emptySet()
   /** Filters for the artifact origin in source control. */
-  open val from: ArtifactOriginFilterSpec? = null
+  open val from: ArtifactOriginFilter? = null
 
   val filteredByBranch: Boolean
     get() = from?.branch != null

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/PublishedArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/PublishedArtifact.kt
@@ -76,7 +76,7 @@ data class PublishedArtifact(
 
   val createdAt: Instant?
     get() = (metadata["createdAt"]
-    //docker artifact createdAt time is under date field
+    // docker artifact createdAt time is under date field
       ?: metadata["date"])
       ?.let {
         when (it) {
@@ -90,6 +90,15 @@ data class PublishedArtifact(
           else -> null
         }
       }
+
+  val branch: String?
+    get() = gitMetadata?.branch ?: metadata["branch"] as? String
+
+  val commitHash: String?
+    get() = gitMetadata?.commit ?: metadata["commitId"] as? String
+
+  val buildNumber: String?
+    get() = buildMetadata?.number ?: metadata["buildNumber"] as? String
 
   fun normalized() = copy(
     type = type.toLowerCase(),

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -15,7 +15,6 @@ import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.model.Image
-import com.netflix.spinnaker.keel.core.NoKnownArtifactVersions
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.persistence.NoSuchArtifactException
@@ -129,7 +128,7 @@ internal class ImageHandlerTests : JUnit5Minutests {
 
     context("the artifact is not a Debian") {
       before {
-        runHandler(DockerArtifact(artifact.name))
+        runHandler(DockerArtifact(artifact.name, branch = "main"))
       }
 
       test("nothing happens") {

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -93,7 +93,11 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
     context("A non-Debian artifact") {
       deriveFixture {
         Fixture(
-          artifact = DockerArtifact("fnord", "bake-constraint-evaluator-tests")
+          artifact = DockerArtifact(
+            name = "fnord",
+            deliveryConfigName = "bake-constraint-evaluator-tests",
+            branch = "main"
+          )
         )
       }
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -3,11 +3,11 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.FINAL
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.SNAPSHOT
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.Commit
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
@@ -45,7 +45,6 @@ import strikt.assertions.isA
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
-import strikt.assertions.isNotEmpty
 import strikt.assertions.isNotEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
@@ -94,8 +93,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       deliveryConfigName = "my-manifest",
       reference = "feature-branch",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
-        branch = BranchFilterSpec(
+      from = ArtifactOriginFilter(
+        branch = BranchFilter(
           name = "my-feature-branch"
         )
       )
@@ -106,8 +105,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       deliveryConfigName = "my-manifest",
       reference = "feature-branch",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
-        branch = BranchFilterSpec(
+      from = ArtifactOriginFilter(
+        branch = BranchFilter(
           startsWith = "feature-"
         )
       )
@@ -118,8 +117,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       deliveryConfigName = "my-manifest",
       reference = "feature-branch",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
-        branch = BranchFilterSpec(
+      from = ArtifactOriginFilter(
+        branch = BranchFilter(
           regex = ".*feature.*"
         )
       )
@@ -130,7 +129,7 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       deliveryConfigName = "my-manifest",
       reference = "pr",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
+      from = ArtifactOriginFilter(
         pullRequestOnly = true
       )
     )
@@ -140,8 +139,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
       deliveryConfigName = "my-manifest",
       reference = "pr",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
-        branch = BranchFilterSpec(
+      from = ArtifactOriginFilter(
+        branch = BranchFilter(
           name = "my-feature-branch"
         ),
         pullRequestOnly = true

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepositoryTests.kt
@@ -57,7 +57,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
   val secondConfigName = "my-config-2"
   val application = "fnord"
   val secondApplication = "fnord-2"
-  val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName)
+  val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName, branch = "main")
   val newArtifact = artifact.copy(reference = "myart")
   val firstResource = resource()
   val secondResource = resource()
@@ -162,7 +162,8 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
               ArtifactRegisteredEvent(
                 DockerArtifact(
                   name = "org/image",
-                  deliveryConfigName = configName
+                  deliveryConfigName = configName,
+                  branch = "main"
                 )
               )
             )
@@ -233,7 +234,7 @@ abstract class CombinedRepositoryTests<D : DeliveryConfigRepository, R : Resourc
         context("artifact properties modified") {
           before {
             val updatedConfig = deliveryConfig.copy(
-              artifacts = setOf(artifact.copy(tagVersionStrategy = BRANCH_JOB_COMMIT_BY_JOB))
+              artifacts = setOf(artifact.copy(from = null, tagVersionStrategy = BRANCH_JOB_COMMIT_BY_JOB))
             )
             subject.upsertDeliveryConfig(updatedConfig)
           }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -8,8 +8,8 @@ import com.netflix.spinnaker.keel.api.NotificationType
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceKind.Companion.parseKind
 import com.netflix.spinnaker.keel.api.Verification
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
@@ -101,7 +101,7 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
     val artifactFromBranch: DebianArtifact = artifact.copy(
       name = "frombranch",
       reference = "frombranch",
-      from = ArtifactOriginFilterSpec(branch = BranchFilterSpec(name = "main"))
+      from = ArtifactOriginFilter(branch = BranchFilter(name = "main"))
     )
 
     fun getByName() = expectCatching {

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleEventRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleEventRepositoryTests.kt
@@ -40,7 +40,7 @@ abstract class LifecycleEventRepositoryTests<T: LifecycleEventRepository> : JUni
   data class Fixture<T : LifecycleEventRepository>(
     val subject: T
   )
-  val artifact = DockerArtifact(name = "my-artifact", deliveryConfigName = "my-config")
+  val artifact = DockerArtifact(name = "my-artifact", deliveryConfigName = "my-config", branch = "main")
   val version = "123.4"
   val link = "http://www.bake.com/$version"
   val event = LifecycleEvent(

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleMonitorRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/LifecycleMonitorRepositoryTests.kt
@@ -35,7 +35,7 @@ abstract class LifecycleMonitorRepositoryTests<T : LifecycleMonitorRepository, E
     val subject: T,
     val eventRepository: EVENT
   )
-  val artifact = DockerArtifact(name = "my-artifact", deliveryConfigName = "my-config")
+  val artifact = DockerArtifact(name = "my-artifact", deliveryConfigName = "my-config", branch = "main")
   val version = "123.4"
   val event = LifecycleEvent(
     scope = LifecycleEventScope.PRE_DEPLOYMENT,

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -3,8 +3,6 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
@@ -43,7 +41,6 @@ import strikt.assertions.map
 import strikt.assertions.one
 import strikt.assertions.withFirst
 import java.time.Duration
-import java.time.Instant
 
 abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationRepository> {
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/VerificationRepositoryTests.kt
@@ -3,6 +3,8 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Verification
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
@@ -41,6 +43,7 @@ import strikt.assertions.map
 import strikt.assertions.one
 import strikt.assertions.withFirst
 import java.time.Duration
+import java.time.Instant
 
 abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationRepository> {
 
@@ -67,17 +70,20 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
       DockerArtifact(
         name = "fnord",
         deliveryConfigName = "fnord-manifest",
-        reference = "fnord-docker-stable"
+        reference = "fnord-docker-stable",
+        branch = "main"
       ),
       DockerArtifact(
         name = "fnord",
         deliveryConfigName = "fnord-manifest",
-        reference = "fnord-docker-unstable"
+        reference = "fnord-docker-unstable",
+        branch = "main"
       ),
       DockerArtifact(
         name = "fnord",
         deliveryConfigName = "fnord-manifest",
-        reference = "test" // an artifact that has a reference name the same as an environment name
+        reference = "test", // an artifact that has a reference name the same as an environment name
+        branch = "main"
       )
     ),
     environments = setOf(
@@ -329,12 +335,14 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
       val artifact1 = DockerArtifact(
         name = "artifact1",
         deliveryConfigName = context.deliveryConfig.name,
-        reference = "ref-1"
+        reference = "ref-1",
+        branch = "main"
       )
       val artifact2 = DockerArtifact(
         name = "artifact2",
         deliveryConfigName = context.deliveryConfig.name,
-        reference = "ref-2"
+        reference = "ref-2",
+        branch = "main"
       )
       val deliveryConfig = context.deliveryConfig.copy(
         artifacts = setOf(artifact1, artifact2)
@@ -376,12 +384,14 @@ abstract class VerificationRepositoryTests<IMPLEMENTATION : VerificationReposito
       val artifact1 = DockerArtifact(
         name = "artifact1",
         deliveryConfigName = context.deliveryConfig.name,
-        reference = "ref-1"
+        reference = "ref-1",
+        branch = "main"
       )
       val artifact2 = DockerArtifact(
         name = "artifact2",
         deliveryConfigName = context.deliveryConfig.name,
-        reference = "ref-2"
+        reference = "ref-2",
+        branch = "main"
       )
       val deliveryConfig = context.deliveryConfig.copy(
         artifacts = setOf(artifact1, artifact2)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.artifacts
 
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
@@ -14,9 +15,11 @@ data class DebianArtifact(
   override val name: String,
   override val deliveryConfigName: String? = null,
   override val reference: String = name,
-  val vmOptions: VirtualMachineOptions,
   override val statuses: Set<ArtifactStatus> = emptySet(),
-  override val from: ArtifactOriginFilterSpec? = null
+  val vmOptions: VirtualMachineOptions,
+  val branch: String? = null,
+  override val from: ArtifactOriginFilterSpec? =
+    branch?.let { ArtifactOriginFilterSpec(BranchFilterSpec(name = branch)) }
 ) : DeliveryArtifact() {
   override val type = DEBIAN
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
@@ -1,8 +1,8 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
@@ -18,8 +18,8 @@ data class DebianArtifact(
   override val statuses: Set<ArtifactStatus> = emptySet(),
   val vmOptions: VirtualMachineOptions,
   val branch: String? = null,
-  override val from: ArtifactOriginFilterSpec? =
-    branch?.let { ArtifactOriginFilterSpec(BranchFilterSpec(name = branch)) }
+  override val from: ArtifactOriginFilter? =
+    branch?.let { ArtifactOriginFilter(BranchFilter(name = branch)) }
 ) : DeliveryArtifact() {
   override val type = DEBIAN
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
@@ -17,7 +18,7 @@ data class DebianArtifact(
   override val reference: String = name,
   override val statuses: Set<ArtifactStatus> = emptySet(),
   val vmOptions: VirtualMachineOptions,
-  val branch: String? = null,
+  @JsonIgnore val branch: String? = null,
   override val from: ArtifactOriginFilter? =
     branch?.let { ArtifactOriginFilter(BranchFilter(name = branch)) }
 ) : DeliveryArtifact() {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
@@ -19,7 +19,7 @@ data class DockerArtifact(
   override val reference: String = name,
   val tagVersionStrategy: TagVersionStrategy? = null,
   val captureGroupRegex: String? = null,
-  val branch: String? = null,
+  @JsonIgnore val branch: String? = null,
   override val from: ArtifactOriginFilter? =
     branch?.let { ArtifactOriginFilter(BranchFilter(name = branch)) }
 ) : DeliveryArtifact() {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
@@ -27,7 +27,7 @@ data class DockerArtifact(
     require(name.count { it == '/' } <= 1) {
       "Docker image name has more than one slash, which is not Docker convention. Please convert to `organization/image-name` format."
     }
-    require(from == null || tagVersionStrategy == null) {
+    require((from != null) xor (tagVersionStrategy != null)) {
       "Either `from` or `tagVersionStrategy` must be specified in the delivery config for Docker artifacts. Please check the documentation."
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
@@ -1,13 +1,12 @@
 package com.netflix.spinnaker.keel.artifacts
 
 import com.fasterxml.jackson.annotation.JsonIgnore
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
-import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
 import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 
@@ -21,8 +20,8 @@ data class DockerArtifact(
   val tagVersionStrategy: TagVersionStrategy? = null,
   val captureGroupRegex: String? = null,
   val branch: String? = null,
-  override val from: ArtifactOriginFilterSpec? =
-    branch?.let { ArtifactOriginFilterSpec(BranchFilterSpec(name = branch)) }
+  override val from: ArtifactOriginFilter? =
+    branch?.let { ArtifactOriginFilter(BranchFilter(name = branch)) }
 ) : DeliveryArtifact() {
   init {
     require(name.count { it == '/' } <= 1) {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifact.kt
@@ -3,11 +3,13 @@ package com.netflix.spinnaker.keel.artifacts
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
+import com.netflix.spinnaker.kork.web.exceptions.ValidationException
 
 /**
  * A [DeliveryArtifact] that describes Docker images.
@@ -16,13 +18,18 @@ data class DockerArtifact(
   override val name: String,
   override val deliveryConfigName: String? = null,
   override val reference: String = name,
-  val tagVersionStrategy: TagVersionStrategy = SEMVER_TAG,
+  val tagVersionStrategy: TagVersionStrategy? = null,
   val captureGroupRegex: String? = null,
-  override val from: ArtifactOriginFilterSpec? = null
+  val branch: String? = null,
+  override val from: ArtifactOriginFilterSpec? =
+    branch?.let { ArtifactOriginFilterSpec(BranchFilterSpec(name = branch)) }
 ) : DeliveryArtifact() {
   init {
     require(name.count { it == '/' } <= 1) {
       "Docker image name has more than one slash, which is not Docker convention. Please convert to `organization/image-name` format."
+    }
+    require(from == null || tagVersionStrategy == null) {
+      "Either `from` or `tagVersionStrategy` must be specified in the delivery config for Docker artifacts. Please check the documentation."
     }
   }
 
@@ -40,9 +47,10 @@ data class DockerArtifact(
   override val sortingStrategy: SortingStrategy
     get() = if (filteredByBranch || filteredByPullRequest) {
       CreatedAtSortingStrategy
-    } else {
+    } else if (tagVersionStrategy != null) {
       DockerVersionSortingStrategy(tagVersionStrategy, captureGroupRegex)
-    }
+    } else throw ValidationException(
+      listOf("Unable to determine sorting strategy for $this. You must specify either `tagVersionStrategy` or `from` in your delivery config."))
 
   override fun toString(): String = super.toString()
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifact.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.NPM
@@ -14,7 +14,7 @@ data class NpmArtifact(
   override val deliveryConfigName: String? = null,
   override val reference: String = name,
   override val statuses: Set<ArtifactStatus> = emptySet(),
-  override val from: ArtifactOriginFilterSpec? = null
+  override val from: ArtifactOriginFilter? = null
 ) : DeliveryArtifact() {
   override val type = NPM
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/DockerArtifactExportError.kt
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.keel.exceptions
 
 import com.netflix.spinnaker.kork.exceptions.UserException
 
-class DockerArtifactExportError(tags: List<String>, container: String) :
+class DockerArtifactExportError(tag: String, container: String) :
   UserException(
-    "Unable to determine tag strategy for docker images with tags ${tags.joinToString()} from container ($container), please supply a custom regex " +
+    "Unable to determine tag strategy for docker images with tag $tag from container ($container), please supply a custom regex " +
       "(see https://www.spinnaker.io/guides/user/managed-delivery/artifacts/#advanced-configuration for more information)"
   )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/DeliveryArtifactMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/DeliveryArtifactMixin.kt
@@ -1,8 +1,11 @@
 package com.netflix.spinnaker.keel.jackson.mixins
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonProperty.Access.WRITE_ONLY
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
 
 internal interface DeliveryArtifactMixin {
@@ -20,4 +23,7 @@ internal interface DeliveryArtifactMixin {
 
   @get:JsonIgnore
   val filteredByReleaseStatus: Boolean
+
+  @get:JsonInclude(NON_EMPTY)
+  val statuses: Set<ArtifactStatus>
 }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/CheckSchedulerTests.kt
@@ -78,7 +78,8 @@ internal object CheckSchedulerTests : JUnit5Minutests {
       )
     ),
     DockerArtifact(
-      name = "fnord-but-like-in-a-container"
+      name = "fnord-but-like-in-a-container",
+      branch = "main"
     )
   )
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/CreatedAtSortingStrategyTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/artifacts/CreatedAtSortingStrategyTests.kt
@@ -1,7 +1,7 @@
 package com.netflix.spinnaker.keel.artifacts
 
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
@@ -21,8 +21,8 @@ class CreatedAtSortingStrategyTests : JUnit5Minutests {
       deliveryConfigName = "my-manifest",
       reference = "feature-branch",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
-        branch = BranchFilterSpec(
+      from = ArtifactOriginFilter(
+        branch = BranchFilter(
           name = "my-feature-branch"
         )
       )
@@ -33,7 +33,7 @@ class CreatedAtSortingStrategyTests : JUnit5Minutests {
       deliveryConfigName = "my-manifest",
       reference = "pr",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
-      from = ArtifactOriginFilterSpec(
+      from = ArtifactOriginFilter(
         pullRequestOnly = true
       )
     )

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/ManualJudgementConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/ManualJudgementConstraintEvaluatorTests.kt
@@ -29,7 +29,12 @@ internal class ManualJudgementConstraintEvaluatorTests : JUnit5Minutests {
 
     val configName = "my-config"
     val version = "1.1.1"
-    val artifact = DockerArtifact("fnord", reference = "dockerfnord", deliveryConfigName = configName)
+    val artifact = DockerArtifact(
+      name = "fnord",
+      reference = "dockerfnord",
+      deliveryConfigName = configName,
+      branch = "main"
+    )
 
     val resource: Resource<DummyResourceSpec> = resource()
     val constraint = ManualJudgementConstraint(timeout = Duration.ofHours(1))

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PendingVerificationsConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PendingVerificationsConstraintEvaluatorTests.kt
@@ -23,7 +23,8 @@ internal class PendingVerificationsConstraintEvaluatorTests {
 
   private val artifact = DockerArtifact(
     name = "fnord",
-    reference = "fnord"
+    reference = "fnord",
+    branch = "main"
   )
 
   private val environmentWithNoVerifications = Environment(

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/validators/DeliveryConfigValidatorTests.kt
@@ -22,7 +22,7 @@ import strikt.assertions.isFailure
 internal class DeliveryConfigValidatorTests : JUnit5Minutests {
 
   private val configName = "my-config"
-  val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName)
+  val artifact = DockerArtifact(name = "org/image", deliveryConfigName = configName, branch = "main")
 
   val subject = DeliveryConfigValidator()
 
@@ -99,8 +99,8 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
     context("a delivery config with non-unique artifact references errors fails validation") {
       // Two different artifacts with the same reference
       val artifacts = setOf(
-        DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing"),
-        DockerArtifact(name = "org/thing-2", deliveryConfigName = configName, reference = "thing")
+        DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing", branch = "main"),
+        DockerArtifact(name = "org/thing-2", deliveryConfigName = configName, reference = "thing", branch = "main")
       )
 
       val submittedConfig = SubmittedDeliveryConfig(
@@ -135,7 +135,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
         name = configName,
         application = "keel",
         serviceAccount = "keel@spinnaker",
-        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing", branch = "main")),
         environments = setOf(
           SubmittedEnvironment(
             name = "test",
@@ -164,7 +164,7 @@ internal class DeliveryConfigValidatorTests : JUnit5Minutests {
         name = configName,
         application = "keel",
         serviceAccount = "keel@spinnaker",
-        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing")),
+        artifacts = setOf(DockerArtifact(name = "org/thing-1", deliveryConfigName = configName, reference = "thing", branch = "main")),
         environments = setOf(
           SubmittedEnvironment(
             name = "test",

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -67,7 +67,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(name = "test")
@@ -92,7 +92,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(
@@ -126,7 +126,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(
@@ -159,7 +159,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(
@@ -195,7 +195,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(
@@ -240,7 +240,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(
@@ -287,7 +287,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(
@@ -344,7 +344,7 @@ internal class VerificationRunnerTests {
         name = "fnord-manifest",
         serviceAccount = "jamm@illuminati.org",
         artifacts = setOf(
-          DockerArtifact(name = "fnord", reference = "fnord-docker")
+          DockerArtifact(name = "fnord", reference = "fnord-docker", branch = "main")
         ),
         environments = setOf(
           Environment(

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
   implementation(project(":keel-orca"))
   implementation(project(":keel-retrofit"))
   implementation(project(":keel-artifact"))
+  implementation(project(":keel-igor"))
   implementation("com.netflix.spinnaker.kork:kork-core")
   implementation("com.netflix.spinnaker.kork:kork-web")
   implementation("org.springframework:spring-context")

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -31,7 +31,6 @@ import com.netflix.spinnaker.keel.ec2.resource.BlockDeviceConfig
 import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
-import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
 import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/config/EC2Config.kt
@@ -31,6 +31,8 @@ import com.netflix.spinnaker.keel.ec2.resource.BlockDeviceConfig
 import com.netflix.spinnaker.keel.ec2.resource.ClassicLoadBalancerHandler
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.SecurityGroupHandler
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -54,7 +56,8 @@ class EC2Config {
     normalizers: List<Resolver<*>>,
     eventPublisher: EventPublisher,
     clusterExportHelper: ClusterExportHelper,
-    blockDeviceConfig : BlockDeviceConfig
+    blockDeviceConfig : BlockDeviceConfig,
+    artifactService: ArtifactService
   ): ClusterHandler =
     ClusterHandler(
       cloudDriverService,
@@ -65,7 +68,8 @@ class EC2Config {
       eventPublisher,
       normalizers,
       clusterExportHelper,
-      blockDeviceConfig
+      blockDeviceConfig,
+      artifactService
     )
 
   @Bean

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -11,7 +11,10 @@ import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.UNKNOWN
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
@@ -46,6 +49,7 @@ import com.netflix.spinnaker.keel.api.plugins.CurrentImages
 import com.netflix.spinnaker.keel.api.plugins.ImageInRegion
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.api.support.Tag
 import com.netflix.spinnaker.keel.api.withDefaultsOmitted
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
@@ -57,7 +61,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.MetricDimensionModel
 import com.netflix.spinnaker.keel.clouddriver.model.PredefinedMetricSpecificationModel
 import com.netflix.spinnaker.keel.clouddriver.model.ScalingPolicy
 import com.netflix.spinnaker.keel.clouddriver.model.StepAdjustmentModel
-import com.netflix.spinnaker.keel.api.support.Tag
 import com.netflix.spinnaker.keel.clouddriver.model.subnet
 import com.netflix.spinnaker.keel.core.orcaClusterMoniker
 import com.netflix.spinnaker.keel.core.parseMoniker
@@ -68,6 +71,7 @@ import com.netflix.spinnaker.keel.ec2.toEc2Api
 import com.netflix.spinnaker.keel.events.ResourceHealthEvent
 import com.netflix.spinnaker.keel.exceptions.ActiveServerGroupsException
 import com.netflix.spinnaker.keel.exceptions.ExportError
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.dependsOn
@@ -91,6 +95,9 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import com.netflix.spinnaker.keel.clouddriver.model.ServerGroup as ClouddriverServerGroup
 
+/**
+ * [ResourceHandler] implementation for EC2 clusters, represented by [ClusterSpec].
+ */
 class ClusterHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
@@ -100,7 +107,8 @@ class ClusterHandler(
   override val eventPublisher: EventPublisher,
   resolvers: List<Resolver<*>>,
   private val clusterExportHelper: ClusterExportHelper,
-  private val blockDeviceConfig: BlockDeviceConfig
+  private val blockDeviceConfig: BlockDeviceConfig,
+  private val artifactService: ArtifactService,
 ) : BaseClusterHandler<ClusterSpec, ServerGroup>(resolvers) {
 
   private val debianArtifactParser = DebianArtifactParser()
@@ -483,25 +491,50 @@ class ClusterHandler(
     }
 
     // TODO: Frigga and Rocket version parsing are not aligned. We should consolidate.
-    val artifactName = checkNotNull(base.launchConfiguration.appVersion).parseAppVersion().packageName
-
-    val status = debianArtifactParser.parseStatus(base.launchConfiguration.appVersion?.substringAfter("$artifactName-"))
-    if (status == UNKNOWN) {
-      throw ExportError("Unable to determine release status from appVersion ${base.launchConfiguration.appVersion}, you'll have to configure this artifact manually.")
+    val appVersion = checkNotNull(base.launchConfiguration.appVersion).parseAppVersion()
+    val artifactName = appVersion.packageName
+    val artifactVersion = base.launchConfiguration.appVersion!!.removePrefix("${artifactName}-")
+    val artifact = try {
+      artifactService.getArtifact(artifactName, artifactVersion, DEBIAN)
+    } catch (e: HttpException) {
+      if (e.isNotFound) null else throw e
     }
 
-    return DebianArtifact(
-      name = artifactName,
-      vmOptions = VirtualMachineOptions(regions = serverGroups.keys, baseOs = guessBaseOsFrom(base.image)),
-      statuses = setOf(status)
-    )
+    // prefer branch-based artifact spec, fallback to release statuses
+    if (artifact?.branch != null) {
+      log.debug("Found branch name '{}' for artifact {}:{} from metadata. Returning source-driven artifact.",
+        artifact.branch, artifactName, artifactVersion)
+
+      return DebianArtifact(
+        name = artifactName,
+        vmOptions = VirtualMachineOptions(regions = serverGroups.keys, baseOs = guessBaseOsFrom(base.image)),
+        from = ArtifactOriginFilterSpec(
+          branch = BranchFilterSpec(name = artifact.branch)
+        )
+      )
+    } else {
+      // fall back to exporting the artifact in the old format if we can't retrieve metadata
+      log.debug("Unable to retrieve branch name for artifact {}:{} from metadata. Returning legacy artifact.",
+        appVersion.packageName, appVersion.version)
+
+      val status = debianArtifactParser.parseStatus(base.launchConfiguration.appVersion?.substringAfter("$artifactName-"))
+      if (status == UNKNOWN) {
+        throw ExportError("Unable to determine release status from appVersion ${base.launchConfiguration.appVersion}, you'll have to configure this artifact manually.")
+      }
+
+      return DebianArtifact(
+        name = artifactName,
+        vmOptions = VirtualMachineOptions(regions = serverGroups.keys, baseOs = guessBaseOsFrom(base.image)),
+        statuses = setOf(status)
+      )
+    }
   }
 
   /**
    * This function attempts to use image description to guess what OS the image is.
    * If not found, it will throw an error.
    */
-  fun guessBaseOsFrom(image: ActiveServerGroupImage?): String =
+  private fun guessBaseOsFrom(image: ActiveServerGroupImage?): String =
     parseBaseOsFrom(image?.description)
       ?: throw ExportError("Unable to determine the base image from image description: $image")
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -11,9 +11,7 @@ import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.UNKNOWN
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
@@ -508,9 +506,7 @@ class ClusterHandler(
       return DebianArtifact(
         name = artifactName,
         vmOptions = VirtualMachineOptions(regions = serverGroups.keys, baseOs = guessBaseOsFrom(base.image)),
-        from = ArtifactOriginFilterSpec(
-          branch = BranchFilterSpec(name = artifact.branch)
-        )
+        branch = artifact.branch
       )
     } else {
       // fall back to exporting the artifact in the old format if we can't retrieve metadata

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -7,7 +7,11 @@ import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.Capacity
@@ -36,17 +40,18 @@ import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.ec2.resource.BlockDeviceConfig
 import com.netflix.spinnaker.keel.ec2.resource.ClusterHandler
 import com.netflix.spinnaker.keel.ec2.resource.toCloudDriverResponse
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.retrofit.RETROFIT_NOT_FOUND
 import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.clearAllMocks
-import io.mockk.coEvery
-import io.mockk.every
+import io.mockk.coEvery as every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expect
@@ -82,6 +87,7 @@ internal class ClusterExportTests : JUnit5Minutests {
   )
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
   val blockDeviceConfig = mockk<BlockDeviceConfig>()
+  val artifactService = mockk<ArtifactService>()
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
   val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
@@ -193,7 +199,8 @@ internal class ClusterExportTests : JUnit5Minutests {
         publisher,
         normalizers,
         clusterExportHelper,
-        blockDeviceConfig
+        blockDeviceConfig,
+        artifactService
       )
     }
 
@@ -226,13 +233,13 @@ internal class ClusterExportTests : JUnit5Minutests {
           setOf(subnet1East.availabilityZone)
       }
 
-      coEvery { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
+      every { orcaService.orchestrate(resource.serviceAccount, any()) } returns TaskRefResponse("/tasks/${UUID.randomUUID()}")
       every { repository.environmentFor(any()) } returns Environment("test")
-      coEvery {
+      every {
         clusterExportHelper.discoverDeploymentStrategy("aws", "test", "keel", any())
       } returns RedBlack()
 
-      coEvery {
+      every {
         springEnv.getProperty("keel.notifications.slack", Boolean::class.java, true)
       } returns false
     }
@@ -242,27 +249,78 @@ internal class ClusterExportTests : JUnit5Minutests {
     }
 
     context("exporting an artifact from a cluster") {
-      before {
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
-      }
-
-      test("deb is exported correctly") {
-        val artifact = runBlocking {
-          exportArtifact(exportable.copy(regions = setOf("us-east-1")))
+      context("with branch metadata available") {
+        before {
+          every { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+          every {
+            artifactService.getArtifact("keel", any(), DEBIAN)
+          } returns PublishedArtifact(
+            name = "keel",
+            reference = "keel",
+            type = DEBIAN,
+            version = "0.0.1",
+            metadata = mapOf("branch" to "main")
+          )
         }
 
-        expectThat(artifact) {
-          get { name }.isEqualTo("keel")
-          isA<DebianArtifact>()
-            .and { get { vmOptions }.isEqualTo(VirtualMachineOptions(regions = setOf("us-east-1"), baseOs = "bionic-classic")) }
-            .and { get { statuses }.isEqualTo(setOf(RELEASE)) }
+        test("deb is exported correctly and includes `from` spec with branch") {
+          val artifact = runBlocking {
+            exportArtifact(exportable.copy(regions = setOf("us-east-1")))
+          }
+
+          expectThat(artifact) {
+            get { name }.isEqualTo("keel")
+            isA<DebianArtifact>()
+              .and {
+                get { vmOptions }.isEqualTo(
+                  VirtualMachineOptions(
+                    regions = setOf("us-east-1"),
+                    baseOs = "bionic-classic"
+                  )
+                )
+              }
+              .and {
+                get { from }.isEqualTo(ArtifactOriginFilterSpec(branch = BranchFilterSpec(name = "main")))
+                get { statuses }.isEmpty()
+              }
+          }
+        }
+      }
+
+      context("with branch metadata unavailable") {
+        before {
+          every { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+          every {
+            artifactService.getArtifact("keel", any(), DEBIAN)
+          } throws RETROFIT_NOT_FOUND
+        }
+
+        test("deb is exported correctly") {
+          val artifact = runBlocking {
+            exportArtifact(exportable.copy(regions = setOf("us-east-1")))
+          }
+
+          expectThat(artifact) {
+            get { name }.isEqualTo("keel")
+            isA<DebianArtifact>()
+              .and {
+                get { vmOptions }.isEqualTo(
+                  VirtualMachineOptions(
+                    regions = setOf("us-east-1"),
+                    baseOs = "bionic-classic"
+                  )
+                )
+                get { statuses }.isEqualTo(setOf(RELEASE))
+                get { from }.isNull()
+              }
+          }
         }
       }
     }
 
     context("basic export behavior") {
       before {
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+        every { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
       }
 
       test("deployment strategy defaults are omitted") {
@@ -285,8 +343,8 @@ internal class ClusterExportTests : JUnit5Minutests {
 
     context("exporting same clusters different regions") {
       before {
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+        every { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+        every { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
       }
 
       test("no overrides") {
@@ -306,8 +364,8 @@ internal class ClusterExportTests : JUnit5Minutests {
 
     context("exporting clusters with capacity difference between regions") {
       before {
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+        every { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+        every { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
           .withDifferentSize()
       }
 
@@ -327,8 +385,8 @@ internal class ClusterExportTests : JUnit5Minutests {
 
     context("exporting clusters that are significantly different between regions") {
       before {
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
-        coEvery { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
+        every { cloudDriverService.activeServerGroup(any(), "us-east-1") } returns activeServerGroupResponseEast
+        every { cloudDriverService.activeServerGroup(any(), "us-west-2") } returns activeServerGroupResponseWest
           .withNonDefaultHealthProps()
           .withNonDefaultLaunchConfigProps()
       }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -7,9 +7,9 @@ import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
@@ -280,7 +280,7 @@ internal class ClusterExportTests : JUnit5Minutests {
                 )
               }
               .and {
-                get { from }.isEqualTo(ArtifactOriginFilterSpec(branch = BranchFilterSpec(name = "main")))
+                get { from }.isEqualTo(ArtifactOriginFilter(branch = BranchFilter(name = "main")))
                 get { statuses }.isEmpty()
               }
           }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -40,6 +40,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCollection
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.model.OrchestrationRequest
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
@@ -100,6 +101,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
 
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
   val blockDeviceConfig = BlockDeviceConfig(VolumeDefaultConfiguration())
+  val artifactService = mockk<ArtifactService>()
 
   val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
   val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
@@ -205,7 +207,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
         publisher,
         normalizers,
         clusterExportHelper,
-        blockDeviceConfig
+        blockDeviceConfig,
+        artifactService
       )
     }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/Ec2BaseClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/Ec2BaseClusterHandlerTests.kt
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import io.mockk.mockk
@@ -33,6 +34,7 @@ class Ec2BaseClusterHandlerTests : BaseClusterHandlerTests<ClusterSpec, ServerGr
   private val taskLauncher: TaskLauncher = mockk()
   private val clusterExportHelper: ClusterExportHelper = mockk()
   private val blockDeviceConfig : BlockDeviceConfig = mockk()
+  val artifactService = mockk<ArtifactService>()
 
   val metadata = mapOf("id" to "1234", "application" to "waffles", "serviceAccount" to "me@you.com" )
 
@@ -66,7 +68,8 @@ class Ec2BaseClusterHandlerTests : BaseClusterHandlerTests<ClusterSpec, ServerGr
       eventPublisher = eventPublisher,
       resolvers = resolvers,
       clusterExportHelper = clusterExportHelper,
-      blockDeviceConfig = blockDeviceConfig
+      blockDeviceConfig = blockDeviceConfig,
+      artifactService = artifactService
     ))
 
   override fun getRegions(resource: Resource<ClusterSpec>): List<String> =

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
@@ -26,6 +26,7 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCollection
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.ec2.resource.BlockDeviceConfig
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.test.resource
@@ -142,7 +143,7 @@ internal class LaunchConfigTests {
   val cloudDriverCache = mockk<CloudDriverCache>()
   val clusterExportHelper = mockk<ClusterExportHelper>(relaxed = true)
   val blockDeviceConfig = mockk<BlockDeviceConfig>()
-
+  val artifactService = mockk<ArtifactService>()
 
   val clusterHandler = ClusterHandler(
     cloudDriverService,
@@ -153,7 +154,8 @@ internal class LaunchConfigTests {
     mockk(relaxUnitFun = true),
     emptyList<Resolver<ClusterSpec>>(),
     clusterExportHelper,
-    blockDeviceConfig
+    blockDeviceConfig,
+    artifactService
   )
 
   fun setup(ramdiskId : String?, launchInfo: LaunchInfo) {

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildService.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/BuildService.kt
@@ -7,7 +7,7 @@ import retrofit2.http.Query
 interface BuildService {
 
   /**
-   * Retrieves build information by commit id and build number from a ci service.
+   * Retrieves build information by commit id and build number from a CI service.
    *
    * @param projectKey The "project" within the SCM system where the repository exists, which can be a user's personal
    *        area (e.g. "SPKR", "~<username>")

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/ArtifactUtils.kt
@@ -195,9 +195,14 @@ private fun filterDockerVersions(artifact: DockerArtifact, versions: List<Publis
  * Returns true if a docker tag is not a match to the regex produces exactly one capture group on the tag, false otherwise.
  */
 internal fun shouldInclude(tag: String, artifact: DockerArtifact) =
-  try {
-    TagComparator.parseWithRegex(tag, artifact.tagVersionStrategy, artifact.captureGroupRegex) != null
-  } catch (e: InvalidRegexException) {
-    log.warn("Version $tag produced more than one capture group based on artifact $artifact, excluding")
+  if (artifact.tagVersionStrategy == null) {
+    log.warn("Attempt to check Docker tag against unspecified tag version strategy for $artifact. Excluding.")
     false
+  } else {
+    try {
+      TagComparator.parseWithRegex(tag, artifact.tagVersionStrategy!!, artifact.captureGroupRegex) != null
+    } catch (e: InvalidRegexException) {
+      log.warn("Version $tag produced more than one capture group based on artifact $artifact. Excluding.")
+      false
+    }
   }

--- a/keel-sql/src/main/resources/db/changelog/20210305-fix-artifacts.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210305-fix-artifacts.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+  - changeSet:
+      id: remove-tag-strategy-from-branch-based-artifacts
+      author: lpollo
+      changes:
+        - sql:
+            sql: >
+              update delivery_artifact
+              set details = json_remove(details, '$.tagVersionStrategy')
+              where type = 'docker'
+              and details -> '$.from' is not null
+              and details -> '$.tagVersionStrategy' is not null

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -242,3 +242,6 @@ databaseChangeLog:
   - include:
       file: changelog/202010303-baked-images.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210305-fix-artifacts.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlVerificationRepositoryTests.kt
@@ -16,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import org.junit.jupiter.api.AfterEach
 import org.springframework.core.env.Environment
+import java.time.Instant
 
 internal class SqlVerificationRepositoryTests :
   VerificationRepositoryTests<SqlVerificationRepository>() {
@@ -87,7 +88,8 @@ internal class SqlVerificationRepositoryTests :
       PublishedArtifact(
         artifact.name,
         artifact.type,
-        version
+        version,
+        createdAt = Instant.now()
       )
     )
   }

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigDeletionTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/tx/DeliveryConfigDeletionTests.kt
@@ -41,7 +41,8 @@ internal class DeliveryConfigDeletionTests
       DockerArtifact(
         name = "fnord",
         deliveryConfigName = "fnord-manifest",
-        reference = "fnord-docker-img"
+        reference = "fnord-docker-img",
+        branch = "main"
       )
     ),
     environments = setOf("test", "production").map {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -27,6 +27,8 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
@@ -86,6 +88,9 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import com.netflix.spinnaker.keel.clouddriver.model.TitusServerGroup as ClouddriverTitusServerGroup
 
+/**
+ * [ResourceHandler] implementation for Titus clusters, represented by [TitusClusterSpec].
+ */
 class TitusClusterHandler(
   private val cloudDriverService: CloudDriverService,
   private val cloudDriverCache: CloudDriverCache,
@@ -142,7 +147,7 @@ class TitusClusterHandler(
     return unhealthyRegions
   }
 
-  fun isHealthy(serverGroup: TitusServerGroup, resource: Resource<TitusClusterSpec>): Boolean =
+  private fun isHealthy(serverGroup: TitusServerGroup, resource: Resource<TitusClusterSpec>): Boolean =
     serverGroup.instanceCounts?.isHealthy(
       resource.spec.deployWith.health,
       resource.spec.resolveCapacity(serverGroup.location.region)
@@ -283,49 +288,34 @@ class TitusClusterHandler(
       )
     }
 
-    val container = serverGroups.values.maxBy { it.capacity.desired ?: it.capacity.max }?.container
+    val container = serverGroups.values.maxByOrNull { it.capacity.desired ?: it.capacity.max }?.container
       ?: throw ExportError("Unable to locate container from the largest server group: $serverGroups")
 
     val registry = getRegistryForTitusAccount(exportable.account)
 
     val images = cloudDriverService.findDockerImages(
-      account = getRegistryForTitusAccount(exportable.account),
+      account = registry,
       repository = container.repository(),
       user = DEFAULT_SERVICE_ACCOUNT
     )
 
-    val matchingImages = images.filter { it.digest == container.digest }
-    if (matchingImages.isEmpty()) {
-      throw ExportError("Unable to find matching image (searching by digest) in registry ($registry) for $container")
-    }
-    val versionStrategy = guessVersioningStrategy(matchingImages)
-      ?: throw DockerArtifactExportError(matchingImages.map { it.tag }, container.toString())
+    val matchingImage = images.firstOrNull { it.digest == container.digest }
+      ?: throw ExportError("Unable to find matching image (searching by digest) in registry ($registry) for $container")
 
-    return DockerArtifact(
-      name = container.repository(),
-      tagVersionStrategy = versionStrategy
-    )
-  }
-
-  /**
-   * Tries to find a matching versioning strategy from a list of docker tags that correspond to the same digest.
-   */
-  fun guessVersioningStrategy(images: List<DockerImage>): TagVersionStrategy? {
-    val versioningStrategies = mutableSetOf<TagVersionStrategy>()
-
-    images.forEach { image ->
-      val versionStrategy = deriveVersioningStrategy(image.tag)
-      if (versionStrategy != null) {
-        versioningStrategies.add(versionStrategy)
-      }
-    }
-    return when (versioningStrategies.size) {
-      1 -> versioningStrategies.first()
-      0 -> null
-      else -> {
-        log.warn("Multiple versioning strategies apply for image, returning first")
-        versioningStrategies.first()
-      }
+    // prefer branch-based artifact spec, fallback to tag version strategy
+    return if (matchingImage.branch != null) {
+      DockerArtifact(
+        name = container.repository(),
+        from = ArtifactOriginFilterSpec(
+          branch = BranchFilterSpec(name = matchingImage.branch)
+        )
+      )
+    } else {
+      DockerArtifact(
+        name = container.repository(),
+        tagVersionStrategy = deriveVersioningStrategy(matchingImage.tag)
+          ?: throw DockerArtifactExportError(matchingImage.tag, container.toString())
+      )
     }
   }
 

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -27,8 +27,6 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
@@ -56,7 +54,6 @@ import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
-import com.netflix.spinnaker.keel.clouddriver.model.DockerImage
 import com.netflix.spinnaker.keel.clouddriver.model.ServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
@@ -306,9 +303,7 @@ class TitusClusterHandler(
     return if (matchingImage.branch != null) {
       DockerArtifact(
         name = container.repository(),
-        from = ArtifactOriginFilterSpec(
-          branch = BranchFilterSpec(name = matchingImage.branch)
-        )
+        branch = matchingImage.branch
       )
     } else {
       DockerArtifact(

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -6,6 +6,8 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
 import com.netflix.spinnaker.keel.api.ec2.Capacity
@@ -37,6 +39,7 @@ import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import com.netflix.spinnaker.keel.titus.resolve
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
+import groovy.xml.Entity.copy
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.confirmVerified
@@ -137,7 +140,6 @@ internal class TitusClusterExportTests : JUnit5Minutests {
   )
 
   val branchJobShaImages = listOf(
-    image.copy(tag = "latest"),
     image.copy(tag = "master-h10.62bbbd6"),
     image.copy(tag = "master-h11.4e26fbd", digest = "sha:2222")
   )
@@ -145,6 +147,13 @@ internal class TitusClusterExportTests : JUnit5Minutests {
   val weirdImages = listOf(
     image.copy(tag = "blahblah")
   )
+
+  val imageWithLatestTag = listOf(
+    image.copy(tag = "latest")
+  )
+
+  val imagesWithBranchName = branchJobShaImages
+    .map { it.copy(branch = "main") }
 
   fun tests() = rootContext<TitusClusterHandler> {
     fixture {
@@ -239,6 +248,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
               .get { tagVersionStrategy }.isEqualTo(TagVersionStrategy.INCREASING_TAG)
           }
         }
+
         context("tags are branch-job.sha") {
           before {
             coEvery { cloudDriverService.findDockerImages("testregistry", (spec.container as DigestProvider).repository()) } returns branchJobShaImages
@@ -254,6 +264,18 @@ internal class TitusClusterExportTests : JUnit5Minutests {
           }
         }
 
+        context("the only tag available is 'latest'") {
+          before {
+            coEvery { cloudDriverService.findDockerImages("testregistry", (spec.container as DigestProvider).repository()) } returns imageWithLatestTag
+          }
+
+          test("exception is throw") {
+            expectThrows<DockerArtifactExportError> {
+              exportArtifact(exportable)
+            }
+          }
+        }
+
         context("tags are just string garbage") {
           before {
             coEvery { cloudDriverService.findDockerImages("testregistry", (spec.container as DigestProvider).repository()) } returns weirdImages
@@ -263,6 +285,23 @@ internal class TitusClusterExportTests : JUnit5Minutests {
             expectThrows<DockerArtifactExportError> {
               exportArtifact(exportable)
             }
+          }
+        }
+
+        context("images have branch information") {
+          before {
+            coEvery {
+              cloudDriverService.findDockerImages("testregistry", (spec.container as DigestProvider).repository())
+            } returns imagesWithBranchName
+          }
+
+          test("artifact includes `from` spec with corresponding branch") {
+            val artifact = runBlocking {
+              exportArtifact(exportable)
+            }
+            expectThat(artifact)
+              .isA<DockerArtifact>()
+              .get { from }.isEqualTo(ArtifactOriginFilterSpec(branch = BranchFilterSpec(name = "main")))
           }
         }
       }

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -6,8 +6,8 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
-import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilterSpec
-import com.netflix.spinnaker.keel.api.artifacts.BranchFilterSpec
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
+import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.BRANCH_JOB_COMMIT_BY_JOB
 import com.netflix.spinnaker.keel.api.ec2.Capacity
@@ -39,7 +39,6 @@ import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import com.netflix.spinnaker.keel.titus.resolve
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import groovy.xml.Entity.copy
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.confirmVerified
@@ -301,7 +300,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
             }
             expectThat(artifact)
               .isA<DockerArtifact>()
-              .get { from }.isEqualTo(ArtifactOriginFilterSpec(branch = BranchFilterSpec(name = "main")))
+              .get { from }.isEqualTo(ArtifactOriginFilter(branch = BranchFilter(name = "main")))
           }
         }
       }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/VerificationControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/VerificationControllerTests.kt
@@ -56,7 +56,8 @@ internal class VerificationControllerTests
   private val artifact = DockerArtifact(
     name = "fnord",
     deliveryConfigName = "fnord-manifest",
-    reference = "fnord-docker"
+    reference = "fnord-docker",
+    branch = "main"
   )
   private val deliveryConfig = DeliveryConfig(
     application = "fnord",

--- a/keel-web/src/test/resources/examples/titus-cluster-with-test-container.yml
+++ b/keel-web/src/test/resources/examples/titus-cluster-with-test-container.yml
@@ -4,6 +4,9 @@ artifacts:
   - name: rocketskates
     type: docker
     reference: rocketskates
+    from:
+      branch:
+        name: main
 environments:
   - name: test
     locations:


### PR DESCRIPTION
Problem: we're promoting the use of "source-driven artifacts" (i.e. artifacts filtered by branch/PR information), which avoids the need for users to worry about version strings/patterns, however we were lacking support for exporting artifacts in that format, which is useful when migrating existing apps to Managed Delivery.

This PR updates the export code for both EC2 and Titus clusters to look up the artifact information from CloudDriver and Igor, respectively, and generate an artifact with the new format. If we can't find the branch metadata for any reason, the code still falls back to the original behavior, generating artifacts with release statuses for Debian and a tag version strategy for Docker.

I recommend viewing with the "Ignore whitespace" option turned on.