### PR TITLE
fix(keel-web): rename keel-web -> keel

### DIFF
--- a/keel-web/keel-web.gradle
+++ b/keel-web/keel-web.gradle
@@ -3,6 +3,7 @@ plugins {
 }
 
 apply(plugin: "com.netflix.dgs.codegen")
+apply(plugin: "io.spinnaker.package")
 
 repositories {
   mavenCentral() // for graphql-java-extended-scalars
@@ -68,4 +69,5 @@ dependencies {
 
 application {
   mainClassName = "com.netflix.spinnaker.keel.MainKt"
+  applicationName("keel")
 }


### PR DESCRIPTION
this name change happened when switch to
groovy-based gradle was made. keel-web breaks creating
the docker image for keel.

Also apply the packaging for springboot configuration
location to populate properly in the run script.

It might be that https://github.com/spinnaker/keel/commit/858c078faafc268ee628172cb9d675e0d66c2c33 impacted the way we used to package keel. 

@luispollo @lorin 