### PR TITLE
fix(docker): use includeDetails query string when getting docker images

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/DockerArtifactSupplier.kt
@@ -37,7 +37,7 @@ class DockerArtifactSupplier(
     return runWithIoContext {
       // TODO: we currently don't have a way to derive account information from artifacts,
       //  so we look in all accounts.
-      cloudDriverService.findDockerImages(account = "*", repository = artifact.name, tag = version)
+      cloudDriverService.findDockerImages(account = "*", repository = artifact.name, tag = version, includeDetails = true)
         .map { dockerImage ->
           PublishedArtifact(
             name = dockerImage.repository,

--- a/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
+++ b/keel-clouddriver/src/main/kotlin/com/netflix/spinnaker/keel/clouddriver/CloudDriverService.kt
@@ -174,6 +174,7 @@ interface CloudDriverService {
     @Query("repository") repository: String? = null,
     @Query("tag") tag: String? = null,
     @Query("q") q: String? = null,
+    @Query("includeDetails") includeDetails: Boolean? = null,
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
   ): List<DockerImage>
 


### PR DESCRIPTION
This fixes an issue where Docker images returned from clouddriver does not contain metadata from labels. This causes Docker artifact versions to not have build information when new versions are added by [`syncArtifactVersions` ](https://github.com/spinnaker/keel/blob/eeaad1dbc1a80cb715684181a28d67b956727ff2/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt#L170 )before being processed by echo events. An artifact version processed by echo events do not add metadata if the version already exists in DB.

Clouddriver requires the `includeDetails=true` [query string ](https://github.com/spinnaker/clouddriver/blob/c17bd4b182eb3ea6b300d8d3fe09299e5abf9c12/clouddriver-docker/src/main/groovy/com/netflix/spinnaker/clouddriver/docker/registry/controllers/DockerRegistryImageLookupController.groovy#L109)to return additional information. 

Example log:
```
2021-04-07 00:34:28.954 DEBUG 1 --- [    scheduler-5] c.n.s.keel.artifacts.ArtifactListener    : Syncing artifact versions...
2021-04-07 00:34:28.956 DEBUG 1 --- [    scheduler-5] c.n.s.keel.artifacts.ArtifactListener    : Last recorded version of DOCKER artifact nabuskey/jenkins-test (ref: my-docker-artifact): PublishedArtifact(name=nabuskey/jenkins-test, type=docker, reference=my-docker-artifact, version=20, customKind=null, location=null, artifactAccount=null, provenance=null, uuid=null, metadata={releaseStatus=null, createdAt=null}, gitMetadata=null, buildMetadata=null)
2021-04-07 00:34:28.959  INFO 1 --- [r.keel:7002/...] okhttp3.OkHttpClient                     : --> GET http://clouddriver.keel:7002/dockerRegistry/images/find?account=*&repository=nabuskey%2Fjenkins-test
2021-04-07 00:34:28.966  INFO 1 --- [r.keel:7002/...] brave.Tracer                             : {"traceId":"51c737fe8aea6cd3","id":"51c737fe8aea6cd3","kind":"CLIENT","name":"GET","timestamp":1617755668962974,"duration":3639,"localEndpoint":{"serviceName":"unknown"},"tags":{"http.method":"GET","http.path":"/dockerRegistry/images/find"}}
2021-04-07 00:34:28.966  INFO 1 --- [r.keel:7002/...] okhttp3.OkHttpClient                     : <-- 200 http://clouddriver.keel:7002/dockerRegistry/images/find?account=*&repository=nabuskey%2Fjenkins-test (6ms, 9944-byte body)
2021-04-07 00:34:28.967 DEBUG 1 --- [    scheduler-5] c.n.s.keel.artifacts.ArtifactListener    : Latest available version of DOCKER artifact nabuskey/jenkins-test (ref: my-docker-artifact): 21
2021-04-07 00:34:28.967 DEBUG 1 --- [    scheduler-5] c.n.s.keel.artifacts.ArtifactListener    : DOCKER artifact nabuskey/jenkins-test (ref: my-docker-artifact) has a missing version 21, persisting.
2021-04-07 00:34:28.967 DEBUG 1 --- [    scheduler-5] c.n.s.k.a.DockerArtifactSupplier         : either commit id: null or build number null is missing, returning null
2021-04-07 00:34:28.967 DEBUG 1 --- [    scheduler-5] c.n.s.keel.artifacts.ArtifactListener    : Publishing build lifecycle event for published artifact PublishedArtifact(name=nabuskey/jenkins-test, type=docker, reference=nabuskey/jenkins-test, version=21, customKind=null, location=null, artifactAccount=null, provenance=null, uuid=null, metadata={}, gitMetadata=null, buildMetadata=null)
2021-04-07 00:34:33.705 DEBUG 1 --- [nio-7010-exec-7] c.n.s.keel.rest.ArtifactController       : Received artifact event: EchoArtifactEvent(payload=ArtifactPublishedEvent(artifacts=[PublishedArtifact(name=nabuskey/jenkins-test, type=DOCKER, reference=igor:dockerRegistry:v2:public-docker-account:nabuskey/jenkins-test:latest, version=latest, customKind=false, location=public-docker-account, artifactAccount=null, provenance=index.docker.io, uuid=null, metadata={registry=public-docker-account, fullname=nabuskey/jenkins-test:latest, tag=latest, commitId=3a86199eaef2e0ed702794634312d3037dc3870d, buildNumber=21, branch=origin/main}, gitMetadata=null, buildMetadata=null)], details={}), eventName=spinnaker_artifacts_docker)
2021-04-07 00:34:3
```
