### PR TITLE
use base image name rather than version for diffs

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/BaseImageCache.kt
@@ -10,7 +10,7 @@ interface BaseImageCache {
    * image, if it exists.
    * @throws UnknownBaseImage if there is no known base image for [os] and [label].
    */
-  fun getBaseAmiVersion(os: String, label: BaseLabel): String
+  fun getBaseAmiName(os: String, label: BaseLabel): String
 
   val allVersions: Map<String, Map<String, String>>
 }

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCache.kt
@@ -17,7 +17,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 class DefaultBaseImageCache(
   private val baseImages: Map<String, Map<String, String>>
 ) : BaseImageCache {
-  override fun getBaseAmiVersion(os: String, label: BaseLabel) =
+  override fun getBaseAmiName(os: String, label: BaseLabel) =
     baseImages[os]?.get(label.name.toLowerCase()) ?: throw UnknownBaseImage(os, label)
 
   override val allVersions: Map<String, Map<String, String>>

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -117,7 +117,7 @@ class BakeryLifecycleMonitor(
         vmType = detail.vmType,
         cloudProvider = detail.cloudProviderType,
         appVersion = detail.`package`.substringBefore("_all.deb").replaceFirst("_", "-"),
-        baseAmiVersion = imageService.findBaseAmiVersion(detail.baseAmiId, detail.region),
+        baseAmiName = imageService.findBaseAmiName(detail.baseAmiId, detail.region),
         timestamp = execution.endTime ?: clock.instant(),
         amiIdsByRegion = details.associate { regionDetail -> regionDetail.region to regionDetail.imageId }
       )

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
@@ -19,7 +19,7 @@ class BakeryTelemetryListener(private val spectator: Registry) {
       IMAGE_REGION_MISMATCH_DETECTED_ID,
       listOf(
         BasicTag("appVersion", event.image.appVersion),
-        BasicTag("baseAmiVersion", event.image.baseAmiVersion),
+        BasicTag("baseAmiVersion", event.image.baseAmiName),
         BasicTag("found", event.image.regions.joinToString()),
         BasicTag("desired", event.regions.joinToString())
       )

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCacheTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/DefaultBaseImageCacheTests.kt
@@ -16,14 +16,19 @@ internal class DefaultBaseImageCacheTests : JUnit5Minutests {
     val config =
       """
       |bionic:
-      |  candidate: nflx-base-5.375.0-h1224.8808866
-      |  unstable: nflx-base-5.375.1-h1225.8808866~unstable
-      |  release: nflx-base-5.365.0-h1191.6a005e3
+      |  candidate: bionicbase-x86_64-202103092356-ebs
+      |  unstable: bionicbase-unstable-x86_64-202103092010-ebs
+      |  release: bionicbase-x86_64-202103092356-ebs
+      |bionic-classic:
+      |  release: bionic-classicbase-x86_64-202102241716-ebs
+      |  candidate: bionic-classicbase-x86_64-202103092356-ebs
+      |  unstable: bionic-classicbase-unstable-x86_64-202103092010-ebs
+      |  previous: bionic-classicbase-x86_64-202101262358-ebs
       |xenial:
-      |  candidate: nflx-base-5.375.0-h1224.8808866
-      |  unstable: nflx-base-5.375.1-h1225.8808866~unstable
-      |  release: nflx-base-5.365.0-h1191.6a005e3
-      |  previous: nflx-base-5.344.0-h1137.cc92ef3
+      |  candidate: xenialbase-x86_64-202103092356-ebs
+      |  unstable: xenialbase-unstable-x86_64-202103092010-ebs
+      |  release: xenialbase-x86_64-202103092356-ebs
+      |  previous: xenialbase-x86_64-202101262358-ebs
       |""".trimMargin()
     val baseImageCache = DefaultBaseImageCache(YAMLMapper().readValue(config))
   }
@@ -31,20 +36,20 @@ internal class DefaultBaseImageCacheTests : JUnit5Minutests {
   fun tests() = rootContext<Fixture> {
     fixture { Fixture }
 
-    test("returns the base AMI version for a valid os/label") {
-      expectThat(baseImageCache.getBaseAmiVersion("bionic", RELEASE))
-        .isEqualTo("nflx-base-5.365.0-h1191.6a005e3")
+    test("returns the base AMI name for a valid os/label") {
+      expectThat(baseImageCache.getBaseAmiName("bionic", RELEASE))
+        .isEqualTo("bionicbase-x86_64-202103092356-ebs")
     }
 
     test("throw an exception for an invalid label") {
       expectThrows<UnknownBaseImage> {
-        baseImageCache.getBaseAmiVersion("bionic", PREVIOUS)
+        baseImageCache.getBaseAmiName("bionic", PREVIOUS)
       }
     }
 
     test("throw an exception for an invalid os") {
       expectThrows<UnknownBaseImage> {
-        baseImageCache.getBaseAmiVersion("windows", RELEASE)
+        baseImageCache.getBaseAmiName("windows", RELEASE)
       }
     }
   }

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.bakery.artifact
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.config.LifecycleConfig
-import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.lifecycle.LifecycleEvent
@@ -28,8 +27,6 @@ import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
@@ -38,8 +35,8 @@ import org.springframework.context.ApplicationEventPublisher
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import strikt.assertions.isTrue
-import java.lang.RuntimeException
 import java.time.Instant
+import io.mockk.coEvery as every
 
 class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
@@ -48,7 +45,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
     val bakedImageRepository: BakedImageRepository = mockk(relaxUnitFun = true)
     val imageService: ImageService = mockk(relaxUnitFun = true) {
-      coEvery { findBaseAmiVersion(any(), any()) } returns "base-1-2-3"
+      every { findBaseAmiName(any(), any()) } returns "base-1-2-3"
     }
     val lifecycleConfig = LifecycleConfig()
     val clock = MutableClock()
@@ -100,7 +97,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
     context("updating status") {
       context("buffered") {
         before {
-          coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
+          every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
             getExecution(BUFFERED)
           runBlocking { subject.monitor(task) }
         }
@@ -117,7 +114,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
       context("running") {
         before {
-          coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
+          every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
             getExecution(RUNNING)
           runBlocking { subject.monitor(task) }
         }
@@ -135,7 +132,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
       context("succeeded") {
         before {
-          coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
+          every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
             getSucceededBakeExecution()
           runBlocking { subject.monitor(task) }
         }
@@ -157,7 +154,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
       context("failed") {
         before {
-          coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
+          every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
             getExecution(TERMINAL)
           runBlocking { subject.monitor(task) }
         }
@@ -178,7 +175,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
       }
       context("unknown") {
         before {
-          coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
+          every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
             getExecution(PAUSED)
           runBlocking { subject.monitor(task) }
         }
@@ -197,7 +194,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
     context("handling failure") {
       before {
-        coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } throws
+        every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } throws
           RuntimeException("this is embarrassing..")
       }
 
@@ -223,7 +220,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
 
     context("handling intermittent failure") {
       before {
-        coEvery { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
+        every { orcaService.getOrchestrationExecution(id, DEFAULT_SERVICE_ACCOUNT) } returns
           getExecution(PAUSED)
       }
       test("failure count is cleared after a success") {

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -141,7 +141,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
               vmType = "hvm",
               cloudProvider = "aws",
               appVersion = appVersion,
-              baseAmiVersion = "base-ami-1",
+              baseAmiName = "base-ami-1",
               amiIdsByRegion = mapOf(
                 "us-east-1" to "ami-11110",
                 "us-west-2" to "ami-22228"
@@ -169,7 +169,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
               vmType = "hvm",
               cloudProvider = "aws",
               appVersion = appVersion,
-              baseAmiVersion = "base-ami-1",
+              baseAmiName = "base-ami-1",
               amiIdsByRegion = mapOf(
                 "us-east-1" to "ami-11110"
               ),

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -168,13 +168,6 @@ interface CloudDriverService {
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): List<NamedImage>
 
-  @GET("/images/find")
-  suspend fun images(
-    @Query("provider") provider: String,
-    @Query("q") name: String,
-    @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
-  ): List<NamedImage>
-
   @GET("/dockerRegistry/images/find")
   suspend fun findDockerImages(
     @Query("account") account: String? = null,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -171,7 +171,7 @@ fun ActiveServerGroup.subnet(cloudDriverCache: CloudDriverCache): String =
 data class ActiveServerGroupImage(
   val imageId: String,
   val appVersion: String?,
-  val baseImageVersion: String?,
+  val baseImageName: String?,
   val name: String,
   val imageLocation: String,
   val description: String?
@@ -186,7 +186,7 @@ data class ActiveServerGroupImage(
   ) : this(
     imageId = imageId,
     appVersion = tags.getTag("appversion")?.substringBefore("/"),
-    baseImageVersion = tags.getTag("base_ami_version"),
+    baseImageName = description?.let{ Regex("""ancestor_name=(.+?),""").find(it)?.groupValues?.get(1) },
     name = name,
     imageLocation = imageLocation,
     description = description

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroup.kt
@@ -186,7 +186,7 @@ data class ActiveServerGroupImage(
   ) : this(
     imageId = imageId,
     appVersion = tags.getTag("appversion")?.substringBefore("/"),
-    baseImageName = description?.let{ Regex("""ancestor_name=(.+?),""").find(it)?.groupValues?.get(1) },
+    baseImageName = description?.let{ Regex("""ancestor_name=([\w-]+)""").find(it)?.groupValues?.get(1) },
     name = name,
     imageLocation = imageLocation,
     description = description

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Image.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/Image.kt
@@ -21,7 +21,7 @@ package com.netflix.spinnaker.keel.clouddriver.model
  * The resolved representation of an AMI.
  */
 data class Image(
-  val baseAmiVersion: String,
+  val baseAmiName: String,
   val appVersion: String,
   val regions: Set<String>
 )

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/model/NamedImage.kt
@@ -41,11 +41,11 @@ val NamedImage.hasAppVersion: Boolean
       vals.isNotEmpty() && vals.all { it != null && it.containsKey("appversion") }
     }
 
-val NamedImage.hasBaseImageVersion: Boolean
+val NamedImage.hasBaseImageName: Boolean
   get() = tagsByImageId
     .values
     .let { vals ->
-      vals.isNotEmpty() && vals.all { it != null && it.containsKey("base_ami_version") }
+      vals.isNotEmpty() && vals.all { it != null && it.containsKey("base_ami_name") }
     }
 
 val NamedImage.appVersion: String
@@ -56,9 +56,9 @@ val NamedImage.appVersion: String
     .toString()
     .substringBefore("/")
 
-val NamedImage.baseImageVersion: String
+val NamedImage.baseImageName: String
   get() = tagsByImageId
     .values
     .first()
-    ?.getValue("base_ami_version")
+    ?.getValue("base_ami_name")
     .toString()

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -50,7 +50,7 @@ class ImageServiceTests : JUnit5Minutests {
     val cloudDriver = mockk<CloudDriverService>()
     val subject = ImageService(cloudDriver, TEST_CACHE_FACTORY)
     val artifact = DebianArtifact("my-package", vmOptions = VirtualMachineOptions(baseOs = "ignored", regions = emptySet()))
-    
+
     val image1 = NamedImage(
       imageName = "my-package-0.0.1_rc.97-h98",
       attributes = mapOf(
@@ -63,6 +63,8 @@ class ImageServiceTests : JUnit5Minutests {
           "appversion" to "my-package-0.0.1~rc.97-h98.1c684a9/JENKINS-job/98",
           "creator" to "emburns@netflix.com",
           "base_ami_version" to "nflx-base-5.292.0-h988",
+          "base_ami_name" to "trustybase-x86_64-201707211843-ebs",
+          "base_ami_id" to "ami-0a00296a",
           "creation_time" to "2018-10-25 13:08:59 UTC"
         )
       ),
@@ -85,6 +87,8 @@ class ImageServiceTests : JUnit5Minutests {
           "appversion" to "my-package-0.0.1~rc.98-h99.4cb755c/JENKINS-job/99",
           "creator" to "emburns@netflix.com",
           "base_ami_version" to "nflx-base-5.292.0-h988",
+          "base_ami_name" to "trustybase-x86_64-201707211843-ebs",
+          "base_ami_id" to "ami-0a00296a",
           "creation_time" to "2018-10-28 13:09:14 UTC"
         )
       ),
@@ -108,6 +112,8 @@ class ImageServiceTests : JUnit5Minutests {
           "appversion" to "my-package-0.0.1~rc.99-h100.8192e02/JENKINS-job/100",
           "creator" to "emburns@netflix.com",
           "base_ami_version" to "nflx-base-5.292.0-h988",
+          "base_ami_name" to "trustybase-x86_64-201707211843-ebs",
+          "base_ami_id" to "ami-0a00296a",
           "creation_time" to "2018-10-31 13:09:55 UTC"
         )
       ),
@@ -153,6 +159,8 @@ class ImageServiceTests : JUnit5Minutests {
           "appversion" to "my-package-0.0.1~rc.99-h100.8192e02/JENKINS-job/100",
           "creator" to "emburns@netflix.com",
           "base_ami_version" to "nflx-base-5.292.0-h988",
+          "base_ami_name" to "trustybase-x86_64-201707211843-ebs",
+          "base_ami_id" to "ami-0a00296a",
           "creation_time" to "2018-10-31 13:24:55 UTC"
         )
       ),
@@ -175,6 +183,8 @@ class ImageServiceTests : JUnit5Minutests {
           "appversion" to "my-package-0.0.1~rc.97-h98.1c684a9/JENKINS-job/98",
           "creator" to "emburns@netflix.com",
           "base_ami_version" to "nflx-base-5.293.0-h989",
+          "base_ami_name" to "xenialbase-x86_64-202103092356-ebs",
+          "base_ami_id" to "ami-0a00296a",
           "creation_time" to "2019-11-25 13:08:59 UTC"
         )
       ),

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTest.kt
@@ -4,11 +4,11 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.support.Tag
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.retrofit.model.ModelParsingTestSupport
-import java.util.UUID.randomUUID
-import kotlin.random.Random.Default.nextInt
 import org.apache.commons.lang3.RandomStringUtils.random
 import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
 import org.apache.commons.lang3.RandomStringUtils.randomNumeric
+import java.util.UUID.randomUUID
+import kotlin.random.Random.Default.nextInt
 
 object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, ActiveServerGroup>(CloudDriverService::class.java) {
 
@@ -414,7 +414,7 @@ object ActiveServerGroupTest : ModelParsingTestSupport<CloudDriverService, Activ
     image = ActiveServerGroupImage(
       imageId = ami,
       appVersion = "$app-3.16.0-h205.121d4ac",
-      baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78",
+      baseImageName = "xenialbase-x86_64-201811142132-ebs",
       description = "name=$app, arch=x86_64, ancestor_name=xenialbase-x86_64-201811142132-ebs, ancestor_id=ami-0fe383ecea7f75eac, ancestor_version=nflx-base-5.308.0-h1044.b4b3f78",
       imageLocation = "$owner/$app-3.16.0-h205.121d4ac-x86_64-20181115184054-xenial-hvm-sriov-ebs-ebs-ebs",
       name = "$app-3.16.0-h205.121d4ac-x86_64-20181115184054-xenial-hvm-sriov-ebs-ebs-ebs"

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/model/ActiveServerGroupTests.kt
@@ -94,7 +94,7 @@ class ActiveServerGroupFixtureMaker : FixtureMaker<ActiveServerGroup> {
       image = ActiveServerGroupImage(
         imageId = "image",
         appVersion = null,
-        baseImageVersion = null,
+        baseImageName = null,
         name = "name",
         imageLocation = "somewhere",
         description = null
@@ -154,7 +154,7 @@ class ServerGroupFixtureMaker: FixtureMaker<ServerGroup> {
       image = ActiveServerGroupImage(
         imageId = "image",
         appVersion = null,
-        baseImageVersion = null,
+        baseImageName = null,
         name = "name",
         imageLocation = "somewhere",
         description = null

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/BakedImageRepositoryTests.kt
@@ -36,7 +36,7 @@ abstract class BakedImageRepositoryTests<T : BakedImageRepository> : JUnit5Minut
     vmType = "hvm",
     cloudProvider = "aws",
     appVersion = version,
-    baseAmiVersion = "base-ami-123",
+    baseAmiName = "base-ami-123",
     timestamp = clock.instant(),
     amiIdsByRegion = amisByRegion
   )

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BakedImage.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/BakedImage.kt
@@ -10,7 +10,7 @@ data class BakedImage(
   val vmType: String,
   val cloudProvider: String,
   val appVersion: String,
-  val baseAmiVersion: String,
+  val baseAmiName: String,
   val amiIdsByRegion: Map<String, String>,
   val timestamp: Instant
 ) {

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpec.kt
@@ -52,7 +52,7 @@ private fun ClusterSpec.resolveLaunchConfiguration(region: SubnetAwareRegionSpec
   ) { "No image resolved / specified for ${region.name}" }
   return LaunchConfiguration(
     appVersion = image.appVersion,
-    baseImageVersion = image.baseImageVersion,
+    baseImageName = image.baseImageName,
     imageId = image.id,
     instanceType = checkNotNull(
       overrides[region.name]?.launchConfiguration?.instanceType

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroup.kt
@@ -72,7 +72,7 @@ data class ServerGroup(
     @get:ExcludedFromDiff
     val imageId: String,
     val appVersion: String?,
-    val baseImageVersion: String?,
+    val baseImageName: String?,
     val name: String,
     val imageLocation: String,
     val description: String?
@@ -112,7 +112,7 @@ data class ServerGroup(
   data class LaunchConfiguration(
     val imageId: String,
     val appVersion: String?,
-    val baseImageVersion: String?,
+    val baseImageName: String?,
     val instanceType: String,
     val ebsOptimized: Boolean = DEFAULT_EBS_OPTIMIZED,
     val iamRole: String,

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/VirtualMachineImage.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/VirtualMachineImage.kt
@@ -3,5 +3,5 @@ package com.netflix.spinnaker.keel.api.ec2
 data class VirtualMachineImage(
   val id: String,
   val appVersion: String,
-  val baseImageVersion: String
+  val baseImageName: String
 )

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/_modelConversions.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/_modelConversions.kt
@@ -35,7 +35,7 @@ internal fun BuildInfo.toEc2Api(): ServerGroup.BuildInfo =
   ServerGroup.BuildInfo(packageName)
 
 internal fun ActiveServerGroupImage.toEc2Api(): ServerGroup.ActiveServerGroupImage =
-  ServerGroup.ActiveServerGroupImage(imageId, appVersion, baseImageVersion, name, imageLocation, description)
+  ServerGroup.ActiveServerGroupImage(imageId, appVersion, baseImageName, name, imageLocation, description)
 
 internal fun InstanceCounts.toEc2Api(): ServerGroup.InstanceCounts =
   ServerGroup.InstanceCounts(total, up, down, unknown, outOfService, starting)

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ActiveServerGroupImageDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ActiveServerGroupImageDeserializer.kt
@@ -8,14 +8,17 @@ import com.netflix.spinnaker.keel.api.ec2.ServerGroup.ActiveServerGroupImage
 import org.springframework.boot.jackson.JsonComponent
 
 @JsonComponent
-class ActiveServerGroupImageDeserializer : StdNodeBasedDeserializer<ActiveServerGroupImage>(ActiveServerGroupImage::class.java) {
+class ActiveServerGroupImageDeserializer :
+  StdNodeBasedDeserializer<ActiveServerGroupImage>(ActiveServerGroupImage::class.java) {
   override fun convert(root: JsonNode, ctxt: DeserializationContext): ActiveServerGroupImage {
     val tags = root.get("tags") as ArrayNode
 
     return ActiveServerGroupImage(
       imageId = root.get("imageId").textValue(),
       appVersion = tags.getTag("appversion")?.substringBefore("/"),
-      baseImageVersion = tags.getTag("base_ami_version"),
+      baseImageName = root.get("description").textValue()?.let {
+        Regex("""ancestor_name=(.+?),""").find(it)?.groupValues?.get(1)
+      },
       name = root.get("name").textValue(),
       imageLocation = root.get("imageLocation").textValue(),
       description = root.get("description").textValue()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ActiveServerGroupImageDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ActiveServerGroupImageDeserializer.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.deser.std.StdNodeBasedDeserializer
 import com.fasterxml.jackson.databind.node.ArrayNode
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.ActiveServerGroupImage
+import com.netflix.spinnaker.keel.clouddriver.model.extractBaseImageName
 import org.springframework.boot.jackson.JsonComponent
 
 @JsonComponent
@@ -16,9 +17,7 @@ class ActiveServerGroupImageDeserializer :
     return ActiveServerGroupImage(
       imageId = root.get("imageId").textValue(),
       appVersion = tags.getTag("appversion")?.substringBefore("/"),
-      baseImageName = root.get("description").textValue()?.let {
-        Regex("""ancestor_name=([\w-]+)""").find(it)?.groupValues?.get(1)
-      },
+      baseImageName = extractBaseImageName(root.get("description").textValue()),
       name = root.get("name").textValue(),
       imageLocation = root.get("imageLocation").textValue(),
       description = root.get("description").textValue()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ActiveServerGroupImageDeserializer.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/jackson/ActiveServerGroupImageDeserializer.kt
@@ -17,7 +17,7 @@ class ActiveServerGroupImageDeserializer :
       imageId = root.get("imageId").textValue(),
       appVersion = tags.getTag("appversion")?.substringBefore("/"),
       baseImageName = root.get("description").textValue()?.let {
-        Regex("""ancestor_name=(.+?),""").find(it)?.groupValues?.get(1)
+        Regex("""ancestor_name=([\w-]+)""").find(it)?.groupValues?.get(1)
       },
       name = root.get("name").textValue(),
       imageLocation = root.get("imageLocation").textValue(),

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.clouddriver.ImageService
 import com.netflix.spinnaker.keel.clouddriver.getLatestNamedImages
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
-import com.netflix.spinnaker.keel.clouddriver.model.baseImageVersion
+import com.netflix.spinnaker.keel.clouddriver.model.baseImageName
 import com.netflix.spinnaker.keel.ec2.NoArtifactVersionHasBeenApproved
 import com.netflix.spinnaker.keel.ec2.NoImageFoundForRegions
 import com.netflix.spinnaker.keel.filterNotNullValues
@@ -96,7 +96,7 @@ class ImageResolver(
       VirtualMachineImage(
         id = imageIdByRegion.getValue(region),
         appVersion = namedImage.appVersion,
-        baseImageVersion = namedImage.baseImageVersion
+        baseImageName = namedImage.baseImageName
       )
     }
 
@@ -108,7 +108,7 @@ class ImageResolver(
           VirtualMachineImage(
             id = amiId,
             appVersion = bakedImage.appVersion,
-            baseImageVersion = bakedImage.baseAmiVersion
+            baseImageName = bakedImage.baseAmiName
           )
         }.toMap()
       } ?: emptyMap()

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -1047,7 +1047,7 @@ class ClusterHandler(
       LaunchConfiguration(
         imageId = image.imageId,
         appVersion = image.appVersion,
-        baseImageVersion = image.baseImageVersion,
+        baseImageName = image.baseImageName,
         instanceType = launchConfig?.instanceType ?: launchTemplateData!!.instanceType,
         ebsOptimized = launchConfig?.ebsOptimized ?: launchTemplateData!!.ebsOptimized,
         iamRole = launchConfig?.iamInstanceProfile ?: launchTemplateData!!.iamInstanceProfile.name,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ClusterSpecTests.kt
@@ -125,7 +125,7 @@ internal class ClusterSpecTests : JUnit5Minutests {
 
 data class Fixture(
   val appVersion: String = "fnord-1.0.0",
-  val baseImageVersion: String = "nflx-base-5.308.0-h1044.b4b3f78",
+  val baseImageName: String = "bionicbase-x86_64-202103092356-ebs",
   val usEastImageId: String = "ami-6874986",
   val usWestImageId: String = "ami-6271051",
 
@@ -171,7 +171,7 @@ data class Fixture(
         launchConfiguration = LaunchConfigurationSpec(
           image = VirtualMachineImage(
             appVersion = appVersion,
-            baseImageVersion = baseImageVersion,
+            baseImageName = baseImageName,
             id = usEastImageId
           ),
           iamRole = "fnordEastInstanceProfile",
@@ -190,7 +190,7 @@ data class Fixture(
         launchConfiguration = LaunchConfigurationSpec(
           image = VirtualMachineImage(
             appVersion = appVersion,
-            baseImageVersion = baseImageVersion,
+            baseImageName = baseImageName,
             id = usWestImageId
           ),
           keyPair = "fnord-keypair-325719997469-us-west-2"

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroupDiffTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/ServerGroupDiffTests.kt
@@ -72,7 +72,7 @@ internal class ServerGroupDiffTests : JUnit5Minutests {
               launchConfiguration = LaunchConfiguration(
                 imageId = "ami-${randomAlphanumeric(7)}",
                 appVersion = "fnord-1.0.0.h23.${randomNumeric(6)}",
-                baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78",
+                baseImageName = "nflx-base-5.308.0-h1044.b4b3f78",
                 instanceType = "r5.4xlarge",
                 ebsOptimized = true,
                 iamRole = "fnordInstanceRole",

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/constraints/Ec2CanaryConstraintDeployHandlerTests.kt
@@ -225,7 +225,7 @@ internal class Ec2CanaryConstraintDeployHandlerTests : JUnit5Minutests {
     name = "fnord-prod",
     region = region,
     zones = emptySet(),
-    image = ActiveServerGroupImage(imageId = "ami-42b", name = "name", imageLocation = "location", appVersion = null, description = null, baseImageVersion = null),
+    image = ActiveServerGroupImage(imageId = "ami-42b", name = "name", imageLocation = "location", appVersion = null, description = null, baseImageName = null),
     launchConfig = LaunchConfig(
       ramdiskId = null,
       ebsOptimized = true,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -51,7 +51,6 @@ import com.netflix.spinnaker.keel.test.resource
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.clearAllMocks
-import io.mockk.coEvery as every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import strikt.api.expect
@@ -67,6 +66,7 @@ import java.time.Clock
 import java.time.Duration
 import java.util.UUID
 import com.netflix.spinnaker.keel.clouddriver.model.Capacity as ClouddriverCapacity
+import io.mockk.coEvery as every
 import org.springframework.core.env.Environment as SpringEnv
 
 internal class ClusterExportTests : JUnit5Minutests {
@@ -128,7 +128,7 @@ internal class ClusterExportTests : JUnit5Minutests {
         image = VirtualMachineImage(
           id = "ami-123543254134",
           appVersion = "keel-0.287.0-h208.fe2e8a1",
-          baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+          baseImageName = "bionicbase-x86_64-202101262358-ebs"
         ),
         instanceType = "r4.8xlarge",
         ebsOptimized = false,
@@ -164,7 +164,7 @@ internal class ClusterExportTests : JUnit5Minutests {
     description = "name=keel, arch=x86_64, ancestor_name=bionic-classicbase-x86_64-202002251430-ebs, ancestor_id=ami-0000, ancestor_version=nflx-base-5.308.0-h1044.b4b3f78",
     imageLocation = "1111/keel-0.287.0-h208.fe2e8a1-x86_64-20200413213533-bionic-classic-hvm-sriov-ebs",
     appVersion = null,
-    baseImageVersion = null
+    baseImageName = null
   )
 
   val serverGroups = spec.resolve()

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -83,7 +83,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           "creationDate" to "2019-07-28T13:01:00.000Z"
         ),
         tagsByImageId = mapOf(
-          "ami-1" to mapOf("appversion" to "fnord-$version1", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
+          "ami-1" to mapOf("appversion" to "fnord-$version1", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8", "base_ami_name" to "xenialbase-x86_64-202103092356-ebs")
         ),
         accounts = setOf(account),
         amis = mapOf(
@@ -96,7 +96,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           "creationDate" to "2019-07-29T13:01:00.000Z"
         ),
         tagsByImageId = mapOf(
-          "ami-2" to mapOf("appversion" to "fnord-$version2", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
+          "ami-2" to mapOf("appversion" to "fnord-$version2", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8", "base_ami_name" to "xenialbase-x86_64-202103092356-ebs")
         ),
         accounts = setOf(account),
         amis = mapOf(
@@ -109,7 +109,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           "creationDate" to "2019-07-30T13:01:00.000Z"
         ),
         tagsByImageId = mapOf(
-          "ami-3" to mapOf("appversion" to "fnord-$version3", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8")
+          "ami-3" to mapOf("appversion" to "fnord-$version3", "base_ami_version" to "nflx-base-5.464.0-h1473.31178a8", "base_ami_name" to "xenialbase-x86_64-202103092356-ebs")
         ),
         accounts = setOf(account),
         amis = mapOf(
@@ -125,7 +125,7 @@ internal class ImageResolverTests : JUnit5Minutests {
       vmType = "hvm",
       cloudProvider = "aws",
       appVersion = "fnord-$version2",
-      baseAmiVersion = "nflx-base-5.464.0-h1473.31178a8",
+      baseAmiName = "xenialbase-x86_64-201811142132-ebs",
       amiIdsByRegion = mapOf(
         imageRegion to "ami-2"
       ),

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -145,7 +145,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
           image = VirtualMachineImage(
             id = "ami-123543254134",
             appVersion = "keel-0.287.0-h208.fe2e8a1",
-            baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+            baseImageName = "nflx-base-5.308.0-h1044.b4b3f78"
           ),
           instanceType = instanceType,
           ebsOptimized = false,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.Network
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.ServerGroupCollection
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
-import com.netflix.spinnaker.keel.ec2.resource.BlockDeviceConfig
 import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
@@ -120,7 +119,7 @@ internal class LaunchConfigTests {
       image = VirtualMachineImage(
         id = "ami-123543254134",
         appVersion = "keel-0.287.0-h208.fe2e8a1",
-        baseImageVersion = "nflx-base-5.308.0-h1044.b4b3f78"
+        baseImageName = "nflx-base-5.308.0-h1044.b4b3f78"
       ),
       instanceType = "r4.8xlarge",
       ebsOptimized = false,

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.ec2.HealthCheckType
 import com.netflix.spinnaker.keel.api.ec2.Metric
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup
 import com.netflix.spinnaker.keel.api.ec2.TerminationPolicy
+import com.netflix.spinnaker.keel.api.support.Tag
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.ActiveServerGroupImage
 import com.netflix.spinnaker.keel.clouddriver.model.AutoScalingGroup
@@ -23,7 +24,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.ScalingPolicyAlarm
 import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupSummary
 import com.netflix.spinnaker.keel.clouddriver.model.Subnet
 import com.netflix.spinnaker.keel.clouddriver.model.SuspendedProcess
-import com.netflix.spinnaker.keel.api.support.Tag
 import com.netflix.spinnaker.keel.clouddriver.model.TargetTrackingConfiguration
 import com.netflix.spinnaker.keel.core.parseMoniker
 import org.apache.commons.lang3.RandomStringUtils
@@ -83,7 +83,7 @@ fun ServerGroup.toCloudDriverResponse(
       image = ActiveServerGroupImage(
         imageId = launchConfiguration.imageId,
         appVersion = launchConfiguration.appVersion,
-        baseImageVersion = launchConfiguration.baseImageVersion,
+        baseImageName = launchConfiguration.baseImageName,
         name = "name",
         imageLocation = "location",
         description = image?.description
@@ -173,7 +173,7 @@ fun ServerGroup.toMultiServerGroupResponse(
       image = ActiveServerGroupImage(
         imageId = launchConfiguration.imageId,
         appVersion = launchConfiguration.appVersion,
-        baseImageVersion = launchConfiguration.baseImageVersion,
+        baseImageName = launchConfiguration.baseImageName,
         name = "name",
         imageLocation = "location",
         description = image?.description
@@ -256,7 +256,7 @@ fun ServerGroup.toMultiServerGroupResponse(
       image = ActiveServerGroupImage(
         imageId = launchConfiguration.imageId,
         appVersion = launchConfiguration.appVersion,
-        baseImageVersion = launchConfiguration.baseImageVersion,
+        baseImageName = launchConfiguration.baseImageName,
         name = "name",
         imageLocation = "location",
         description = image?.description

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/orca/ClusterExportHelperTests.kt
@@ -19,8 +19,6 @@ import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
 import io.mockk.coEvery
 import io.mockk.mockk
-import java.time.Duration
-import java.time.Instant
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectCatching
 import strikt.api.expectThat
@@ -28,6 +26,8 @@ import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isNull
 import strikt.assertions.isSuccess
+import java.time.Duration
+import java.time.Instant
 
 class ClusterExportHelperTests : JUnit5Minutests {
   class Fixture {
@@ -38,7 +38,7 @@ class ClusterExportHelperTests : JUnit5Minutests {
       name = "keel-test-v001",
       region = "us-east-1",
       zones = listOf("a", "b", "c").map { "us-east-1$it" }.toSet(),
-      image = ActiveServerGroupImage(imageId = "foo", appVersion = "bar", baseImageVersion = "baz", name = "name", imageLocation = "location", description = "description"),
+      image = ActiveServerGroupImage(imageId = "foo", appVersion = "bar", baseImageName = "baz", name = "name", imageLocation = "location", description = "description"),
       launchConfig = LaunchConfig(
         ramdiskId = "diskId",
         ebsOptimized = false,


### PR DESCRIPTION
Currently we use the `base_ami_version` tag from the active server group to determine if its base AMI is up-to-date. However, since the versions for bionic and bionic-classic OS variants are identical, we have no way to detect a diff if a user changes from one OS to the other, and they will have to push a new version of their app to trigger a bake.

This PR changes things so that we use the base AMI _name_ rather than version. This has a number of advantages:
- It's unique to each OS variant so we'll detect a diff if the user changes from `bionic` to `bionic-classic` or vice-versa
- It's easier for us to get either via Bakery's API or via Bakery fast properties as we do now (currently we have to do an additional lookup via Clouddriver to turn the AMI name into a version)
- It's a more meaningful string to a user

@ajordens has made a corresponding change so that CloudDriver's AMI lookup endpoint `/aws/images/find?q=` will include the `base_ami_name` tag. This change should not go out until the CloudDriver change is live. However, it's a little fiddlier to get the AMI name from an active server group (see comments below) since it's not present as a tag there.