### PR TITLE
get the base image name, not the base image's base image name

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitor.kt
@@ -117,7 +117,7 @@ class BakeryLifecycleMonitor(
         vmType = detail.vmType,
         cloudProvider = detail.cloudProviderType,
         appVersion = detail.`package`.substringBefore("_all.deb").replaceFirst("_", "-"),
-        baseAmiName = imageService.findBaseAmiName(detail.baseAmiId, detail.region),
+        baseAmiName = imageService.findBaseImageName(detail.baseAmiId, detail.region),
         timestamp = execution.endTime ?: clock.instant(),
         amiIdsByRegion = details.associate { regionDetail -> regionDetail.region to regionDetail.imageId }
       )

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/BakeryLifecycleMonitorTests.kt
@@ -45,7 +45,7 @@ class BakeryLifecycleMonitorTests : JUnit5Minutests {
     val publisher: ApplicationEventPublisher = mockk(relaxUnitFun = true)
     val bakedImageRepository: BakedImageRepository = mockk(relaxUnitFun = true)
     val imageService: ImageService = mockk(relaxUnitFun = true) {
-      every { findBaseAmiName(any(), any()) } returns "base-1-2-3"
+      every { findBaseImageName(any(), any()) } returns "base-1-2-3"
     }
     val lifecycleConfig = LifecycleConfig()
     val clock = MutableClock()

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -153,33 +153,14 @@ class ImageService(
     }
   }
 
-  suspend fun findBaseAmiName(baseImageName: String): String {
-    return cloudDriverService.namedImages(DEFAULT_SERVICE_ACCOUNT, baseImageName, "test")
-      .lastOrNull()
-      ?.let { namedImage ->
-        findBaseAmiName(namedImage)
-      } ?: throw BaseAmiNotFound(baseImageName)
-  }
-
-  suspend fun findBaseAmiName(baseImageId: String, region: String): String {
-    return cloudDriverService.getImage("test", region, baseImageId)
-      .lastOrNull()
-      ?.let { namedImage ->
-        findBaseAmiName(namedImage)
-      } ?: throw BaseAmiNotFound(baseImageId)
-  }
-
   /**
-   * Extracts the base ami version from the tags of a named image
+   * Given a [baseImageId] this function returns its name.
    */
-  private fun findBaseAmiName(image: NamedImage): String? =
-    image
-      .tagsByImageId
-      .values
-      .filterNotNull()
-      .find { it.containsKey("base_ami_name") }
-      ?.getValue("base_ami_name")
-
+  suspend fun findBaseImageName(baseImageId: String, region: String): String =
+    cloudDriverService.getImage("test", region, baseImageId)
+      .lastOrNull()
+      ?.imageName
+      ?: throw BaseAmiNotFound(baseImageId)
 
   private fun tagsExistForAllAmis(tagsByImageId: Map<String, Map<String, String?>?>): Boolean {
     tagsByImageId.keys.forEach { key ->


### PR DESCRIPTION
This causes continual rebaking because the base_ami_name of the image we bake does not match the one this bit of code finds by looking up the base image by id.