### PR TITLE
feat(scaling): automatically add a AutoScalingGroupName dimension to Titus target tracking policies

### DIFF
--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -543,9 +543,11 @@ class TitusClusterHandler(
                 namespace = namespace,
                 statistic = statistic,
                 unit = unit,
-                dimensions = dimensions?.map { d ->
-                  MetricDimensionModel(name = d.name, value = d.value)
-                }
+                dimensions = (
+                  dimensions?.map { d ->
+                    MetricDimensionModel(name = d.name, value = d.value)
+                  } ?: emptyList()
+                ) + MetricDimensionModel("AutoScalingGroupName", serverGroup.name)
               )
             }
           }


### PR DESCRIPTION
(cherry picked from commit 19c615c4fe51fa16a5e881c8885a5add413547b5)