### PR TITLE
fix(plugins): Convert StatefulConstraintEvaluator and StatelessConstraintEvaluator to interfaces

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatefulConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatefulConstraintEvaluator.kt
@@ -23,22 +23,22 @@ import com.netflix.spinnaker.keel.api.events.ConstraintStateChanged
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 
 /**
- * An abstract constraint evaluator that deals with the logic for stateful constraints.
+ * A [ConstraintEvaluator] that deals with the logic for stateful constraints.
  *
  * The [canPromote] function handles reading state from the repository and saving initial state.
  * If the state is 'done' (failed or passed) the specific implementations don't get called.
  * If the state is not 'done', underlying implementations [canPromote] functions get called.
  */
-abstract class StatefulConstraintEvaluator<T : Constraint, A : ConstraintStateAttributes>(
-  protected val repository: ConstraintRepository
-) : ConstraintEvaluator<T> {
-
+interface StatefulConstraintEvaluator<T : Constraint, A : ConstraintStateAttributes> : ConstraintEvaluator<T> {
   /**
    * The type of the metadata saved about the constraint, surfaced here to automatically register it
    * for serialization
    */
-  abstract val attributeType: SupportedConstraintAttributesType<A>
+  val attributeType: SupportedConstraintAttributesType<A>
 
+  val repository: ConstraintRepository
+
+  @JvmDefault
   override fun canPromote(
     artifact: DeliveryArtifact,
     version: String,
@@ -83,7 +83,7 @@ abstract class StatefulConstraintEvaluator<T : Constraint, A : ConstraintStateAt
   /**
    * TODO: Docs.
    */
-  abstract fun canPromote(
+  fun canPromote(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatelessConstraintEvaluator.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/StatelessConstraintEvaluator.kt
@@ -7,19 +7,18 @@ import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.plugins.ConstraintEvaluator
 
 /**
- * An abstract constraint evaluator that deals with constraints that
- * don't need to check the database for their status.
+ * A [ConstraintEvaluator] that deals with constraints that don't need to check the database for their status.
  *
  * This class should be implemented if a constraint has a user-facing (or api-facing)
  * summary. This does not apply to implicit constraints.
  */
-abstract class StatelessConstraintEvaluator<T: Constraint, A : ConstraintStateAttributes>()
+interface StatelessConstraintEvaluator<T: Constraint, A : ConstraintStateAttributes>
   : ConstraintEvaluator<T>{
   /**
    * The type of the metadata saved about the constraint, surfaced here to automatically register it
    * for serialization
    */
-  abstract val attributeType: SupportedConstraintAttributesType<A>
+  val attributeType: SupportedConstraintAttributesType<A>
 
   /**
    * @return a constraint state object that captures the current state of the constraint.
@@ -32,7 +31,8 @@ abstract class StatelessConstraintEvaluator<T: Constraint, A : ConstraintStateAt
    * If a summary of the constraint will not be shown to the user (like with an implicit constraint)
    * this function does not need to be implemented.
    */
-  open fun generateConstraintStateSnapshot(
+  @JvmDefault
+  fun generateConstraintStateSnapshot(
     artifact: DeliveryArtifact,
     version: String,
     deliveryConfig: DeliveryConfig,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
@@ -54,7 +54,7 @@ class AllowedTimesConstraintEvaluator(
   private val clock: Clock,
   private val dynamicConfigService: DynamicConfigService,
   override val eventPublisher: EventPublisher
-) : StatelessConstraintEvaluator<TimeWindowConstraint, AllowedTimesConstraintAttributes>() {
+) : StatelessConstraintEvaluator<TimeWindowConstraint, AllowedTimesConstraintAttributes> {
   override val attributeType = SupportedConstraintAttributesType<AllowedTimesConstraintAttributes>("allowed-times")
 
   companion object {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/DependsOnConstraintEvaluator.kt
@@ -30,8 +30,11 @@ class DependsOnConstraintEvaluator(
   private val verificationRepository: VerificationRepository,
   override val eventPublisher: EventPublisher,
   private val clock: Clock
-) : StatelessConstraintEvaluator<DependsOnConstraint, DependsOnConstraintAttributes>() {
-  val CONSTRAINT_NAME = "depends-on"
+) : StatelessConstraintEvaluator<DependsOnConstraint, DependsOnConstraintAttributes> {
+  companion object {
+    const val CONSTRAINT_NAME = "depends-on"
+  }
+  
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
   override val supportedType = SupportedConstraintType<DependsOnConstraint>("depends-on")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ManualJudgementConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/ManualJudgementConstraintEvaluator.kt
@@ -17,10 +17,10 @@ import org.springframework.stereotype.Component
 
 @Component
 class ManualJudgementConstraintEvaluator(
-  repository: ConstraintRepository,
+  override val repository: ConstraintRepository,
   private val clock: Clock,
   override val eventPublisher: EventPublisher
-) : StatefulConstraintEvaluator<ManualJudgementConstraint, DefaultConstraintAttributes>(repository) {
+) : StatefulConstraintEvaluator<ManualJudgementConstraint, DefaultConstraintAttributes> {
 
   override val supportedType = SupportedConstraintType<ManualJudgementConstraint>("manual-judgement")
   override val attributeType = SupportedConstraintAttributesType<DefaultConstraintAttributes>("manual-judgement")

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/StatefulConstraintEvaluatorTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/constraints/StatefulConstraintEvaluatorTests.kt
@@ -42,10 +42,10 @@ internal class StatefulConstraintEvaluatorTests : JUnit5Minutests {
     class FakeConstraint : StatefulConstraint("fake")
 
     class FakeStatefulConstraintEvaluator(
-      repository: ConstraintRepository,
+      override val repository: ConstraintRepository,
       override val eventPublisher: EventPublisher,
       val delegate: StatefulConstraintEvaluator<FakeConstraint, DefaultConstraintAttributes>
-    ) : StatefulConstraintEvaluator<FakeConstraint, DefaultConstraintAttributes>(repository) {
+    ) : StatefulConstraintEvaluator<FakeConstraint, DefaultConstraintAttributes> {
       override fun canPromote(
         artifact: DeliveryArtifact,
         version: String,

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluator.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/CanaryConstraintEvaluator.kt
@@ -64,10 +64,10 @@ import java.time.Clock
 class CanaryConstraintEvaluator(
   private val handlers: List<CanaryConstraintDeployHandler>,
   private val orcaService: OrcaService,
-  repository: ConstraintRepository,
+  override val repository: ConstraintRepository,
   private val clock: Clock,
   override val eventPublisher: EventPublisher
-) : StatefulConstraintEvaluator<CanaryConstraint, CanaryConstraintAttributes>(repository) {
+) : StatefulConstraintEvaluator<CanaryConstraint, CanaryConstraintAttributes> {
   override val supportedType = SupportedConstraintType<CanaryConstraint>("canary")
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
   private val correlatedMessagePrefix = "Correlated canary tasks found"

--- a/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluator.kt
+++ b/keel-orca/src/main/kotlin/com/netflix/spinnaker/keel/constraints/PipelineConstraintEvaluator.kt
@@ -41,10 +41,10 @@ import org.springframework.stereotype.Component
 @Component
 class PipelineConstraintEvaluator(
   private val orcaService: OrcaService,
-  repository: ConstraintRepository,
+  override val repository: ConstraintRepository,
   override val eventPublisher: EventPublisher,
   private val clock: Clock
-) : StatefulConstraintEvaluator<PipelineConstraint, PipelineConstraintStateAttributes>(repository) {
+) : StatefulConstraintEvaluator<PipelineConstraint, PipelineConstraintStateAttributes> {
   override val supportedType = SupportedConstraintType<PipelineConstraint>("pipeline")
   override val attributeType = SupportedConstraintAttributesType<PipelineConstraintStateAttributes>("pipeline")
 


### PR DESCRIPTION
As seen previously with `ResourceHandler` (#1404), the plugin framework cannot proxy abstract classes. This PR converts `StatefulConstraintEvaluator` and `StatelessConstraintEvaluator` to interfaces to allow for 3rd-party extensions.