### PR TITLE
fix(events): Add VerificationBlockedActuation

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/events/ResourceEvent.kt
@@ -66,7 +66,8 @@ import java.time.Instant
   Type(value = ResourceActuationVetoed::class, name = "ResourceActuationVetoed"),
   Type(value = ResourceTaskFailed::class, name = "ResourceTaskFailed"),
   Type(value = ResourceTaskSucceeded::class, name = "ResourceTaskSucceeded"),
-  Type(value = ResourceDiffNotActionable::class, name = "ResourceDiffNotActionable")
+  Type(value = ResourceDiffNotActionable::class, name = "ResourceDiffNotActionable"),
+  Type(value = VerificationBlockedActuation::class, name = "VerificationBlockedActuation")
 )
 abstract class ResourceEvent(
   open val message: String? = null,


### PR DESCRIPTION
#### Problem

Getting the following error when viewing the environment for an app where a verification blocked actuation in the event history:

```
com.fasterxml.jackson.databind.exc.InvalidTypeIdException:
Could not resolve type id 'VerificationBlockedActuation' as a subtype of PersistentEvent
```

#### Implemented solution

Register the type so that jackson knows about it.
