### PR TITLE
chore(titus): bump default container mem to 4GB

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/batch/ContainerJobConfig.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/batch/ContainerJobConfig.kt
@@ -22,7 +22,7 @@ data class ContainerJobConfig(
   val location: TitusServerGroup.Location,
   val resources: TitusServerGroup.Resources = TitusServerGroup.Resources(
     cpu = 2,
-    memory = 2048,
+    memory = 4096,
     disk = 256,
     networkMbps = 1024
   ),


### PR DESCRIPTION
Problem:

Currently, Titus containers we use for verification jobs are allocated 2GB of
memory. We had an internal customer who wanted to run a verification job
that required more memory (4GB was enough for him).

Solution:

Change the default to 4GB for now. Longer-term, this should probably be
more configurable, either by user, or by property, but this seems like a
reasonable quick fix for now.

(cherry picked from commit 65b62f06a7ce328488f0af9ce43de3ae2ceb141e)
