### PR TITLE
fix(notification): Use the correct emoji for pluginNotification PASS/FAIL

### DIFF
--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PluginNotificationHandler.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PluginNotificationHandler.kt
@@ -47,8 +47,8 @@ class PluginNotificationHandler(
       log.debug("Sending plugin notification for application ${notification.application} and environment ${notification.targetEnvironment}")
 
       val emoji = when(config.status) {
-        FAILED -> ":gear:"
-        SUCCEEDED -> ":x: :gear:"
+        FAILED -> ":x: :gear:"
+        SUCCEEDED -> ":white_check_mark: :gear:"
       }
 
       val blocks = withBlocks {


### PR DESCRIPTION
(cherry picked from commit 2fa25613d1b8596c3adc255fa9ac89af47a48159)
