### PR TITLE
fix(deps): bump graphql-dgs-platform-dependencies version

### DIFF
--- a/keel-web/keel-web.gradle
+++ b/keel-web/keel-web.gradle
@@ -44,7 +44,7 @@ dependencies {
   implementation("io.spinnaker.kork:kork-plugins")
   implementation("com.slack.api:bolt-servlet:1.6.0")
   implementation("com.graphql-java:graphql-java-extended-scalars:16.0.1")
-  implementation(platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:4.2.1-rc.1'))
+  implementation(platform('com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:4.3.1'))
   implementation("com.netflix.graphql.dgs:graphql-dgs-spring-boot-starter")
 
   runtimeOnly("io.spinnaker.kork:kork-runtime")


### PR DESCRIPTION
The `4.2.1-rc.1` of `com.netflix.graphql.dgs:graphql-dgs-platform-dependencies` doesn't appear that it was [released to maven central](https://mvnrepository.com/artifact/com.netflix.graphql.dgs/graphql-dgs-platform-dependencies), so this breaks builds for OSS with the following error:

```
> Could not find com.netflix.graphql.dgs:graphql-dgs-platform-dependencies:4.2.1-rc.1.
```

@luispollo this _might_ be [related to this conversation here,](https://spinnakerteam.slack.com/archives/CERACDPDZ/p1623713629075400?thread_ts=1623702803.062700&cid=CERACDPDZ) but I think I'm missing context on that one.
Tagging @nimakaviani on this one because he was in that thread as well. 

