### PR TITLE
fix(notification): only send delivery config changed if changed

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/NotificationEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/NotificationEvent.kt
@@ -79,7 +79,8 @@ data class ArtifactDeployedNotification(
 
 data class DeliveryConfigChangedNotification(
   val config: DeliveryConfig,
-  val gitMetadata: GitMetadata? = null
+  val gitMetadata: GitMetadata? = null,
+  val new: Boolean = false
 ) : NotificationEvent() {
   override val type = DELIVERY_CONFIG_CHANGED
   override val scope = APPLICATION

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/NotificationEventListener.kt
@@ -349,7 +349,8 @@ class NotificationEventListener(
           time = clock.instant(),
           application = config.application,
           config = config,
-          gitMetadata = gitMetadata
+          gitMetadata = gitMetadata,
+          new = notification.new
         ),
         DELIVERY_CONFIG_CHANGED)
     }

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackNotificationEvent.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackNotificationEvent.kt
@@ -97,7 +97,8 @@ data class SlackConfigNotification(
   override val time: Instant,
   override val application: String,
   val config: DeliveryConfig,
-  val gitMetadata: GitMetadata?
+  val gitMetadata: GitMetadata?,
+  val new: Boolean
 ) : SlackNotificationEvent(time, application)
 
 enum class DeploymentStatus {

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/DeliveryConfigNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/DeliveryConfigNotificationHandler.kt
@@ -24,8 +24,14 @@ class DeliveryConfigNotificationHandler(
       log.debug("Sending config changed notification for application ${notification.application}")
       val imageUrl = "https://raw.githubusercontent.com/spinnaker/spinnaker.github.io/master/assets/images/md_icons/config_change.png"
 
-      val headerText = "Delivery config changed"
-      val altText = "config changed"
+      val action = if (notification.new) {
+        "created"
+      } else {
+        "updated"
+      }
+
+      val headerText = "Delivery config $action"
+      val altText = "config $action"
 
       val blocks = withBlocks {
         header {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/rest/DeliveryConfigControllerTests.kt
@@ -283,6 +283,8 @@ internal class DeliveryConfigControllerTests
               firstArg<SubmittedDeliveryConfig>().toDeliveryConfig()
             }
 
+            every { repository.getDeliveryConfigForApplication(deliveryConfig.application) } returns deliveryConfig.toDeliveryConfig()
+
             val request = post("/delivery-configs")
               .accept(contentType)
               .contentType(contentType)


### PR DESCRIPTION
Only send a notification to users if the config they submit is different than what we have. Using a simple object comparison for now, will re-evaluate if this doesn't work for some use cases.

Updating notification text to say "created" if the config is new, or "updated" if it's not new.