### PR TITLE
Version environments when a resource changes

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
@@ -7,8 +7,6 @@ data class Environment(
   val verifyWith: List<Verification> = emptyList(),
   val notifications: Set<NotificationConfig> = emptySet() // applies to each resource
 ) {
-  override fun toString(): String = "Environment $name"
-
   val resourceIds: Set<String>
     get() = resources.map { it.id }.toSet()
 }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryPeriodicallyCheckedTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ResourceRepositoryPeriodicallyCheckedTests.kt
@@ -1,8 +1,10 @@
 package com.netflix.spinnaker.keel.persistence
 
+import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.deliveryConfig
 import com.netflix.spinnaker.keel.test.resource
 
 abstract class ResourceRepositoryPeriodicallyCheckedTests<S : ResourceRepository> :
@@ -10,11 +12,17 @@ abstract class ResourceRepositoryPeriodicallyCheckedTests<S : ResourceRepository
 
   override val descriptor = "resource"
 
+  abstract val storeDeliveryConfig: (DeliveryConfig) -> Unit
+
   override val createAndStore: Fixture<Resource<ResourceSpec>, S>.(Int) -> Collection<Resource<ResourceSpec>> =
     { count ->
-      (1..count)
-        .map { i ->
-          resource(id = "fnord-$i").also(subject::store)
+      (1..count).mapTo(mutableSetOf()) { i ->
+        resource(id = "fnord-$i").also {
+          subject.store(it)
+        }
+      }
+        .also { resources ->
+          storeDeliveryConfig(deliveryConfig(resources = resources))
         }
     }
 

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -42,6 +42,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_PIN
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VETO
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.LATEST_ENVIRONMENT
 import com.netflix.spinnaker.keel.services.StatusInfoForArtifactInEnvironment
 import com.netflix.spinnaker.keel.sql.RetryCategory.READ
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
@@ -987,7 +988,7 @@ class SqlArtifactRepository(
             ENVIRONMENT_ARTIFACT_VERSIONS,
             ARTIFACT_VERSIONS,
             DELIVERY_ARTIFACT,
-            ENVIRONMENT,
+            LATEST_ENVIRONMENT,
             DELIVERY_CONFIG
           )
           .where(DELIVERY_ARTIFACT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID))
@@ -996,9 +997,9 @@ class SqlArtifactRepository(
           .and(DELIVERY_ARTIFACT.REFERENCE.eq(artifact.reference))
           .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
           .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(ARTIFACT_VERSIONS.VERSION))
-          .and(ENVIRONMENT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID))
-          .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
-          .and(ENVIRONMENT.NAME.eq(environment.name))
+          .and(LATEST_ENVIRONMENT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID))
+          .and(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+          .and(LATEST_ENVIRONMENT.NAME.eq(environment.name))
           .and(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
           .and(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
           .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type))
@@ -1022,16 +1023,16 @@ class SqlArtifactRepository(
           .from(
             ARTIFACT_VERSIONS,
             DELIVERY_ARTIFACT,
-            ENVIRONMENT,
+            LATEST_ENVIRONMENT,
             DELIVERY_CONFIG
           )
           .where(DELIVERY_ARTIFACT.NAME.eq(artifact.name))
           .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type))
           .and(DELIVERY_ARTIFACT.REFERENCE.eq(artifact.reference))
           .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(deliveryConfig.name))
-          .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+          .and(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
           .and(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
-          .and(ENVIRONMENT.NAME.eq(environment.name))
+          .and(LATEST_ENVIRONMENT.NAME.eq(environment.name))
           .and(ARTIFACT_VERSIONS.NAME.eq(artifact.name))
           .and(ARTIFACT_VERSIONS.TYPE.eq(artifact.type))
           .apply { if (artifact.statuses.isNotEmpty()) and(ARTIFACT_VERSIONS.RELEASE_STATUS.`in`(*artifact.statuses.toTypedArray())) }
@@ -1039,7 +1040,7 @@ class SqlArtifactRepository(
             selectOne()
               .from(ENVIRONMENT_ARTIFACT_VERSIONS)
               .where(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_VERSION.eq(ARTIFACT_VERSIONS.VERSION))
-              .and(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(ENVIRONMENT.UID))
+              .and(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(LATEST_ENVIRONMENT.UID))
               .and(ENVIRONMENT_ARTIFACT_VERSIONS.ARTIFACT_UID.eq(DELIVERY_ARTIFACT.UID))
           )
 
@@ -1514,23 +1515,23 @@ class SqlArtifactRepository(
     }
 
   private fun DeliveryConfig.getUidFor(environment: Environment): Select<Record1<String>> =
-    select(ENVIRONMENT.UID)
-      .from(ENVIRONMENT)
-      .where(ENVIRONMENT.NAME.eq(environment.name))
-      .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
+    select(LATEST_ENVIRONMENT.UID)
+      .from(LATEST_ENVIRONMENT)
+      .where(LATEST_ENVIRONMENT.NAME.eq(environment.name))
+      .and(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
 
   private fun DeliveryConfig.getUidFor(environmentName: String): Select<Record1<String>> =
-    select(ENVIRONMENT.UID)
-      .from(ENVIRONMENT)
-      .where(ENVIRONMENT.NAME.eq(environmentName))
-      .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
+    select(LATEST_ENVIRONMENT.UID)
+      .from(LATEST_ENVIRONMENT)
+      .where(LATEST_ENVIRONMENT.NAME.eq(environmentName))
+      .and(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
 
   private fun DeliveryConfig.getUidStringFor(environment: Environment): String =
-    jooq.select(ENVIRONMENT.UID)
-      .from(ENVIRONMENT)
-      .where(ENVIRONMENT.NAME.eq(environment.name))
-      .and(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
-      .fetchOne(ENVIRONMENT.UID) ?: error("environment not found for $name / ${environment.name}")
+    jooq.select(LATEST_ENVIRONMENT.UID)
+      .from(LATEST_ENVIRONMENT)
+      .where(LATEST_ENVIRONMENT.NAME.eq(environment.name))
+      .and(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(uid))
+      .fetchOne(LATEST_ENVIRONMENT.UID) ?: error("environment not found for $name / ${environment.name}")
 
   private val DeliveryArtifact.uid: Select<Record1<String>>
     get() = select(DELIVERY_ARTIFACT.UID)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepository.kt
@@ -19,6 +19,7 @@ import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DIFF_FINGERPRINT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.EVENT
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.LATEST_ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.PAUSED
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.RESOURCE_LAST_CHECKED
@@ -358,11 +359,11 @@ open class SqlResourceRepository(
         val resourceUids =
           txn.select(ENVIRONMENT_RESOURCE.RESOURCE_UID)
             .from(ENVIRONMENT_RESOURCE)
-            .innerJoin(ENVIRONMENT)
-            .on(ENVIRONMENT.UID.eq(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID))
+            .innerJoin(LATEST_ENVIRONMENT)
+            .on(LATEST_ENVIRONMENT.UID.eq(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID))
             .innerJoin(DELIVERY_CONFIG)
-            .on(ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
-            .where(ENVIRONMENT.NAME.eq(environmentName))
+            .on(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+            .where(LATEST_ENVIRONMENT.NAME.eq(environmentName))
             .and(DELIVERY_CONFIG.APPLICATION.eq(application))
             .fetch()
 

--- a/keel-sql/src/main/resources/db/changelog/20210322-environment-version-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210322-environment-version-table.yml
@@ -1,0 +1,53 @@
+databaseChangeLog:
+- changeSet:
+    id: environment-version-table
+    author: fletch
+    changes:
+    - createTable:
+        tableName: environment_version
+        columns:
+        - column:
+            name: environment_uid
+            type: char(26)
+            constraints:
+              nullable: false
+        - column:
+            name: version
+            type: integer
+            defaultValueNumeric: 1
+            constraints:
+              nullable: false
+    - addUniqueConstraint:
+        tableName: environment_version
+        columnNames: environment_uid, version
+        constraintName: environment_version_environment_uid_version_idx
+    - addForeignKeyConstraint:
+        baseTableName: environment_version
+        baseColumnNames: environment_uid
+        constraintName: fk_environment_version_environment
+        referencedTableName: environment
+        referencedColumnNames: uid
+        referencesUniqueColumn: true
+        onDelete: CASCADE
+    - sql:
+        sql: |
+          insert into environment_version (environment_uid, version) select uid, 1 from environment;
+    - addColumn:
+        tableName: environment_resource
+        columns:
+        - name: environment_version
+          type: integer
+          afterColumn: environment_uid
+          constraints:
+            nullable: false
+          value: 1
+    - dropForeignKeyConstraint:
+        baseTableName: environment_resource
+        constraintName: fk_environment_resource_environment
+    - addForeignKeyConstraint:
+        baseTableName: environment_resource
+        baseColumnNames: environment_uid, environment_version
+        constraintName: fk_environment_resource_environment_version
+        referencedTableName: environment_version
+        referencedColumnNames: environment_uid, version
+        onDelete: CASCADE

--- a/keel-sql/src/main/resources/db/changelog/20210325-latest-environment-view.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210325-latest-environment-view.yml
@@ -1,0 +1,12 @@
+databaseChangeLog:
+- changeSet:
+    id: latest-environment-view
+    author: fletch
+    changes:
+    - createView:
+        viewName: latest_environment
+        selectQuery: |
+          select uid, delivery_config_uid, name, max(version) as version, constraints, notifications, verifications
+          from environment, environment_version
+          where environment.uid = environment_version.environment_uid
+          group by environment.uid

--- a/keel-sql/src/main/resources/db/changelog/20210331-fix-environment-resource-pk.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210331-fix-environment-resource-pk.yml
@@ -1,0 +1,10 @@
+databaseChangeLog:
+- changeSet:
+    id: fix-environment-resource-pk
+    author: fletch
+    changes:
+    - dropPrimaryKey:
+        tableName: environment_resource
+    - addPrimaryKey:
+        tableName: environment_resource
+        columnNames: environment_uid, environment_version, resource_uid

--- a/keel-sql/src/main/resources/db/changelog/20210331-fix-resource-with-metadata-view.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210331-fix-resource-with-metadata-view.yml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+- changeSet:
+    id: fix-resource-with-metadata-view
+    author: fletch
+    changes:
+    - dropView:
+        viewName: resource_with_metadata
+    - createView:
+        viewName: resource_with_metadata
+        selectQuery: |
+          select
+            resource.uid,
+            resource.id,
+            resource.application,
+            resource.kind,
+            json_object(
+              'uid', resource.uid,
+              'id', resource.id,
+              'version', resource.version,
+              'application', resource.application,
+              'environment', latest_environment.uid,
+              'environmentName', latest_environment.name,
+              'deliveryConfig', delivery_config.uid,
+              'serviceAccount', delivery_config.service_account
+            ) as metadata,
+            resource.spec
+          from resource
+          left join environment_resource on resource.uid = environment_resource.resource_uid
+          join latest_environment on latest_environment.uid = environment_resource.environment_uid and latest_environment.version = environment_resource.environment_version
+          left join delivery_config on delivery_config.uid = latest_environment.delivery_config_uid
+          where resource.version = (select max(r2.version) from resource r2 where resource.id = r2.id)

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -254,3 +254,15 @@ databaseChangeLog:
   - include:
       file: changelog/20210316-update-env-artifact-constr.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210322-environment-version-table.yml
+      relativeToChangelogFile: true
+  - include:
+      file: changelog/20210325-latest-environment-view.yml
+      relativeToChangelogFile: true
+  - include:
+      file: changelog/20210331-fix-environment-resource-pk.yml
+      relativeToChangelogFile: true
+  - include:
+      file: changelog/20210331-fix-resource-with-metadata-view.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/EnvironmentVersioningTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/EnvironmentVersioningTests.kt
@@ -1,0 +1,221 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.NotificationConfig
+import com.netflix.spinnaker.keel.api.NotificationFrequency.normal
+import com.netflix.spinnaker.keel.api.NotificationType.slack
+import com.netflix.spinnaker.keel.api.Verification
+import com.netflix.spinnaker.keel.api.plugins.kind
+import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.LATEST_ENVIRONMENT
+import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
+import com.netflix.spinnaker.keel.test.DummyResourceSpec
+import com.netflix.spinnaker.keel.test.configuredTestObjectMapper
+import com.netflix.spinnaker.keel.test.defaultArtifactSuppliers
+import com.netflix.spinnaker.keel.test.deliveryConfig
+import com.netflix.spinnaker.keel.test.randomString
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.api.expectThat
+import strikt.assertions.first
+import strikt.assertions.hasSize
+import strikt.assertions.isEmpty
+import strikt.assertions.isEqualTo
+import strikt.assertions.isSuccess
+import java.time.Clock
+import java.time.Duration
+
+class EnvironmentVersioningTests {
+  private val jooq = testDatabase.context
+  private val objectMapper = configuredTestObjectMapper()
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+  private val resourceSpecIdentifier =
+    ResourceSpecIdentifier(
+      kind<DummyResourceSpec>("test/whatever@v1")
+    )
+  val deliveryConfig = deliveryConfig()
+
+  private val deliveryConfigRepository = SqlDeliveryConfigRepository(
+    jooq,
+    Clock.systemUTC(),
+    resourceSpecIdentifier,
+    objectMapper,
+    sqlRetry,
+    defaultArtifactSuppliers()
+  )
+
+  private val resourceRepository = SqlResourceRepository(
+    jooq,
+    Clock.systemUTC(),
+    resourceSpecIdentifier,
+    emptyList(),
+    objectMapper,
+    sqlRetry
+  )
+
+  @BeforeEach
+  fun storeDeliveryConfig() {
+    deliveryConfig.resources.forEach(resourceRepository::store)
+    deliveryConfigRepository.store(deliveryConfig)
+  }
+
+  @AfterEach
+  fun flush() {
+    cleanupDb(jooq)
+  }
+
+  @Test
+  fun `storing an environment with no changes does not create a new version`() {
+    val initialVersion = latestVersion()
+    expectThat(initialVersion).describedAs("initial version") isEqualTo 1
+
+    deliveryConfigRepository.store(deliveryConfig)
+
+    val updatedVersion = latestVersion()
+    expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion
+  }
+
+  @Test
+  fun `storing an environment with updated constraints, verifications, or notifications does not create a new version`() {
+    val initialVersion = latestVersion()
+    expectThat(initialVersion).describedAs("initial version") isEqualTo 1
+
+    deliveryConfig.run {
+      copy(
+        environments = environments.first().run {
+          copy(
+            constraints = setOf(ManualJudgementConstraint()),
+            verifyWith = listOf(DummyVerification()),
+            notifications = setOf(NotificationConfig(type = slack,
+              address = "#trashpandas",
+              frequency = normal))
+          )
+        }
+          .let(::setOf)
+      )
+    }
+    deliveryConfigRepository.store(deliveryConfig)
+
+    val updatedVersion = latestVersion()
+    expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion
+  }
+
+  @Test
+  fun `storing an environment with an updated resource creates a new version`() {
+    val initialVersion = latestVersion()
+    expectThat(initialVersion).describedAs("initial version") isEqualTo 1
+
+    deliveryConfig.withUpdatedResource()
+      .also(deliveryConfigRepository::store)
+
+    val updatedVersion = latestVersion()
+    expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion + 1
+  }
+
+  @Test
+  fun `after creating a new environment version it's still possible to get the environment for a resource`() {
+    deliveryConfig.withUpdatedResource()
+      .also(deliveryConfigRepository::store)
+
+    expectCatching {
+      deliveryConfigRepository.environmentFor(deliveryConfig.resources.first().id)
+    }
+      .isSuccess()
+      .and {
+        get(Environment::name) isEqualTo deliveryConfig.environments.first().name
+        get(Environment::resources) hasSize deliveryConfig.environments.first().resources.size
+      }
+  }
+
+  @Test
+  fun `after creating a new environment version it's still possible to get the delivery config for a resource`() {
+    deliveryConfig.withUpdatedResource()
+      .also(deliveryConfigRepository::store)
+
+    expectCatching {
+      deliveryConfigRepository.deliveryConfigFor(deliveryConfig.resources.first().id)
+    }
+      .isSuccess()
+      .get(DeliveryConfig::name) isEqualTo deliveryConfig.name
+  }
+
+  @Test
+  fun `after creating a new environment version only the newest resource version gets checked`() {
+    deliveryConfig.withUpdatedResource()
+      .also(deliveryConfigRepository::store)
+
+    expectCatching {
+      resourceRepository.itemsDueForCheck(Duration.ofMinutes(1), 1)
+    }
+      .isSuccess()
+      .hasSize(1)
+      .first()
+      .get { metadata["version"] } isEqualTo 2
+
+    expectCatching {
+      resourceRepository.itemsDueForCheck(Duration.ofMinutes(1), 1)
+    }
+      .isSuccess()
+      .isEmpty()
+  }
+
+  @Test
+  fun `after creating a new environment version only the newest environment version gets checked`() {
+    deliveryConfig.withUpdatedResource()
+      .also(deliveryConfigRepository::store)
+
+    expectCatching {
+      deliveryConfigRepository.itemsDueForCheck(Duration.ofMinutes(1), 1)
+    }
+      .isSuccess()
+      .hasSize(1)
+      .first()
+      .get(DeliveryConfig::environments)
+      .hasSize(1)
+      .first()
+      .get(Environment::resources)
+      .hasSize(1)
+      .first()
+      .get { metadata["version"] } isEqualTo 2
+
+    expectCatching {
+      deliveryConfigRepository.itemsDueForCheck(Duration.ofMinutes(1), 1)
+    }
+      .isSuccess()
+      .isEmpty()
+  }
+
+  private fun DeliveryConfig.withUpdatedResource() =
+    copy(
+      environments = environments.first().run {
+        copy(resources = resources.first().run {
+          copy(spec = (spec as DummyResourceSpec).run {
+            copy(data = randomString())
+          })
+        }
+          .also(resourceRepository::store)
+          .let(::setOf)
+        )
+      }
+        .let(::setOf)
+    )
+
+  private fun latestVersion() =
+    jooq
+      .select(LATEST_ENVIRONMENT.VERSION)
+      .from(LATEST_ENVIRONMENT)
+      .fetchOne(LATEST_ENVIRONMENT.VERSION)
+
+  data class DummyVerification(
+    override val id: String = "whatever",
+  ) : Verification {
+    override val type = "verification"
+  }
+}

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlResourceRepositoryTests.kt
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.keel.sql
 
+import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.persistence.DummyResourceSpecIdentifier
 import com.netflix.spinnaker.keel.persistence.ResourceRepositoryTests
 import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
@@ -12,6 +13,13 @@ internal class SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceR
   private val jooq = testDatabase.context
   private val retryProperties = RetryProperties(5, 100)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+  private val deliveryConfigRepository = SqlDeliveryConfigRepository(
+    jooq,
+    clock,
+    DummyResourceSpecIdentifier,
+    configuredObjectMapper(),
+    sqlRetry
+  )
 
   override fun factory(clock: Clock): SqlResourceRepository {
     return SqlResourceRepository(
@@ -23,6 +31,8 @@ internal class SqlResourceRepositoryTests : ResourceRepositoryTests<SqlResourceR
       sqlRetry
     )
   }
+
+  override val storeDeliveryConfig: (DeliveryConfig) -> Unit = deliveryConfigRepository::store
 
   override fun flush() {
     cleanupDb(jooq)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/DeliveryConfigs.kt
@@ -14,11 +14,30 @@ import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 fun deliveryConfig(
   resource: Resource<*> = resource(),
   env: Environment = Environment("test", setOf(resource)),
+  application: String = "fnord",
   configName: String = "myconfig",
   artifact: DeliveryArtifact = DebianArtifact(name = "fnord", deliveryConfigName = configName, vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2"))),
   deliveryConfig: DeliveryConfig = DeliveryConfig(
     name = configName,
-    application = "fnord",
+    application = application,
+    serviceAccount = "keel@spinnaker",
+    artifacts = setOf(artifact),
+    environments = setOf(env),
+    metadata = mapOf("some" to "meta")
+  )
+): DeliveryConfig {
+  return deliveryConfig
+}
+
+fun deliveryConfig(
+  resources: Set<Resource<*>>,
+  env: Environment = Environment("test", resources),
+  application: String = "fnord",
+  configName: String = "myconfig",
+  artifact: DeliveryArtifact = DebianArtifact(name = "fnord", deliveryConfigName = configName, vmOptions = VirtualMachineOptions(baseOs = "bionic", regions = setOf("us-west-2"))),
+  deliveryConfig: DeliveryConfig = DeliveryConfig(
+    name = configName,
+    application = application,
     serviceAccount = "keel@spinnaker",
     artifacts = setOf(artifact),
     environments = setOf(env),


### PR DESCRIPTION
A new version of an environment is created whenever a resource in that environment changes. There are currently no user-facing implications, but this is laying the groundwork for using environment versions rather than artifact versions to drive promotion.