### PR TITLE
chore(env): add timer for envt exclusion checks

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.actuation
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Resource
@@ -72,7 +73,7 @@ class IntermittentFailureTests : JUnit5Minutests {
     val clock = MutableClock()
     val vetoRepository = mockk<UnhappyVetoRepository>(relaxUnitFun = true)
 
-    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv)
+    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
 
     val dynamicConfigService: DynamicConfigService = mockk(relaxUnitFun = true) {
       every {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.actuation
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.keel.actuation.SleepyJavaResourceHandler.SLEEPY_RESOURCE_KIND
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
@@ -93,7 +94,7 @@ internal class ResourceActuatorTests : JUnit5Minutests {
     val veto = mockk<Veto>()
     val vetoEnforcer = VetoEnforcer(listOf(veto))
     val clock = Clock.systemUTC()
-    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv)
+    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
     val subject = ResourceActuator(
       resourceRepository,
       artifactRepository,

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcerTest.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcerTest.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.enforcers
 
+import com.netflix.spectator.api.NoopRegistry
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runBlockingTest
 import io.mockk.every
@@ -14,7 +15,7 @@ import org.springframework.core.env.Environment as SpringEnvironment
 internal class EnvironmentExclusionEnforcerTest {
 
   private val springEnv : SpringEnvironment = mockk()
-  private val enforcer = EnvironmentExclusionEnforcer(springEnv)
+  private val enforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
 
   @ParameterizedTest(name="withVerificationLease executes action, enabled={0}")
   @ValueSource(booleans = [true, false])
@@ -30,6 +31,7 @@ internal class EnvironmentExclusionEnforcerTest {
     }
   }
 
+  @kotlinx.coroutines.ExperimentalCoroutinesApi
   @ParameterizedTest(name="withActuationLease executes action, enabled={0}")
   @ValueSource(booleans = [true, false])
   fun `withActuationLease invokes the action whether the feature flag is enabled or not`(enabled: Boolean) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.verification
 
+import com.netflix.spectator.api.NoopRegistry
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.ResourceKind
@@ -58,7 +59,7 @@ internal class VerificationRunnerTests {
     every { getImages(any(), any()) } returns images
   }
 
-  private val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv)
+  private val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
 
   private val subject = VerificationRunner(
     repository,


### PR DESCRIPTION
Use a percentile timer to record the time spent doing the EnvironmentExclusionEnforcer checks, so we can identify if this code leads to performance issues.

Other than the timer, this PR doesn't introduce any (intended) changes in behavior.
