### PR TITLE
feat(slack): hide long commit msgs, show in modal

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ArtifactDeploymentNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ArtifactDeploymentNotificationHandler.kt
@@ -60,6 +60,7 @@ class ArtifactDeploymentNotificationHandler(
             details,
             env)
         }
+        gitDataGenerator.conditionallyAddFullCommitMsgButton(this, artifact)
 
         section {
           gitDataGenerator.generateScmInfo(this, application, artifact)

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/LifecycleEventNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/LifecycleEventNotificationHandler.kt
@@ -42,6 +42,7 @@ class LifecycleEventNotificationHandler(
         section {
           gitDataGenerator.generateCommitInfo(this, application, imageUrl, artifact, "lifecycle")
         }
+        gitDataGenerator.conditionallyAddFullCommitMsgButton(this, artifact)
 
         section {
           gitDataGenerator.generateScmInfo(this, application, artifact)

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
@@ -45,6 +45,7 @@ class ManualJudgmentNotificationHandler(
             "mj_needed",
             env = env)
         }
+        gitDataGenerator.conditionallyAddFullCommitMsgButton(this, artifactCandidate)
 
         section {
           gitDataGenerator.generateScmInfo(this, application, artifactCandidate)

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/MarkAsBadNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/MarkAsBadNotificationHandler.kt
@@ -44,6 +44,7 @@ class MarkAsBadNotificationHandler(
             "vetoed",
             env = env)
         }
+        gitDataGenerator.conditionallyAddFullCommitMsgButton(this, vetoedArtifact)
 
         section {
           gitDataGenerator.generateScmInfo(this, application, vetoedArtifact)

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PinnedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/PinnedNotificationHandler.kt
@@ -49,6 +49,8 @@ class PinnedNotificationHandler(
             env)
         }
 
+        gitDataGenerator.conditionallyAddFullCommitMsgButton(this, pinnedArtifact)
+
         section {
           gitDataGenerator.generateScmInfo(this,
             application,
@@ -64,5 +66,4 @@ class PinnedNotificationHandler(
       slackService.sendSlackNotification(channel, blocks, application = application, type = supportedTypes, fallbackText = headerText)
     }
   }
-
 }

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/UnpinnedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/UnpinnedNotificationHandler.kt
@@ -68,6 +68,9 @@ class UnpinnedNotificationHandler(
               env)
           }
         }
+        if (pinnedArtifact != null) {
+          gitDataGenerator.conditionallyAddFullCommitMsgButton(this, pinnedArtifact)
+        }
 
         section {
           if (latestArtifact != null) {

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/VerificationCompletedNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/VerificationCompletedNotificationHandler.kt
@@ -46,6 +46,7 @@ class VerificationCompletedNotificationHandler(
         section {
           gitDataGenerator.generateCommitInfo(this, application, imageUrl, artifact, "verification")
         }
+        gitDataGenerator.conditionallyAddFullCommitMsgButton(this, artifact)
 
         section {
           gitDataGenerator.generateScmInfo(this, application, artifact)


### PR DESCRIPTION
Large commit messages were driving me crazy. This pr hides characters > 100 (configurable, but I picked 100 for now) behind a little "Show full commit" modal. Will add some photos shortly.

I wish I could make this code a bit nicer, but I could not figure out how to do the correct slack things in one function. So it's two for now. 

Deployd notification and a glimpse of the popup:
![Screen Shot 2021-03-10 at 3 09 36 PM](https://user-images.githubusercontent.com/8454927/110710425-af4aaa80-81b2-11eb-8dc5-dba0ca3891aa.png)
![Screen Shot 2021-03-10 at 3 09 44 PM](https://user-images.githubusercontent.com/8454927/110710427-afe34100-81b2-11eb-8e53-bf504670a340.png)

(there is an "Ok" button and a "close" button because I'm hacking the confirmation dialog page. If anyone knows how to just launch a modal let me know!)

pinned:
![Screen Shot 2021-03-10 at 3 10 50 PM](https://user-images.githubusercontent.com/8454927/110710498-d5704a80-81b2-11eb-86b3-64e955812e02.png)

example of a message that isn't too long:
![Screen Shot 2021-03-10 at 3 11 46 PM](https://user-images.githubusercontent.com/8454927/110710574-f8026380-81b2-11eb-9b06-377afccc939e.png)
