### PR TITLE
fix(slack): don't send an empty message .. ever

### DIFF
--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/config/SlackConfiguration.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/config/SlackConfiguration.kt
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration
 @ConfigurationProperties(prefix = "slack")
 class SlackConfiguration {
   var token: String? = null
+  var defaultEmailDomain: String? = null
 }
 
 @Configuration

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackService.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/SlackService.kt
@@ -98,6 +98,37 @@ class SlackService(
   }
 
   /**
+   * Get slack username by the user's [email], apending the default domain if it is
+   * not null and not present in [emailUsername].
+   * Return the original email if username is not found.
+   */
+  fun getUsernameByEmailPrefix(emailUsername: String): String {
+    val defaultDomain = slackConfig.defaultEmailDomain
+    var email = emailUsername
+    if (defaultDomain != null) {
+      // sometimes we get responses from other systems that don't contain the full email
+      // so we add the default domain to the username to construct our best guess at their email
+      if (!emailUsername.contains(defaultDomain)) {
+          email+= "@${defaultDomain}"
+        }
+    }
+    log.debug("lookup user id for username $emailUsername - email guess $email")
+    val response = slack.methods(configToken).usersLookupByEmail { req ->
+      req.email(emailUsername)
+    }
+
+    if (!response.isOk) {
+      log.warn("slack couldn't get username by email for $emailUsername - email guess $email. error is: ${response.error}")
+      return emailUsername
+    }
+
+    if (response.user != null && response.user.name != null) {
+      return "@${response.user.name}"
+    }
+    return emailUsername
+  }
+
+  /**
    * Get user's email address by slack [userId]. Return the original userId if email is not found.
    */
   fun getEmailByUserId(userId: String): String {

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGenerator.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.ScmInfo
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.artifacts.getScmBaseLink
+import com.netflix.spinnaker.keel.slack.SlackService
 import com.slack.api.model.kotlin_extension.block.SectionBlockBuilder
 import com.slack.api.model.kotlin_extension.block.dsl.LayoutBlockDsl
 import com.slack.api.model.kotlin_extension.view.blocks
@@ -24,11 +25,13 @@ import org.springframework.stereotype.Component
 @EnableConfigurationProperties(BaseUrlConfig::class)
 class GitDataGenerator(
   private val scmInfo: ScmInfo,
-  val config: BaseUrlConfig
+  val config: BaseUrlConfig,
+  val slackService: SlackService
 ) {
 
   companion object {
     const val GIT_COMMIT_MESSAGE_LENGTH = 100
+    const val EMPTY_COMMIT_TEXT = "_No commit message to display_"
   }
 
   private val log by lazy { LoggerFactory.getLogger(javaClass) }
@@ -65,9 +68,9 @@ class GitDataGenerator(
    * Doesn't do anything if there is no commit message or the commit message is not too long.
    */
   fun conditionallyAddFullCommitMsgButton(layoutBlockDsl: LayoutBlockDsl, gitMetadata: GitMetadata) {
-    val commitMessage = gitMetadata.commitInfo?.message ?: ""
-    val hash = gitMetadata.commitInfo?.sha ?: ""
-    if (commitMessage != "" && commitMessage.length > GIT_COMMIT_MESSAGE_LENGTH) {
+    val commitMessage = gitMetadata.commitInfo?.message ?: EMPTY_COMMIT_TEXT
+    val hash = gitMetadata.commitInfo?.sha ?: "no-hash"
+    if (commitMessage != EMPTY_COMMIT_TEXT && commitMessage.length > GIT_COMMIT_MESSAGE_LENGTH) {
       layoutBlockDsl.actions {
         elements {
           button {
@@ -82,9 +85,9 @@ class GitDataGenerator(
     }
   }
 
-  fun formatCommitMessage(gitMetadata: GitMetadata): String {
-    val message = gitMetadata.commitInfo?.message ?: "No commit message for commit ${gitMetadata.commit}"
-    return if (gitMetadata.commitInfo?.message != null && message.length > GIT_COMMIT_MESSAGE_LENGTH) {
+  fun formatCommitMessage(gitMetadata: GitMetadata?): String {
+    val message = gitMetadata?.commitInfo?.message ?: EMPTY_COMMIT_TEXT
+    return if (message != EMPTY_COMMIT_TEXT && message.length > GIT_COMMIT_MESSAGE_LENGTH) {
       message.take(GIT_COMMIT_MESSAGE_LENGTH) + "..."
     } else {
       message
@@ -97,7 +100,12 @@ class GitDataGenerator(
    * Or: "spkr/keel › master › c25a358" (if it's a commit without a PR)
    * Each component will have the corresponding link attached to SCM
    */
-  fun generateScmInfo(sectionBlockBuilder: SectionBlockBuilder, application: String, gitMetadata: GitMetadata, artifact: PublishedArtifact?): SectionBlockBuilder {
+  fun generateScmInfo(
+    sectionBlockBuilder: SectionBlockBuilder,
+    application: String,
+    gitMetadata: GitMetadata,
+    artifact: PublishedArtifact?
+  ): SectionBlockBuilder {
     with(sectionBlockBuilder) {
       var details = ""
       with(gitMetadata) {
@@ -149,28 +157,40 @@ class GitDataGenerator(
                          artifact: PublishedArtifact,
                          altText: String,
                          olderVersion: String?  = null,
-                         env: String? = null): SectionBlockBuilder {
+                         env: String? = null
+  ): SectionBlockBuilder {
     var details = ""
     if (olderVersion != null && olderVersion.isNotEmpty()) {
       details += "~$olderVersion~ →"
     }
     var envDetails = ""
     if (env != null) {
-      envDetails +=  "*Environment:* $env\n\n "
+      envDetails +=  "*Environment:* $env\n "
     }
+
+    var text = "*App:* $application\n $envDetails"
 
     val artifactUrl = generateArtifactUrl(application, artifact.reference, artifact.version)
     with(sectionBlockBuilder) {
       with(artifact) {
-        if (buildMetadata != null && gitMetadata != null && gitMetadata!!.commitInfo != null) {
-          markdownText("*App:* $application\n" +
-            "*Version:* $details <$artifactUrl|#${buildMetadata!!.number}> " +
-            "by @${gitMetadata!!.author}\n " + envDetails +
-            formatCommitMessage(gitMetadata!!))
-
-          accessory {
-            image(imageUrl = imageUrl, altText = altText)
+        if (buildMetadata != null) {
+          text += "*Version:* $details <$artifactUrl|#${buildMetadata!!.number}> "
+        }
+        if (gitMetadata != null && gitMetadata?.commitInfo != null) {
+          val author = gitMetadata?.author
+          if (author != null) {
+            val username = slackService.getUsernameByEmailPrefix(author)
+            text += "by $username"
           }
+          text += "\n\n ${formatCommitMessage(gitMetadata)}"
+        }
+        if (buildMetadata == null && gitMetadata == null) {
+          // fall back to info on the artifact
+          text += "*Version:* ${artifact.version} for artifact reference ${artifact.reference}"
+        }
+        markdownText(text)
+        accessory {
+          image(imageUrl = imageUrl, altText = altText)
         }
       }
       return this
@@ -218,21 +238,33 @@ class GitDataGenerator(
                          imageUrl: String,
                          artifact: PublishedArtifact,
                          altText: String,
-                         env: String): SectionBlockBuilder {
+                         env: String,
+                         username: String? = null
+  ): SectionBlockBuilder {
     val artifactUrl = generateArtifactUrl(application, artifact.reference, artifact.version)
+    var text = "*App:* $application\n*Environment:* $env\n\n"
     with(sectionBlockBuilder) {
       with(artifact) {
-        if (buildMetadata != null && gitMetadata != null && gitMetadata!!.commitInfo != null) {
-          markdownText("*App:* $application\n" +
-            "*Environment:* $env\n\n " +
-            ":arrow_down: *PREVIOUSLY PINNED* :arrow_down:\n" +
-            "*Version:* <$artifactUrl|#${buildMetadata!!.number}> " +
-            "by @${gitMetadata!!.author}\n\n" +
-            formatCommitMessage(gitMetadata!!))
-
-          accessory {
-            image(imageUrl = imageUrl, altText = altText)
+        if (buildMetadata != null) {
+          text += ":arrow_down: *PREVIOUSLY PINNED* :arrow_down:\n" +
+            "*Version:* <$artifactUrl|#${buildMetadata!!.number}> "
+        }
+        if (gitMetadata != null && gitMetadata!!.commitInfo != null && username != null) {
+          val author = gitMetadata?.author
+          if (author != null) {
+            val username = slackService.getUsernameByEmailPrefix(author)
+            text += "by $username"
           }
+          text += "\n\n${formatCommitMessage(gitMetadata)}"
+        }
+        if (buildMetadata == null && gitMetadata == null) {
+          // fall back to info on the artifact
+          text += "*Version:* ${artifact.version} for artifact reference ${artifact.reference}"
+        }
+
+        markdownText(text)
+        accessory {
+          image(imageUrl = imageUrl, altText = altText)
         }
       }
       return this

--- a/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
+++ b/keel-slack/src/main/kotlin/com/netflix/spinnaker/keel/slack/handlers/ManualJudgmentNotificationHandler.kt
@@ -54,7 +54,7 @@ class ManualJudgmentNotificationHandler(
         }
 
         // Add a warning section in case there's a pinned artifact
-        if (pinnedArtifact != null){
+        if (pinnedArtifact != null) {
           section {
             markdownText(":warning: Another version is pinned here. You will need to unpin it first to promote this version.")
             accessory {

--- a/keel-slack/src/test/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGeneratorTests.kt
+++ b/keel-slack/src/test/kotlin/com/netflix/spinnaker/keel/slack/handlers/GitDataGeneratorTests.kt
@@ -1,0 +1,82 @@
+package com.netflix.spinnaker.keel.slack.handlers
+
+import com.netflix.spinnaker.config.BaseUrlConfig
+import com.netflix.spinnaker.keel.api.ScmInfo
+import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
+import com.netflix.spinnaker.keel.slack.SlackService
+import com.netflix.spinnaker.time.MutableClock
+import com.slack.api.model.block.SectionBlock
+import com.slack.api.model.block.composition.TextObject
+import com.slack.api.model.kotlin_extension.block.withBlocks
+import dev.minutest.junit.JUnit5Minutests
+import dev.minutest.rootContext
+import io.mockk.every
+import io.mockk.mockk
+import strikt.api.expect
+import strikt.api.expectThat
+import strikt.assertions.isA
+import strikt.assertions.isNotNull
+import strikt.assertions.isTrue
+
+class GitDataGeneratorTests : JUnit5Minutests {
+
+  class Fixture {
+    val scmInfo: ScmInfo = mockk()
+    val slackService: SlackService = mockk()
+    val config: BaseUrlConfig = BaseUrlConfig()
+
+    val subject = GitDataGenerator(scmInfo, config, slackService)
+
+    val clock: MutableClock = MutableClock()
+
+    val application = "keel"
+    val environment = "test"
+    val imageUrl = "http://image-of-something-cute"
+    val altText = "notification about something"
+
+    val artifactNoMetadata = PublishedArtifact(
+      name = "keel-service",
+      type = "docker",
+      version = "keel-service-1234",
+    )
+  }
+
+  fun tests() = rootContext<Fixture> {
+    fixture {
+      Fixture()
+    }
+
+    before {
+      every {
+        slackService.getUsernameByEmail(any())
+      } returns "@keel"
+    }
+
+    context("generating commit info") {
+     test("generates something even if there is no commit info") {
+       val blocks = withBlocks {
+         section {
+           subject.generateCommitInfo(
+             sectionBlockBuilder = this,
+             application = application,
+             imageUrl = imageUrl,
+             artifact = artifactNoMetadata,
+             altText = altText,
+             env = environment
+           )
+         }
+       }
+
+       expectThat(blocks.first())
+         .isA<SectionBlock>()
+         .get { text }.isNotNull()
+
+       val text: TextObject = (blocks.first() as SectionBlock).text
+       expect {
+         that(text.toString().contains(artifactNoMetadata.version)).isTrue()
+         that(text.toString().contains(artifactNoMetadata.reference)).isTrue()
+       }
+     }
+    }
+  }
+}


### PR DESCRIPTION
If an artifact has no commit data, ignore that and still send a manual judgment.

I saw a bunch of failing messages because we were constructing an empty section block if there was no commit message. This PR fixes that by breaking out the text into steps and then sending partial text if we only have partial information.

This also takes a stab at fixing broken slack mentions by taking the email info we get from stash and tacking a domain name on it before searching for a user name.