### PR TITLE
feat(admin): api to force skip and fail

### DIFF
--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -196,13 +196,16 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
 
   /**
    * Marks a version of an artifact as skipped for an environment, with information on what version superseded it.
+   *
+   * We allow [supersededByVersion] to be null to enable an operator to mark a version as skipped even when no other
+   * versions have been deployed yet (e.g., the first version got stuck).
    */
   fun markAsSkipped(
     deliveryConfig: DeliveryConfig,
     artifact: DeliveryArtifact,
     version: String,
     targetEnvironment: String,
-    supersededByVersion: String
+    supersededByVersion: String?
   )
 
   /**

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -6,12 +6,14 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.NotificationConfig
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.events.ArtifactRegisteredEvent
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.api.verification.VerificationRepository
@@ -382,7 +384,7 @@ class CombinedRepository(
   override fun deleteVeto(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String) =
     artifactRepository.deleteVeto(deliveryConfig, artifact, version, targetEnvironment)
 
-  override fun markAsSkipped(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String, supersededByVersion: String) {
+  override fun markAsSkipped(deliveryConfig: DeliveryConfig, artifact: DeliveryArtifact, version: String, targetEnvironment: String, supersededByVersion: String?) {
     artifactRepository.markAsSkipped(deliveryConfig, artifact, version, targetEnvironment, supersededByVersion)
   }
 
@@ -433,6 +435,14 @@ class CombinedRepository(
     limit: Int
   ) : Collection<VerificationContext> =
     verificationRepository.nextEnvironmentsForVerification(minTimeSinceLastCheck, limit)
+
+  override fun updateState(
+    context: VerificationContext,
+    verification: Verification,
+    status: ConstraintStatus,
+    metadata: Map<String, Any?>
+  ) = verificationRepository.updateState(context, verification, status, metadata)
+
 
   override fun getVerificationStatesBatch(contexts: List<VerificationContext>) : List<Map<String, VerificationState>> =
     verificationRepository.getStatesBatch(contexts)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/KeelRepository.kt
@@ -3,12 +3,14 @@ package com.netflix.spinnaker.keel.persistence
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
+import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactMetadata
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.constraints.ConstraintState
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.persistence.KeelReadOnlyRepository
 import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
@@ -193,7 +195,7 @@ interface KeelRepository : KeelReadOnlyRepository {
     artifact: DeliveryArtifact,
     version: String,
     targetEnvironment: String,
-    supersededByVersion: String
+    supersededByVersion: String?
   )
 
   /**
@@ -207,7 +209,7 @@ interface KeelRepository : KeelReadOnlyRepository {
     artifactReference: String,
     versions: List<String>
   ): List<ArtifactSummaryInEnvironment>
-  
+
   /**
    * Given information about a delivery config, environment, artifact and version, returns a summary that can be
    * used by the UI, or null if the artifact version is not applicable to the environment.
@@ -249,5 +251,18 @@ interface KeelRepository : KeelReadOnlyRepository {
     minTimeSinceLastCheck: Duration,
     limit: Int
   ) : Collection<VerificationContext>
+
+
+  /**
+   * Updates the state of [verification] as run against [context].
+   *
+   * @param metadata if non-empty this will overwrite any existing metadata.
+   */
+  fun updateState(
+    context: VerificationContext,
+    verification: Verification,
+    status: ConstraintStatus,
+    metadata: Map<String, Any?> = emptyMap()
+  )
   // END VerificationRepository methods
 }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -4,13 +4,16 @@ import com.netflix.spinnaker.keel.api.StatefulConstraint
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DOCKER
 import com.netflix.spinnaker.keel.api.artifacts.NPM
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.api.verification.VerificationContext
 import com.netflix.spinnaker.keel.core.api.ApplicationSummary
 import com.netflix.spinnaker.keel.exceptions.NoSuchEnvironmentException
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.kork.exceptions.UserException
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationEventPublisher
@@ -113,4 +116,55 @@ class AdminService(
     }
   }
 
+  /**
+   * Mark artifact [version] as SKIPPED in [environment]
+   *
+   * Preconditions:
+   *   - there is a delivery config in the repository that corresponds to [application]
+   *   - config has an environment named [environment]
+   *   - config has an artifact with reference [artifactReference]
+   *   - there is a version of artifact with reference [artifactReference], in environment [environment], with a status of CURRENT
+   *
+   * Postconditions:
+   *   - the artifact version [version] record is updated with:
+   *      * promotion_status set to skipped
+   *      * replaced_by set to the version that is CURRENT
+   *      * replaced_at set to now
+   */
+  fun forceSkipArtifactVersion(application: String, environment: String, artifactReference: String, version: String) {
+    val deliveryConfig = repository.getDeliveryConfigForApplication(application)
+    val artifact = deliveryConfig.matchingArtifactByReference(artifactReference)
+      ?: throw UserException("application $application contains no artifact ref $artifactReference. Artifact references are: ${deliveryConfig.artifacts.map { it.reference }}")
+
+     // Identify the current version in the environment
+    val currentVersion = repository.getCurrentArtifactVersions(deliveryConfig, environment)
+      .firstOrNull { it.reference == artifactReference }
+
+    if(currentVersion == null) {
+      log.warn("forcing application $application artifact $artifactReference version $version to SKIPPED even though there is no version in CURRENT state")
+    }
+
+    // Mark as skipped
+    repository.markAsSkipped(deliveryConfig, artifact, version, environment, currentVersion?.version)
+  }
+
+  fun forceFailVerifications(application: String, environmentName: String, artifactReference: String, version: String, verificationId: String) {
+    val deliveryConfig = repository.getDeliveryConfigForApplication(application)
+    val context = VerificationContext(
+      deliveryConfig = deliveryConfig,
+      environmentName = environmentName,
+      artifactReference = artifactReference,
+      version = version
+    )
+
+    val environment = deliveryConfig.environments
+      .firstOrNull { it.name == environmentName }
+      ?: throw UserException("application $application has no environment named $environmentName. Names are: ${deliveryConfig.environments.map { it.name }}")
+
+    val verification = environment.verifyWith
+      .firstOrNull { it.id == verificationId }
+      ?: throw UserException("application $application in environment $environmentName has no verification with ID $verificationId. IDs are: ${environment.verifyWith.map { it.id }}")
+
+    repository.updateState(context, verification, ConstraintStatus.OVERRIDE_FAIL)
+  }
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -922,7 +922,7 @@ class SqlArtifactRepository(
     artifact: DeliveryArtifact,
     version: String,
     targetEnvironment: String,
-    supersededByVersion: String
+    supersededByVersion: String?
   ) {
     val environment = deliveryConfig.environmentNamed(targetEnvironment)
     val environmentUid = deliveryConfig.getUidFor(environment)


### PR DESCRIPTION
## Context

In the process of implementing checks to prevent concurrent verifications running in the same environment, or verifications running at the same time as a deployment in an environment.

## Problem

The enforcement checks can block verifications or deployments if a verification gets stuck in a PENDING state or a deployment gets stuck in a DEPLOYING state.

## Implemented solution

Provide admin APIs that allow an operator to force:
* an environment artifact version to SKIPPED state
* a verification into OVERRIDE_FAIL state