### PR TITLE
chore(metrics): monitor threadpool of Spring ThreadPoolTaskExecutor

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/telemetry/TelemetryListenerTests.kt
@@ -35,7 +35,7 @@ internal class TelemetryListenerTests : JUnit5Minutests {
 
   fun tests() = rootContext<TelemetryListener> {
     fixture {
-      TelemetryListener(registry, Clock.systemUTC(), emptyList())
+      TelemetryListener(registry, Clock.systemUTC(), emptyList(), emptyList())
     }
 
     context("successful metric submission") {


### PR DESCRIPTION
Context:

Keel is configured to use a ThreadPoolTaskExecutor as the implementation
for its ApplicationEventTaskExecutor, which is configured in
the EventsConfiguration class (and is not modified in this PR).

This is the executor that handles published spring events. It is
configured with a single thread in the pool.

It has a thread prefix of "event-pool-", which you can see in the logs.

Problem:

We aren't currently reporting metrics on this threadpool. I have a hunch
that it is this threadpool that is getting backed up and bottlenecking
us when we get an avalanche of submitArtifact events.

Change in this PR:

Inject ThreadPoolTaskExecutors into TelemetryListener and monitor them
using Spectator thread pool monitors, so we can capture metrics on this
thread pool.
