### PR TITLE
chore(env): implement ensureNoActiveVerifications

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/verification/VerificationRepository.kt
@@ -57,6 +57,11 @@ interface VerificationRepository {
   )
 
   fun nextEnvironmentsForVerification(minTimeSinceLastCheck: Duration, limit: Int) : Collection<VerificationContext>
+
+  /**
+   * Return the number of verifications in the [environment] of [deliveryConfig] with [status]
+   */
+  fun countVerifications(deliveryConfig: DeliveryConfig, environment: Environment, status: ConstraintStatus): Int
 }
 
 data class VerificationState(

--- a/keel-core/keel-core.gradle.kts
+++ b/keel-core/keel-core.gradle.kts
@@ -47,6 +47,5 @@ dependencies {
   testImplementation("dev.minutest:minutest")
 
   testImplementation("org.assertj:assertj-core")
-  testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
   testImplementation("org.springframework.boot:spring-boot-test-autoconfigure")
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuator.kt
@@ -165,7 +165,7 @@ class ResourceActuator(
               log.info("Resource {} delta: {}", id, diff.toDebug())
               publisher.publishEvent(ResourceDeltaDetected(resource, diff.toDeltaJson(), clock))
 
-              environmentExclusionEnforcer.withActuationLease(environment) {
+              environmentExclusionEnforcer.withActuationLease(deliveryConfig, environment) {
                 plugin.update(resource, diff)
                   .also { tasks ->
                     if (tasks.isNotEmpty()) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/IntermittentFailureTests.kt
@@ -62,8 +62,6 @@ class IntermittentFailureTests : JUnit5Minutests {
       every { getProperty("keel.events.diff-not-actionable.enabled", Boolean::class.java, any()) } returns true
       every { getProperty("keel.enforcement.environment-exclusion.enabled", Boolean::class.java, any()) } returns true
     }
-
-
     val plugin1 = mockk<ResourceHandler<DummyResourceSpec, DummyResourceSpec>>(relaxUnitFun = true) {
       every { name } returns "plugin1"
       every { supportedKind } returns SupportedKind(parseKind("plugin1/foo@v1"), DummyResourceSpec::class.java)

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/actuation/ResourceActuatorTests.kt
@@ -12,6 +12,7 @@ import com.netflix.spinnaker.keel.api.plugins.ActionDecision
 import com.netflix.spinnaker.keel.api.plugins.ResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.SupportedKind
 import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
+import com.netflix.spinnaker.keel.api.verification.VerificationRepository
 import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.keel.core.api.EnvironmentArtifactVeto
@@ -94,7 +95,10 @@ internal class ResourceActuatorTests : JUnit5Minutests {
     val veto = mockk<Veto>()
     val vetoEnforcer = VetoEnforcer(listOf(veto))
     val clock = Clock.systemUTC()
-    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
+    val verificationRepository = mockk<VerificationRepository>() {
+      every { countVerifications(any(), any(), any()) } returns 0
+    }
+    val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, verificationRepository, NoopRegistry(), clock)
     val subject = ResourceActuator(
       resourceRepository,
       artifactRepository,

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcerTest.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcerTest.kt
@@ -1,21 +1,64 @@
 package com.netflix.spinnaker.keel.enforcers
 
 import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.verification.VerificationRepository
+import io.mockk.Called
 import io.mockk.coVerify
-import kotlinx.coroutines.test.runBlockingTest
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
 
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+import java.time.Clock
 
 import org.springframework.core.env.Environment as SpringEnvironment
 
 internal class EnvironmentExclusionEnforcerTest {
 
-  private val springEnv : SpringEnvironment = mockk()
-  private val enforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
+  private val springEnv : SpringEnvironment = mockk() {
+    every { getProperty("keel.enforcement.environment-exclusion.enabled", Boolean::class.java, any())} returns true
+  }
+
+  private val verificationRepository = mockk<VerificationRepository>() {
+    every { countVerifications(any(), any(), any()) }  returns 0
+  }
+
+  private val enforcer = EnvironmentExclusionEnforcer(springEnv, verificationRepository, NoopRegistry(), Clock.systemUTC())
+
+  @Test
+  fun `invoke the action when there are no pending verifications`() {
+    every { verificationRepository.countVerifications(any(), any(), ConstraintStatus.PENDING) } returns 0
+    val action : () -> Unit = mockk(relaxed=true)
+
+    enforcer.withVerificationLease(mockk(relaxed=true), action)
+
+    verify(exactly=1) {
+      action.invoke()
+    }
+  }
+
+  @Test
+  fun `throw an exception when there are pending verifications`() {
+    every { verificationRepository.countVerifications(any(), any(), ConstraintStatus.PENDING) } returns 1
+
+    val action : () -> Unit = mockk(relaxed=true)
+
+    expectCatching { enforcer.withVerificationLease(mockk(relaxed=true), action) }
+      .isFailure()
+      .isA<ActiveVerifications>()
+
+    verify {
+      action wasNot Called
+    }
+  }
+
 
   @ParameterizedTest(name="withVerificationLease executes action, enabled={0}")
   @ValueSource(booleans = [true, false])
@@ -31,15 +74,14 @@ internal class EnvironmentExclusionEnforcerTest {
     }
   }
 
-  @kotlinx.coroutines.ExperimentalCoroutinesApi
   @ParameterizedTest(name="withActuationLease executes action, enabled={0}")
   @ValueSource(booleans = [true, false])
   fun `withActuationLease invokes the action whether the feature flag is enabled or not`(enabled: Boolean) {
     every { springEnv.getProperty("keel.enforcement.environment-exclusion.enabled", Boolean::class.java, any())} returns enabled
 
     val action : suspend () -> Unit = mockk(relaxed=true)
-    runBlockingTest {
-      enforcer.withActuationLease(mockk(), action)
+    runBlocking {
+      enforcer.withActuationLease(mockk(), mockk(), action)
     }
 
     coVerify(exactly=1) {

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/verification/VerificationRunnerTests.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.springframework.context.ApplicationEventPublisher
+import java.time.Clock
 import org.springframework.core.env.Environment as SpringEnvironment
 import java.time.Instant.now
 
@@ -59,7 +60,12 @@ internal class VerificationRunnerTests {
     every { getImages(any(), any()) } returns images
   }
 
-  private val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, NoopRegistry())
+  private val verificationRepository = mockk<VerificationRepository>() {
+    every { countVerifications(any(), any(), any()) }  returns 0
+  }
+
+
+  private val environmentExclusionEnforcer = EnvironmentExclusionEnforcer(springEnv, verificationRepository, NoopRegistry(), Clock.systemUTC())
 
   private val subject = VerificationRunner(
     repository,


### PR DESCRIPTION
Implement the EnvironmentExclusionEnforcer.ensureNoActiveVerifications method. This is progress towards the work started in #1865.

## Main changes

* EnvironmentExclusionEnforcer.ensureNoActiveVerifications is now implemented
* new SqlVerificationRepository.countVerifications method
* EnvironmentExclusionEnforcer.withActuationLease now runs checks inside of IO dispatcher


## Other changes 

* Change how spectator (atlas) timer is called. I was previously passing a function to spectator, but now instead I'm using traditional start/end timestamps for invoking the timer.
* Switch from the experimental `runBlockingTest` to the regular `runBlocking` in test code