### PR TITLE
fix(slack): truncate long commits to 300 chars

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -53,7 +53,7 @@ class GitDataGenerator(
             confirm {
               deny("Close")
               title("Commit message for $hash")
-              markdownText(commitMessage)
+              markdownText(commitMessage.take(300))
             }
           }
         }


### PR DESCRIPTION
Turns out the confirm dialog can only handle 300 characters. I'm going to look into using an actual modal, but truncating for now so notifications aren't failing to send.