### PR TITLE
fix(plugins): Add default 'name' getter for ConstraintEvaluator

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/plugins/ConstraintEvaluator.kt
@@ -50,6 +50,10 @@ interface ConstraintEvaluator<T : Constraint> : SpinnakerExtensionPoint {
     }
   }
 
+  @JvmDefault
+  val name: String
+    get() = extensionClass.simpleName
+
   /**
    * TODO: Docs
    */


### PR DESCRIPTION
Attempt to fix exception loading external `ConstraintEvaluator` plugin:
```
java.lang.ClassCastException: class com.sun.proxy.$Proxy160 cannot be cast to class com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator (com.sun.proxy.$Proxy160 is in unnamed module of loader org.pf4j.PluginClassLoader @345292c1; com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator is in unnamed module of loader 'app')
```