### PR TITLE
fix(repo): handle artifact name change in delivery config

### DIFF
--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepositoryTests.kt
@@ -298,6 +298,12 @@ abstract class ArtifactRepositoryTests<T : ArtifactRepository> : JUnit5Minutests
         expectThat(subject.isRegistered(versionedSnapshotDebian.name, versionedSnapshotDebian.type)).isTrue()
       }
 
+      test("changing an artifact name works") {
+        subject.register(versionedSnapshotDebian.copy(name="keeldemo-but-a-different-name"))
+        val artifact = subject.get(versionedSnapshotDebian.deliveryConfigName!!, versionedSnapshotDebian.reference)
+        expectThat(artifact.name).isEqualTo("keeldemo-but-a-different-name")
+      }
+
       context("no versions exist") {
         test("listing versions returns an empty list") {
           expectThat(subject.versions(versionedSnapshotDebian, limit)).isEmpty()

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -82,8 +82,7 @@ class SqlArtifactRepository(
           .select(DELIVERY_ARTIFACT.UID)
           .from(DELIVERY_ARTIFACT)
           .where(
-            DELIVERY_ARTIFACT.NAME.eq(artifact.name)
-              .and(DELIVERY_ARTIFACT.TYPE.eq(artifact.type))
+              DELIVERY_ARTIFACT.TYPE.eq(artifact.type)
               .and(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME.eq(artifact.deliveryConfigName))
               .and(DELIVERY_ARTIFACT.REFERENCE.eq(artifact.reference))
           )
@@ -102,7 +101,7 @@ class SqlArtifactRepository(
         .set(DELIVERY_ARTIFACT.DELIVERY_CONFIG_NAME, artifact.deliveryConfigName)
         .set(DELIVERY_ARTIFACT.DETAILS, artifact.detailsAsJson())
         .onDuplicateKeyUpdate()
-        .set(DELIVERY_ARTIFACT.REFERENCE, artifact.reference)
+        .set(DELIVERY_ARTIFACT.NAME, artifact.name)
         .set(DELIVERY_ARTIFACT.DETAILS, artifact.detailsAsJson())
         .execute()
       jooq.insertInto(ARTIFACT_LAST_CHECKED)


### PR DESCRIPTION
Problem: if the user changes the name of an artifact, this breaks keel.

The problematic code is in the method: SqlArtifactRepository.register, and has to do with how mysql handles unique constraints.

Here is the problematic sequence of events in SqlArtifactRepository.register

1. Looks for a matching artifact record, but doesn't find it because the name is different.
2. Generates a new ulid because no matching artifact record
3. Does an insert-on-duplicate-update to upsert into the delivery_artifact table and ends up doing an update(!) even though the ulid is different, because there's a unique constraint on (delivery_config_name, reference) that matches(!!!).
4. Attempts to insert-on-duplicate-update into artifact_last_checked table with the new ulid, which does an insert, which violates the foreign key constraints, because this record did not get inserted into delivery_artifact_table.

See this dbfiddle for a reproduction of the issue in step 3: https://dbfiddle.uk/?rdbms=mysql_5.7&fiddle=bc09a78b09143a7a23b31410ed949a79

Implemented solution:

When retrieving the id of the delivery artifact, don't try to match on the name. This way, if an artifact with an existing reference gets renamed, it will be treated as the same artifact, and so it will update in step 3 above instead of inserting.