### PR TITLE
feat(constraints): freeze status of stateless constraints when artifact approved

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatefulConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatefulConstraintEvaluator.kt
@@ -23,7 +23,11 @@ import com.netflix.spinnaker.keel.api.events.ConstraintStateChanged
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 
 /**
- * TODO: Docs.
+ * An abstract constraint evaluator that deals with the logic for stateful constraints.
+ *
+ * The [canPromote] function handles reading state from the repository and saving initial state.
+ * If the state is 'done' (failed or passed) the specific implementations don't get called.
+ * If the state is not 'done', underlying implementations [canPromote] functions get called.
  */
 abstract class StatefulConstraintEvaluator<T : Constraint, A : ConstraintStateAttributes>(
   protected val repository: ConstraintRepository

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatelessConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatelessConstraintEvaluator.kt
@@ -1,0 +1,42 @@
+package com.netflix.spinnaker.keel.api.constraints
+
+import com.netflix.spinnaker.keel.api.Constraint
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
+
+/**
+ * An abstract constraint evaluator that deals with constraints that
+ * don't need to check the database for their status.
+ *
+ * This class should be implemented if a constraint has a user-facing (or api-facing)
+ * summary. This does not apply to implicit constraints.
+ */
+abstract class StatelessConstraintEvaluator<T: Constraint, A : ConstraintStateAttributes>()
+  : ConstraintEvaluator<T>{
+  /**
+   * The type of the metadata saved about the constraint, surfaced here to automatically register it
+   * for serialization
+   */
+  abstract val attributeType: SupportedConstraintAttributesType<A>
+
+  /**
+   * @return a constraint state object that captures the current state of the constraint.
+   * This will be used for stateless constraints to construct and save a summary of the state
+   * when they are passing.
+   *
+   * @param currentStatus the status of the constraint if it has already been evaluated.
+   * If this is null this function should call [canPromote] and get the current status.
+   *
+   * If a summary of the constraint will not be shown to the user (like with an implicit constraint)
+   * this function does not need to be implemented.
+   */
+  open fun generateConstraintState(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment,
+    currentStatus: ConstraintStatus? = null
+  ): ConstraintState? = null
+}

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatelessConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatelessConstraintEvaluator.kt
@@ -32,7 +32,7 @@ abstract class StatelessConstraintEvaluator<T: Constraint, A : ConstraintStateAt
    * If a summary of the constraint will not be shown to the user (like with an implicit constraint)
    * this function does not need to be implemented.
    */
-  open fun generateConstraintState(
+  open fun generateConstraintStateSnapshot(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ConstraintEvaluator.kt
@@ -75,19 +75,4 @@ interface ConstraintEvaluator<T : Constraint> : SpinnakerExtensionPoint {
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment
   ): Boolean
-
-  /**
-   * @return a constraint state object that captures the current state of the constraint.
-   * This will be used for stateless constraints to construct and save a summary of the state
-   * when they are passing.
-   *
-   * If a summary of the constraint will not be shown to the user (like with an implicit constraint)
-   * this function does not need to be implemented.
-   */
-  fun generateConstraintState(
-    artifact: DeliveryArtifact,
-    version: String,
-    deliveryConfig: DeliveryConfig,
-    targetEnvironment: Environment
-  ): ConstraintState? = null
 }

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ConstraintEvaluator.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.keel.api.Constraint
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.kork.plugins.api.internal.SpinnakerExtensionPoint
@@ -60,13 +61,13 @@ interface ConstraintEvaluator<T : Constraint> : SpinnakerExtensionPoint {
   val eventPublisher: EventPublisher
 
   /**
-   * returns true if a constraint should be run for every environment in every delivery config, without being
+   * @return true if a constraint should be run for every environment in every delivery config, without being
    * exposed to delivery config author.
    */
   fun isImplicit(): Boolean = false
 
   /**
-   * TODO: Docs
+   * @return true if the constraint passes, false otherwise.
    */
   fun canPromote(
     artifact: DeliveryArtifact,
@@ -74,4 +75,19 @@ interface ConstraintEvaluator<T : Constraint> : SpinnakerExtensionPoint {
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment
   ): Boolean
+
+  /**
+   * @return a constraint state object that captures the current state of the constraint.
+   * This will be used for stateless constraints to construct and save a summary of the state
+   * when they are passing.
+   *
+   * If a summary of the constraint will not be shown to the user (like with an implicit constraint)
+   * this function does not need to be implemented.
+   */
+  fun generateConstraintState(
+    artifact: DeliveryArtifact,
+    version: String,
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: Environment
+  ): ConstraintState? = null
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
@@ -8,7 +8,6 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
-import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
 import com.netflix.spinnaker.keel.api.constraints.StatelessConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
@@ -185,7 +184,7 @@ class EnvironmentConstraintRunner(
     }
   }
 
-  fun generateStatelessConstraintState(
+  fun getStatelessConstraintSnapshots(
     artifact: DeliveryArtifact,
     deliveryConfig: DeliveryConfig,
     version: String,
@@ -195,7 +194,7 @@ class EnvironmentConstraintRunner(
     environment.constraints.mapNotNull { constraint ->
       constraint
         .findStatelessEvaluator()
-        ?.generateConstraintState(
+        ?.generateConstraintStateSnapshot(
           artifact = artifact,
           deliveryConfig = deliveryConfig,
           version = version,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentConstraintRunner.kt
@@ -8,7 +8,9 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.api.constraints.StatefulConstraintEvaluator
+import com.netflix.spinnaker.keel.api.constraints.StatelessConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import org.slf4j.LoggerFactory
@@ -187,7 +189,8 @@ class EnvironmentConstraintRunner(
     artifact: DeliveryArtifact,
     deliveryConfig: DeliveryConfig,
     version: String,
-    environment: Environment
+    environment: Environment,
+    currentStatus: ConstraintStatus?
   ): List<ConstraintState> =
     environment.constraints.mapNotNull { constraint ->
       constraint
@@ -196,7 +199,8 @@ class EnvironmentConstraintRunner(
           artifact = artifact,
           deliveryConfig = deliveryConfig,
           version = version,
-          targetEnvironment = environment
+          targetEnvironment = environment,
+          currentStatus = currentStatus
         )
     }
 
@@ -254,6 +258,6 @@ class EnvironmentConstraintRunner(
   private fun Environment.hasSupportedConstraint(constraintEvaluator: ConstraintEvaluator<*>) =
     constraints.any { it.javaClass.isAssignableFrom(constraintEvaluator.supportedType.type) }
 
-  private fun Constraint.findStatelessEvaluator(): ConstraintEvaluator<*>? =
-    statelessEvaluators.firstOrNull { javaClass.isAssignableFrom(it.supportedType.type) }
+  private fun Constraint.findStatelessEvaluator(): StatelessConstraintEvaluator<*,*>? =
+    statelessEvaluators.filterIsInstance<StatelessConstraintEvaluator<*, *>>().firstOrNull { javaClass.isAssignableFrom(it.supportedType.type) }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -62,7 +62,7 @@ class EnvironmentPromotionChecker(
                 if (pinnedEnvs.hasPinFor(environment.name, artifact)) {
                   val pinnedVersion = pinnedEnvs.versionFor(environment.name, artifact)
                   // approve version first to fast track deployment
-                  approveVersion(deliveryConfig, artifact, pinnedVersion!!, environment.name)
+                  approveVersion(deliveryConfig, artifact, pinnedVersion!!, environment)
                   // then evaluate constraints
                   constraintRunner.checkEnvironment(envContext)
                 } else {
@@ -89,7 +89,7 @@ class EnvironmentPromotionChecker(
                           "and being evaluated for stateless constraints in environment ${environment.name}"
                       )
                       if (constraintRunner.checkStatelessConstraints(artifact, deliveryConfig, artifactVersion.version, environment)) {
-                        approveVersion(deliveryConfig, artifact, artifactVersion.version, environment.name)
+                        approveVersion(deliveryConfig, artifact, artifactVersion.version, environment)
                         repository.deleteArtifactVersionQueuedForApproval(
                           deliveryConfig.name, environment.name, artifact, artifactVersion.version)
                       } else {
@@ -124,11 +124,11 @@ class EnvironmentPromotionChecker(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
     version: String,
-    targetEnvironment: String
+    targetEnvironment: Environment
   ) {
-    log.debug("Approving version $version of ${artifact.type} artifact ${artifact.name} in environment $targetEnvironment")
+    log.debug("Approving version $version of ${artifact.type} artifact ${artifact.name} in environment ${targetEnvironment.name}")
     val isNewVersion = repository
-      .approveVersionFor(deliveryConfig, artifact, version, targetEnvironment)
+      .approveVersionFor(deliveryConfig, artifact, version, targetEnvironment.name)
     if (isNewVersion) {
       log.info(
         "Approved {} {} version {} for {} environment {} in {}",
@@ -136,7 +136,7 @@ class EnvironmentPromotionChecker(
         artifact.type,
         version,
         deliveryConfig.name,
-        targetEnvironment,
+        targetEnvironment.name,
         deliveryConfig.application
       )
 
@@ -144,16 +144,49 @@ class EnvironmentPromotionChecker(
         ArtifactVersionApproved(
           deliveryConfig.application,
           deliveryConfig.name,
-          targetEnvironment,
+          targetEnvironment.name,
           artifact.name,
           artifact.type,
           version
         )
       )
 
+      // persist the status of stateless constraints because their current value is all we care about
+      freezeStatelessConstraintStatus(deliveryConfig, artifact, version, targetEnvironment)
+
       // recheck all resources in an environment, so action can be taken right away
-      repository.triggerResourceRecheck(targetEnvironment, deliveryConfig.application)
+      repository.triggerResourceRecheck(targetEnvironment.name, deliveryConfig.application)
     }
+  }
+
+  /**
+   * Save the passing status of all stateless constraints when a version is approved so that
+   * their status stays the same forever. We don't want them to be evaluated anymore.
+   */
+  private fun freezeStatelessConstraintStatus(
+    deliveryConfig: DeliveryConfig,
+    artifact: DeliveryArtifact,
+    version: String,
+    environment: Environment
+  ) {
+    constraintRunner.generateStatelessConstraintState(
+      artifact = artifact,
+      deliveryConfig = deliveryConfig,
+      version = version,
+      environment = environment
+    ).forEach { constraintState ->
+      log.debug("Storing final constraint state for {} constraint for artifact {} {} version {} for {} environment {} in {}",
+        constraintState.type,
+        artifact.name,
+        artifact.type,
+        version,
+        deliveryConfig.name,
+        environment.name,
+        deliveryConfig.application
+      )
+      repository.storeConstraintState(constraintState)
+    }
+
   }
 
   private fun Map<String, PinnedEnvironment>.hasPinFor(

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionChecker.kt
@@ -169,14 +169,14 @@ class EnvironmentPromotionChecker(
     version: String,
     environment: Environment
   ) {
-    constraintRunner.generateStatelessConstraintState(
+    constraintRunner.getStatelessConstraintSnapshots(
       artifact = artifact,
       deliveryConfig = deliveryConfig,
       version = version,
       environment = environment,
       currentStatus = PASS // We just checked that all these pass since a version was approved
     ).forEach { constraintState ->
-      log.debug("Storing final constraint state for {} constraint for {} version {} for {} environment {} in {}",
+      log.debug("Storing final constraint state snapshot for {} constraint for {} version {} for {} environment {} in {}",
         constraintState.type,
         artifact,
         version,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintAttributes.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintAttributes.kt
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStateAttributes
+import com.netflix.spinnaker.keel.core.api.TimeWindowNumeric
+
+data class AllowedTimesConstraintAttributes(
+  val allowedTimes: List<TimeWindowNumeric>,
+  val timezone: String? = null
+) : ConstraintStateAttributes("allowed-times")
+

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintAttributes.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintAttributes.kt
@@ -5,6 +5,6 @@ import com.netflix.spinnaker.keel.core.api.TimeWindowNumeric
 
 data class AllowedTimesConstraintAttributes(
   val allowedTimes: List<TimeWindowNumeric>,
-  val timezone: String? = null
+  val timezone: String? = null,
+  val currentlyPassing: Boolean = true
 ) : ConstraintStateAttributes("allowed-times")
-

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
@@ -4,9 +4,12 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
+import com.netflix.spinnaker.keel.api.constraints.StatelessConstraintEvaluator
+import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintAttributesType
 import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
-import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator.Companion.getConstraintForEnvironment
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
@@ -51,7 +54,9 @@ class AllowedTimesConstraintEvaluator(
   private val clock: Clock,
   private val dynamicConfigService: DynamicConfigService,
   override val eventPublisher: EventPublisher
-) : ConstraintEvaluator<TimeWindowConstraint> {
+) : StatelessConstraintEvaluator<TimeWindowConstraint, AllowedTimesConstraintAttributes>() {
+  override val attributeType = SupportedConstraintAttributesType<AllowedTimesConstraintAttributes>("allowed-times")
+
   companion object {
     const val CONSTRAINT_NAME = "allowed-times"
 
@@ -260,10 +265,17 @@ class AllowedTimesConstraintEvaluator(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,
-    targetEnvironment: Environment
+    targetEnvironment: Environment,
+    currentStatus: ConstraintStatus?
   ): ConstraintState {
     val constraint = getConstraintForEnvironment(deliveryConfig, targetEnvironment.name, supportedType.type)
 
+    val status = currentStatus
+      ?: if (canPromote(artifact, version, deliveryConfig, targetEnvironment)) {
+        PASS
+      } else {
+        FAIL
+      }
     val tz: String = constraint.tz ?: dynamicConfigService.getConfig(String::class.java, "default.time-zone", "America/Los_Angeles")
 
     return ConstraintState(
@@ -272,7 +284,7 @@ class AllowedTimesConstraintEvaluator(
       artifactVersion = version,
       artifactReference = artifact.reference,
       type = CONSTRAINT_NAME,
-      status = PASS,
+      status = status,
       attributes = AllowedTimesConstraintAttributes(
         toNumericTimeWindows(constraint),
         tz

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
@@ -261,7 +261,7 @@ class AllowedTimesConstraintEvaluator(
     return false
   }
 
-  override fun generateConstraintState(
+  override fun generateConstraintStateSnapshot(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintAttributes.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintAttributes.kt
@@ -3,5 +3,6 @@ package com.netflix.spinnaker.keel.constraints
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStateAttributes
 
 data class DependsOnConstraintAttributes(
-  val dependsOnEnvironment: String
+  val dependsOnEnvironment: String,
+  val currentlyPassing: Boolean = true
 ) : ConstraintStateAttributes("depends-on")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintAttributes.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintAttributes.kt
@@ -1,0 +1,7 @@
+package com.netflix.spinnaker.keel.constraints
+
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStateAttributes
+
+data class DependsOnConstraintAttributes(
+  val dependsOnEnvironment: String
+) : ConstraintStateAttributes("depends-on")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
@@ -4,14 +4,16 @@ import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.FAIL
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.NOT_EVALUATED
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_FAIL
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.OVERRIDE_PASS
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PENDING
+import com.netflix.spinnaker.keel.api.constraints.StatelessConstraintEvaluator
+import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintAttributesType
 import com.netflix.spinnaker.keel.api.constraints.SupportedConstraintType
-import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator.Companion.getConstraintForEnvironment
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
@@ -28,12 +30,12 @@ class DependsOnConstraintEvaluator(
   private val verificationRepository: VerificationRepository,
   override val eventPublisher: EventPublisher,
   private val clock: Clock
-) : ConstraintEvaluator<DependsOnConstraint> {
+) : StatelessConstraintEvaluator<DependsOnConstraint, DependsOnConstraintAttributes>() {
   val CONSTRAINT_NAME = "depends-on"
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override val supportedType = SupportedConstraintType<DependsOnConstraint>("depends-on")
-
+  override val attributeType = SupportedConstraintAttributesType<DependsOnConstraintAttributes>("depends-on")
 
   override fun canPromote(
     artifact: DeliveryArtifact,
@@ -66,9 +68,16 @@ class DependsOnConstraintEvaluator(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,
-    targetEnvironment: Environment
+    targetEnvironment: Environment,
+    currentStatus: ConstraintStatus?
   ): ConstraintState {
     val constraint = getConstraintForEnvironment(deliveryConfig, targetEnvironment.name, supportedType.type)
+    val status = currentStatus
+      ?: if (canPromote(artifact, version, deliveryConfig, targetEnvironment)) {
+        PASS
+      } else {
+        FAIL
+      }
 
     return ConstraintState(
       deliveryConfigName = deliveryConfig.name,
@@ -76,7 +85,7 @@ class DependsOnConstraintEvaluator(
       artifactVersion = version,
       artifactReference = artifact.reference,
       type = CONSTRAINT_NAME,
-      status = PASS,
+      status = status,
       attributes = DependsOnConstraintAttributes(
         dependsOnEnvironment = constraint.environment,
       ),

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
@@ -64,7 +64,7 @@ class DependsOnConstraintEvaluator(
     )
   }
 
-  override fun generateConstraintState(
+  override fun generateConstraintStateSnapshot(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ArtifactSummary.kt
@@ -51,8 +51,9 @@ data class ArtifactSummaryInEnvironment(
   val replacedBy: String? = null,
   val pinned: ActionMetadata? = null,
   val vetoed: ActionMetadata? = null,
-  val statefulConstraints: List<StatefulConstraintSummary> = emptyList(),
-  val statelessConstraints: List<StatelessConstraintSummary> = emptyList(),
+  val statefulConstraints: List<StatefulConstraintSummary> = emptyList(), //todo eb: remove in favor of [constraints]
+  val statelessConstraints: List<StatelessConstraintSummary> = emptyList(), //todo eb: remove in favor of [constraints]
+  val constraints: List<StatefulConstraintSummary> = emptyList(),
   val compareLink: String? = null,
   val verifications : List<VerificationSummary> = emptyList()
 )

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -41,7 +41,7 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
     val constraint = TimeWindowConstraint(windows = listOf(TimeWindow(days = "Monday-Sunday", hours = "0-23")))
 
     val environmentConstraintRunner: EnvironmentConstraintRunner = mockk(relaxed = true) {
-      every { generateStatelessConstraintState(any(), any(), any(), any(), PASS) } returns
+      every { getStatelessConstraintSnapshots(any(), any(), any(), any(), PASS) } returns
         listOf(ConstraintState(
           deliveryConfigName = "config",
           environmentName = "env",

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -41,7 +41,7 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
     val constraint = TimeWindowConstraint(windows = listOf(TimeWindow(days = "Monday-Sunday", hours = "0-23")))
 
     val environmentConstraintRunner: EnvironmentConstraintRunner = mockk(relaxed = true) {
-      every { generateStatelessConstraintState(any(), any(), any(), any()) } returns
+      every { generateStatelessConstraintState(any(), any(), any(), any(), PASS) } returns
         listOf(ConstraintState(
           deliveryConfigName = "config",
           environmentName = "env",

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/EnvironmentPromotionCheckerTests.kt
@@ -5,10 +5,16 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.TagVersionStrategy.SEMVER_TAG
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.constraints.AllowedTimesConstraintAttributes
+import com.netflix.spinnaker.keel.constraints.AllowedTimesConstraintEvaluator
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
+import com.netflix.spinnaker.keel.core.api.TimeWindow
+import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.telemetry.ArtifactVersionApproved
 import com.netflix.spinnaker.keel.test.DummyArtifactReferenceResourceSpec
@@ -17,10 +23,13 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
 import strikt.assertions.isSuccess
 
 internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
@@ -29,7 +38,26 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
 
     val publisher = mockk<ApplicationEventPublisher>(relaxUnitFun = true)
 
-    val environmentConstraintRunner: EnvironmentConstraintRunner = mockk(relaxed = true)
+    val constraint = TimeWindowConstraint(windows = listOf(TimeWindow(days = "Monday-Sunday", hours = "0-23")))
+
+    val environmentConstraintRunner: EnvironmentConstraintRunner = mockk(relaxed = true) {
+      every { generateStatelessConstraintState(any(), any(), any(), any()) } returns
+        listOf(ConstraintState(
+          deliveryConfigName = "config",
+          environmentName = "env",
+          artifactVersion = "version",
+          artifactReference = "my-artifact",
+          type = AllowedTimesConstraintEvaluator.CONSTRAINT_NAME,
+          status = PASS,
+          attributes = AllowedTimesConstraintAttributes(
+            AllowedTimesConstraintEvaluator.toNumericTimeWindows(constraint),
+            null
+          ),
+          judgedAt = null,
+          judgedBy = "Spinnaker"
+        ))
+    }
+
     val subject = EnvironmentPromotionChecker(
       repository,
       environmentConstraintRunner,
@@ -58,7 +86,8 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
             artifactReference = dockerArtifact.reference
           )
         )
-      )
+      ),
+      constraints = setOf(constraint)
     )
     val deliveryConfig = DeliveryConfig(
       name = "my-manifest",
@@ -165,7 +194,15 @@ internal class NewEnvironmentPromotionCheckerTests : JUnit5Minutests {
             }
           }
 
-          test("a recheck is triggered for the environemtn") {
+          test("final status of stateless constraints is saved") {
+            val state = slot<ConstraintState>()
+            verify {
+              repository.storeConstraintState(capture(state))
+            }
+            expectThat(state.captured.type).isEqualTo("allowed-times")
+          }
+
+          test("a recheck is triggered for the environment") {
             verify {
               repository.triggerResourceRecheck(environment.name, deliveryConfig.application)
             }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluatorTests.kt
@@ -3,7 +3,6 @@ package com.netflix.spinnaker.keel.constraints
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.TimeWindow
@@ -390,7 +389,7 @@ internal class AllowedTimesConstraintEvaluatorTests : JUnit5Minutests {
         )
       }
       test("can generate status") {
-        val state = subject.generateConstraintState(artifact = artifact, deliveryConfig = manifest, targetEnvironment = environment, version = "me-123")
+        val state = subject.generateConstraintStateSnapshot(artifact = artifact, deliveryConfig = manifest, targetEnvironment = environment, version = "me-123")
         expectThat(state)
           .and { get { type }.isEqualTo("allowed-times") }
           .and { get { status }.isEqualTo(PASS) }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluatorTests.kt
@@ -3,6 +3,8 @@ package com.netflix.spinnaker.keel.constraints
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus.PASS
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.TimeWindow
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
@@ -23,6 +25,7 @@ import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
 import strikt.assertions.isTrue
 
 internal class AllowedTimesConstraintEvaluatorTests : JUnit5Minutests {
@@ -368,6 +371,32 @@ internal class AllowedTimesConstraintEvaluatorTests : JUnit5Minutests {
         }
           .isFailure()
           .isA<IllegalArgumentException>()
+      }
+    }
+
+    context("generating the pass state") {
+      fixture {
+        Fixture(
+          clock = businessHoursClock,
+          constraint = TimeWindowConstraint(
+            windows = listOf(
+              TimeWindow(
+                days = "Monday-Tuesday,Thursday-Friday",
+                hours = "09-16"
+              )
+            ),
+            tz = "America/Los_Angeles"
+          )
+        )
+      }
+      test("can generate status") {
+        val state = subject.generateConstraintState(artifact = artifact, deliveryConfig = manifest, targetEnvironment = environment, version = "me-123")
+        expectThat(state)
+          .and { get { type }.isEqualTo("allowed-times") }
+          .and { get { status }.isEqualTo(PASS) }
+          .and { get { judgedAt }.isNotNull() }
+          .and { get { judgedBy }.isNotNull() }
+          .and { get { attributes }.isNotNull() }
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorTests.kt
@@ -109,7 +109,7 @@ internal class DependsOnConstraintEvaluatorTests : JUnit5Minutests {
 
     context("generating constraint state") {
       test("can get state") {
-        val state = subject.generateConstraintState(artifact = artifact, version = "1.1", deliveryConfig = manifest, targetEnvironment = constrainedEnvironment)
+        val state = subject.generateConstraintStateSnapshot(artifact = artifact, version = "1.1", deliveryConfig = manifest, targetEnvironment = constrainedEnvironment)
         expectThat(state)
           .and { get { type }.isEqualTo("depends-on") }
           .and { get { status }.isEqualTo(ConstraintStatus.PASS) }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorTests.kt
@@ -3,11 +3,13 @@ package com.netflix.spinnaker.keel.constraints
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -16,8 +18,10 @@ import strikt.api.expectCatching
 import strikt.api.expectThat
 import strikt.assertions.contains
 import strikt.assertions.isA
+import strikt.assertions.isEqualTo
 import strikt.assertions.isFailure
 import strikt.assertions.isFalse
+import strikt.assertions.isNotNull
 import strikt.assertions.isTrue
 
 internal class DependsOnConstraintEvaluatorTests : JUnit5Minutests {
@@ -42,10 +46,10 @@ internal class DependsOnConstraintEvaluatorTests : JUnit5Minutests {
     )
 
     val artifactRepository: ArtifactRepository = mockk(relaxUnitFun = true)
-
     val verificationRepository : VerificationRepository = mockk()
+    val clock = MutableClock()
 
-    val subject = DependsOnConstraintEvaluator(artifactRepository, verificationRepository, mockk())
+    val subject = DependsOnConstraintEvaluator(artifactRepository, verificationRepository, mockk(), clock)
   }
 
   fun tests() = rootContext<Fixture> {
@@ -100,6 +104,18 @@ internal class DependsOnConstraintEvaluatorTests : JUnit5Minutests {
       test("promotion is allowed") {
         expectThat(subject.canPromote(artifact, "1.1", manifest, constrainedEnvironment))
           .isTrue()
+      }
+    }
+
+    context("generating constraint state") {
+      test("can get state") {
+        val state = subject.generateConstraintState(artifact = artifact, version = "1.1", deliveryConfig = manifest, targetEnvironment = constrainedEnvironment)
+        expectThat(state)
+          .and { get { type }.isEqualTo("depends-on") }
+          .and { get { status }.isEqualTo(ConstraintStatus.PASS) }
+          .and { get { judgedAt }.isNotNull() }
+          .and { get { judgedBy }.isNotNull() }
+          .and { get { attributes }.isNotNull() }
       }
     }
   }

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorWithVerificationsTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluatorWithVerificationsTests.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.every
@@ -55,10 +56,10 @@ class DependsOnConstraintEvaluatorWithVerificationsTests : JUnit5Minutests {
   }
 
   val artifactRepository: ArtifactRepository = mockk(relaxUnitFun = true)
-
   val verificationRepository: VerificationRepository = mockk()
+  val clock = MutableClock()
 
-  val subject = DependsOnConstraintEvaluator(artifactRepository, verificationRepository, mockk())
+  val subject = DependsOnConstraintEvaluator(artifactRepository, verificationRepository, mockk(), clock)
 
 
   fun tests() = rootContext<Fixture> {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/config/KeelConfigurationFinalizer.kt
@@ -19,6 +19,8 @@ import com.netflix.spinnaker.keel.api.support.ExtensionRegistry
 import com.netflix.spinnaker.keel.api.support.extensionsOf
 import com.netflix.spinnaker.keel.api.support.register
 import com.netflix.spinnaker.keel.bakery.BaseImageCache
+import com.netflix.spinnaker.keel.constraints.AllowedTimesConstraintAttributes
+import com.netflix.spinnaker.keel.constraints.DependsOnConstraintAttributes
 import com.netflix.spinnaker.keel.ec2.jackson.registerEc2Subtypes
 import com.netflix.spinnaker.keel.ec2.jackson.registerKeelEc2ApiModule
 import com.netflix.spinnaker.keel.resources.SpecMigrator
@@ -96,6 +98,9 @@ class KeelConfigurationFinalizer(
         log.info("Registering Constraint Attributes sub-type {}: {}", attributeType.name, attributeType.type.simpleName)
         extensionRegistry.register(attributeType.type, attributeType.name)
       }
+
+    extensionRegistry.register(DependsOnConstraintAttributes::class.java, "depends-on")
+    extensionRegistry.register(AllowedTimesConstraintAttributes::class.java, "allowed-times")
   }
 
   @PostConstruct


### PR DESCRIPTION
**Problem**
Stateless constraint status is always evaluated on the fly. So if you have an `allowed-times` constraint, we will evaluate whether it passes at this exact moment. That's fine when we haven't approved an artifact. But, when we've approved an artifact, that constant evaluation becomes misleading if you were to look at the non-existant UI at a time when the constraint doesn't pass.

**Solution** 
I'm saving the constraint status to the database when an artifact version is approved (`EnvironmentPromotionChecker`). We only approve a version when all constraints pass. So, at that moment we can capture the state of all the stateless constraints and save it.

**Implementation details**
You can think of the constraints like this:
- Stateful constraints need to check database information to decide if they pass or fail.
- Stateless constraints do not need to check the database.

I'm taking advantage of the fact that the two kinds of constraints are evaluated differently. Since stateless constraints don't read from the database while being evaluated it's okay that we save information about the stateless constraint in the database (or "freeze it" as I like to say). This information will only be looked at when we generate the application summary information.

**Gross things that I feel bad about**
I'm sort of misusing the types of constraints. This makes it harder to understand where information is coming from. I feel kinda bad about it. But my thought is that the distinction between the types of constraints is fine at evaluation time, it's just confusing when we generate the data. And we can hide this by fixing the API. Which I'm doing by adding a new list of `constraintSummaries` that duplicates the data of `statefulConstraintSummaries` and `StatelessConstraintSummaries`. We can switch to using that and then I can remove the duplication. This new list uses the data type of the stateful summaries. For stateless constraints, I'm now representing whether they're currently passing by adding a field to the attributes.

Api examples:

```"environments": [
  {
    "name": "testing",
    "state": "pending",
    "statefulConstraints": [
      {
        "type": "manual-judgement",
        "status": "PENDING",
        "startedAt": "2021-03-08T22:25:32.029Z"
      }
    ],
    "statelessConstraints": [
      {
        "type": "allowed-times",
        "currentlyPassing": true,
        "attributes": {
          "windows": [
            {
              "days": [1,2,3,4,5],
              "hours": [9,10,11,12,13,14,15,16]
            }
          ]
        }}],
    "constraints": [
      {
        "type": "allowed-times",
        "status": "PASS",
        "startedAt": "2021-03-08T22:26:02.165Z",
        "judgedBy": "Spinnaker",
        "judgedAt": "2021-03-08T22:26:02.165Z",
        "attributes": {
          "allowedTimes": [
            {
              "days": [1,2,3,4,5],
              "hours": [16,9,10,11,12,13,14,15]
            }
          ],
          "timezone": "America/Los_Angeles",
          "currentlyPassing": true,
          "type": "allowed-times"
        }
      },
      {
        "type": "manual-judgement",
        "status": "OVERRIDE_PASS",
        "startedAt": "2021-03-08T06:25:45.503Z",
        "judgedBy": "emburns@netflix.com",
        "judgedAt": "2021-03-08T22:25:45.498Z"
      }
    ]
  }
]```