### PR TITLE
only consider images with the same base os when checking if we need to bake

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -90,7 +90,7 @@ class ImageHandler(
     }
   }
 
-  private suspend fun DeliveryArtifact.findLatestAmi() =
+  private suspend fun DebianArtifact.findLatestAmi() =
     imageService.getLatestImage(this, "test")
 
   private fun DebianArtifact.findLatestBaseAmiName() =

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.keel.clouddriver
 
 import com.github.benmanes.caffeine.cache.AsyncCache
 import com.netflix.frigga.ami.AppVersion
-import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.caffeine.CacheFactory
 import com.netflix.spinnaker.keel.clouddriver.model.Image
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
@@ -52,10 +52,10 @@ class ImageService(
    *
    * If no images at all exist for [artifact] this method returns `null`.
    */
-  suspend fun getLatestImage(artifact: DeliveryArtifact, account: String): Image? {
+  suspend fun getLatestImage(artifact: DebianArtifact, account: String): Image? {
     val candidateImages = cloudDriverService
       .namedImages(DEFAULT_SERVICE_ACCOUNT, artifact.name, account)
-      .filter { it.hasAppVersion && it.hasBaseImageName }
+      .filter { it.hasAppVersion && it.hasBaseImageName && it.baseImageName.startsWith("${artifact.vmOptions.baseOs}base") }
       .sortedWith(NamedImageComparator)
     val latest = candidateImages
       .firstOrNull {

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -49,7 +49,7 @@ class ImageServiceTests : JUnit5Minutests {
   class Fixture {
     val cloudDriver = mockk<CloudDriverService>()
     val subject = ImageService(cloudDriver, TEST_CACHE_FACTORY)
-    val artifact = DebianArtifact("my-package", vmOptions = VirtualMachineOptions(baseOs = "ignored", regions = emptySet()))
+    val artifact = DebianArtifact("my-package", vmOptions = VirtualMachineOptions(baseOs = "trusty", regions = emptySet()))
 
     val image1 = NamedImage(
       imageName = "my-package-0.0.1_rc.97-h98",
@@ -136,6 +136,8 @@ class ImageServiceTests : JUnit5Minutests {
           "appversion" to "my-package-foo-0.0.1~rc.99-h100.8192e02/JENKINS-job/100",
           "creator" to "emburns@netflix.com",
           "base_ami_version" to "nflx-base-5.292.0-h988",
+          "base_ami_name" to "trustybase-x86_64-201707211843-ebs",
+          "base_ami_id" to "ami-0a00296a",
           "creation_time" to "2018-10-31 13:09:55 UTC"
         )
       ),


### PR DESCRIPTION
This is pretty hacky and I'd like to reconsider how we determine if we need to bake or not, but this fix should get us unblocked in the meantime.