### PR TITLE
fix(mj): remove buttons, change text location

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/callbacks/ManualJudgmentCallbackHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/callbacks/ManualJudgmentCallbackHandler.kt
@@ -66,7 +66,7 @@ class ManualJudgmentCallbackHandler(
       val originalCommitText = response.message.blocks[1].getText
       val action = actionsMap[response.actions.first().value]
 
-      val newBlocks = withBlocks {
+      val updatedBlocks = withBlocks {
         header {
           when (action) {
             "approve" -> text("Manual judgement approved", emoji = true)
@@ -82,7 +82,9 @@ class ManualJudgmentCallbackHandler(
             }
           }
         }
+      }
 
+      val newFooterBlock = withBlocks {
         context {
           elements {
             markdownText(fallbackText(response))
@@ -94,7 +96,8 @@ class ManualJudgmentCallbackHandler(
       //remove the first two blocks because we're replacing them
       originalBlocks.removeFirstOrNull()
       originalBlocks.removeFirstOrNull()
-      return newBlocks + originalBlocks
+      originalBlocks.removeLast() // removes mj buttons
+      return updatedBlocks + originalBlocks + newFooterBlock
     } catch (ex: Exception) {
       log.debug("exception occurred while creating updated MJ notification. Will use a fallback text instead: {}", ex)
       return emptyList()


### PR DESCRIPTION
I was close (thankfully) but needed two tweaks. I needed to remove the mj buttons, and also move the fallback text (the thing that says who did what) to the bottom after the link to the artifact.

![Screen Shot 2021-03-13 at 5 28 59 PM](https://user-images.githubusercontent.com/8454927/111054488-e246a580-8421-11eb-954b-38754ffdbd35.png)

