### PR TITLE
fix(bakery): remove hardcoded account name

### DIFF
--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/config/BakeryConfiguration.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/config/BakeryConfiguration.kt
@@ -18,6 +18,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
 
 @Configuration
 @ConditionalOnProperty("keel.plugins.bakery.enabled")
@@ -34,7 +35,8 @@ class BakeryConfiguration {
     publisher: ApplicationEventPublisher,
     taskLauncher: TaskLauncher,
     @Value("\${bakery.defaults.serviceAccount:keel@spinnaker.io}") defaultServiceAccount: String,
-    @Value("\${bakery.defaults.application:keel}") defaultApplication: String
+    @Value("\${bakery.defaults.application:keel}") defaultApplication: String,
+    springEnv: Environment
   ) = ImageHandler(
     keelRepository,
     baseImageCache,
@@ -43,7 +45,8 @@ class BakeryConfiguration {
     imageService,
     publisher,
     taskLauncher,
-    BakeCredentials(defaultServiceAccount, defaultApplication)
+    BakeCredentials(defaultServiceAccount, defaultApplication),
+    springEnv
   )
 
   @Bean

--- a/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
+++ b/keel-bakery-plugin/src/test/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandlerTests.kt
@@ -29,6 +29,7 @@ import io.mockk.CapturingSlot
 import io.mockk.mockk
 import io.mockk.slot
 import org.springframework.context.ApplicationEventPublisher
+import org.springframework.mock.env.MockEnvironment
 import strikt.api.Assertion
 import strikt.api.expect
 import strikt.api.expectCatching
@@ -66,7 +67,8 @@ internal class ImageHandlerTests : JUnit5Minutests {
       imageService,
       publisher,
       taskLauncher,
-      BakeCredentials("keel@spinnaker.io", "keel")
+      BakeCredentials("keel@spinnaker.io", "keel"),
+      MockEnvironment()
     )
 
     val artifact = DebianArtifact(


### PR DESCRIPTION
Replace the hardcoded "test" account with dynamicConfigService.