### PR TITLE
    fix(test): fix occasional failing sql test

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/time/MutableClock.kt
@@ -8,7 +8,51 @@ import java.time.temporal.ChronoUnit.MILLIS
 import java.time.temporal.TemporalAmount
 
 class MutableClock(
-  private var instant: Instant = Instant.now().truncatedTo(MILLIS),
+
+  /**
+   * The [instant] field in this class has two invariants:
+   *
+   * 1. Cannot have greater than millisecond precision. i.e., this must always be true:
+   *
+   *          instant == instant.truncatedTo(MILLIS)
+   *
+   *    This is because the database uses millisecond precision timestamps (`timestamp(3)`), and so any tests
+   *    that compare timestamps that came from the database will always only have millisecond precision. To make
+   *    time-related test assertions simpler, we just ensure that all times are millisecond precision.
+   *
+   * 2. Cannot have a nanoseconds component of exactly 0. i.e., this must always be true:
+   *
+   *         instant.nano != 0
+   *
+   *    This is because of an interaction of how Instant serializes to a string and how we use the `str_to_date` mysql
+   *    function for the `timestamp` generated column in the `event` table.
+   *
+   *    If the nanoseconds component is zero, then the Jackson serializing of the Instant object will not have the
+   *    fractional second component.
+   *
+   *    Consider following two serialization: the first has fraction seconds, the second doesn't.
+   *
+   *    "2021-04-03T19:06:08.123Z"  <-- with fractional second (nano is non-zero)
+   *    "2021-04-03T19:06:08Z"      <-- without fractional second (nano is zero)
+   *
+   *    The `event` table has a generated column that looks like this:
+   *
+   *    timestamp datetime(3) generated always as (str_to_date(json->>'$.timestamp', '%Y-%m-%dT%T.%fZ'));
+   *
+   *    The str_to_date function will fail if there's no fractional component, resulting in error that looks like this:
+   *
+   *       Incorrect datetime value: '2021-04-03T19:06:08Z' for function str_to_date
+   *
+   *    This is potentially a problem for production as well, but it's much less likely to happen because we don't
+   *    truncate to millisecond in that case.
+   */
+  private var instant: Instant = Instant.now().truncatedTo(MILLIS).let {
+    when(it.nano) {
+      0 -> it.plusMillis(1)
+      else -> it
+    }
+  },
+
   private val zone: ZoneId = ZoneId.of("UTC"),
   val start: Instant = instant
 ) : Clock() {


### PR DESCRIPTION
## Problem

Occasionally, we see an SQL test failure that looks like this:

```
SqlCombinedRepositoryTests individual resources are persisted FAILED

  org.jooq.exception.DataAccessException: SQL [insert into `keel`.`event` (`uid`, `scope`, `json`) values (?, ?, ?)]; Incorrect datetime value: '2021-04-03T19:06:08Z' for function str_to_date

  Caused by: java.sql.SQLException: Incorrect datetime value: '2021-04-03T19:06:08Z' for function str_to_date
```

This happens when the fractional second component of the serialized Instant object is *exactly* zero. In that case, the string representation doens't have a fractional second component. This causes the mysql str_to_date function to fail, because it expects a fractional component to be there.

## Implemented solution

In the MutableClock class, which is used for generating Instant values in the tests, ensure that the returned Instant objects never has a zero nanosecond component.

This could potentially manifest in prod, although it's less likely, and we've never actually seen it.

Logner term, we could fix this by writing a custom serializer for Instant to ensure it writes out a fractional component of `.000000` instead of leaving it out.
