### PR TITLE
Disambiguate base OS of AMIs

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/config/BakeryConfiguration.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/config/BakeryConfiguration.kt
@@ -1,6 +1,5 @@
 package com.netflix.spinnaker.config
 
-import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.bakery.BaseImageCache
 import com.netflix.spinnaker.keel.bakery.BaseImageCacheProperties
@@ -9,7 +8,8 @@ import com.netflix.spinnaker.keel.bakery.artifact.BakeCredentials
 import com.netflix.spinnaker.keel.bakery.artifact.ImageHandler
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.clouddriver.ImageService
-import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
+import com.netflix.spinnaker.keel.persistence.BakedImageRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -27,10 +27,10 @@ class BakeryConfiguration {
   fun imageHandler(
     keelRepository: KeelRepository,
     baseImageCache: BaseImageCache,
+    bakedImageRepository: BakedImageRepository,
     clouddriverService: CloudDriverService,
     igorService: ArtifactService,
     imageService: ImageService,
-    diffFingerprintRepository: DiffFingerprintRepository,
     publisher: ApplicationEventPublisher,
     taskLauncher: TaskLauncher,
     @Value("\${bakery.defaults.serviceAccount:keel@spinnaker.io}") defaultServiceAccount: String,
@@ -38,9 +38,9 @@ class BakeryConfiguration {
   ) = ImageHandler(
     keelRepository,
     baseImageCache,
+    bakedImageRepository,
     igorService,
     imageService,
-    diffFingerprintRepository,
     publisher,
     taskLauncher,
     BakeCredentials(defaultServiceAccount, defaultApplication)

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluator.kt
@@ -54,7 +54,8 @@ class ImageExistsConstraintEvaluator(
       imageService.getLatestNamedImages(
         appVersion = version.parseAppVersion(),
         account = defaultImageAccount,
-        regions = vmOptions.regions
+        regions = vmOptions.regions,
+        baseOs = vmOptions.baseOs
       )
     }
 
@@ -83,4 +84,3 @@ class ImageExistsConstraintEvaluator(
 }
 
 data class MissingRegionsDetected(val version: String)
-

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/telemetry/BakeryTelemetryListener.kt
@@ -18,10 +18,10 @@ class BakeryTelemetryListener(private val spectator: Registry) {
     spectator.counter(
       IMAGE_REGION_MISMATCH_DETECTED_ID,
       listOf(
-        BasicTag("appVersion", event.image.appVersion),
-        BasicTag("baseAmiVersion", event.image.baseAmiName),
-        BasicTag("found", event.image.regions.joinToString()),
-        BasicTag("desired", event.regions.joinToString())
+        BasicTag("appVersion", event.appVersion),
+        BasicTag("baseAmiName", event.baseAmiName),
+        BasicTag("found", event.foundRegions.joinToString()),
+        BasicTag("desired", event.desiredRegions.joinToString())
       )
     )
       .runCatching { increment() }

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/constraint/ImageExistsConstraintEvaluatorTests.kt
@@ -119,7 +119,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
     context("CloudDriver cannot find an image for an artifact version") {
       before {
         every {
-          imageService.getLatestNamedImage(any(), any(), any())
+          imageService.getLatestNamedImage(any(), any(), any(), any())
         } returns null
       }
 
@@ -193,6 +193,7 @@ internal class ImageExistsConstraintEvaluatorTests : JUnit5Minutests {
           imageService.getLatestNamedImage(
             AppVersion.parseName(appVersion),
             "test",
+            any(),
             any()
           )
         } returns NamedImage(

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -87,7 +87,7 @@ class ImageService(
     val appVersion: AppVersion,
     val account: String,
     val region: String,
-    val baseOs: String?
+    val baseOs: String
   )
 
   private val namedImageCache = cacheFactory
@@ -107,7 +107,7 @@ class ImageService(
         .filter { image ->
           // using the xxxxbase pattern means we won't get matches for base OS values that are
           // substrings of others -- e.g. bionic and bionic-classic
-          baseOs == null || image.baseImageName.startsWith("${baseOs}base")
+          image.baseImageName.startsWith("${baseOs}base")
         }
         // filter to images with matching app version
         .filter { image ->
@@ -137,7 +137,7 @@ class ImageService(
     appVersion: AppVersion,
     account: String,
     region: String,
-    baseOs: String? = null
+    baseOs: String
   ): NamedImage? {
     val key = NamedImageCacheKey(appVersion, account, region, baseOs)
     return namedImageCache.get(key).await()
@@ -200,8 +200,7 @@ suspend fun ImageService.getLatestNamedImages(
   appVersion: AppVersion,
   account: String,
   regions: Collection<String>,
-  // TODO: make this non-nullable
-  baseOs: String? = null
+  baseOs: String
 ): Map<String, NamedImage> = coroutineScope {
   regions.associateWith { region ->
     async {

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageService.kt
@@ -86,11 +86,12 @@ class ImageService(
   private data class NamedImageCacheKey(
     val appVersion: AppVersion,
     val account: String,
-    val region: String
+    val region: String,
+    val baseOs: String?
   )
 
   private val namedImageCache = cacheFactory
-    .asyncLoadingCache<NamedImageCacheKey, NamedImage>("namedImages") { (appVersion, account, region) ->
+    .asyncLoadingCache<NamedImageCacheKey, NamedImage>("namedImages") { (appVersion, account, region, baseOs) ->
       log.debug("Searching for baked image for {} in {}", appVersion.toImageName(), region)
       cloudDriverService.namedImages(
         user = DEFAULT_SERVICE_ACCOUNT,
@@ -101,6 +102,12 @@ class ImageService(
         .asSequence()
         .filter { image ->
           tagsExistForAllAmis(image.tagsByImageId) && image.hasAppVersion
+        }
+        // filter to images with the correct base os
+        .filter { image ->
+          // using the xxxxbase pattern means we won't get matches for base OS values that are
+          // substrings of others -- e.g. bionic and bionic-classic
+          baseOs == null || image.baseImageName.startsWith("${baseOs}base")
         }
         // filter to images with matching app version
         .filter { image ->
@@ -123,13 +130,16 @@ class ImageService(
    *
    * As a side effect this method will prime the cache for any additional regions where the image is
    * available.
+   *
+   * @param baseOs if supplied only images with that base OS are considered.
    */
   suspend fun getLatestNamedImage(
     appVersion: AppVersion,
     account: String,
-    region: String
+    region: String,
+    baseOs: String? = null
   ): NamedImage? {
-    val key = NamedImageCacheKey(appVersion, account, region)
+    val key = NamedImageCacheKey(appVersion, account, region, baseOs)
     return namedImageCache.get(key).await()
       // prime the cache if the image is also in other regions
       ?.also { image ->
@@ -183,18 +193,23 @@ class ImageService(
  *
  * The resulting map will contain no entry for regions where an image is not found. The calling
  * code must check this if it requires all regions to be present.
+ *
+ * @param baseOs if supplied only images with that base OS are considered.
  */
 suspend fun ImageService.getLatestNamedImages(
   appVersion: AppVersion,
   account: String,
-  regions: Collection<String>
+  regions: Collection<String>,
+  // TODO: make this non-nullable
+  baseOs: String? = null
 ): Map<String, NamedImage> = coroutineScope {
   regions.associateWith { region ->
     async {
       getLatestNamedImage(
         appVersion = appVersion,
         account = account,
-        region = region
+        region = region,
+        baseOs = baseOs
       )
     }
   }

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.keel.caffeine.TEST_CACHE_FACTORY
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImage
 import com.netflix.spinnaker.keel.clouddriver.model.NamedImageComparator
 import com.netflix.spinnaker.keel.clouddriver.model.appVersion
+import com.netflix.spinnaker.keel.clouddriver.model.baseImageName
 import com.netflix.spinnaker.keel.clouddriver.model.creationDate
 import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import dev.minutest.junit.JUnit5Minutests
@@ -75,7 +76,7 @@ class ImageServiceTests : JUnit5Minutests {
       )
     )
 
-    val image2 = NamedImage(
+    val imageWithNewerAppVersion = NamedImage(
       imageName = "my-package-0.0.1_rc.98-h99",
       attributes = mapOf(
         "virtualizationType" to "hvm",
@@ -100,7 +101,7 @@ class ImageServiceTests : JUnit5Minutests {
     )
 
     // image that is only in one region
-    val image3 = NamedImage(
+    val imageWithEventNewerAppVersionButOnlyInOneRegion = NamedImage(
       imageName = "my-package-0.0.1_rc.99-h100",
       attributes = mapOf(
         "virtualizationType" to "hvm",
@@ -124,7 +125,7 @@ class ImageServiceTests : JUnit5Minutests {
     )
 
     // mismatched app name (desired app name is a substring of this one)
-    val image4 = NamedImage(
+    val imageWithPartialMatchName = NamedImage(
       imageName = "my-package-foo-0.0.1_rc.99-h100",
       attributes = mapOf(
         "virtualizationType" to "hvm",
@@ -149,7 +150,7 @@ class ImageServiceTests : JUnit5Minutests {
     )
 
     // image3 but in a different region
-    val image5 = NamedImage(
+    val imageWithEventNewerAppVersionInRemainingRegions = NamedImage(
       imageName = "my-package-0.0.1_rc.99-h100",
       attributes = mapOf(
         "virtualizationType" to "hvm",
@@ -173,7 +174,7 @@ class ImageServiceTests : JUnit5Minutests {
     )
 
     // image1 but with a newer creation_time and base_ami_version than image3
-    val image6 = NamedImage(
+    val imageWithNewerBaseImageName = NamedImage(
       imageName = "my-package-0.0.1_rc.97-h98",
       attributes = mapOf(
         "virtualizationType" to "hvm",
@@ -197,8 +198,33 @@ class ImageServiceTests : JUnit5Minutests {
       )
     )
 
+    // image1 but with a different base OS
+    val imageWithDifferentBaseOs = NamedImage(
+      imageName = "my-package-0.0.1_rc.97-h98",
+      attributes = mapOf(
+        "virtualizationType" to "hvm",
+        "creationDate" to "2021-03-15T16:32:59.000Z"
+      ),
+      tagsByImageId = mapOf(
+        "ami-007" to mapOf(
+          "build_host" to "https://jenkins/",
+          "appversion" to "my-package-0.0.1~rc.97-h98.1c684a9/JENKINS-job/98",
+          "creator" to "emburns@netflix.com",
+          "base_ami_version" to "nflx-base-5.293.0-h989",
+          "base_ami_name" to "bionic-classicbase-x86_64-202103092356-ebs",
+          "base_ami_id" to "ami-0ec2ca6820be6b79e",
+          "creation_time" to "2021-03-15 16:32:59 UTC"
+        )
+      ),
+      accounts = setOf("test"),
+      amis = mapOf(
+        "us-west-1" to listOf("ami-007"),
+        "ap-south-1" to listOf("ami-007")
+      )
+    )
+
     // Excludes image4 which is for a different package
-    val newestImage = listOf(image1, image2, image3, image5, image6)
+    val newestImage = listOf(image1, imageWithDifferentBaseOs, imageWithNewerAppVersion, imageWithEventNewerAppVersionButOnlyInOneRegion, imageWithEventNewerAppVersionInRemainingRegions, imageWithNewerBaseImageName)
       .sortedWith(NamedImageComparator)
       .first()
   }
@@ -212,14 +238,14 @@ class ImageServiceTests : JUnit5Minutests {
       }
 
       test("finds correct image") {
-        val sortedImages = listOf(image2, image3, image1, image5, image6).sortedWith(NamedImageComparator)
+        val sortedImages = listOf(imageWithNewerAppVersion, imageWithEventNewerAppVersionButOnlyInOneRegion, image1, imageWithEventNewerAppVersionInRemainingRegions, imageWithNewerBaseImageName).sortedWith(NamedImageComparator)
         expectThat(sortedImages.first()) {
           get { imageName }.isEqualTo("my-package-0.0.1_rc.99-h100")
         }
       }
 
       test("images are sorted by appversion, then creation date") {
-        val sortedImages = listOf(image2, image3, image1, image5, image6).sortedWith(NamedImageComparator)
+        val sortedImages = listOf(imageWithNewerAppVersion, imageWithEventNewerAppVersionButOnlyInOneRegion, image1, imageWithEventNewerAppVersionInRemainingRegions, imageWithNewerBaseImageName).sortedWith(NamedImageComparator)
         val first = sortedImages[0]
         val second = sortedImages[1]
         expectThat(first.imageName)
@@ -239,7 +265,7 @@ class ImageServiceTests : JUnit5Minutests {
             imageName = "my-package",
             account = "test"
           )
-        } returns listOf(image2, image4, image3, image1, image5, image6)
+        } returns listOf(imageWithNewerAppVersion, imageWithPartialMatchName, imageWithEventNewerAppVersionButOnlyInOneRegion, image1, imageWithEventNewerAppVersionInRemainingRegions, imageWithNewerBaseImageName)
       }
 
       test("latest image returns actual image") {
@@ -264,7 +290,7 @@ class ImageServiceTests : JUnit5Minutests {
             imageName = "my-package",
             account = "test"
           )
-        } returns listOf(image2, image4, image3, image1, image5)
+        } returns listOf(imageWithDifferentBaseOs, imageWithNewerAppVersion, imageWithPartialMatchName, imageWithEventNewerAppVersionButOnlyInOneRegion, image1, imageWithEventNewerAppVersionInRemainingRegions)
       }
 
       test("get latest named image returns actual latest image") {
@@ -314,7 +340,7 @@ class ImageServiceTests : JUnit5Minutests {
             account = "test",
             region = null
           )
-        } returns listOf(image3, image5)
+        } returns listOf(imageWithEventNewerAppVersionButOnlyInOneRegion, imageWithEventNewerAppVersionInRemainingRegions)
       }
 
       test("result includes both regions") {
@@ -328,8 +354,8 @@ class ImageServiceTests : JUnit5Minutests {
         expectThat(image)
           .isNotNull()
           .get {regions}
-          .contains(image3.amis.keys)
-          .contains(image5.amis.keys)
+          .contains(imageWithEventNewerAppVersionButOnlyInOneRegion.amis.keys)
+          .contains(imageWithEventNewerAppVersionInRemainingRegions.amis.keys)
       }
     }
 
@@ -339,7 +365,7 @@ class ImageServiceTests : JUnit5Minutests {
       before {
         every {
           cloudDriver.namedImages(any(), any(), any())
-        } returns listOf(image1, image6)
+        } returns listOf(image1, imageWithNewerBaseImageName, imageWithDifferentBaseOs)
       }
 
       test("searching for a specific appversion finds latest complete image") {
@@ -393,7 +419,7 @@ class ImageServiceTests : JUnit5Minutests {
       before {
         every {
           cloudDriver.namedImages(any(), any(), any())
-        } returns listOf(image3, image5)
+        } returns listOf(imageWithEventNewerAppVersionButOnlyInOneRegion, imageWithEventNewerAppVersionInRemainingRegions)
       }
 
       test("searching for a specific appversion finds all images for required regions") {
@@ -409,10 +435,10 @@ class ImageServiceTests : JUnit5Minutests {
           .hasSize(2)
           .containsKeys(*regions.toTypedArray())
           .and {
-            getValue("us-west-1").get { imageName }.isEqualTo(image3.imageName)
+            getValue("us-west-1").get { imageName }.isEqualTo(imageWithEventNewerAppVersionButOnlyInOneRegion.imageName)
           }
           .and {
-            getValue("ap-south-1").get { imageName }.isEqualTo(image5.imageName)
+            getValue("ap-south-1").get { imageName }.isEqualTo(imageWithEventNewerAppVersionInRemainingRegions.imageName)
           }
       }
     }
@@ -423,7 +449,7 @@ class ImageServiceTests : JUnit5Minutests {
       before {
         every {
           cloudDriver.namedImages(any(), any(), any())
-        } returns listOf(image3)
+        } returns listOf(imageWithEventNewerAppVersionButOnlyInOneRegion)
       }
 
       test("images that were found are returned") {
@@ -439,7 +465,55 @@ class ImageServiceTests : JUnit5Minutests {
           .hasSize(1)
           .get(Map<*, NamedImage>::values)
           .map { it.imageName }
-          .containsExactly(image3.imageName)
+          .containsExactly(imageWithEventNewerAppVersionButOnlyInOneRegion.imageName)
+      }
+    }
+
+    context("image with multiple base os versions") {
+      val appVersion = AppVersion.parseName("my-package-0.0.1~rc.97-h98.1c684a9")
+      val regions = setOf("us-west-1", "ap-south-1")
+
+      before {
+        every {
+          cloudDriver.namedImages(any(), any(), any())
+        } returns listOf(image1, imageWithNewerBaseImageName, imageWithDifferentBaseOs)
+      }
+
+      test("newest image is returned if base os is not specified") {
+        val images = runBlocking {
+          subject.getLatestNamedImages(
+            appVersion = appVersion,
+            account = "test",
+            regions = regions
+          )
+        }
+
+        expectThat(images)
+          .hasSize(2)
+          .get(Map<*, NamedImage>::values)
+          .map { it.baseImageName }
+          .all {
+            isEqualTo(imageWithDifferentBaseOs.baseImageName)
+          }
+      }
+
+      test("newest image with desired base os is returned if base os is specified") {
+        val images = runBlocking {
+          subject.getLatestNamedImages(
+            appVersion = appVersion,
+            baseOs = "xenial",
+            account = "test",
+            regions = regions,
+          )
+        }
+
+        expectThat(images)
+          .hasSize(2)
+          .get(Map<*, NamedImage>::values)
+          .map { it.baseImageName }
+          .all {
+            isEqualTo(imageWithNewerBaseImageName.baseImageName)
+          }
       }
     }
   }

--- a/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
+++ b/keel-clouddriver/src/test/kotlin/com/netflix/spinnaker/keel/clouddriver/ImageServiceTests.kt
@@ -373,7 +373,8 @@ class ImageServiceTests : JUnit5Minutests {
           subject.getLatestNamedImages(
             appVersion = appVersion,
             account = "test",
-            regions = regions
+            regions = regions,
+            baseOs = "xenial"
           )
         }
         expectThat(images)
@@ -388,7 +389,7 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("the newest image is selected when searching in a single region") {
         val image = runBlocking {
-          subject.getLatestNamedImage(appVersion, "test", regions.first())
+          subject.getLatestNamedImage(appVersion, "test", regions.first(), "xenial")
         }
 
         expectThat(image)
@@ -399,10 +400,10 @@ class ImageServiceTests : JUnit5Minutests {
 
       test("any other regions supported by the same image are subsequently served from cache") {
         val r1Image = runBlocking {
-          subject.getLatestNamedImage(appVersion, "test", regions.first())
+          subject.getLatestNamedImage(appVersion, "test", regions.first(), "xenial")
         }
         val r2Image = runBlocking {
-          subject.getLatestNamedImage(appVersion, "test", regions.last())
+          subject.getLatestNamedImage(appVersion, "test", regions.last(), "xenial")
         }
 
         expectThat(r1Image).isEqualTo(r2Image)
@@ -427,7 +428,8 @@ class ImageServiceTests : JUnit5Minutests {
           subject.getLatestNamedImages(
             appVersion = appVersion,
             account = "test",
-            regions = regions
+            regions = regions,
+            baseOs = "trusty"
           )
         }
 
@@ -457,7 +459,8 @@ class ImageServiceTests : JUnit5Minutests {
           subject.getLatestNamedImages(
             appVersion = appVersion,
             account = "test",
-            regions = regions
+            regions = regions,
+            baseOs = "trusty"
           )
         }
 
@@ -479,31 +482,13 @@ class ImageServiceTests : JUnit5Minutests {
         } returns listOf(image1, imageWithNewerBaseImageName, imageWithDifferentBaseOs)
       }
 
-      test("newest image is returned if base os is not specified") {
+      test("newest image with desired base os is returned") {
         val images = runBlocking {
           subject.getLatestNamedImages(
             appVersion = appVersion,
-            account = "test",
-            regions = regions
-          )
-        }
-
-        expectThat(images)
-          .hasSize(2)
-          .get(Map<*, NamedImage>::values)
-          .map { it.baseImageName }
-          .all {
-            isEqualTo(imageWithDifferentBaseOs.baseImageName)
-          }
-      }
-
-      test("newest image with desired base os is returned if base os is specified") {
-        val images = runBlocking {
-          subject.getLatestNamedImages(
-            appVersion = appVersion,
-            baseOs = "xenial",
             account = "test",
             regions = regions,
+            baseOs = "xenial"
           )
         }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintDeployHandler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintDeployHandler.kt
@@ -3,6 +3,7 @@ package com.netflix.spinnaker.keel.constraints
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.actuation.Task
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.core.api.CanaryConstraint
 
 /**
@@ -27,6 +28,7 @@ interface CanaryConstraintDeployHandler {
    */
   suspend fun deployCanary(
     constraint: CanaryConstraint,
+    artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolver.kt
@@ -85,7 +85,8 @@ class ImageResolver(
     val images = imageService.getLatestNamedImages(
       appVersion = artifactVersion.parseAppVersion(),
       account = account,
-      regions = regions
+      regions = regions,
+      baseOs = artifact.vmOptions.baseOs
     )
 
     val imageIdByRegion: Map<String, String> = images

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/ImageResolverTests.kt
@@ -199,7 +199,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
+              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion, artifact.vmOptions.baseOs)
             } answers {
               images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }
             }
@@ -231,7 +231,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion)
+              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), resourceRegion, artifact.vmOptions.baseOs)
             } returns null
           }
 
@@ -274,7 +274,7 @@ internal class ImageResolverTests : JUnit5Minutests {
           before {
             every { repository.latestVersionApprovedIn(deliveryConfig, artifact, "test") } returns "${artifact.name}-$version2"
             every {
-              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), any())
+              imageService.getLatestNamedImage(AppVersion.parseName("${artifact.name}-$version2"), any(), any(), any())
             } answers {
               if (thirdArg<String>() == imageRegion) {
                 images.lastOrNull { AppVersion.parseName(it.appVersion).version == firstArg<AppVersion>().version }

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluator.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluator.kt
@@ -16,12 +16,12 @@ import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.core.api.CanaryConstraint
 import com.netflix.spinnaker.keel.orca.OrcaExecutionStatus
 import com.netflix.spinnaker.keel.orca.OrcaService
-import java.time.Clock
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import java.time.Clock
 
 /**
  * An environment promotion constraint that deploys control (baseline) and experiment (canary)
@@ -173,6 +173,7 @@ class CanaryConstraintEvaluator(
     val tasks = runBlocking {
       deployHandler.deployCanary(
         constraint = constraint,
+        artifact = artifact,
         version = version,
         deliveryConfig = deliveryConfig,
         targetEnvironment = targetEnvironment,

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
@@ -31,13 +31,8 @@ import dev.minutest.rootContext
 import io.mockk.CapturingSlot
 import io.mockk.MockKAnswerScope
 import io.mockk.Runs
-import io.mockk.coEvery as every
-import io.mockk.coVerify as verify
 import io.mockk.just
 import io.mockk.mockk
-import java.time.Clock
-import java.time.Duration
-import java.util.concurrent.atomic.AtomicInteger
 import strikt.api.expectThat
 import strikt.assertions.all
 import strikt.assertions.contains
@@ -50,6 +45,11 @@ import strikt.assertions.isTrue
 import strikt.assertions.last
 import strikt.mockk.captured
 import strikt.mockk.isCaptured
+import java.time.Clock
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+import io.mockk.coEvery as every
+import io.mockk.coVerify as verify
 
 internal class CanaryConstraintEvaluatorTests : JUnit5Minutests {
 
@@ -498,6 +498,7 @@ class DummyCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
 
   override suspend fun deployCanary(
     constraint: CanaryConstraint,
+    artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment,
@@ -514,6 +515,7 @@ class FailCanaryConstraintDeployHandler : CanaryConstraintDeployHandler {
 
   override suspend fun deployCanary(
     constraint: CanaryConstraint,
+    artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,
     targetEnvironment: Environment,


### PR DESCRIPTION
This PR ensures we always specify the base OS when looking for latest AMIs for a particular package. There are 4 situations where this is relevant:

1. when we check to see if something is already baked before launching a bake task
2. the implicit constraint that checks an appropriate AMI exists before promoting an artifact version to an environment
3. when materializing the desired state of a cluster
4. when launching a canary

In all those scenarios we want to be sure that we're selecting an image with the correct base OS according to the artifact definition in the delivery config. If a user updates their delivery config to use a new base OS we want to consider that a delta, re-bake, and re-deploy.

This also simplifies the logic around determining if we need to bake an AMI as there are basically only 3 situations where we should:

1. the user has a new release of their code (new artifact version)
2. there is a new base image
3. for some reason not all the regions we need are currently baked.

Previously we were pulling down all images for the artifact from CloudDriver which was sometimes quite slow and totally unnecessary since we know exactly what artifact version we need an image for.