### PR TITLE
chore(release): Make periodic releases final

### DIFF
--- a/.github/workflows/periodic_release.yml
+++ b/.github/workflows/periodic_release.yml
@@ -57,4 +57,4 @@ jobs:
           release_name: ${{ github.event.repository.name }} ${{ steps.changelog.outputs.tag }}
           body: ${{ steps.changelog.outputs.clean_changelog }}
           draft: false
-          prerelease: true
+          prerelease: false


### PR DESCRIPTION
There's no reason to make them pre-release.
