### PR TITLE
fix(ec2): increment image tag launch metric

### DIFF
--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/ImageTagger.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/ImageTagger.kt
@@ -92,7 +92,7 @@ class ImageTagger(
       spectator.counter(
         TAG_AMI_JOB_LAUNCHED,
         listOf(BasicTag("application", event.application))
-      )
+      ).increment()
     }
   }
 


### PR DESCRIPTION
We were creating a counter but we weren't incrementing it.

(cherry picked from commit 61e714432d8fd4710987ea1725747bfcbcf615df)
