### PR TITLE
Refactor resource versioning

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Environment.kt
@@ -8,7 +8,7 @@ data class Environment(
   val notifications: Set<NotificationConfig> = emptySet() // applies to each resource
 ) {
   val resourceIds: Set<String>
-    get() = resources.map { it.id }.toSet()
+    get() = resources.mapTo(mutableSetOf(), Resource<*>::id)
 }
 
 val Set<Constraint>.anyStateful: Boolean

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -19,8 +19,8 @@ data class Resource<out T : ResourceSpec>(
 
   @get:ExcludedFromDiff
   val version: Int
-    // version is not a mandatory metadata field, so we default to -1 when missing
-    get() = metadata.getValue("version") as? Int ?: -1
+    // version is not a mandatory metadata field, so we default to 0 when missing
+    get() = metadata["version"] as? Int ?: 0
 
   val serviceAccount: String
     get() = metadata.getValue("serviceAccount").toString()

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -701,8 +701,8 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
       }
 
       before {
-        store()
         storeResources()
+        store()
       }
 
       test("application summary can be retrieved successfully") {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/CombinedRepository.kt
@@ -131,8 +131,6 @@ class CombinedRepository(
    * delivery config and are not present in the [new] delivery config
    */
   override fun removeDependents(old: DeliveryConfig, new: DeliveryConfig) {
-    val newResources = new.resources.map { it.id }
-
     old.artifacts.forEach { artifact ->
       val stillPresent = new.artifacts.any {
         it.name == artifact.name &&
@@ -145,19 +143,19 @@ class CombinedRepository(
       }
     }
 
+    val newResources = new.resources.map { it.id }
+
     old.environments
       .forEach { environment ->
-        environment.resources.forEach { resource ->
-          if (resource.id !in newResources) {
-            log.debug("Updating config ${new.name}: removing resource ${resource.id} in environment ${environment.name}")
-            deliveryConfigRepository.deleteResourceFromEnv(
-              deliveryConfigName = old.name, environmentName = environment.name, resourceId = resource.id
-            )
-            deleteResource(resource.id)
-          }
-        }
         if (environment.name !in new.environments.map { it.name }) {
           log.debug("Updating config ${new.name}: removing environment ${environment.name}")
+          environment.resources.map(Resource<*>::id).forEach {
+            // only delete the resource if it's not somewhere else in the delivery config -- e.g.
+            // it's been moved from one environment to another or the environment has been renamed
+            if (it !in newResources) {
+              resourceRepository.delete(it)
+            }
+          }
           deliveryConfigRepository.deleteEnvironment(new.name, environment.name)
         }
       }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhappyVetoRepository.kt
@@ -96,5 +96,4 @@ class SqlUnhappyVetoRepository(
     get() = jooq.select(RESOURCE.UID)
       .from(RESOURCE)
       .where(RESOURCE.ID.eq(id))
-      .and(RESOURCE.VERSION.eq(version))
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhealthyRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlUnhealthyRepository.kt
@@ -51,5 +51,4 @@ class SqlUnhealthyRepository(
       .select(RESOURCE.UID)
       .from(RESOURCE)
       .where(RESOURCE.ID.eq(id))
-      .and(RESOURCE.VERSION.eq(version))
 }

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/deliveryconfigs/deliveryconfigs.kt
@@ -114,6 +114,7 @@ internal fun SqlStorageContext.resourcesForEnvironment(uid: String) =
       .from(RESOURCE_WITH_METADATA, ENVIRONMENT_RESOURCE, LATEST_ENVIRONMENT)
       .where(RESOURCE_WITH_METADATA.UID.eq(ENVIRONMENT_RESOURCE.RESOURCE_UID))
       .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(LATEST_ENVIRONMENT.UID))
+      .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_VERSION.eq(LATEST_ENVIRONMENT.VERSION))
       .and(LATEST_ENVIRONMENT.UID.eq(uid))
       .fetch { (kind, metadata, spec) ->
         resourceFactory.invoke(kind, metadata, spec)

--- a/keel-sql/src/main/resources/db/changelog/20210404-resource-version-table.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210404-resource-version-table.yml
@@ -1,0 +1,98 @@
+databaseChangeLog:
+- changeSet:
+    id: resource-version-table
+    author: fletch
+    changes:
+    - createTable:
+        tableName: resource_version
+        columns:
+        - column:
+            name: resource_uid
+            type: char(26)
+            constraints:
+              nullable: false
+        - column:
+            name: version
+            type: integer
+            defaultValueNumeric: 1
+            constraints:
+              nullable: false
+        - column:
+            name: spec
+            type: json
+            constraints:
+              nullable: false
+    - sql:
+        sql: |
+          insert into resource_version
+          select lr.uid, r.version, r.spec
+          from resource r, resource_with_metadata lr
+          where r.id = lr.id;
+    - addColumn:
+        tableName: environment_resource
+        columns:
+        - column:
+            name: resource_version
+            type: integer
+            constraints:
+              nullable: true
+    - sql:
+        sql: |
+          update environment_resource
+          join resource on resource.uid = environment_resource.resource_uid
+          join resource_with_metadata on resource.id = resource_with_metadata.id
+          set environment_resource.resource_uid = resource_with_metadata.uid,
+              environment_resource.resource_version = resource.version;
+    - addNotNullConstraint:
+        tableName: environment_resource
+        columnName: resource_version
+        columnDataType: integer
+    - sql:
+        sql: |
+          delete r1 from resource r1
+          inner join resource r2
+          where r1.version < r2.version
+          and r1.id = r2.id;
+    - dropColumn:
+        tableName: resource
+        columns:
+        - column:
+            name: spec
+        - column:
+            name: version
+    - dropView:
+        viewName: resource_with_metadata
+    - createView:
+        viewName: resource_with_metadata
+        selectQuery: |
+          select
+            resource.uid,
+            resource.id,
+            resource.application,
+            resource.kind,
+            json_object(
+              'uid', resource.uid,
+              'id', resource.id,
+              'version', resource_version.version,
+              'application', resource.application,
+              'environment', latest_environment.uid,
+              'environmentName', latest_environment.name,
+              'deliveryConfig', delivery_config.uid,
+              'serviceAccount', delivery_config.service_account
+            ) as metadata,
+            resource_version.spec
+          from resource
+          join resource_version
+            on resource.uid = resource_version.resource_uid
+            and resource_version.version = (
+              select max(rv2.version)
+              from resource_version rv2
+              where resource.uid = rv2.resource_uid
+            )
+          left join environment_resource
+            on resource.uid = environment_resource.resource_uid
+          join latest_environment
+            on latest_environment.uid = environment_resource.environment_uid
+            and latest_environment.version = environment_resource.environment_version
+          left join delivery_config
+            on delivery_config.uid = latest_environment.delivery_config_uid;

--- a/keel-sql/src/main/resources/db/changelog/20210409-resource-version-foreign-keys.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210409-resource-version-foreign-keys.yml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+- changeSet:
+    id: resource-version-foreign-keys
+    author: fletch
+    changes:
+    - sql:
+        sql: delete from resource_version where not exists (select 1 from resource where resource.uid = resource_version.resource_uid);
+    - addPrimaryKey:
+        tableName: resource_version
+        columnNames: resource_uid, version
+    - addForeignKeyConstraint:
+        baseTableName: resource_version
+        baseColumnNames: resource_uid
+        referencedTableName: resource
+        referencedColumnNames: uid
+        constraintName: fk_resource_version_resource
+        onDelete: CASCADE
+    - dropForeignKeyConstraint:
+        baseTableName: environment_resource
+        constraintName: fk_environment_resource_resource
+    - addForeignKeyConstraint:
+        baseTableName: environment_resource
+        baseColumnNames: resource_uid, resource_version
+        referencedTableName: resource_version
+        referencedColumnNames: resource_uid, version
+        constraintName: fk_environment_resource_resource_version
+        onDelete: CASCADE

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -272,3 +272,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210404-resource-version-table.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210409-resource-version-foreign-keys.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -269,3 +269,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210331-add-environment-lease-repository.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210404-resource-version-table.yml
+      relativeToChangelogFile: true


### PR DESCRIPTION
Refactors resource versioning so that there's a separate `resource_version` table with a many-to-one relationship with `resource`. This is closer to how environment versioning works which should be less confusing. It also reduces some associated code complexity.