### PR TITLE
fix(artifacts): Fix Docker artifact exclusion filter by tag

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/DeliveryArtifact.kt
@@ -80,6 +80,9 @@ abstract class DeliveryArtifact {
   val filteredByPullRequest: Boolean
     get() = from?.pullRequestOnly == true
 
+  val filteredBySource: Boolean
+    get() = filteredByBranch || filteredByPullRequest
+
   val filteredByReleaseStatus: Boolean
     get() = statuses.isNotEmpty()
 

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ApplicationSummaryGenerationTests.kt
@@ -3,8 +3,10 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.RELEASE
+import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.core.api.DependsOnConstraint
 import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
 import com.netflix.spinnaker.time.MutableClock
@@ -32,14 +34,19 @@ abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit
   data class Fixture<T : ArtifactRepository>(
     val subject: T
   ) {
-    val artifact = DebianArtifact(
+    val debianArtifact = DebianArtifact(
       name = "keeldemo",
       deliveryConfigName = "my-manifest",
       reference = "my-artifact",
       vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2")),
       statuses = setOf(RELEASE)
     )
-
+    val dockerArtifact = DockerArtifact(
+      name = "myorg/myapp",
+      deliveryConfigName = "my-manifest",
+      reference = "my-docker-artifact",
+      branch = "main"
+    )
     val environmentA = Environment("aa")
     val environmentB = Environment(
       name = "bb",
@@ -49,19 +56,22 @@ abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit
       name = "my-manifest",
       application = "fnord",
       serviceAccount = "keel@spinnaker",
-      artifacts = setOf(artifact),
+      artifacts = setOf(debianArtifact, dockerArtifact),
       environments = setOf(environmentA, environmentB)
     )
-    val version1 = "keeldemo-1.0.1-h11.1a1a1a1" // release
-    val version2 = "keeldemo-1.0.2-h12.2b2b2b2" // release
+    val debVersion1 = "keeldemo-1.0.1-h11.1a1a1a1" // release
+    val debVersion2 = "keeldemo-1.0.2-h12.2b2b2b2" // release
+    val dockerVersion = "doesn't-really-matter"
   }
 
   open fun Fixture<T>.persist() {
     with(subject) {
-      register(artifact)
-      setOf(version1, version2).forEach {
-        storeArtifactVersion(artifact.toArtifactVersion(it, RELEASE))
+      register(debianArtifact)
+      register(dockerArtifact)
+      setOf(debVersion1, debVersion2).forEach {
+        storeArtifactVersion(debianArtifact.toArtifactVersion(it, RELEASE))
       }
+      storeArtifactVersion(dockerArtifact.toArtifactVersion(dockerVersion))
     }
     persist(manifest)
   }
@@ -82,27 +92,43 @@ abstract class ApplicationSummaryGenerationTests<T : ArtifactRepository> : JUnit
     context("artifact 1 skipped in envA, manual judgement before envB") {
       before {
         // version 1 and 2 are approved in env A
-        subject.approveVersionFor(manifest, artifact, version1, environmentA.name)
-        subject.approveVersionFor(manifest, artifact, version2, environmentA.name)
+        subject.approveVersionFor(manifest, debianArtifact, debVersion1, environmentA.name)
+        subject.approveVersionFor(manifest, debianArtifact, debVersion2, environmentA.name)
         // only version 2 is approved in env B
-        subject.approveVersionFor(manifest, artifact, version2, environmentB.name)
+        subject.approveVersionFor(manifest, debianArtifact, debVersion2, environmentB.name)
         // version 1 has been skipped in env A by version 2
-        subject.markAsSkipped(manifest, artifact, version1, environmentA.name, version2)
+        subject.markAsSkipped(manifest, debianArtifact, debVersion1, environmentA.name, debVersion2)
         // version 2 was successfully deployed to both envs
-        subject.markAsSuccessfullyDeployedTo(manifest, artifact, version2, environmentA.name)
-        subject.markAsSuccessfullyDeployedTo(manifest, artifact, version2, environmentB.name)
+        subject.markAsSuccessfullyDeployedTo(manifest, debianArtifact, debVersion2, environmentA.name)
+        subject.markAsSuccessfullyDeployedTo(manifest, debianArtifact, debVersion2, environmentB.name)
       }
 
       test("skipped versions don't get a pending status in the next env") {
         val envSummaries = subject.getEnvironmentSummaries(manifest).sortedBy { it.name }
         expect {
           that(envSummaries.size).isEqualTo(2)
-          that(envSummaries[0].artifacts.first().versions.current).isEqualTo(version2)
+          that(envSummaries[0].artifacts.first().versions.current).isEqualTo(debVersion2)
           that(envSummaries[0].artifacts.first().versions.pending).isEmpty()
-          that(envSummaries[0].artifacts.first().versions.skipped).containsExactly(version1)
-          that(envSummaries[1].artifacts.first().versions.current).isEqualTo(version2)
+          that(envSummaries[0].artifacts.first().versions.skipped).containsExactly(debVersion1)
+          that(envSummaries[1].artifacts.first().versions.current).isEqualTo(debVersion2)
           that(envSummaries[1].artifacts.first().versions.pending).isEmpty()
-          that(envSummaries[1].artifacts.first().versions.skipped).containsExactly(version1)
+          that(envSummaries[1].artifacts.first().versions.skipped).containsExactly(debVersion1)
+        }
+      }
+    }
+
+    context("version of docker artifact filtered by source is deployed in envA") {
+      before {
+        // version approved in env A
+        subject.approveVersionFor(manifest, dockerArtifact, dockerVersion, environmentA.name)
+        subject.markAsSuccessfullyDeployedTo(manifest, dockerArtifact, dockerVersion, environmentA.name)
+      }
+
+      test("version is found to be CURRENT") {
+        val envSummary = subject.getEnvironmentSummaries(manifest).find { it.name == environmentA.name }
+        expect {
+          val current = envSummary!!.artifacts.find { it.type == DOCKER }!!.versions.current
+          that(current).isEqualTo(dockerVersion)
         }
       }
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DebianArtifact.kt
@@ -25,7 +25,7 @@ data class DebianArtifact(
   override val type = DEBIAN
 
   override val sortingStrategy: SortingStrategy
-    get() = if (filteredByBranch || filteredByPullRequest) {
+    get() = if (filteredBySource) {
       CreatedAtSortingStrategy
     } else {
       DebianVersionSortingStrategy

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifact.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/NpmArtifact.kt
@@ -19,7 +19,7 @@ data class NpmArtifact(
   override val type = NPM
 
   override val sortingStrategy: SortingStrategy
-    get() = if (filteredByBranch || filteredByPullRequest) {
+    get() = if (filteredBySource) {
       CreatedAtSortingStrategy
     } else {
       NpmVersionSortingStrategy

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -1037,7 +1037,7 @@ class SqlArtifactRepository(
           .filter { (artifactVersion, _) ->
             if (artifact is DockerArtifact) {
               // filter out invalid docker tags
-              shouldInclude(artifactVersion.version, artifact)
+              filterDockerTag(artifactVersion.version, artifact)
             } else {
               true
             }


### PR DESCRIPTION
**Problem**
In #1848, I made [a change](https://github.com/spinnaker/keel/pull/1848/files#diff-9f58dc9351553d788680e001e102b4f871451189100572f06de9dc554acab0ebR198-R200) to the `ArtifactUtils.shouldInclude` function to account for the fact that I made `DockerArtifact.tagVersionStrategy` nullable. This function is called when building environment and artifact summaries for the UI to filter out docker tags that don't match the tag version strategy. However, when the artifact is filtered by source (branch, PR), that filter should not apply, but was incorrectly excluding all versions.

**Solution**
This PR fixes the bug in that function and replaces the condition with a more explicit check on `DockerArtifact.filteredBySource`.