### PR TITLE
feat(mj) don't time out manual judgement

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/ConstraintState.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/constraints/ConstraintState.kt
@@ -40,6 +40,10 @@ data class ConstraintState(
 
   fun failed() = status.failed()
 
-  fun timedOut(timeout: Duration, now: Instant) =
-    createdAt.plus(timeout).isBefore(now)
+  fun timedOut(timeout: Duration?, now: Instant) =
+    if (timeout == null) {
+      false
+    } else {
+      createdAt.plus(timeout).isBefore(now)
+    }
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ManualJudgementConstraint.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/ManualJudgementConstraint.kt
@@ -3,6 +3,10 @@ package com.netflix.spinnaker.keel.core.api
 import com.netflix.spinnaker.keel.api.StatefulConstraint
 import java.time.Duration
 
+/**
+ * A manual judgement constraint.
+ * Unless a timeout is set by the user, this constraint will never time out.
+ */
 data class ManualJudgementConstraint(
-  val timeout: Duration = Duration.ofDays(7)
+  val timeout: Duration? = null
 ) : StatefulConstraint("manual-judgement")


### PR DESCRIPTION
Timing out a manual judgement is left over from the pipeline implementation. with pipelines, we didn't want a stage running indefinitely. But MD doesn't have that technical constraint. So, let's just not time out manual judgements. It's frustrating and confusing to users and isn't getting us anything.

I've changed the default to be no time out. is that an appropriate default, or should we have a timeout as default?