### PR TITLE
fix(verif): use env lease to address race condition

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,21 @@
+# Configuration
+
+Configuration lives in classes in the `com.netflix.spinnaker.config` package, annotated with `@ConfigurationProperties`.
+
+## Dynamic configuration
+
+The standard Spring configuration values are initialized once, on startup.
+If you want configuration values that can change at runtime, use a pattern like this:
+
+```kotlin
+import org.springframework.core.env.Environment
+
+class Notifier(
+  private val springEnv: Environment,
+  ...
+) {
+
+  private val notificationsEnabled: Boolean
+    get() = springEnv.getProperty("keel.notifications.resource", Boolean::class.java, true)
+
+```

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,45 @@
+# Database
+
+Keel assumes a SQL database backend.
+The codebase uses the [jOOQ](https://jooq.org) library for generating and executing SQL queries.
+Internally, Netflix uses Amazon Aurora MySQL to back keel, so that's the most battle-tested back-end.
+
+## Migrations
+
+Keel uses [liquibase](https://www.liquibase.org/) for database migrations.
+We use the YAML representation for specifying migrations.
+
+Migration files are in keel-sql/src/main/resources/db/changelog.
+
+## Conventions
+
+### Table names
+
+Table names use snake_case.
+Table names are (usually) singular (e.g., `delivery_config` not `delivery_configs`).
+
+### Primary key column
+
+The primary key column is named `uid`, and is a 26-character string.
+Like the other Spinnaker apps, keel uses [ULIDs](https://github.com/ulid/spec) for primary key ids.
+A ULID is canonically represented as a 26 character string, so the primary key column definition looks like this in the liquibase migrations:
+
+```yaml
+- createTable:
+    tableName: ...
+        - column:
+          name: uid
+          type: char(26)
+          constraints:
+          nullable: false
+```
+
+
+To generate a ULID in code:
+
+```kotlin
+import com.netflix.spinnaker.keel.core.api.randomUID
+
+val uid = randomUID().toString()
+```
+

--- a/docs/environment-exclusion/environment-leases.md
+++ b/docs/environment-exclusion/environment-leases.md
@@ -1,0 +1,72 @@
+# Environment leases
+
+As described in the [overview](overview.md), the enforcer needs to ensure that only one process at a time can take the following two actions:
+1. check that a verification / resource actuation can safely be run in an environment, E
+2. record that E is now in use (e.g., a version is recorded as DEPLOYING, a verification is recorded as PENDING).
+
+Once that the environment has been recorded as being in use, it is safe to release the lock.
+
+In keel, this locking mechanism is implemented as a *lease*, which behaves just like a lock, except that it also has an expiration time.
+Once a lease expires, another process can take the lock. 
+The reason we use a lease instead of a lock is to recover from the situation where an instance crashes while holding a lock.
+
+## Interface
+
+A lease is acquired by calling the `EnvironmentLeaseRepository.tryAcquireLease` method.
+
+```kotlin
+val repository : EnvironmentLeaseRepository = ...
+val lease = repository.tryAcquireLease(...)
+
+// do stuff here while holding the lease
+
+lease.close()
+```
+
+Because the `Lease` interface implements Java's *Autocloseable* interface, you can use Kotlin's *use* function to ensure that the lease always gets closed, as explained in this [Baeldung article](https://www.baeldung.com/kotlin/try-with-resources).
+
+```kotlin
+repository.tryAcquireLease(...).use{
+    // do stuff here while holding the lease
+}
+```
+
+## Implementation
+
+The `SqlEnvironmentLeaseRepository` class implements the environment leases.
+A lease is represented by a row in the `environment_lease` table, with the following columns:
+
+* `uid` - lease id
+* `environment_uid` - environment being locked
+* `leased_by` - a string that describes who is currently holding the lease. We use hostnames for this description.
+* `leased_at` - the time the lease was taken
+* `comment` - human readable info to help with debugging if a human needs to examine the record (e.g., "actuation" if the lease was taken for actuation, "verification" if lease was taken for verification).
+
+When the `tryAcquireLease` method is called, the repository checks to see if there is a record in the database that hasn't expired yet.
+
+The duration of the lease is controlled by the `keel.environment-exclusion.lease.duration` property (see [configuration values](../config.md) for more details.
+
+### Primary key rationale
+
+We never expect more than one lease per environment.
+Therefore, we could theoretically use the envrionment_uid as a primary key.
+However, we use as separate id to handle the following scenario:
+
+1. Instance A requests a lease for environment E.
+2. The repository grants A a lease for E.
+3. Instance A gets wedged.
+4. Time passes that exceeds the lease duration
+5. Instance B requests a lease for E.
+6. The repository grants B a lease for E because A's lease is expired.
+7. Instance A becomes unstuck.
+8. Instance A return its lease.
+9. The repository deletes the record associated with E.
+10. Instance C requests a lease for E.
+11. The repository grants C a lease for E(!).
+
+Now B and C both think they have the lease.
+
+By giving each lease its own identifier, it is safe to return an expired lease.
+
+In addition, if we ever decide to increase the granularity of the locks, we will need to have a primary key that is not the environment uid.
+

--- a/docs/environment-exclusion/metrics.md
+++ b/docs/environment-exclusion/metrics.md
@@ -1,0 +1,29 @@
+# Metrics (environment exclusion)
+
+### lease.env.count
+
+A counter which tracks the number of times that clients attempt to take a lease.
+
+Tags:
+
+* action: `verification` or `actuation`
+* outcome:
+  - `granted` if lease was granted
+  - `denied` if lease was denied
+* status:
+  - `free` if there was no existing lease
+  - `expired` if there was an existing lease, but it was expired
+  - `active` if there was an existing lease that is still active (success will be `false`)
+
+### lease.env.duration
+
+A percentile timer which records the amount of time spent holding a lease or attempting to get a lease.
+
+Note that this includes the time spent initiating an actuation or a verification since those actions are performed while holding the lease.
+
+Tags:
+* action: `verification` or `actuation`
+* outcome:
+  - `granted` if lease was granted
+  - `denieed` if lease was denied
+

--- a/docs/environment-exclusion/overview.md
+++ b/docs/environment-exclusion/overview.md
@@ -1,0 +1,90 @@
+# Environment exclusion
+
+This doc describes the purpose and behavior of environment exclusion, as implemented by the  `EnvironmentExclusionEnforcer` class.
+
+For related configuration paramters, see [config.md](config.md).
+For related metrics, see [metrics.md](metrics.md).
+
+## Context
+
+Two [safety properties][1] we want to enforce:
+
+P1. Two verifications should never execute concurrently against the same environment.
+
+P2. Verification against an environment should never happen concurrently with the actuation of any resources in an environment (including any artifact being deployed to that environment).
+
+The `EnvironmentExclusionEnforcer` class (the enforcer) exists to enforce these properties.
+
+Note: these properties are more coarse grained than we really need. For example, it may be safe to run two different types of verifications in the same environment, or to run a verification while a resource like a security group is being updated.
+In the future, we may increase the granularity of these checks in order to improve performance.
+
+[1]: https://buttondown.email/hillelwayne/archive/safety-and-liveness-properties/
+
+
+## Basic strategy
+
+* Before starting a verification, check if any other verifications or actuations are happening in the environment.
+* Before actuating a resource, check if any verifications are happening in the environment.
+
+Our basic strategy looks like this:
+
+```
+status = get_status()
+if (status == "free") {
+    take_action()
+    set_status("busy")
+}
+```
+
+The problem is that this block of code must be executed atomically.
+Otherwise, there's a risk that two separate processes both call `take_action()`.
+
+For example, if you had two processes, P1, and P2, and they were scheduled like this:
+
+```
+Time
+ |
+ |    P1: status = get_status()
+ |        if (status == "free") {
+ |
+ |                                      P2: status = get_status()
+ |                                          if (status == "free") {
+ |                                            take_action()
+ |                                            set_status("busy")
+ |          take_action()
+ |          set_status("busy")
+ ↓
+```
+
+We need to treat the block of code as a [critical section][2].
+The enforcer implements a locking mechanism to ensure that only one process can be in the above block of code, per environment.
+
+See [environment leases](environment-leases.md) for details on how the locking mechanism is implemented.
+
+[2]: https://en.wikipedia.org/wiki/Critical_section
+
+
+## How the enforcer is used
+
+The enforcer works by granting leases. A client must hold a lease before either:
+* starting a verification in an environemnt, by calling `EnvironmentExclusionEnforcer.withVerificationLease`
+* deploying an artifact version into an environment, by calling `EnvironmentExclusionEnforcer.withActuationLease`
+
+
+For how the enforcer is used, see:
+* [Verifications and environment execlusion](verifications.md)
+* [Resource actuation and environment exclusion](resource-actuation.md)
+
+## How the enforcer works
+
+The enforcer relies on an `EnvironmentLeaseRepository` implementation to implement the actual locking mechanism.
+We'll call that the "low-level lease" here.
+
+The enforcer does the following:
+
+1. Try to get a low-level lease from the `EnvironmentLeaseRepository`.
+2. If successful, check to see if the proposed action is safe.
+3. If safe, execute the action.
+4. Release the lease.
+
+See [environment-leases.md](environment-leases.md) for more details.

--- a/docs/environment-exclusion/resource-actuation.md
+++ b/docs/environment-exclusion/resource-actuation.md
@@ -1,0 +1,74 @@
+### Resource actuation and environment exclusion
+
+## Behavior
+
+The `EnvironmentExclusionEnforcer.withActuationLease` method has the following preconditions and postconditions:
+
+**precondition**
+
+ * The client requests an actuation lease for an environment E before attempting to update a resource in E
+
+**postconditions**
+
+* If client is granted a deployment lease for E, there are no active verifications in E
+* if client is not granted an actuation lease, the enforcer will throw an EnvironmentCurrentlyBeingActedOn exception subclass
+
+Note: The deployment lease doesn't check for active deployments because the ArtifacctRepository already enforces only one active deployment in an environment for a given artifact.
+
+
+## Implementation
+
+The `ResourceActuator.checkResource` method uses the enforcer to protect the `ResourceHandler.update` extension function, and handles the exceptions:
+
+```
+class ResourceActuator {
+
+    fun checkResource(...) {
+        ...
+        environmentExclusionEnforcer.withActuationLease(deliveryConfig, environment) {
+            plugin.update(resource, diff)
+            .also{ ... }
+        }
+        ...
+      } catch (e: ActiveVerifications) {
+          ...
+      } catch (e: EnvironmentCurrentlyBeingActedOn) {
+          ...
+      }
+```
+
+## Existing race condition: asynchronous marking of artifact as deploying
+
+In the current implementation, keel implements the APPROVED → DEPLOYING version-in-environment repository state transition like this:
+
+1. ResourceHandler upsert methods (e.g., `ClusterHandler.upsert`, `TitusClusterHandler.upsert`) call `notifyArtifactDeploying`
+2. `notifyArtifactDeploying` emits an `artifactVersionDeploying` event.
+3. The `onArtifactVersionDeploying` event handler writes DEPLOYING to the database.
+
+Keel is configured to use a [threadpool][1] so that events are handled asynchronously.
+(The original motivation was to prevent metric publishing from blocking, see [PR #268][2].)
+
+Because the database update may not happen until after the `plugin.update` method returns, we can get race conditions.
+
+Consider the following code, with instances A,B, environment E, version V, where A is trying to promote a version, and B is trying to verify a version:
+
+```kotlin
+enforcer.requestLease(...)
+ .withLease {
+    plugin.update(resource, diff)
+}
+```
+
+1. A: gets lease on env E
+2. A: starts deploying V in E
+3. A: emits ArtifactVersionDeploying event async
+4. A: releases lease on E
+  *  **DANGER: There is now no lease on E, and (E,V) promotion status is still APPROVED**
+5. B: gets lease (!) on env V
+6. A: ArtifactVersionDeploying listener fires, writes promotion status DEPLOYING to database
+7. B: starts running a verification against E
+
+To fix this, we need to enforce that DEPLOYING gets written out to the database before the lease gets released.
+
+[1]: https://github.com/spinnaker/keel/blob/9db12ff2949db3c38501747e6cae3de3ec11fc6f/keel-web/src/main/kotlin/com/netflix/spinnaker/config/EventsConfiguration.kt#L13
+[2]: https://github.com/spinnaker/keel/pull/26

--- a/docs/environment-exclusion/verifications.md
+++ b/docs/environment-exclusion/verifications.md
@@ -1,0 +1,45 @@
+
+# Verifications and environment execlusion
+
+## Behavior
+
+The `EnvironmentExclusionEnforcer.withVerificationLease` method has the following preconditions and postconditions:
+
+**precondition**
+
+ * The client requests a verification lease for an environment E before attempting to start a verification in E
+
+**postcondition**
+
+ * if client is granted a verification lease for an environment E, there are no active verifications or deployments in E
+ * if client is not granted a verification lease, the enforcer will throw an EnvironmentCurrentlyBeingActedOn exception subclass
+
+## Implementation
+
+The VerificationRunner.runVerificationsFor method uses the enforcer to protect the `VerificationContext.start` extension function.
+
+```kotlin
+class VerificationRunner {
+
+  private fun VerificationContext.start(...) {
+        ...
+
+        enforcer.withVerificationLease(this) {
+            start(verification, ...)
+        }
+```
+
+The CheckScheduler.verifyEnvironments method handles the exception:
+
+```kotlin
+class CheckScheduler {
+
+  fun verifyEnvironments() {
+    ...
+    try {
+        verificationRunner.runVerificationsFor(it)
+    } catch (e: EnvironmentCurrentlyBeingActedOn) {
+        ...
+    }
+
+```

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -296,6 +296,10 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         test("listing versions returns an empty list") {
           expectThat(subject.versions(versionedSnapshotDebian)).isEmpty()
         }
+
+        test("no version is deploying") {
+          expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isFalse()
+        }
       }
 
       context("an artifact version already exists") {
@@ -442,6 +446,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             get(ArtifactVersionStatus::deploying).isNull()
             get(ArtifactVersionStatus::previous).isEmpty()
           }
+
+          expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isFalse()
         }
 
         test("an artifact version can be vetoed even if it was not previously deployed") {
@@ -521,12 +527,16 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
             get(ArtifactVersionStatus::previous).isEmpty()
           }
 
+          expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isTrue()
+
           expectThat(versionsIn(stagingEnvironment, versionedDockerArtifact)) {
             get(ArtifactVersionStatus::pending).isEmpty()
             get(ArtifactVersionStatus::current).isNull()
             get(ArtifactVersionStatus::deploying).isEqualTo(version6)
             get(ArtifactVersionStatus::previous).isEmpty()
           }
+
+          expectThat(subject.isDeployingTo(manifest, stagingEnvironment.name)).isTrue()
         }
 
         test("promoting the same version again returns false") {
@@ -574,6 +584,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
               get(ArtifactVersionStatus::deploying).isNull()
               get(ArtifactVersionStatus::previous).isEmpty()
             }
+
+            expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isFalse()
           }
 
           test("querying for current returns the full artifact") {
@@ -608,6 +620,9 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
                 get(ArtifactVersionStatus::deploying).isEqualTo(version2)
                 get(ArtifactVersionStatus::previous).isEmpty()
               }
+
+              expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isTrue()
+
             }
 
             context("the new version is marked as successfully deployed") {
@@ -637,6 +652,9 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
                   get(ArtifactVersionStatus::deploying).isNull()
                   get(ArtifactVersionStatus::previous).containsExactly(version1)
                 }
+
+                expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isFalse()
+
               }
             }
           }
@@ -658,6 +676,8 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
                 get(ArtifactVersionStatus::previous).containsExactly(version1)
                 get(ArtifactVersionStatus::skipped).containsExactly(version2)
               }
+
+              expectThat(subject.isDeployingTo(manifest, testEnvironment.name)).isFalse()
             }
           }
         }

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/EnvironmentLeaseRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/EnvironmentLeaseRepositoryTests.kt
@@ -1,0 +1,98 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.exceptions.ActiveLeaseExists
+import com.netflix.spinnaker.time.MutableClock
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+import strikt.assertions.isSuccess
+import java.time.Duration
+
+abstract class EnvironmentLeaseRepositoryTests<IMPLEMENTATION : EnvironmentLeaseRepository> {
+  abstract fun createSubject(): IMPLEMENTATION
+
+  protected val leaseDuration : Duration = Duration.ofSeconds(60)
+
+  private val testEnv = Environment(name="test")
+  private val prodEnv = Environment(name="prod")
+  protected val deliveryConfig = DeliveryConfig(
+    application = "fnord",
+    name = "fnord-manifest",
+    serviceAccount = "jamm@illuminati.org",
+    artifacts = setOf(
+      DockerArtifact(
+        name = "fnord",
+        deliveryConfigName = "fnord-manifest",
+        reference = "fnord-docker-stable",
+        branch = "main"
+      )
+    ),
+    environments = setOf( testEnv, prodEnv )
+  )
+
+  val clock = MutableClock()
+  val subject: IMPLEMENTATION by lazy { createSubject() }
+
+  @Test
+  fun `can get a lease when there are no leases yet`() {
+    expectCatching { subject.tryAcquireLease(deliveryConfig, testEnv, "unit test") }
+      .isSuccess()
+  }
+
+  @Test
+  fun `cannot get a lease when there is an active lease`() {
+    // Add a lease
+    subject.tryAcquireLease(deliveryConfig, testEnv, "unit test")
+
+    // Try again 1 second later
+    clock.tickSeconds(1)
+    expectCatching { subject.tryAcquireLease(deliveryConfig, testEnv, "unit test") }
+      .isFailure()
+      .isA<ActiveLeaseExists>()
+  }
+
+  @Test
+  fun `can get a lease when the previous lease has expired`() {
+    // Add a lease
+    subject.tryAcquireLease(deliveryConfig, testEnv, "unit test")
+
+    // Try again 5 minutes later
+    clock.tickMinutes(5)
+    expectCatching { subject.tryAcquireLease(deliveryConfig, testEnv, "unit test") }
+      .isSuccess()
+  }
+
+
+  @Test
+  fun `can get a lease for a different environment`() {
+    // Add a lease
+    subject.tryAcquireLease(deliveryConfig, testEnv, "unit test")
+
+    // Try a different environment one second later
+    clock.tickSeconds(1)
+    expectCatching { subject.tryAcquireLease(deliveryConfig, prodEnv, "unit test") }
+      .isSuccess()
+  }
+
+
+  @Test
+  fun `can get a new lease after returning the old one`() {
+    // add a lease
+    val lease = subject.tryAcquireLease(deliveryConfig, testEnv, "unit test")
+
+    clock.tickSeconds(1)
+
+    // return the lease
+    lease.close()
+
+    clock.tickSeconds(1)
+
+    // try to get another lease
+    expectCatching { subject.tryAcquireLease(deliveryConfig, testEnv, "unit test") }
+      .isSuccess()
+  }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/config/EnvironmentExclusionConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/config/EnvironmentExclusionConfig.kt
@@ -1,0 +1,14 @@
+package com.netflix.spinnaker.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "keel.environment-exclusion")
+class EnvironmentExclusionConfig {
+  /**
+   * The maximum duration of an environment exclusion lease.
+   *
+   * If a lease has expired, the enforcer assumes that the instance holding the lease has failed.
+   */
+  var leaseDuration : Duration  = Duration.ofSeconds(60)
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/actuation/CheckScheduler.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.actuation
 
 import com.netflix.spinnaker.keel.activation.ApplicationDown
 import com.netflix.spinnaker.keel.activation.ApplicationUp
-import com.netflix.spinnaker.keel.enforcers.EnvironmentCurrentlyBeingActedOn
+import com.netflix.spinnaker.keel.exceptions.EnvironmentCurrentlyBeingActedOn
 import com.netflix.spinnaker.keel.logging.TracingSupport.Companion.blankMDC
 import com.netflix.spinnaker.keel.persistence.AgentLockRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
@@ -192,7 +192,7 @@ class CheckScheduler(
                     try {
                       verificationRunner.runVerificationsFor(it)
                     } catch (e: EnvironmentCurrentlyBeingActedOn) {
-                      log.warn("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is currently being acted on", e)
+                      log.info("Couldn't verify ${it.version} in ${it.deliveryConfig.application}/${it.environmentName} because environment is currently being acted on", e.message)
                     }
                   }
                 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/ActiveLeaseExists.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/ActiveLeaseExists.kt
@@ -1,0 +1,11 @@
+package com.netflix.spinnaker.keel.exceptions
+
+import com.netflix.spinnaker.keel.api.Environment
+import java.time.Instant
+
+class ActiveLeaseExists(
+  environment: Environment,
+  holder: String,
+  leasedAt: Instant
+) : EnvironmentCurrentlyBeingActedOn("Active lease exists on ${environment.name}: leased by $holder at $leasedAt") {}
+

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/EnvironmentCurrentlyBeingActedOn.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/exceptions/EnvironmentCurrentlyBeingActedOn.kt
@@ -1,0 +1,10 @@
+package com.netflix.spinnaker.keel.exceptions
+
+import com.netflix.spinnaker.kork.exceptions.SystemException
+
+/**
+ * Exception thrown when it's not safe to take action against the environment because
+ * something is already acting on it.
+ */
+open class EnvironmentCurrentlyBeingActedOn(message: String) : SystemException(message)
+

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -121,6 +121,14 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   )
 
   /**
+   * @return `true` if any versions are in the process of deploying to [targetEnvironment]
+   */
+  fun isDeployingTo(
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: String
+  ) : Boolean
+
+  /**
    * @return `true` if [version] has (previously or currently) been deployed successfully to
    * [targetEnvironment].
    */

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/EnvironmentLeaseRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/EnvironmentLeaseRepository.kt
@@ -1,0 +1,24 @@
+package com.netflix.spinnaker.keel.persistence
+
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.exceptions.EnvironmentCurrentlyBeingActedOn
+import java.time.Instant
+
+/**
+ * A repository that allows you to take a lease (expiring lock) on an environment.
+ *
+ */
+interface EnvironmentLeaseRepository {
+
+  /**
+   * Try to take a lease on an environment
+   *
+   * @param actionType identifies the type of action (e.g., "verification"). Intended just for metric tagging purposes.
+   *
+   * @returns a lease, if no other client currently holds an active lease on the environment
+   *
+   * @throws [ActiveLeaseExists] if someone else has a lease on the environment
+   */
+  fun tryAcquireLease(deliveryConfig: DeliveryConfig, environment: Environment, actionType: String) : Lease
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/Lease.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/Lease.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.persistence
+
+/**
+ * A lease that can be checked out from the lease repository
+ *
+ * To release the lease, call [close] on it
+ */
+interface Lease : AutoCloseable
+

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcerTest.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/enforcers/EnvironmentExclusionEnforcerTest.kt
@@ -1,13 +1,19 @@
 package com.netflix.spinnaker.keel.enforcers
 
-import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
+import com.netflix.spinnaker.keel.artifacts.DockerArtifact
+import com.netflix.spinnaker.keel.exceptions.ActiveLeaseExists
+import com.netflix.spinnaker.keel.persistence.ArtifactRepository
+import com.netflix.spinnaker.keel.persistence.EnvironmentLeaseRepository
 import io.mockk.Called
-import io.mockk.coVerify
+import io.mockk.coVerify as verify
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 
@@ -16,7 +22,6 @@ import org.junit.jupiter.params.provider.ValueSource
 import strikt.api.expectCatching
 import strikt.assertions.isA
 import strikt.assertions.isFailure
-import java.time.Clock
 
 import org.springframework.core.env.Environment as SpringEnvironment
 
@@ -29,11 +34,38 @@ internal class EnvironmentExclusionEnforcerTest {
   private val verificationRepository = mockk<VerificationRepository>() {
     every { getContextsWithStatus(any(), any(), any()) }  returns emptyList()
   }
+  private val artifactRepository = mockk<ArtifactRepository>()
+  private val environmentLeaseRepository = mockk<EnvironmentLeaseRepository>(relaxUnitFun = true) {
+    every { tryAcquireLease(any(), any(), any()) } returns mockk(relaxUnitFun = true)
+  }
 
-  private val enforcer = EnvironmentExclusionEnforcer(springEnv, verificationRepository, NoopRegistry(), Clock.systemUTC())
+  data class DummyVerification(val value: String) : Verification {
+    override val type = "dummy"
+    override val id: String = "$type:$value"
+  }
+
+  private val enforcer = EnvironmentExclusionEnforcer(springEnv, verificationRepository, artifactRepository, environmentLeaseRepository)
+  private val verification = DummyVerification("1")
+  private val environment = Environment(name="test", verifyWith=listOf(verification))
+  private val deliveryConfig = DeliveryConfig(
+    application = "fnord",
+    name = "fnord-manifest",
+    serviceAccount = "jamm@illuminati.org",
+    artifacts = setOf(
+      DockerArtifact(
+        name = "fnord",
+        deliveryConfigName = "fnord-manifest",
+        reference = "fnord-docker-stable",
+        branch = "main"
+      ),
+    ),
+    environments = setOf( environment )
+  )
+
 
   @Test
-  fun `invoke the action when there are no pending verifications`() {
+  fun `withVerificationLease invokes the action when there are no pending verifications or deployments`() {
+    every { artifactRepository.isDeployingTo(any(), any()) } returns false
     every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns emptyList()
     val action : () -> Unit = mockk(relaxed=true)
 
@@ -45,7 +77,41 @@ internal class EnvironmentExclusionEnforcerTest {
   }
 
   @Test
-  fun `throw an exception when there are pending verifications`() {
+  fun `withActuationLease invokes the action when there are no pending verifications`() {
+    every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns emptyList()
+    val action : suspend () -> Unit = mockk(relaxed=true)
+    runBlocking {
+      enforcer.withActuationLease(mockk(), mockk(), action)
+    }
+
+    verify(exactly=1) {
+      action.invoke()
+    }
+  }
+
+
+  @Test
+  fun `withActuationLease does not invoke the action when there are pending verifications`() {
+    every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns
+      listOf(VerificationContext(deliveryConfig, "test", "fnord-docker-stable", "fnord-0.190.0-h378.eacb135"))
+
+    val action : suspend () -> Unit = mockk(relaxed=true)
+
+    expectCatching {
+      runBlocking {
+        enforcer.withActuationLease(deliveryConfig, environment, action)
+      }
+    }.isFailure()
+      .isA<ActiveVerifications>()
+
+    verify {
+      action wasNot Called
+    }
+  }
+
+  @Test
+  fun `withVerificationLease throws an exception when there are pending verifications`() {
+    every { artifactRepository.isDeployingTo(any(), any()) } returns false
     every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns listOf(mockk(relaxed=true))
 
     val action : () -> Unit = mockk(relaxed=true)
@@ -59,11 +125,42 @@ internal class EnvironmentExclusionEnforcerTest {
     }
   }
 
+  @Test
+  fun `withVerificationLease throws an exception when there are ongoing deployments`() {
+    every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns emptyList()
+    every { artifactRepository.isDeployingTo(any(), any()) } returns true
+
+    val action : () -> Unit = mockk(relaxed=true)
+
+    expectCatching { enforcer.withVerificationLease(mockk(relaxed=true), action) }
+      .isFailure()
+      .isA<ActiveDeployments>()
+
+    verify {
+      action wasNot Called
+    }
+  }
+
+  @Test
+  fun `withVerificationLease  throw an exception when there is an active lease`() {
+    val environment = mockk<Environment>() {
+      every { name } returns "testing"
+    }
+    every { environmentLeaseRepository.tryAcquireLease(any(), any(), any()) } throws ActiveLeaseExists(environment, "mystery", mockk())
+    val action : () -> Unit = mockk(relaxed=true)
+    expectCatching { enforcer.withVerificationLease(mockk(relaxed=true), action) }
+      .isFailure()
+      .isA<ActiveLeaseExists>()
+  }
+
 
   @ParameterizedTest(name="withVerificationLease executes action, enabled={0}")
   @ValueSource(booleans = [true, false])
   fun `withVerificationLease invokes the action whether the feature flag is enabled or not`(enabled: Boolean) {
     every { springEnv.getProperty("keel.enforcement.environment-exclusion.enabled", Boolean::class.java, any())} returns enabled
+
+    every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns emptyList()
+    every { artifactRepository.isDeployingTo(any(), any()) } returns false
 
     val action : () -> Unit = mockk(relaxed=true)
 
@@ -79,12 +176,15 @@ internal class EnvironmentExclusionEnforcerTest {
   fun `withActuationLease invokes the action whether the feature flag is enabled or not`(enabled: Boolean) {
     every { springEnv.getProperty("keel.enforcement.environment-exclusion.enabled", Boolean::class.java, any())} returns enabled
 
+    every { verificationRepository.getContextsWithStatus(any(), any(), ConstraintStatus.PENDING) } returns emptyList()
+    every { artifactRepository.isDeployingTo(any(), any()) } returns false
+
     val action : suspend () -> Unit = mockk(relaxed=true)
     runBlocking {
       enforcer.withActuationLease(mockk(), mockk(), action)
     }
 
-    coVerify(exactly=1) {
+    verify(exactly=1) {
       action.invoke()
     }
   }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -508,6 +508,17 @@ class SqlArtifactRepository(
     }
   }
 
+  override fun isDeployingTo(
+    deliveryConfig: DeliveryConfig,
+    targetEnvironment: String
+  ) : Boolean =
+    jooq.selectCount()
+      .from(ENVIRONMENT_ARTIFACT_VERSIONS)
+      .where(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID.eq(deliveryConfig.getUidFor(targetEnvironment)))
+      .and(ENVIRONMENT_ARTIFACT_VERSIONS.PROMOTION_STATUS.eq(DEPLOYING))
+      .fetchOneInto(Int::class.java) > 0
+
+
   override fun markAsSuccessfullyDeployedTo(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlEnvironmentLeaseRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlEnvironmentLeaseRepository.kt
@@ -1,0 +1,203 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spectator.api.Id
+import com.netflix.spectator.api.Registry
+import com.netflix.spectator.api.histogram.PercentileTimer
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Environment
+import com.netflix.spinnaker.keel.core.api.UID
+import com.netflix.spinnaker.keel.core.api.randomUID
+import com.netflix.spinnaker.keel.exceptions.ActiveLeaseExists
+import com.netflix.spinnaker.keel.persistence.EnvironmentLeaseRepository
+import com.netflix.spinnaker.keel.persistence.Lease
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_LEASE
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.LATEST_ENVIRONMENT
+import com.netflix.spinnaker.keel.persistence.metamodel.tables.records.EnvironmentLeaseRecord
+import org.jooq.DSLContext
+import org.jooq.exception.DataAccessException
+import java.net.InetAddress
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * An implementation of [EnvironmentLeaseRepository] that represents a lease as a record in the environment_lease
+ * table.
+ */
+class SqlEnvironmentLeaseRepository(
+  private val jooq: DSLContext,
+  private val clock: Clock,
+  private val spectator: Registry,
+  private val leaseDuration: Duration) : EnvironmentLeaseRepository {
+
+  private val leaseCountId = spectator.createId("lease.env.count")
+
+  /**
+   * Percentile timer builder for measuring how long the lease is held
+   *
+   * We use the default percentile time range: 10ms to 1 minute
+   */
+  private val timerBuilder = PercentileTimer.builder(spectator).withName("lease.env.duration")
+
+
+  /**
+   * Check the database to see if there is an active lease for [environment]
+   *
+   * @return a valid Lease object on success
+   *
+   * @throws ActiveLeaseExists if another client is holding a lease
+   *
+   */
+  override fun tryAcquireLease(deliveryConfig: DeliveryConfig, environment: Environment, actionType: String): Lease {
+    val startTime = clock.instant()
+
+    try {
+      val environmentUid = getEnvironmentUid(deliveryConfig, environment)
+      val leaseUid = randomUID()
+
+      jooq.inTransaction {
+
+        /**
+         *  This select uses forShare() (LOCK IN SHARE MODE) to ensure that the transaction is serializable
+         *  Without it, there's a race condition where two processes could both check for an active lease,
+         *  both find none, and then both take the lease.
+         */
+        val record: EnvironmentLeaseRecord? = selectFrom(ENVIRONMENT_LEASE)
+          .where(ENVIRONMENT_LEASE.ENVIRONMENT_UID.eq(environmentUid))
+          .forShare()
+          .fetchOne()
+
+        when {
+          // no existing lease
+          record == null -> insertRecord(this, leaseUid, environmentUid, actionType)
+            .also { leaseCountId.incrementGranted("free", actionType, deliveryConfig.application, environment.name) }
+
+          // expired lease
+          isExpired(record.leasedAt) -> updateRecord(this, leaseUid, environmentUid, actionType)
+            .also { leaseCountId.incrementGranted("expired", actionType, deliveryConfig.application, environment.name) }
+
+          // active lease
+          else -> throw ActiveLeaseExists(environment, record.leasedBy, record.leasedAt)
+            .also { leaseCountId.incrementDenied(actionType, deliveryConfig.application, environment.name) }
+        }
+      }
+      return SqlLease(this, leaseUid, startTime, actionType, timerBuilder, clock)
+
+    } catch (e: DataAccessException) {
+      recordDeniedLeaseTime(startTime, actionType)
+
+      // jooq.inTransaction wraps our exception in a DataAccessException so we need to unwrap it
+      (e.cause as? ActiveLeaseExists)
+        ?.let { throw it }
+        ?: throw e
+    } catch (e: Exception) {
+      recordDeniedLeaseTime(startTime, actionType)
+      throw e
+    }
+  }
+
+  private fun recordDeniedLeaseTime(startTime: Instant, actionType: String) {
+    timerBuilder
+      .withTag("action", actionType)
+      .withTag("outcome", "denied")
+      .build()
+      .record(Duration.between(startTime, clock.instant()))
+  }
+
+  /**
+   * Return true if the expiration date of the lease is in the past
+   */
+  private fun isExpired(leasedAt: Instant): Boolean {
+    val expirationDate = leasedAt + leaseDuration
+    val now = clock.instant()
+    return expirationDate < now
+  }
+
+  private fun insertRecord(ctx: DSLContext, uid: UID, environmentUid: String, comment: String) {
+    ctx.insertInto(ENVIRONMENT_LEASE)
+      .set(ENVIRONMENT_LEASE.UID, uid.toString())
+      .set(ENVIRONMENT_LEASE.ENVIRONMENT_UID, environmentUid)
+      .set(ENVIRONMENT_LEASE.LEASED_BY, lesseeIdentifier())
+      .set(ENVIRONMENT_LEASE.LEASED_AT, clock.instant())
+      .set(ENVIRONMENT_LEASE.COMMENT, comment)
+      .execute()
+  }
+
+  /**
+   * Functionally, this method deletes the expired lease and creates a new one.
+   *
+   * Instead of deleting the old record and inserting a new one, we simply update the uid
+   */
+  private fun updateRecord(ctx: DSLContext, uid: UID, environmentUid: String, comment: String) {
+    ctx.update(ENVIRONMENT_LEASE)
+      .set(ENVIRONMENT_LEASE.UID, uid.toString())
+      .set(ENVIRONMENT_LEASE.LEASED_BY, lesseeIdentifier())
+      .set(ENVIRONMENT_LEASE.LEASED_AT, clock.instant())
+      .set(ENVIRONMENT_LEASE.COMMENT, comment)
+      .where(ENVIRONMENT_LEASE.ENVIRONMENT_UID.eq(environmentUid))
+      .execute()
+  }
+
+  fun release(lease: SqlLease) {
+    jooq.deleteFrom(ENVIRONMENT_LEASE)
+      .where(ENVIRONMENT_LEASE.UID.eq(lease.uid.toString()))
+      .execute()
+  }
+
+  private fun getEnvironmentUid(deliveryConfig: DeliveryConfig, environment: Environment): String =
+    jooq.select(LATEST_ENVIRONMENT.UID)
+      .from(DELIVERY_CONFIG)
+      .join(LATEST_ENVIRONMENT)
+      .on(LATEST_ENVIRONMENT.DELIVERY_CONFIG_UID.eq(DELIVERY_CONFIG.UID))
+      .where(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
+      .and(LATEST_ENVIRONMENT.NAME.eq(environment.name))
+      .fetchOneInto<String>()
+
+  /**
+   * A string that identifies the client who took the lease
+   */
+  private fun lesseeIdentifier() : String =
+    InetAddress.getLocalHost().hostName
+
+
+  //
+  // Metric helpers
+  //
+
+  private fun Id.incrementGranted(status: String, actionType: String, application: String, environment: String)  =
+    increment("granted", status, actionType, application, environment)
+
+  private fun Id.incrementDenied(actionType: String, application: String, environment: String) =
+    increment("denied", "active", actionType, application, environment)
+
+  private fun Id.increment(outcome: String, status: String, actionType: String, application: String, environment: String) {
+    val id =
+      this.withTags(
+        "outcome", outcome,
+        "status", status,
+        "action", actionType,
+        "application", application,
+        "environment", environment)
+    spectator.counter(id).increment()
+  }
+
+  class SqlLease(
+    val repository: SqlEnvironmentLeaseRepository,
+    val uid: UID,
+    private val startTime: Instant,
+    private val actionType: String,
+    private val timerBuilder: PercentileTimer.Builder,
+    private val clock: Clock
+  ) : Lease {
+    override fun close() {
+      repository.release(this)
+
+      timerBuilder
+        .withTag("action", actionType)
+        .withTag("outcome", "granted")
+        .build()
+        .record(Duration.between(startTime, clock.instant()))
+    }
+  }
+}

--- a/keel-sql/src/main/resources/db/changelog/20210331-add-environment-lease-repository.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210331-add-environment-lease-repository.yml
@@ -1,0 +1,54 @@
+databaseChangeLog:
+- changeSet:
+    id: add-environment-lease-repository
+    author: lhochstein
+    changes:
+    - createTable:
+        tableName: environment_lease
+        columns:
+          - column:
+              name: uid
+              type: char(26)
+              constraints:
+                nullable: false
+          - column:
+              name: environment_uid
+              type: char(26)
+              constraints:
+                nullable: false
+          - column:
+              name: leased_by
+              type: varchar(63)
+              constraints:
+                nullable: false
+          - column:
+              name: leased_at
+              type: timestamp(3)
+              constraints:
+                nullable: false
+          - column:
+              name: comment
+              type: varchar(511)
+              constraints:
+                nullable: false
+    - addPrimaryKey:
+        constraintName: environment_lease_pk
+        tableName: environment_lease
+        columnNames: uid
+    - addForeignKeyConstraint:
+        baseTableName: environment_lease
+        baseColumnNames: environment_uid
+        constraintName: fk_environment_lease_environment_uid
+        referencedTableName: environment
+        referencedColumnNames: uid
+        referencesUniqueColumn: true
+        onDelete: CASCADE
+    - createIndex:
+        indexName: environment_lease_environment_uid_idx
+        tableName: environment_lease
+        columns:
+        - column:
+            name: environment_uid
+    rollback:
+    - dropTable:
+        tableName: environment_lease

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -266,3 +266,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210331-fix-resource-with-metadata-view.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210331-add-environment-lease-repository.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlEnvironmentLeaseRepositoryTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/SqlEnvironmentLeaseRepositoryTests.kt
@@ -1,0 +1,52 @@
+package com.netflix.spinnaker.keel.sql
+
+import com.netflix.spectator.api.NoopRegistry
+import com.netflix.spinnaker.keel.artifacts.DockerArtifactSupplier
+import com.netflix.spinnaker.keel.jackson.registerKeelApiModule
+import com.netflix.spinnaker.keel.persistence.EnvironmentLeaseRepositoryTests
+import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
+import com.netflix.spinnaker.keel.serialization.configuredObjectMapper
+import com.netflix.spinnaker.kork.sql.config.RetryProperties
+import com.netflix.spinnaker.kork.sql.config.SqlRetryProperties
+import com.netflix.spinnaker.kork.sql.test.SqlTestUtil
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import java.time.Duration
+
+internal class SqlEnvironmentLeaseRepositoryTests :
+  EnvironmentLeaseRepositoryTests<SqlEnvironmentLeaseRepository>() {
+  private val jooq = testDatabase.context
+  private val retryProperties = RetryProperties(1, 0)
+  private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
+  private val artifactSuppliers = listOf(DockerArtifactSupplier(mockk(), mockk(), mockk()))
+  private val mapper = configuredObjectMapper()
+    .registerKeelApiModule()
+
+  private val deliveryConfigRepository = SqlDeliveryConfigRepository(
+    jooq = jooq,
+    clock = clock,
+    resourceSpecIdentifier = ResourceSpecIdentifier(),
+    objectMapper = mapper,
+    sqlRetry = sqlRetry,
+    artifactSuppliers = artifactSuppliers
+  )
+  override fun createSubject() =
+    SqlEnvironmentLeaseRepository(
+      jooq = jooq,
+      clock = clock,
+      spectator = NoopRegistry(),
+      leaseDuration = leaseDuration
+    )
+
+  @BeforeEach
+  fun setup() {
+    deliveryConfigRepository.store(deliveryConfig)
+  }
+
+  @AfterEach
+  fun flush() {
+    SqlTestUtil.cleanupDb(jooq)
+  }
+
+}


### PR DESCRIPTION
Introduce environment leases to prevent concurrent verifcations or verifications concurrent with deployments.

See new docs for details.