### PR TITLE
chore(admin): give an age for backfilling

### DIFF
--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
+import java.time.format.DateTimeParseException
 
 @RestController
 @RequestMapping(path = ["/poweruser"])
@@ -122,8 +124,17 @@ class AdminController(
   @PostMapping(
     path = ["/artifacts/metadata/backfill"]
   )
-  fun backFillAllArtifactMetadata() {
-    adminService.backfillArtifactMetadataAsync()
+  fun backFillAllArtifactMetadata(
+    @RequestParam("age", required = false) age: String?
+  ) {
+    if (age.isNullOrBlank()) {
+      // use default
+      adminService.backfillArtifactMetadataAsync(Duration.ofDays(3))
+    } else {
+      val parsedAge = Duration.parse(age)
+      adminService.backfillArtifactMetadataAsync(parsedAge)
+    }
+
   }
 
   /**

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -96,20 +96,20 @@ class AdminService(
   /**
    * Updates last 10 artifact's versions with the corresponding metadata, if available, by type [deb/docker/npm]
    */
-  fun backfillArtifactMetadataAsync() {
+  fun backfillArtifactMetadataAsync(age: Duration) {
     launch(TracingSupport.blankMDC) {
-      backfillArtifactMetadata()
+      backfillArtifactMetadata(age)
     }
   }
 
   /**
    * Updates last 10 artifact's versions with the corresponding metadata, if available, by type [deb/docker/npm]
    */
-  suspend fun backfillArtifactMetadata() {
+  suspend fun backfillArtifactMetadata(age: Duration = Duration.ofHours(3)) {
     log.debug("Starting to back-fill old artifacts versions with artifact metadata...")
     val versions = repository
       // only check versions that are < 3 hours old, and probably nothing changes after one hour
-      .getVersionsWithoutMetadata(100, Duration.ofHours(3))
+      .getVersionsWithoutMetadata(100, age)
       versions.forEach { artifactVersion ->
         log.debug("Evaluating version ${artifactVersion.version} as candidate to back-fill metadata")
         try {


### PR DESCRIPTION
Sometimes we fix a problem that was preventing us from finding metadata. i've updated the admin endpoint here to accept a max age so that we can trigger a backfill of older versions with the fixed code.

(cherry picked from commit 95fc97bc6ee6ad75a3b4eb696f58dd18f52c2b27)
