### PR TITLE
Sketch of proposed lease approach for preventing concurrent verifications/deployments

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.activation.ApplicationDown
 import com.netflix.spinnaker.keel.activation.ApplicationUp
+import com.netflix.spinnaker.keel.enforcers.EnvironmentCurrentlyBeingActedOn
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.blankMDC
 import com.netflix.spinnaker.keel.persistence.AgentLockRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
@@ -194,6 +195,8 @@ class CheckScheduler(
               } catch (e: TimeoutCancellationException) {
                 log.error("Timed out verifying ${it.version} in ${it.deliveryConfig.application}/${it.environmentName}", e)
                 publisher.publishEvent(VerificationTimedOut(it))
+              } catch (e: EnvironmentCurrentlyBeingActedOn) {
+                log.warn("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is in use", e)
               }
             }
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -189,14 +189,16 @@ class CheckScheduler(
               try {
                 withTimeout(checkTimeout.toMillis()) {
                   launch {
-                    verificationRunner.runVerificationsFor(it)
+                    try {
+                      verificationRunner.runVerificationsFor(it)
+                    } catch (e: EnvironmentCurrentlyBeingActedOn) {
+                      log.warn("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is in use", e)
+                    }
                   }
                 }
               } catch (e: TimeoutCancellationException) {
                 log.error("Timed out verifying ${it.version} in ${it.deliveryConfig.application}/${it.environmentName}", e)
                 publisher.publishEvent(VerificationTimedOut(it))
-              } catch (e: EnvironmentCurrentlyBeingActedOn) {
-                log.warn("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is in use", e)
               }
             }
         }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -95,8 +95,12 @@ class CheckScheduler(
                    */
                   withTimeout(checkTimeout.toMillis()) {
                     launch {
-                      resourceActuator.checkResource(it)
-                      publisher.publishEvent(ResourceCheckCompleted(Duration.between(startTime, clock.instant())))
+                      try {
+                        resourceActuator.checkResource(it)
+                        publisher.publishEvent(ResourceCheckCompleted(Duration.between(startTime, clock.instant())))
+                      } catch (e: EnvironmentCurrentlyBeingActedOn) {
+                        log.warn("Couldn't actuate resource ${it.id} because environment is currently being acted on", e)
+                      }
                     }
                   }
                 } catch (e: TimeoutCancellationException) {
@@ -192,7 +196,7 @@ class CheckScheduler(
                     try {
                       verificationRunner.runVerificationsFor(it)
                     } catch (e: EnvironmentCurrentlyBeingActedOn) {
-                      log.warn("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is in use", e)
+                      log.warn("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is currently being acted on", e)
                     }
                   }
                 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.keel.enforcers
+
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Verification
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
+import org.springframework.stereotype.Component
+
+interface Lease {
+  fun <T> withLease(action: () -> T) : T
+
+}
+
+
+@Component
+class EnvironmentExclusionEnforcer(
+) {
+  /**
+   * This lease takes the simple repository lease as well as checking that
+   */
+  class CompoundLease : Lease {
+    override fun <T> withLease(action: () -> T): T {
+      /**
+       * Take simple lease
+       * Check if it's actually safe
+       */
+      return action.invoke()
+    }
+  }
+
+  fun requestVerificationLease(context: VerificationContext, verification: Verification) : Lease {
+    return CompoundLease()
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
@@ -6,7 +6,11 @@ import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.persistence.EnvironmentLeaseRepository
 import com.netflix.spinnaker.keel.persistence.Lease
 
-class StuffIsHappeningInTheEnvironment(msg: String) : Exception(msg) {
+/**
+ * Exception thrown when it's not safe to take action against the environment because
+ * something is is acting on it
+ */
+class EnvironmentCurrentlyBeingActedOn(msg: String) : Exception(msg) {
 
 }
 
@@ -50,7 +54,7 @@ class EnvironmentExclusionEnforcer(
 
 
   /**
-   * @throws StuffIsHappeningInTheEnvironment if there's an active deployment
+   * @throws EnvironmentCurrentlyBeingActedOn if there's an active deployment
    */
   private fun ensureNoActiveDeployments(environment: Environment) {
     /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
@@ -6,6 +6,7 @@ import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.persistence.ActiveLeaseExists
 import com.netflix.spinnaker.keel.persistence.EnvironmentLeaseRepository
 import com.netflix.spinnaker.keel.persistence.Lease
+import org.springframework.stereotype.Component
 
 /**
  * Exception thrown when it's not safe to take action against the environment because
@@ -15,6 +16,7 @@ class EnvironmentCurrentlyBeingActedOn(message: String, cause: Throwable? = null
   constructor(ex: ActiveLeaseExists) : this("active lease held against the environment", ex)
 }
 
+@Component
 class EnvironmentExclusionEnforcer(
   private val environmentLeaseRepository: EnvironmentLeaseRepository,
   private val keelRepository: KeelReadOnlyRepository

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
@@ -69,6 +69,8 @@ class EnvironmentExclusionEnforcer(
 
   /**
    * take an action and then release the lease.
+   *
+   * Also releases the lease if an exception is thrown
    */
   private fun <T> Lease.withLease(action: () -> T): T =
     try {
@@ -81,6 +83,8 @@ class EnvironmentExclusionEnforcer(
 
   /**
    * take an action and then release the lease, suspend flavor
+   *
+   * Also releases the lease if an exception is thrown
    */
   private suspend fun <T> Lease.withLeaseSuspend(action: suspend () -> T) : T =
     try {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
@@ -18,10 +18,8 @@ class EnvironmentCurrentlyBeingActedOn(message: String, cause: Throwable? = null
 
 @Component
 class EnvironmentExclusionEnforcer(
-  private val environmentLeaseRepository: EnvironmentLeaseRepository,
-  private val keelRepository: KeelReadOnlyRepository
+  private val environmentLeaseRepository: EnvironmentLeaseRepository
 ) {
-
   /**
    * To get a verification lease against an environment, need:
    *
@@ -61,17 +59,17 @@ class EnvironmentExclusionEnforcer(
    */
   private fun ensureNoActiveDeployments(environment: Environment) {
     /**
-     * Use keelRepository to check if deployment is happening in this environment
+     * To be implemented in a future PR.
      */
-    TODO("Not yet implemented")
   }
 
-  private fun ensureNoActiveVerifications(environment: Environment): Boolean {
+  /**
+   * @throws EnvironmentCurrentlyBeingActedOn if there's an active verification
+   */
+  private fun ensureNoActiveVerifications(environment: Environment) {
     /**
-     * Use keelRepository to check if verification is running in this environment
+     * To be implemented in a future PR
      */
-
-    TODO("Not yet implemented")
   }
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcer.kt
@@ -75,8 +75,6 @@ class EnvironmentExclusionEnforcer(
   private fun <T> Lease.withLease(action: () -> T): T =
     try {
       action.invoke()
-    } catch (ex: Exception) {
-      throw ex
     } finally {
       environmentLeaseRepository.release(this)
     }
@@ -89,8 +87,6 @@ class EnvironmentExclusionEnforcer(
   private suspend fun <T> Lease.withLeaseSuspend(action: suspend () -> T) : T =
     try {
       action.invoke()
-    } catch (ex: Exception) {
-      throw ex
     } finally {
       environmentLeaseRepository.release(this)
     }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/EnvironmentLeaseRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/EnvironmentLeaseRepository.kt
@@ -1,0 +1,34 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.Environment
+import java.time.Instant
+
+interface Lease {}
+
+class ActiveLeaseExists(
+  environment: Environment,
+  holder: String,
+  takenAt: Instant
+) : Exception("Active lease exists on ${environment.name}: taken by $holder at $takenAt") {}
+
+
+/**
+ * A repository that allows you to take a lease (expiring lock) on an environment.
+ *
+ */
+interface EnvironmentLeaseRepository {
+
+  /**
+   * Try to take a lease on an environment
+   *
+   * @returns a lease if nobody else has one
+   *
+   * @throws ActiveLeaseExists if someone else has a lease on the environment
+   */
+  fun tryAcquireLease(environment: Environment) : Lease
+
+  /**
+   * Release a held lease
+   */
+  fun release(lease: Lease)
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
@@ -8,6 +8,7 @@ import com.netflix.spinnaker.keel.api.plugins.CurrentImages
 import com.netflix.spinnaker.keel.api.plugins.VerificationEvaluator
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
+import com.netflix.spinnaker.keel.enforcers.EnvironmentExclusionEnforcer
 import com.netflix.spinnaker.keel.telemetry.VerificationCompleted
 import com.netflix.spinnaker.keel.telemetry.VerificationStarted
 import org.slf4j.LoggerFactory
@@ -19,7 +20,8 @@ class VerificationRunner(
   private val verificationRepository: VerificationRepository,
   private val evaluators: List<VerificationEvaluator<*>>,
   private val eventPublisher: ApplicationEventPublisher,
-  private val imageFinder: ImageFinder
+  private val imageFinder: ImageFinder,
+  private val enforcer: EnvironmentExclusionEnforcer
 ) {
   /**
    * Evaluates the state of any currently running verifications and launches the next, against a
@@ -39,7 +41,9 @@ class VerificationRunner(
       }
 
       statuses.firstOutstanding?.let { verification ->
-        start(verification, imageFinder.getImages(context.deliveryConfig, context.environmentName))
+        enforcer.requestVerificationLease(this, verification).withLease {
+          start(verification, imageFinder.getImages(context.deliveryConfig, context.environmentName))
+        }
       } ?: log.debug("Verification complete for environment {} of application {}", environment.name, deliveryConfig.application)
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunner.kt
@@ -41,7 +41,7 @@ class VerificationRunner(
       }
 
       statuses.firstOutstanding?.let { verification ->
-        enforcer.requestVerificationLease(this, verification).withLease {
+        enforcer.withVerificationLease(this) {
           start(verification, imageFinder.getImages(context.deliveryConfig, context.environmentName))
         }
       } ?: log.debug("Verification complete for environment {} of application {}", environment.name, deliveryConfig.application)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -10,12 +10,14 @@ import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
+import com.netflix.spinnaker.keel.enforcers.EnvironmentExclusionEnforcer
 import com.netflix.spinnaker.keel.events.ResourceValid
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.TrivialEnvironmentLeaseRepository
 import com.netflix.spinnaker.keel.persistence.UnhappyVetoRepository
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
 import com.netflix.spinnaker.keel.test.resource
@@ -70,6 +72,8 @@ class IntermittentFailureTests : JUnit5Minutests {
     val clock = MutableClock()
     val vetoRepository = mockk<UnhappyVetoRepository>(relaxUnitFun = true)
 
+    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(TrivialEnvironmentLeaseRepository())
+
     val dynamicConfigService: DynamicConfigService = mockk(relaxUnitFun = true) {
       every {
         // mimicking how a cluster is set up
@@ -99,7 +103,8 @@ class IntermittentFailureTests : JUnit5Minutests {
       vetoEnforcer,
       publisher,
       Clock.systemUTC(),
-      springEnv
+      springEnv,
+      environmentExclusionEnforcer
     )
     val desired = DummyResourceSpec(data = "fnord")
     val current = DummyResourceSpec()

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -17,6 +17,7 @@ import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
 import com.netflix.spinnaker.keel.core.api.PromotionStatus
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.DEPLOYING
 import com.netflix.spinnaker.keel.core.api.randomUID
+import com.netflix.spinnaker.keel.enforcers.EnvironmentExclusionEnforcer
 import com.netflix.spinnaker.keel.events.ResourceActuationLaunched
 import com.netflix.spinnaker.keel.events.ResourceActuationPaused
 import com.netflix.spinnaker.keel.events.ResourceActuationVetoed
@@ -36,6 +37,7 @@ import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.DeliveryConfigRepository
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.ResourceRepository
+import com.netflix.spinnaker.keel.persistence.TrivialEnvironmentLeaseRepository
 import com.netflix.spinnaker.keel.plugin.CannotResolveCurrentState
 import com.netflix.spinnaker.keel.plugin.CannotResolveDesiredState
 import com.netflix.spinnaker.keel.telemetry.ArtifactVersionVetoed
@@ -90,6 +92,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
     val veto = mockk<Veto>()
     val vetoEnforcer = VetoEnforcer(listOf(veto))
     val clock = Clock.systemUTC()
+    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(TrivialEnvironmentLeaseRepository())
     val subject = ResourceActuator(
       resourceRepository,
       artifactRepository,
@@ -100,7 +103,8 @@ internal class ResourceActuatorTests : JUnit5Minutests {
       vetoEnforcer,
       publisher,
       clock,
-      springEnv
+      springEnv,
+      environmentExclusionEnforcer
     )
   }
 

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/TrivialEnvironmentLeaseRepository.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/persistence/TrivialEnvironmentLeaseRepository.kt
@@ -1,0 +1,18 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.Environment
+
+/**
+ * A trivial (no-op) implementation, used to simplify testing
+ */
+class TrivialEnvironmentLeaseRepository : EnvironmentLeaseRepository {
+  class TrivialLease : Lease {}
+
+  override fun tryAcquireLease(environment: Environment): Lease {
+    return TrivialLease()
+  }
+
+  override fun release(lease: Lease) {
+    // nothing to do
+  }
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -15,6 +15,8 @@ import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationState
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.enforcers.EnvironmentExclusionEnforcer
+import com.netflix.spinnaker.keel.persistence.TrivialEnvironmentLeaseRepository
 import com.netflix.spinnaker.keel.telemetry.VerificationCompleted
 import com.netflix.spinnaker.keel.telemetry.VerificationStarted
 import de.huxhorn.sulky.ulid.ULID
@@ -51,11 +53,14 @@ internal class VerificationRunnerTests {
     every { getImages(any(), any()) } returns images
   }
 
+  private val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(TrivialEnvironmentLeaseRepository())
+
   private val subject = VerificationRunner(
     repository,
     listOf(evaluator),
     publisher,
-    imageFinder
+    imageFinder,
+    environmentExclusionEnforcer
   )
 
   @Test

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/config/SqlConfiguration.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.sql.SqlArtifactRepository
 import com.netflix.spinnaker.keel.sql.SqlBakedImageRepository
 import com.netflix.spinnaker.keel.sql.SqlDeliveryConfigRepository
 import com.netflix.spinnaker.keel.sql.SqlDiffFingerprintRepository
+import com.netflix.spinnaker.keel.sql.SqlEnvironmentLeaseRepository
 import com.netflix.spinnaker.keel.sql.SqlLifecycleEventRepository
 import com.netflix.spinnaker.keel.sql.SqlLifecycleMonitorRepository
 import com.netflix.spinnaker.keel.sql.SqlNotificationRepository
@@ -199,4 +200,8 @@ class SqlConfiguration {
     properties: SqlProperties,
     objectMapper: ObjectMapper
   ) = SqlBakedImageRepository(jooq, clock, objectMapper, SqlRetry(sqlRetryProperties))
+
+  @Bean
+  fun environmentLeaseRepository(
+  ) = SqlEnvironmentLeaseRepository()
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlEnvironmentLeaseRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlEnvironmentLeaseRepository.kt
@@ -1,0 +1,19 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.persistence.EnvironmentLeaseRepository
+import com.netflix.spinnaker.keel.persistence.Lease
+
+/**
+ * This code would be implemented by making calls against a new table: environment_lease
+ *
+ */
+class SqlEnvironmentLeaseRepository : EnvironmentLeaseRepository {
+  override fun tryAcquireLease(environment: Environment): Lease {
+    TODO("Not yet implemented")
+  }
+
+  override fun release(lease: Lease) {
+    TODO("Not yet implemented")
+  }
+}


### PR DESCRIPTION
Illustrates how we could use the proposed "environment leases" approach.

There's a low-level (Sql)EnvironmentLeaseRepository that just does the short-term locking on an environment.

There's an EnvironmentExclusionEnforcer which consumes the EnvironmentLeaseRepository and does some additional checking to see if there are active deployments or verifications, depending on why a lease is being taken.