### PR TITLE
veto comment can be longer than 255 characters

### DIFF
--- a/keel-sql/src/main/resources/db/changelog/20210305-embiggen-reason-column.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210305-embiggen-reason-column.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+- changeSet:
+    id: embiggen-reason-column
+    author: fletch
+    changes:
+    - modifyDataType:
+        tableName: environment_artifact_veto
+        columnName: comment
+        newDataType: text

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -245,3 +245,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210305-fix-artifacts.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210305-embiggen-reason-column.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Deck allows any length of comment and users get an error if they enter more than 255 characters.