### PR TITLE
Version environment on changes

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -285,71 +285,58 @@ class SqlDeliveryConfigRepository(
           .set(ENVIRONMENT.UID, environmentUid)
           .set(ENVIRONMENT.DELIVERY_CONFIG_UID, deliveryConfigUid)
           .set(ENVIRONMENT.NAME, environment.name)
-          .set(ENVIRONMENT.CONSTRAINTS, environment.constraints.toJson())
-          .set(ENVIRONMENT.NOTIFICATIONS, environment.notifications.toJson())
-          .set(ENVIRONMENT.VERIFICATIONS, environment.verifyWith.toJson())
-          .onDuplicateKeyUpdate()
-          .set(ENVIRONMENT.CONSTRAINTS, environment.constraints.toJson())
-          .set(ENVIRONMENT.NOTIFICATIONS, environment.notifications.toJson())
-          .set(ENVIRONMENT.VERIFICATIONS, environment.verifyWith.toJson())
+          .onDuplicateKeyIgnore()
           .execute()
         val currentVersion = jooq
           .select(coalesce(max(ENVIRONMENT_VERSION.VERSION), value(0)))
           .from(ENVIRONMENT_VERSION)
           .where(ENVIRONMENT_VERSION.ENVIRONMENT_UID.eq(environmentUid))
           .fetchOneInto<Int>()
-        val currentVersionResources = when (currentVersion) {
-          0 -> emptyMap()
-          else -> jooq
-            .select(RESOURCE.UID, RESOURCE_VERSION.VERSION)
-            .from(RESOURCE)
-            .join(RESOURCE_VERSION)
-            .on(RESOURCE.UID.eq(RESOURCE_VERSION.RESOURCE_UID))
-            .whereExists(
-              selectOne()
-                .from(ENVIRONMENT_RESOURCE)
-                .where(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(RESOURCE.UID))
-                .and(ENVIRONMENT_RESOURCE.RESOURCE_VERSION.eq(RESOURCE_VERSION.VERSION))
-                .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(environmentUid))
-                .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_VERSION.eq(currentVersion))
-            )
-            .fetch { (uid, version) -> uid to version }
-            .toMap()
-        }
-        val newVersionResources = environment.resources.let { resources ->
-          jooq.select(RESOURCE.UID, max(RESOURCE_VERSION.VERSION))
-            .from(RESOURCE)
-            .join(RESOURCE_VERSION)
-            .on(RESOURCE.UID.eq(RESOURCE_VERSION.RESOURCE_UID))
-            .where(RESOURCE.ID.`in`(resources.map(Resource<*>::id)))
-            .groupBy(RESOURCE.UID)
-            .fetch { (uid, version) -> uid to version }
-            .toMap()
-        }
-        if (currentVersion == 0 || currentVersionResources != newVersionResources) {
-          val newVersion = currentVersion + 1
-          if (newVersion > 1) {
-            log.debug(
-              "Creating a new version {} of environment {}/{} current resources: {}, new resources: {}",
-              newVersion,
-              application,
-              environment.name,
-              currentVersionResources,
-              newVersionResources
-            )
-          } else {
-            log.debug(
-              "Creating initial version of environment {}/{} with resources: {}",
-              application,
-              environment.name,
-              newVersionResources
-            )
-          }
 
+        val newVersion = currentVersion + 1
+
+        val currentVersionResources = resourceUidsAndVersionsFor(environmentUid, currentVersion)
+        val newVersionResources = environment.latestResourceUidsAndVersions()
+        val currentVersionConfig = configFor(environmentUid, currentVersion)
+        val newVersionConfig = mapOf(
+          "constraints" to environment.constraints.toJson(),
+          "verifications" to environment.verifyWith.toJson(),
+          "notifications" to environment.notifications.toJson()
+        )
+
+        val newVersionRequired = if (currentVersion == 0) {
+          log.debug("Creating initial version of environment {}/{}", application, environment.name)
+          true
+        } else if (currentVersionConfig != newVersionConfig) {
+          log.debug(
+            "Creating a new version {} of environment {}/{} because environment configuration changed",
+            newVersion,
+            application,
+            environment.name
+          )
+          true
+        } else if (currentVersionResources != newVersionResources) {
+          log.debug(
+            "Creating a new version {} of environment {}/{} because resources changed from {} to {}",
+            newVersion,
+            application,
+            environment.name,
+            currentVersionResources,
+            newVersionResources
+          )
+          true
+        } else {
+          false
+        }
+
+        if (newVersionRequired) {
           jooq.insertInto(ENVIRONMENT_VERSION)
             .set(ENVIRONMENT_VERSION.ENVIRONMENT_UID, environmentUid)
             .set(ENVIRONMENT_VERSION.VERSION, newVersion)
             .set(ENVIRONMENT_VERSION.CREATED_AT, clock.instant())
+            .set(ENVIRONMENT_VERSION.CONSTRAINTS, environment.constraints.toJson())
+            .set(ENVIRONMENT_VERSION.VERIFICATIONS, environment.verifyWith.toJson())
+            .set(ENVIRONMENT_VERSION.NOTIFICATIONS, environment.notifications.toJson())
             .execute()
 
           newVersionResources.forEach { (resourceUid, resourceVersion) ->
@@ -371,6 +358,65 @@ class SqlDeliveryConfigRepository(
         .execute()
     }
   }
+
+  /**
+   * @return a map of uid to version for the latest versions of all resources used in this
+   * environment.
+   */
+  private fun Environment.latestResourceUidsAndVersions() =
+    jooq.select(RESOURCE.UID, max(RESOURCE_VERSION.VERSION))
+      .from(RESOURCE)
+      .join(RESOURCE_VERSION)
+      .on(RESOURCE.UID.eq(RESOURCE_VERSION.RESOURCE_UID))
+      .where(RESOURCE.ID.`in`(resources.map(Resource<*>::id)))
+      .groupBy(RESOURCE.UID)
+      .fetch { (uid, version) -> uid to version }
+      .toMap()
+
+  /**
+   * @return a map of uid to version for all resources used in [version] of an environment.
+   */
+  private fun resourceUidsAndVersionsFor(environmentUid: String, version: Int) =
+    when (version) {
+      0 -> emptyMap()
+      else -> jooq
+        .select(RESOURCE.UID, RESOURCE_VERSION.VERSION)
+        .from(RESOURCE)
+        .join(RESOURCE_VERSION)
+        .on(RESOURCE.UID.eq(RESOURCE_VERSION.RESOURCE_UID))
+        .whereExists(
+          selectOne()
+            .from(ENVIRONMENT_RESOURCE)
+            .where(ENVIRONMENT_RESOURCE.RESOURCE_UID.eq(RESOURCE.UID))
+            .and(ENVIRONMENT_RESOURCE.RESOURCE_VERSION.eq(RESOURCE_VERSION.VERSION))
+            .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_UID.eq(environmentUid))
+            .and(ENVIRONMENT_RESOURCE.ENVIRONMENT_VERSION.eq(version))
+        )
+        .fetch { (uid, version) -> uid to version }
+        .toMap()
+    }
+
+  /**
+   * @return the constraints, verifications, and notifications used in [version] of an environment.
+   */
+  private fun configFor(environmentUid: String, version: Int) =
+    when (version) {
+      0 -> emptyMap()
+      else -> jooq
+        .select(ENVIRONMENT_VERSION.CONSTRAINTS,
+          ENVIRONMENT_VERSION.VERIFICATIONS,
+          ENVIRONMENT_VERSION.NOTIFICATIONS)
+        .from(ENVIRONMENT_VERSION)
+        .where(ENVIRONMENT_VERSION.ENVIRONMENT_UID.eq(environmentUid))
+        .and(ENVIRONMENT_VERSION.VERSION.eq(version))
+        .fetchOne { (constraints, verifications, notifications) ->
+          mapOf(
+            "constraints" to constraints,
+            "verifications" to verifications,
+            "notifications" to notifications
+          )
+        }
+    }
 
   override fun get(name: String): DeliveryConfig =
     deliveryConfigByName(name)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -328,6 +328,23 @@ class SqlDeliveryConfigRepository(
         }
         if (currentVersion == 0 || currentVersionResources != newVersionResources) {
           val newVersion = currentVersion + 1
+          if (newVersion > 1) {
+            log.debug(
+              "Creating a new version {} of environment {}/{} current resources: {}, new resources: {}",
+              newVersion,
+              application,
+              environment.name,
+              currentVersionResources,
+              newVersionResources
+            )
+          } else {
+            log.debug(
+              "Creating initial version of environment {}/{} with resources: {}",
+              application,
+              environment.name,
+              newVersionResources
+            )
+          }
 
           jooq.insertInto(ENVIRONMENT_VERSION)
             .set(ENVIRONMENT_VERSION.ENVIRONMENT_UID, environmentUid)

--- a/keel-sql/src/main/resources/db/changelog/20210409-add-version-timestamps.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210409-add-version-timestamps.yml
@@ -12,16 +12,6 @@ databaseChangeLog:
             afterColumn: version
             constraints:
               nullable: true
-    - sql:
-        sql: |
-          update resource_version
-          join resource
-          on resource.uid = resource_version.resource_uid
-          join event
-          on event.json -> '$.ref' = resource.id
-          and event.json -> '$.type' = 'ResourceCreated'
-          set resource_version.created_at = event.timestamp
-          where resource_version.version = 1;
     - addColumn:
         tableName: environment_version
         columns:

--- a/keel-sql/src/main/resources/db/changelog/20210413-environment-features-per-version.yml
+++ b/keel-sql/src/main/resources/db/changelog/20210413-environment-features-per-version.yml
@@ -1,0 +1,54 @@
+databaseChangeLog:
+- changeSet:
+    id: environment-features-per-version
+    author: fletch
+    changes:
+    - dropView:
+        viewName: latest_environment
+    - addColumn:
+        tableName: environment_version
+        columns:
+        - column:
+            name: constraints
+            type: json
+            constraints:
+              nullable: false
+        - column:
+            name: verifications
+            type: json
+            constraints:
+              nullable: false
+        - column:
+            name: notifications
+            type: json
+            constraints:
+              nullable: false
+    - sql:
+        sql: |
+          update environment_version
+          join environment
+          on environment.uid = environment_version.environment_uid
+          set environment_version.constraints = environment.constraints
+            , environment_version.verifications = environment.verifications
+            , environment_version.notifications = environment.notifications;
+    - dropColumn:
+        tableName: environment
+        columns:
+        - column:
+            name: constraints
+        - column:
+            name: verifications
+        - column:
+            name: notifications
+    - createView:
+        viewName: latest_environment
+        selectQuery: |
+          select uid, delivery_config_uid, name, version, constraints, notifications, verifications
+          from environment
+          join environment_version
+            on environment.uid = environment_version.environment_uid
+            and environment_version.version = (
+              select max(ev2.version)
+              from environment_version ev2
+              where environment.uid = ev2.environment_uid
+            );

--- a/keel-sql/src/main/resources/db/databaseChangeLog.yml
+++ b/keel-sql/src/main/resources/db/databaseChangeLog.yml
@@ -281,3 +281,6 @@ databaseChangeLog:
   - include:
       file: changelog/20210409-add-verif-link-column.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/20210413-environment-features-per-version.yml
+      relativeToChangelogFile: true

--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/EnvironmentVersioningTests.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/EnvironmentVersioningTests.kt
@@ -1,5 +1,7 @@
 package com.netflix.spinnaker.keel.sql
 
+import com.fasterxml.jackson.databind.jsontype.NamedType
+import com.netflix.spinnaker.keel.api.Constraint
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.NotificationConfig
@@ -7,7 +9,6 @@ import com.netflix.spinnaker.keel.api.NotificationFrequency.normal
 import com.netflix.spinnaker.keel.api.NotificationType.slack
 import com.netflix.spinnaker.keel.api.Verification
 import com.netflix.spinnaker.keel.api.plugins.kind
-import com.netflix.spinnaker.keel.core.api.ManualJudgementConstraint
 import com.netflix.spinnaker.keel.persistence.CombinedRepository
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_RESOURCE
@@ -26,7 +27,9 @@ import com.netflix.spinnaker.kork.sql.test.SqlTestUtil.cleanupDb
 import org.jooq.Table
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
 import org.springframework.mock.env.MockEnvironment
 import strikt.api.Assertion
 import strikt.api.expect
@@ -36,16 +39,16 @@ import strikt.assertions.first
 import strikt.assertions.hasSize
 import strikt.assertions.isEmpty
 import strikt.assertions.isEqualTo
-import strikt.assertions.isNull
 import strikt.assertions.isSuccess
 import java.time.Clock.systemUTC
-import kotlin.math.exp
-import java.time.Clock
 import java.time.Duration
 
 class EnvironmentVersioningTests {
   private val jooq = testDatabase.context
-  private val objectMapper = configuredTestObjectMapper()
+  private val objectMapper = configuredTestObjectMapper().apply {
+    registerSubtypes(NamedType(DummyConstraint::class.java, "dummy"))
+    registerSubtypes(NamedType(DummyVerification::class.java, "dummy"))
+  }
   private val retryProperties = RetryProperties(1, 0)
   private val sqlRetry = SqlRetry(SqlRetryProperties(retryProperties, retryProperties))
   private val resourceSpecIdentifier =
@@ -119,42 +122,23 @@ class EnvironmentVersioningTests {
     expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion
   }
 
-  @Test
-  fun `storing an environment with updated constraints, verifications, or notifications does not create a new version`() {
-    val initialVersion = latestVersion()
-    expectThat(initialVersion).describedAs("initial version") isEqualTo 1
+  @TestFactory
+  fun `storing an updated environment creates a new version`() =
+    mapOf(
+      "constraints" to deliveryConfig.withConstraint(),
+      "verifications" to deliveryConfig.withVerification(),
+      "notifications" to deliveryConfig.withNotification(),
+      "resources" to deliveryConfig.withUpdatedResource()
+    ).map { (description, updatedDeliveryConfig) ->
+      dynamicTest("storing an environment with updated $description creates a new version") {
+        val initialVersion = latestVersion()
 
-    deliveryConfig.run {
-      copy(
-        environments = environments.first().run {
-          copy(
-            constraints = setOf(ManualJudgementConstraint()),
-            verifyWith = listOf(DummyVerification()),
-            notifications = setOf(NotificationConfig(type = slack,
-              address = "#trashpandas",
-              frequency = normal))
-          )
-        }
-          .let(::setOf)
-      )
+        repository.upsertDeliveryConfig(updatedDeliveryConfig)
+
+        val updatedVersion = latestVersion()
+        expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion + 1
+      }
     }
-    repository.upsertDeliveryConfig(deliveryConfig)
-
-    val updatedVersion = latestVersion()
-    expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion
-  }
-
-  @Test
-  fun `storing an environment with an updated resource creates a new version`() {
-    val initialVersion = latestVersion()
-    expectThat(initialVersion).describedAs("initial version") isEqualTo 1
-
-    deliveryConfig.withUpdatedResource()
-      .also(repository::upsertDeliveryConfig)
-
-    val updatedVersion = latestVersion()
-    expectThat(updatedVersion).describedAs("updated version") isEqualTo initialVersion + 1
-  }
 
   @Test
   fun `after creating a new environment version it's still possible to get the environment for a resource`() {
@@ -299,6 +283,34 @@ class EnvironmentVersioningTests {
   private fun DeliveryConfig.withNoEnvironments() =
     copy(environments = emptySet())
 
+  private fun DeliveryConfig.withConstraint() =
+    copy(
+      environments = environments.first().run {
+        copy(constraints = setOf(DummyConstraint()))
+      }
+        .let(::setOf)
+    )
+
+  private fun DeliveryConfig.withVerification() =
+    copy(
+      environments = environments.first().run {
+        copy(verifyWith = listOf(DummyVerification()))
+      }
+        .let(::setOf)
+    )
+
+  private fun DeliveryConfig.withNotification() =
+    copy(
+      environments = environments.first().run {
+        copy(notifications = setOf(NotificationConfig(
+          type = slack,
+          address = "#trashpandas",
+          frequency = normal
+        )))
+      }
+        .let(::setOf)
+    )
+
   private fun latestVersion() =
     jooq
       .select(LATEST_ENVIRONMENT.VERSION)
@@ -313,16 +325,18 @@ class EnvironmentVersioningTests {
 
   private fun <T : Table<*>> Assertion.Builder<T>.isEmpty() =
     assert("has no rows") { subject ->
-      when(val rowCount = subject.count()) {
+      when (val rowCount = subject.count()) {
         0 -> pass("found 0 rows")
         1 -> fail("found 1 row")
         else -> fail("found $rowCount rows")
       }
     }
 
+  class DummyConstraint : Constraint("dummy")
+
   data class DummyVerification(
     override val id: String = "whatever",
   ) : Verification {
-    override val type = "verification"
+    override val type = "dummy"
   }
 }


### PR DESCRIPTION
Create a new environment version if constraints, notifications, or verifications change. Maintain history of those properties.