### PR TITLE
fix(test): return connection string with ssl disabled in sql-tests

### DIFF
--- a/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/TestContainer.kt
+++ b/keel-sql/src/test/kotlin/com/netflix/spinnaker/keel/sql/TestContainer.kt
@@ -19,4 +19,4 @@ internal val mySQLContainer = MySQLContainerProvider()
 
 @Suppress("UsePropertyAccessSyntax")
 private val JdbcDatabaseContainer<*>.authenticatedJdbcUrl: String
-  get() = "${getJdbcUrl()}?user=${getUsername()}&password=${getPassword()}"
+  get() = "${getJdbcUrl()}?user=${getUsername()}&password=${getPassword()}&useSSL=false"


### PR DESCRIPTION
Builds in GitHub actions are failing due to:
```
The last packet sent successfully to the server was 0 milliseconds ago. The driver has not received any packets from the server.
      at com.netflix.spinnaker.keel.sql.EnvironmentVersioningTests.<init>(EnvironmentVersioningTests.kt:47)
  Caused by: javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
      at com.netflix.spinnaker.keel.sql.EnvironmentVersioningTests.<init>(EnvironmentVersioningTests.kt:47)
```

According to [this file](https://github.com/spinnaker/keel/blob/57ef8a89cf39128c44c9baba5430e8e130c2f0f3/keel-sql/keel-sql.gradle.kts#L141), the intention seems to be to disable SSL in tests.

Note that this is happening in the image used by GitHub actions only and I have not been able to pinpoint what the issue is. Failures do not occur if tests were run in a VM with the same version of OS and JDK used by the GitHub actions image. 