### PR TITLE
fix(constraints): require artifact reference in constraint state

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/ConstraintState.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/ConstraintState.kt
@@ -26,9 +26,7 @@ data class ConstraintState(
   val deliveryConfigName: String,
   val environmentName: String,
   val artifactVersion: String,
-  // FIXME: this should not be nullable as it's the only field uniquely identifying the artifact,
-  //  but would need a DB migration.
-  val artifactReference: String? = null,
+  val artifactReference: String,
   val type: String,
   val status: ConstraintStatus,
   val createdAt: Instant = Instant.now(),

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -390,33 +390,6 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
               .isEqualTo(ConstraintStatus.PASS)
           }
 
-          // TODO: this should be removed when the artifactReference is made non-nullable in the repository methods
-          test("backwards-compatibility: constraint state can be retrieved with missing artifact reference in the database") {
-            val environment = deliveryConfig.environments.first { it.name == "staging" }
-            val originalState = repository.getConstraintState(
-              deliveryConfig.name, environment.name, "keel-1.0.1", "manual-judgement", "keel"
-            )
-            val stateWithNullReference = originalState!!.copy(artifactReference = null)
-            repository.storeConstraintState(stateWithNullReference)
-            val updatedState = repository.getConstraintState(
-              deliveryConfig.name, environment.name, "keel-1.0.1", "manual-judgement", "keel"
-            )
-            expectThat(updatedState).isNotNull()
-            expectThat(updatedState!!.artifactReference).isNull()
-          }
-
-          // TODO: this should be removed when the artifactReference is made non-nullable in the repository methods
-          test("backwards-compatibility: constraint state can be retrieved without passing artifact reference") {
-            val environment = deliveryConfig.environments.first { it.name == "staging" }
-            // This only works currently because the artifactVersion contains the artifact name for debians and makes them
-            // unique, but won't work for Docker.
-            val constraintState = repository.getConstraintState(
-              deliveryConfig.name, environment.name, "keel-1.0.1", "manual-judgement", null
-            )
-            expectThat(constraintState).isNotNull()
-            expectThat(constraintState!!.artifactReference).isNotNull()
-          }
-
           test("can queue constraint approvals") {
             queueConstraintApproval()
             expectThat(repository

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluatorTests.kt
@@ -471,7 +471,8 @@ internal class CanaryConstraintEvaluatorTests : JUnit5Minutests {
     artifactVersion = thirdArg(),
     type = arg(3),
     status = status,
-    attributes = attributes
+    attributes = attributes,
+    artifactReference = "myartifact"
   )
 
   fun Fixture.executionDetailResponse(

--- a/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
+++ b/keel-orca/src/test/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluatorTests.kt
@@ -261,7 +261,8 @@ internal class PipelineConstraintEvaluatorTests : JUnit5Minutests {
     artifactVersion = thirdArg(),
     type = arg(3),
     status = status,
-    attributes = attributes
+    attributes = attributes,
+    artifactReference = "myartifact"
   )
 
   private fun Fixture.getExecutionDetailResponse(id: String, status: OrcaExecutionStatus) =

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -426,7 +426,8 @@ class SqlDeliveryConfigRepository(
             .where(
               ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(envUid),
               ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(state.type),
-              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(state.artifactVersion)
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(state.artifactVersion),
+              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_REFERENCE.eq(state.artifactReference)
             )
             .fetchOne(ENVIRONMENT_ARTIFACT_CONSTRAINT.UID)
         } ?: randomUID().toString()
@@ -552,20 +553,9 @@ class SqlDeliveryConfigRepository(
         .where(
           ENVIRONMENT_ARTIFACT_CONSTRAINT.ENVIRONMENT_UID.eq(environmentUID),
           ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_VERSION.eq(artifactVersion),
-          ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(type)
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.TYPE.eq(type),
+          ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_REFERENCE.eq(artifactReference)
         )
-        .let {
-          // For backwards-compatibility, only use the artifact reference in the query when passed in, but also match
-          // rows with a missing reference.
-          if (artifactReference != null) {
-            it.and(
-              ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_REFERENCE.eq(artifactReference)
-                .or(ENVIRONMENT_ARTIFACT_CONSTRAINT.ARTIFACT_REFERENCE.isNull)
-            )
-          } else {
-            it
-          }
-        }
         .fetchOne { (
                       deliveryConfigName,
                       environmentName,

--- a/keel-sql/src/main/resources/db/changelog/20210316-update-env-artifact-constr.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210316-update-env-artifact-constr.yml
@@ -1,0 +1,28 @@
+databaseChangeLog:
+  - changeSet:
+      id: drop-null-artifact-reference
+      author: emjburns
+      changes:
+        - sql:
+            dbms: mysql
+            sql: DELETE FROM environment_artifact_constraint WHERE artifact_reference is NULL
+  - changeSet:
+      id: non-null-artifact-reference
+      author: embjurns
+      changes:
+        - addNotNullConstraint:
+            tableName: environment_artifact_constraint
+            columnName: artifact_reference
+            columnDataType: varchar(150)
+  - changeSet:
+      id: new-unique-constraint
+      author: emjburns
+      changes:
+        - dropUniqueConstraint:
+            tableName: environment_artifact_constraint
+            constraintName: constraint_pk
+            uniqueColumns: environment_uid, type, artifact_version
+        - addUniqueConstraint:
+            tableName: environment_artifact_constraint
+            constraintName: constraint_pk
+            columnNames: environment_uid, type, artifact_version, artifact_reference

--- a/keel-sql/src/main/resources/db/changelog/20210316-update-env-artifact-constr.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210316-update-env-artifact-constr.yml
@@ -24,5 +24,5 @@ databaseChangeLog:
             uniqueColumns: environment_uid, type, artifact_version
         - addUniqueConstraint:
             tableName: environment_artifact_constraint
-            constraintName: constraint_pk
+            constraintName: constraint_unique
             columnNames: environment_uid, type, artifact_version, artifact_reference

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -251,3 +251,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210302-drop-old-event-columns.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210316-update-env-artifact-constr.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
An artifact version isn't unique across artifacts, but an artifact reference is unique within a delivery config. This pr addresses a longstanding bug where we didn't have the artifact reference as part of the unique constraint on the `environment_artifact_constraint` table.

We've been recording artifact reference in the database since august. In this pr I'm deleting all columns where artifact reference is null. I think this is fine since the data is months old. I tested the migrations locally and it worked just fine (I inserted one row where the artifact reference was null)!