### PR TITLE
chore(artifacts): don't treat missing metadata on local artifact build as an error

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -74,7 +74,7 @@ class ArtifactController(
          artifactMetadataService.getArtifactMetadata(buildNumber, commitId)
        }
     } catch (ex: Exception) {
-      if(buldNumber == "LOCAL") {
+      if(buildNumber == "LOCAL") {
         // this is expected as metadata service doesn't provide info for local builds
         log.info("tried to get artifact metadata for LOCAL build, commit $commitId", ex)
       } else {

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/ArtifactController.kt
@@ -74,7 +74,12 @@ class ArtifactController(
          artifactMetadataService.getArtifactMetadata(buildNumber, commitId)
        }
     } catch (ex: Exception) {
-      log.error("failed to get artifact metadata for build $buildNumber and commit $commitId", ex)
+      if(buldNumber == "LOCAL") {
+        // this is expected as metadata service doesn't provide info for local builds
+        log.info("tried to get artifact metadata for LOCAL build, commit $commitId", ex)
+      } else {
+        log.error("failed to get artifact metadata for build $buildNumber and commit $commitId", ex)
+      }
       null
     }
 }


### PR DESCRIPTION
## Context

When a user builds a deb package locally, the build number is set to LOCAL. These builds are not tracked by the artifact metadata service. 

## Problem

For local builds, keel logs an ERROR level log message when it fails to retrieve the metadata.

## Implemented solution

When  keel tries and fails to retrieve artifact metadata for a local build, log at info level instead.

## Alternate solution

We could detect that it's a LOCAL build and not even make the artifact metadata call in the first place. The current implementation feels a little safer because there's no risk of not calling the service.