### PR TITLE
chore(versioning): timestamp to indicate when a version went active

### DIFF
--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -1443,8 +1443,10 @@ class SqlDeliveryConfigRepository(
     insertInto(ACTIVE_ENVIRONMENT_VERSION)
       .set(ACTIVE_ENVIRONMENT_VERSION.ENVIRONMENT_UID, uid)
       .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_VERSION, version)
+      .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_SINCE, clock.instant())
       .onDuplicateKeyUpdate()
       .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_VERSION, version)
+      .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_SINCE, clock.instant())
       .where(ACTIVE_ENVIRONMENT_VERSION.ENVIRONMENT_UID.eq(uid))
       .execute()
   }
@@ -1453,8 +1455,10 @@ class SqlDeliveryConfigRepository(
     insertInto(ACTIVE_ENVIRONMENT_VERSION)
       .set(ACTIVE_ENVIRONMENT_VERSION.ENVIRONMENT_UID, uid)
       .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_VERSION, version)
+      .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_SINCE, clock.instant())
       .onDuplicateKeyUpdate()
       .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_VERSION, version)
+      .set(ACTIVE_ENVIRONMENT_VERSION.ACTIVE_SINCE, clock.instant())
       .where(ACTIVE_ENVIRONMENT_VERSION.ENVIRONMENT_UID.eq(uid))
       .execute()
   }


### PR DESCRIPTION
Record when a version became active

(cherry picked from commit bb03ab814e8d9c77462be3701e6d26cc53cd96d3)