### PR TITLE
fix(constraints): use reference to find constraint when saving

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -426,7 +426,8 @@ class SqlDeliveryConfigRepository(
             .where(
               ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(envUid),
               ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(state.type),
-              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(state.artifactVersion)
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(state.artifactVersion),
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_REFERENCE.eq(state.artifactReference)
             )
             .fetchOne(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID)
         } ?: randomUID().toString()


### PR DESCRIPTION
we need to use the reference field here since version is not guaranteed to be unique across all artifacts