### PR TITLE
feat(slack): updating notifications based on user feedback

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackNotificationEvent.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackNotificationEvent.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactPin
+import com.netflix.spinnaker.keel.core.api.PinnedEnvironment
 import com.netflix.spinnaker.keel.core.api.UID
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEventType
 import java.time.Instant
@@ -27,7 +28,8 @@ data class SlackUnpinnedNotification(
   override val time: Instant,
   override val application: String,
   val user: String,
-  val targetEnvironment: String
+  val targetEnvironment: String,
+  val originalPin: PinnedEnvironment
 ) : SlackNotificationEvent(time, application)
 
 data class SlackMarkAsBadNotification(

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -137,9 +137,9 @@ class GitDataGenerator(
         if (buildMetadata != null && gitMetadata != null && gitMetadata!!.commitInfo != null) {
           markdownText("*App:* $application\n" +
             "*Environment:* $env\n\n " +
-            ":arrow_down: *PREVIOUSLY PINNED* :arrow_down:\\n" +
+            ":arrow_down: *PREVIOUSLY PINNED* :arrow_down:\n" +
             "*Version:* <$artifactUrl|#${buildMetadata!!.number}> " +
-            "by @${gitMetadata!!.author}\n " +
+            "by @${gitMetadata!!.author}\n\n" +
             "${gitMetadata!!.commitInfo?.message}")
 
           accessory {

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.slack.handlers
 
 import com.netflix.spinnaker.keel.api.ScmInfo
+import com.netflix.spinnaker.keel.api.artifacts.BuildMetadata
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.artifacts.getScmBaseLink
@@ -74,12 +75,13 @@ class GitDataGenerator(
 
   /**
    * generateCommitInfo will create a slack section blocks, which looks like:
-   * "Version: #36 by @emburns
-      Where:  TESTING
+   * "App: keel
+   *  Version: #36 by @emburns
+      Environment:  TESTING
               Update README.md"
    * Or (if [olderVersion] exists):
    *      "Version: #93 → #94 by @msrc
-          Where: TEST"
+          Environment: TEST"
    */
   fun generateCommitInfo(sectionBlockBuilder: SectionBlockBuilder,
                          application: String,
@@ -94,15 +96,50 @@ class GitDataGenerator(
     }
     var envDetails = ""
     if (env != null) {
-      envDetails +=  "*Where:* $env\n\n "
+      envDetails +=  "*Environment:* $env\n\n "
     }
 
     val artifactUrl = generateArtifactUrl(application, artifact.reference, artifact.version)
     with(sectionBlockBuilder) {
       with(artifact) {
         if (buildMetadata != null && gitMetadata != null && gitMetadata!!.commitInfo != null) {
-          markdownText("*Version:* $details <$artifactUrl|#${buildMetadata!!.number}> " +
+          markdownText("*App:* $application\n" +
+            "*Version:* $details <$artifactUrl|#${buildMetadata!!.number}> " +
             "by @${gitMetadata!!.author}\n " + envDetails +
+            "${gitMetadata!!.commitInfo?.message}")
+
+          accessory {
+            image(imageUrl = imageUrl, altText = altText)
+          }
+        }
+      }
+      return this
+    }
+  }
+
+  /**
+   * generateUnpinCommitInfo will create a slack section blocks, which looks like:
+   * "App: keel
+   *  Environment:  TESTING
+   *  V PREVIOUSLY PINNED V        (V is a down arrow emoji)
+   *  Version: #36 by @emburns
+   *    Update README.md"
+   */
+  fun generateUnpinCommitInfo(sectionBlockBuilder: SectionBlockBuilder,
+                         application: String,
+                         imageUrl: String,
+                         artifact: PublishedArtifact,
+                         altText: String,
+                         env: String): SectionBlockBuilder {
+    val artifactUrl = generateArtifactUrl(application, artifact.reference, artifact.version)
+    with(sectionBlockBuilder) {
+      with(artifact) {
+        if (buildMetadata != null && gitMetadata != null && gitMetadata!!.commitInfo != null) {
+          markdownText("*App:* $application\n" +
+            "*Environment:* $env\n\n " +
+            ":arrow_down: *PREVIOUSLY PINNED* :arrow_down:\\n" +
+            "*Version:* <$artifactUrl|#${buildMetadata!!.number}> " +
+            "by @${gitMetadata!!.author}\n " +
             "${gitMetadata!!.commitInfo?.message}")
 
           accessory {
@@ -117,4 +154,6 @@ class GitDataGenerator(
   fun generateArtifactUrl(application: String, reference: String, version: String) =
     "$spinnakerBaseUrl/#/applications/${application}/environments/${reference}/${version}"
 
+  fun generateBuildNumberLink(application: String, reference: String, version: String, buildMetadata: BuildMetadata) =
+    "<${generateArtifactUrl(application, reference, version)}|#${buildMetadata!!.number}>"
 }

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PausedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PausedNotificationHandler.kt
@@ -42,7 +42,7 @@ class PausedNotificationHandler(
         }
 
         section {
-          markdownText("_This app's deployments must be via <$appUrl/executions|pipelines> until management is resumed_")
+          markdownText("_This app's deployments must be via <$appUrl/executions|pipelines> or tasks until management is resumed_")
           accessory {
             button {
               text("More...")

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PinnedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PinnedNotificationHandler.kt
@@ -26,7 +26,11 @@ class PinnedNotificationHandler(
 
       val env = Strings.toRootUpperCase(pin.targetEnvironment)
       val username = pin.pinnedBy?.let { slackService.getUsernameByEmail(it) }
-      val headerText = "$env is pinned"
+      val buildNumberText = when (pinnedArtifact.buildNumber) {
+        null -> ""
+        else -> "to #${pinnedArtifact.buildNumber}"
+      }
+      val headerText = "$env is pinned${buildNumberText}"
       val imageUrl = "https://raw.githubusercontent.com/spinnaker/spinnaker.github.io/master/assets/images/md_icons/pinned.png"
 
       val blocks = withBlocks {

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PinnedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PinnedNotificationHandler.kt
@@ -28,7 +28,7 @@ class PinnedNotificationHandler(
       val username = pin.pinnedBy?.let { slackService.getUsernameByEmail(it) }
       val buildNumberText = when (pinnedArtifact.buildNumber) {
         null -> ""
-        else -> "to #${pinnedArtifact.buildNumber}"
+        else -> " to #${pinnedArtifact.buildNumber}"
       }
       val headerText = "$env is pinned${buildNumberText}"
       val imageUrl = "https://raw.githubusercontent.com/spinnaker/spinnaker.github.io/master/assets/images/md_icons/pinned.png"

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/UnpinnedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/UnpinnedNotificationHandler.kt
@@ -34,7 +34,7 @@ class UnpinnedNotificationHandler(
 
       val buildNumberText = when (pinnedArtifact?.buildNumber) {
         null -> ""
-        else -> "from #${pinnedArtifact.buildNumber}"
+        else -> " from #${pinnedArtifact.buildNumber}"
       }
       val headerText = "$env was unpinned${buildNumberText}"
       val imageUrl = "https://raw.githubusercontent.com/spinnaker/spinnaker.github.io/master/assets/images/md_icons/unpinned.png"

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/UnpinnedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/UnpinnedNotificationHandler.kt
@@ -28,7 +28,15 @@ class UnpinnedNotificationHandler(
 
       val env = Strings.toRootUpperCase(targetEnvironment)
       val username = slackService.getUsernameByEmail(user)
-      val headerText = "$env was unpinned"
+      val usernameThatPinned: String = if (originalPin.pinnedBy != null ) {
+        slackService.getUsernameByEmail(originalPin.pinnedBy!!)
+      } else originalPin.pinnedBy!!
+
+      val buildNumberText = when (pinnedArtifact?.buildNumber) {
+        null -> ""
+        else -> "from #${pinnedArtifact.buildNumber}"
+      }
+      val headerText = "$env was unpinned${buildNumberText}"
       val imageUrl = "https://raw.githubusercontent.com/spinnaker/spinnaker.github.io/master/assets/images/md_icons/unpinned.png"
 
       val blocks = withBlocks {
@@ -36,15 +44,27 @@ class UnpinnedNotificationHandler(
           text(headerText, emoji = true)
         }
 
+        context {
+          elements {
+            markdownText("$username unpinned on <!date^${time.epochSecond}^{date_num} {time_secs}|fallback-text-include-PST>")
+          }
+        }
+
+        context {
+          elements {
+            markdownText("$usernameThatPinned originally pinned on " +
+              "<!date^${originalPin.pinnedAt!!.epochSecond}^{date_num} {time_secs}|fallback-text-include-PST>" +
+              ": \"${originalPin.comment}\"")
+          }
+        }
+
         section {
-          val olderVersion = "#${pinnedArtifact?.buildMetadata?.number}"
           if (latestArtifact != null) {
-            gitDataGenerator.generateCommitInfo(this,
+            gitDataGenerator.generateUnpinCommitInfo(this,
               application,
               imageUrl,
               latestArtifact,
-              "vetoed",
-              olderVersion,
+              "unpinned",
               env)
           }
         }
@@ -54,12 +74,6 @@ class UnpinnedNotificationHandler(
             gitDataGenerator.generateScmInfo(this, application, latestArtifact)
           }
         }
-        context {
-          elements {
-            markdownText("$username unpinned on <!date^${time.epochSecond}^{date_num} {time_secs}|fallback-text-include-PST>")
-          }
-        }
-
       }
       slackService.sendSlackNotification(channel, blocks, application = application, type = supportedTypes, fallbackText = headerText)
     }


### PR DESCRIPTION
Updating the notifications based on gregs updated designs.

This biggest change is in the unpin notification, where we now show the pin reason and who pinned it. We also don't cross out the commit in the manual judgment after someone has taken action.