### PR TITLE
fix(build): ensure keel is built with spinnaker buildtool

### DIFF
--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -17,6 +17,5 @@ RUN usermod -d /var/lib/mysql/ mysql && \
     mysql -u root --password=sa -e "GRANT PROXY ON ''@'' TO 'root'@'%' WITH GRANT OPTION;" && \
     /etc/init.d/mysql restart && \
     mysql -u root --password=sa -e 'CREATE DATABASE `keel` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;'
-
-CMD /etc/init.d/mysql restart && \
-    ./gradlew --no-daemon -PbuildingInDocker=true keel-web:installDist -x test
+ADD build-scripts/entrypoint.sh /usr/bin/
+ENTRYPOINT ["/usr/bin/entrypoint.sh"]

--- a/build-scripts/entrypoint.sh
+++ b/build-scripts/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -ex
+set -o pipefail
+
+BUILD_ARGS="$*"
+
+/etc/init.d/mysql restart
+
+echo "starting gradle job"
+if [[ -z "${BUILD_ARGS// }" ]]
+then
+  echo "no argument received. running default build"
+  ./gradlew --no-daemon -PbuildingInDocker=true keel-web:installDist -x test
+else
+  echo "running ${BUILD_ARGS}"
+  ${BUILD_ARGS}
+fi


### PR DESCRIPTION
Attempt at fixing a build issue reported here: https://spinnakerteam.slack.com/archives/CERACDPDZ/p1618879421016700

Specify the new bash script as Docker `ENTRYPOINT` instead of `CMD`.  If no arguments are passed, run the same command previously specified in the Dockerfile. Otherwise, run whatever is specified in args. 
Tested locally and it worked. I have no way of testing this in cloudbuild and there isn't a way to test it outside of the master branch. 

Background:
During deb build in cloudbuild, [arguments are specified](https://github.com/spinnaker/buildtool/blob/bbc00505b02314c9d17803cb22a615206036cf87/dev/buildtool/cloudbuild/debs.yml#L20) and `CMD` supplied in Dockerfile is ignored. Because of this mysqld is never started and build fails with:

```
Step #2 - "publishDeb": Caused by: java.net.ConnectException: Connection refused (Connection refused)
Step #2 - "publishDeb":         at java.base/java.net.PlainSocketImpl.socketConnect(Native Method)
Step #2 - "publishDeb":         at java.base/java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:399)
Step #2 - "publishDeb":         at java.base/java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:242)
Step #2 - "publishDeb":         at java.base/java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:224)
Step #2 - "publishDeb":         at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
Step #2 - "publishDeb":         at java.base/java.net.Socket.connect(Socket.java:609)
Step #2 - "publishDeb":         at com.mysql.cj.protocol.StandardSocketFactory.connect(StandardSocketFactory.java:155)
Step #2 - "publishDeb":         at com.mysql.cj.protocol.a.NativeSocketConnection.connect(NativeSocketConnection.java:65)
Step #2 - "publishDeb":         ... 12 common frames omitted
```

Docker image build is not affected because it [does not specify args](https://github.com/spinnaker/buildtool/blob/bbc00505b02314c9d17803cb22a615206036cf87/dev/buildtool/cloudbuild/containers.yml#L17)

