### PR TITLE
fix(slack): launch a modal with the full commit

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/callbacks/CommitModalCallbackHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/callbacks/CommitModalCallbackHandler.kt
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.keel.slack.callbacks
+
+import com.netflix.spinnaker.keel.slack.handlers.GitDataGenerator
+import com.slack.api.app_backend.interactive_components.payload.BlockActionPayload
+import com.slack.api.model.view.View
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+
+/**
+ * A handler that builds the modal for launching the full commit modal
+ */
+@Component
+class CommitModalCallbackHandler(
+  private val gitDataGenerator: GitDataGenerator
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  fun buildView(slackCallbackResponse: BlockActionPayload): View {
+    val message = slackCallbackResponse.actions.first().value
+    val hash = slackCallbackResponse.actions.first().actionId.split(":")[1]
+    return gitDataGenerator.buildFullCommitModal(message = message, hash = hash)
+  }
+}

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/callbacks/CommitModalCallbackHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/callbacks/CommitModalCallbackHandler.kt
@@ -1,7 +1,10 @@
 package com.netflix.spinnaker.keel.slack.callbacks
 
+import com.netflix.spinnaker.config.SlackConfiguration
 import com.netflix.spinnaker.keel.slack.handlers.GitDataGenerator
 import com.slack.api.app_backend.interactive_components.payload.BlockActionPayload
+import com.slack.api.bolt.context.builtin.ActionContext
+import com.slack.api.bolt.request.builtin.BlockActionRequest
 import com.slack.api.model.view.View
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -11,14 +14,34 @@ import org.springframework.stereotype.Component
  */
 @Component
 class CommitModalCallbackHandler(
-  private val gitDataGenerator: GitDataGenerator
+  private val gitDataGenerator: GitDataGenerator,
+  private val slackConfiguration: SlackConfiguration
 ) {
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
 
+  fun openModal(req: BlockActionRequest, ctx: ActionContext) {
+    val modal: View = buildView(req.payload)
+    val response = ctx.client().viewsOpen { r ->
+      r
+        .token(slackConfiguration.token)
+        .triggerId(req.payload.triggerId)
+        .view(modal)
+    }
+    if (!response.isOk) {
+      log.error("Failed to send slack callback: {}", response)
+    }
+  }
+
   fun buildView(slackCallbackResponse: BlockActionPayload): View {
-    val message = slackCallbackResponse.actions.first().value
-    val hash = slackCallbackResponse.actions.first().actionId.split(":")[1]
+    val message = slackCallbackResponse.getMessage
+    val hash = slackCallbackResponse.getHash
     return gitDataGenerator.buildFullCommitModal(message = message, hash = hash)
   }
+
+  val BlockActionPayload.getMessage: String
+    get() = actions.first().value
+
+  val BlockActionPayload.getHash: String
+    get() = actions.first().actionId.split(":")[1]
 }


### PR DESCRIPTION
Launch an actual modal with the actual full commit (well, 2000 characters of it) instead of hacking the "close" dialog.
<img width="602" alt="Screen Shot 2021-03-18 at 3 08 37 PM" src="https://user-images.githubusercontent.com/8454927/111704433-5a371600-87fc-11eb-9aaf-81dc17c4b820.png">
