### PR TITLE
chore(*): Upstream latest batch of Netflix changes

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/DeliveryConfig.kt
@@ -17,7 +17,7 @@ data class DeliveryConfig(
   @get:ExcludedFromDiff
   val rawConfig: String? = null,
   @get:ExcludedFromDiff
-  val updatedAt: Instant? = null
+  val updatedAt: Instant? = null,
 ) {
   @get:ExcludedFromDiff
   val resources: Set<Resource<*>>

--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/Resource.kt
@@ -30,10 +30,13 @@ data class Resource<out T : ResourceSpec>(
   val application: String
     get() = metadata.getValue("application").toString()
 
+  val basedOn: String?
+    get() = metadata["basedOn"] as? String
+
   val name: String
     get() = (spec as? Monikered)?.moniker?.toString() ?: metadata["name"] as? String ?: id
 
-  /**
+    /**
    * Attempts to find an artifact in the delivery config based on information in this resource's spec.
    */
   fun findAssociatedArtifact(deliveryConfig: DeliveryConfig) =

--- a/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
+++ b/keel-core-test/src/main/kotlin/com/netflix/spinnaker/keel/persistence/DeliveryConfigRepositoryTests.kt
@@ -553,16 +553,16 @@ abstract class DeliveryConfigRepositoryTests<T : DeliveryConfigRepository, R : R
             expectThat(resourceRepository.applicationEventHistory(deliveryConfig.application)).isEmpty()
           }
 
-          test("deletes related application pause records") {
-            repository.deleteByApplication(deliveryConfig.application)
-            expectThat(pausedRepository.getPause(PauseScope.APPLICATION, deliveryConfig.application)).isNull()
-          }
-
           test("deletes related resource events") {
             repository.deleteByApplication(deliveryConfig.application)
             // FIXME: can't check resource event history because it tries to read the resource record first.
             //  We should break out the event stuff into its own repository.
             // expectThat(resourceRepository.eventHistory(firstResource.id)).isEmpty()
+          }
+
+          test("deletes related application pause records") {
+            repository.deleteByApplication(deliveryConfig.application)
+            expectThat(pausedRepository.getPause(PauseScope.APPLICATION, deliveryConfig.application)).isNull()
           }
 
           test("deletes related resource pause records") {

--- a/keel-core/keel-core.gradle
+++ b/keel-core/keel-core.gradle
@@ -31,6 +31,7 @@ dependencies {
   testImplementation(project(":keel-core-test"))
   testImplementation(project(":keel-ec2-api"))  // needed for resource dependency logic
   testImplementation("io.strikt:strikt-jackson")
+  testImplementation("io.strikt:strikt-mockk")
   testImplementation("dev.minutest:minutest")
 
   testImplementation("org.assertj:assertj-core")

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/constraints/AllowedTimesConstraintEvaluator.kt
@@ -79,8 +79,8 @@ class AllowedTimesConstraintEvaluator(
     artifactRepository.deploymentsBetween(
       deliveryConfig,
       targetEnvironment.name,
-      windowRange.start,
-      windowRange.endInclusive
+      windowRange.start.toInstant(),
+      windowRange.endInclusive.toInstant()
     ) to constraint.maxDeploysPerWindow
   } else {
     null

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/core/api/SubmittedDeliveryConfig.kt
@@ -36,7 +36,7 @@ data class SubmittedDeliveryConfig(
     name = safeName,
     application = application,
     serviceAccount = serviceAccount
-      ?: error("No service account specified, and no default applied"),
+      ?: error("No service account specified for app ${application}, and no default applied"),
     artifacts = artifacts.mapTo(mutableSetOf()) { artifact ->
       artifact.withDeliveryConfigName(safeName)
     },

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/KeelApiModule.kt
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ser.Serializers
 import com.netflix.spinnaker.keel.api.ClusterDeployStrategy
 import com.netflix.spinnaker.keel.api.Constraint
 import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.Dependent
 import com.netflix.spinnaker.keel.api.Locatable
 import com.netflix.spinnaker.keel.api.Monikered
 import com.netflix.spinnaker.keel.api.PreviewEnvironmentSpec
@@ -43,6 +44,7 @@ import com.netflix.spinnaker.keel.jackson.mixins.CommitMixin
 import com.netflix.spinnaker.keel.jackson.mixins.ConstraintStateMixin
 import com.netflix.spinnaker.keel.jackson.mixins.DeliveryArtifactMixin
 import com.netflix.spinnaker.keel.jackson.mixins.DeliveryConfigMixin
+import com.netflix.spinnaker.keel.jackson.mixins.DependentMixin
 import com.netflix.spinnaker.keel.jackson.mixins.LocatableMixin
 import com.netflix.spinnaker.keel.jackson.mixins.MonikeredMixin
 import com.netflix.spinnaker.keel.jackson.mixins.PreviewEnvironmentSpecMixin
@@ -76,6 +78,7 @@ object KeelApiModule : SimpleModule("Keel API") {
       setMixInAnnotations<Commit, CommitMixin>()
       setMixInAnnotations<Verification, VerificationMixin>()
       setMixInAnnotations<PreviewEnvironmentSpec, PreviewEnvironmentSpecMixin>()
+      setMixInAnnotations<Dependent, DependentMixin>()
       insertAnnotationIntrospector(FactoryAnnotationIntrospector())
     }
   }

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/DependentMixin.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/jackson/mixins/DependentMixin.kt
@@ -1,0 +1,9 @@
+package com.netflix.spinnaker.keel.jackson.mixins
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.netflix.spinnaker.keel.api.Dependency
+
+interface DependentMixin {
+  @get:JsonIgnore
+  val dependsOn: Set<Dependency>
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/persistence/ArtifactRepository.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.core.api.PublishedArtifactInEnvironment
 import com.netflix.spinnaker.keel.services.StatusInfoForArtifactInEnvironment
 import com.netflix.spinnaker.kork.exceptions.UserException
 import java.time.Duration
-import java.time.temporal.TemporalAccessor
+import java.time.Instant
 
 interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
 
@@ -395,8 +395,8 @@ interface ArtifactRepository : PeriodicallyCheckedRepository<DeliveryArtifact> {
   fun deploymentsBetween(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
-    startTime: TemporalAccessor,
-    endTime: TemporalAccessor
+    startTime: Instant,
+    endTime: Instant
   ): Int
 }
 

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/SpecMigrator.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/resources/SpecMigrator.kt
@@ -28,4 +28,4 @@ fun <I : ResourceSpec> Collection<SpecMigrator<*, *>>.migrate(
       val result = migrator.migrate(spec)
       migrate(migrator.output.kind, result)
     }
-    ?: kind to spec
+    ?: (kind to spec)

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/scm/codeEvents.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/scm/codeEvents.kt
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory
 abstract class CodeEvent(
   open val repoKey: String,
   open val targetBranch: String,
+  open val commitHash: String? = null,
   open val pullRequestId: String? = null,
   open val authorName: String? = null,
   open val authorEmail: String? = null
@@ -104,6 +105,7 @@ data class PrMergedEvent(
   override val targetBranch: String,
   override val pullRequestId: String,
   override val pullRequestBranch: String,
+  override val commitHash: String,
   override val authorName: String? = null,
   override val authorEmail: String? = null
 ) : PrEvent(repoKey, targetBranch, pullRequestId, pullRequestBranch, authorName, authorEmail) {
@@ -148,7 +150,7 @@ data class CommitCreatedEvent(
   override val repoKey: String,
   override val targetBranch: String,
   override val pullRequestId: String? = null,
-  val commitHash: String,
+  override val commitHash: String,
   override val authorName: String? = null,
   override val authorEmail: String? = null
 ) : CodeEvent(repoKey, targetBranch, pullRequestId, authorName, authorEmail) {
@@ -192,7 +194,8 @@ fun PublishedArtifact.toCodeEvent(): CodeEvent? {
       pullRequestId = pullRequestId,
       pullRequestBranch = pullRequestBranch,
       authorName = authorName,
-      authorEmail = authorEmail
+      authorEmail = authorEmail,
+      commitHash = sha,
     )
     "pr_declined" -> PrDeclinedEvent(
       repoKey = repoKey,

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/upsert/DeliveryConfigUpserter.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/upsert/DeliveryConfigUpserter.kt
@@ -1,0 +1,88 @@
+package com.netflix.spinnaker.keel.upsert
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.convertValue
+import com.netflix.spinnaker.keel.api.DeliveryConfig
+import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
+import com.netflix.spinnaker.keel.events.DeliveryConfigChangedNotification
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.persistence.NoDeliveryConfigForApplication
+import com.netflix.spinnaker.keel.validators.DeliveryConfigValidator
+import org.slf4j.LoggerFactory
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Component
+import org.springframework.core.env.Environment as SpringEnvironment
+
+/**
+ * The [DeliveryConfigUpserter] is responsible for handling a new [SubmittedDeliveryConfig],
+ * including validation, insertion to the DB and notifying the user if necessary
+ */
+@Component
+class DeliveryConfigUpserter(
+  private val repository: KeelRepository,
+  private val mapper: ObjectMapper,
+  private val validator: DeliveryConfigValidator,
+  private val publisher: ApplicationEventPublisher,
+  private val springEnv: SpringEnvironment
+) {
+
+  private val log by lazy { LoggerFactory.getLogger(javaClass) }
+
+  private val sendConfigChangedNotification: Boolean
+    get() = springEnv.getProperty("keel.notifications.send-config-changed", Boolean::class.java, true)
+
+  fun upsertConfig(deliveryConfig: SubmittedDeliveryConfig): DeliveryConfig {
+    val existing: DeliveryConfig? = try {
+      repository.getDeliveryConfigForApplication(deliveryConfig.application)
+    } catch (e: NoDeliveryConfigForApplication) {
+      null
+    }
+    log.info("Validating config for app ${deliveryConfig.application}")
+    validator.validate(deliveryConfig)
+    log.debug("Upserting delivery config '${deliveryConfig.name}' for app '${deliveryConfig.application}'")
+    val config = repository.upsertDeliveryConfig(deliveryConfig)
+    if (shouldNotifyOfConfigChange(existing, config)) {
+      log.debug("Publish deliveryConfigChange event for app ${deliveryConfig.application}")
+      publisher.publishEvent(
+        DeliveryConfigChangedNotification(
+          config = config,
+          gitMetadata = getGitMetadata(deliveryConfig),
+          new = existing == null
+        )
+      )
+    } else {
+      log.debug("No config changes for app ${deliveryConfig.application}. Skipping notification")
+    }
+    return config.copy(rawConfig = null)
+  }
+
+  private fun getGitMetadata(deliveryConfig: SubmittedDeliveryConfig): GitMetadata? {
+    val metadata: Map<String, Any?> = deliveryConfig.metadata ?: mapOf()
+    return try {
+      val candidateMetadata = metadata.getOrDefault("gitMetadata", null)
+      if (candidateMetadata != null) {
+        mapper.convertValue<GitMetadata>(candidateMetadata)
+      } else {
+        null
+      }
+    } catch (e: IllegalArgumentException) {
+      log.debug("Error converting git metadata ${metadata.getOrDefault("gitMetadata", null)}: {}", e)
+      // not properly formed, so ignore the metadata and move on
+      null
+    }
+  }
+
+  fun shouldNotifyOfConfigChange(existing: DeliveryConfig?, new: DeliveryConfig) =
+    when {
+      !sendConfigChangedNotification -> false
+      existing == null -> true
+      DefaultResourceDiff(existing, new).also {
+        if (it.hasChanges()) {
+          log.debug("Found diffs in delivery config ${it.affectedRootPropertyNames}")
+        }
+      }.hasChanges() -> true
+      else -> false
+    }
+}

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/upsert/DeliveryConfigUpserter.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/upsert/DeliveryConfigUpserter.kt
@@ -33,7 +33,10 @@ class DeliveryConfigUpserter(
   private val sendConfigChangedNotification: Boolean
     get() = springEnv.getProperty("keel.notifications.send-config-changed", Boolean::class.java, true)
 
-  fun upsertConfig(deliveryConfig: SubmittedDeliveryConfig): DeliveryConfig {
+  /**
+   * This function returns the upsertted [DeliveryConfig] and a boolean indicating if the config was just inserted for the first time
+   */
+  fun upsertConfig(deliveryConfig: SubmittedDeliveryConfig): Pair<DeliveryConfig, Boolean>  {
     val existing: DeliveryConfig? = try {
       repository.getDeliveryConfigForApplication(deliveryConfig.application)
     } catch (e: NoDeliveryConfigForApplication) {
@@ -55,7 +58,7 @@ class DeliveryConfigUpserter(
     } else {
       log.debug("No config changes for app ${deliveryConfig.application}. Skipping notification")
     }
-    return config.copy(rawConfig = null)
+    return Pair(config.copy(rawConfig = null), existing == null)
   }
 
   private fun getGitMetadata(deliveryConfig: SubmittedDeliveryConfig): GitMetadata? {

--- a/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/util.kt
+++ b/keel-core/src/main/kotlin/com/netflix/spinnaker/keel/util.kt
@@ -1,6 +1,14 @@
 package com.netflix.spinnaker.keel
 
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.jackson.readValueInliningAliases
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
 
 inline fun <reified T> DynamicConfigService.getConfig(configName: String, defaultValue: T): T =
   getConfig(T::class.java, configName, defaultValue)
+
+fun YAMLMapper.parseDeliveryConfig(rawDeliveryConfig: String): SubmittedDeliveryConfig {
+  return readValueInliningAliases<SubmittedDeliveryConfig>(rawDeliveryConfig)
+    .copy(rawConfig = rawDeliveryConfig)
+}

--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/upsert/DeliveryConfigUpserterTest.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/upsert/DeliveryConfigUpserterTest.kt
@@ -1,0 +1,92 @@
+package com.netflix.spinnaker.keel.upsert
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.exceptions.ValidationException
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.test.deliveryArtifact
+import com.netflix.spinnaker.keel.test.submittedDeliveryConfig
+import com.netflix.spinnaker.keel.validators.DeliveryConfigValidator
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.core.env.Environment
+import strikt.api.expectThrows
+
+internal class DeliveryConfigUpserterTest {
+  private val repository: KeelRepository = mockk()
+  private val mapper: ObjectMapper = mockk()
+  private val validator: DeliveryConfigValidator = mockk()
+  private val publisher: ApplicationEventPublisher = mockk()
+  private val springEnv: Environment = mockk()
+
+  private val subject = DeliveryConfigUpserter(
+    repository = repository,
+    mapper = mapper,
+    validator = validator,
+    publisher = publisher,
+    springEnv = springEnv
+  )
+
+  private val submittedDeliveryConfig = submittedDeliveryConfig()
+  private val deliveryConfig = submittedDeliveryConfig.toDeliveryConfig()
+
+  @BeforeEach
+  fun setupMocks() {
+    every {
+      repository.getDeliveryConfigForApplication(any())
+    } returns deliveryConfig
+
+    every {
+      validator.validate(any())
+    } just Runs
+
+    every {
+      repository.upsertDeliveryConfig(submittedDeliveryConfig)
+    } returns deliveryConfig
+
+    every {
+      springEnv.getProperty("keel.notifications.send-config-changed", Boolean::class.java, true)
+    } returns true
+  }
+
+  @Test
+  fun `no upsert if validation fails`() {
+    every {
+      validator.validate(any())
+    }.throws(ValidationException("bad config"))
+
+    expectThrows<ValidationException> {
+      subject.upsertConfig(submittedDeliveryConfig)
+    }
+    verify(exactly = 0) { repository.upsertDeliveryConfig(any<SubmittedDeliveryConfig>()) }
+  }
+
+  @Test
+  fun `can upsert a valid delivery config`() {
+    subject.upsertConfig(submittedDeliveryConfig)
+    verify { repository.upsertDeliveryConfig(submittedDeliveryConfig) }
+    verify(exactly = 0) { publisher.publishEvent(any<Object>()) } // No diff
+  }
+
+  @Test
+  fun `notify on config changes`() {
+    every {
+      publisher.publishEvent(any<Object>())
+    } just Runs
+
+    every {
+      repository.getDeliveryConfigForApplication(any())
+    } returns deliveryConfig.copy(artifacts = setOf(deliveryArtifact(name = "differentArtifact")))
+
+    subject.upsertConfig(submittedDeliveryConfig)
+
+    verify { repository.upsertDeliveryConfig(submittedDeliveryConfig) }
+    verify { publisher.publishEvent(any<Object>()) }
+  }
+}

--- a/keel-docker/keel-docker.gradle
+++ b/keel-docker/keel-docker.gradle
@@ -4,7 +4,10 @@ dependencies {
   implementation("org.springframework:spring-context")
   implementation("net.swiftzer.semver:semver:1.1.0")
 
-  implementation(project(":keel-test"))
+  testImplementation(project(":keel-test")) {
+    // avoid circular dependency which breaks Liquibase
+    exclude(module: "keel-docker")
+  }
   testImplementation("dev.minutest:minutest")
   testImplementation("io.strikt:strikt-core")
 }

--- a/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
+++ b/keel-docker/src/main/kotlin/com/netflix/spinnaker/keel/docker/DockerImageResolver.kt
@@ -37,7 +37,7 @@ import com.netflix.spinnaker.kork.exceptions.ConfigurationException
  * Implement the methods in this interface for each cloud provider.
  */
 abstract class DockerImageResolver<T : ResourceSpec>(
-  val repository: KeelRepository
+  open val repository: KeelRepository
 ) : Resolver<T> {
 
   /**
@@ -68,7 +68,7 @@ abstract class DockerImageResolver<T : ResourceSpec>(
   /**De
    * Get the digest for a specific image
    */
-  abstract fun getDigest(account: String, organization: String, image: String, tag: String): String
+  abstract fun getDigest(account: String, artifact: DockerArtifact, tag: String): String
 
   override fun invoke(resource: Resource<T>): Resource<T> {
     val container = getContainerFromSpec(resource)
@@ -134,7 +134,7 @@ abstract class DockerImageResolver<T : ResourceSpec>(
     artifact: DockerArtifact,
     tag: String
   ): DigestProvider {
-    val digest = getDigest(account, artifact.organization, artifact.image, tag)
+    val digest = getDigest(account, artifact, tag)
     return DigestProvider(
       organization = artifact.organization,
       image = artifact.image,

--- a/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
+++ b/keel-docker/src/test/kotlin/com/netflix/spinnaker/keel/docker/SampleDockerImageResolver.kt
@@ -51,7 +51,7 @@ class SampleDockerImageResolver(
     listOf("latest", "v0.0.1", "v0.0.2", "v0.0.4", "v0.1.1", "v0.1.0")
 
   // this would normally call out to clouddriver
-  override fun getDigest(account: String, organization: String, image: String, tag: String) =
+  override fun getDigest(account: String, artifact: DockerArtifact, tag: String) =
     when (tag) {
       "v0.0.1" -> "sha256:2763a2b9d53e529c62b326b7331d1b44aae344be0b79ff64c74559c5c96b76b7"
       "v0.0.2" -> "sha256:b4857d7596462aeb1977e6e5d1e31b20a5b5eecf890cd64ac62f145b3839ee97"

--- a/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ec2.kt
+++ b/keel-ec2-api/src/main/kotlin/com/netflix/spinnaker/keel/api/ec2/ec2.kt
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.keel.api.ec2.old.ApplicationLoadBalancerV1_1Spec
 import com.netflix.spinnaker.keel.api.ec2.old.ClusterV1Spec
 import com.netflix.spinnaker.keel.api.plugins.kind
 
-const val CLOUD_PROVIDER = "aws"
+const val EC2_CLOUD_PROVIDER = "aws"
 
 val EC2_CLUSTER_V1_1 = kind<ClusterSpec>("ec2/cluster@v1.1")
 

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandler.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.Action
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec.ApplicationLoadBalancerOverride
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.Location
@@ -204,7 +204,7 @@ class ApplicationLoadBalancerHandler(
           try {
             getApplicationLoadBalancer(
               serviceAccount,
-              CLOUD_PROVIDER,
+              EC2_CLOUD_PROVIDER,
               account,
               region,
               name
@@ -292,7 +292,7 @@ class ApplicationLoadBalancerHandler(
         mapOf(
           "application" to moniker.app,
           "credentials" to location.account,
-          "cloudProvider" to CLOUD_PROVIDER,
+          "cloudProvider" to EC2_CLOUD_PROVIDER,
           "name" to moniker.toString(),
           "region" to location.region,
           "availabilityZones" to mapOf(location.region to location.availabilityZones),

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandler.kt
@@ -6,18 +6,18 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
+import com.netflix.spinnaker.keel.api.actuation.Job
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerHealthCheck
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerListener
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerOverride
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerDependencies
 import com.netflix.spinnaker.keel.api.ec2.Location
-import com.netflix.spinnaker.keel.api.plugins.ResolvableResourceHandler
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.keel.clouddriver.ResourceNotFound
 import com.netflix.spinnaker.keel.core.parseMoniker
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.diff.toIndividualDiffs
-import com.netflix.spinnaker.keel.api.actuation.Job
 import com.netflix.spinnaker.keel.model.OrcaJob
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.retrofit.isNotFound
@@ -200,7 +199,7 @@ class ClassicLoadBalancerHandler(
           try {
             getClassicLoadBalancer(
               serviceAccount,
-              CLOUD_PROVIDER,
+              EC2_CLOUD_PROVIDER,
               account,
               region,
               name
@@ -303,7 +302,7 @@ class ClassicLoadBalancerHandler(
         mapOf(
           "application" to moniker.app,
           "credentials" to location.account,
-          "cloudProvider" to CLOUD_PROVIDER,
+          "cloudProvider" to EC2_CLOUD_PROVIDER,
           "name" to moniker.toString(),
           "region" to location.region,
           "availabilityZones" to mapOf(location.region to location.availabilityZones),

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandler.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.api.artifacts.ArtifactStatus.UNKNOWN
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.Capacity.AutoScalingCapacity
 import com.netflix.spinnaker.keel.api.ec2.Capacity.DefaultCapacity
@@ -668,7 +668,7 @@ class ClusterHandler(
 
     return mapOf(
       "type" to "disableServerGroup",
-      "cloudProvider" to CLOUD_PROVIDER,
+      "cloudProvider" to EC2_CLOUD_PROVIDER,
       "credentials" to desired.location.account,
       "moniker" to sgToDisable.moniker.orcaClusterMoniker,
       "region" to sgToDisable.region,
@@ -723,7 +723,7 @@ class ClusterHandler(
         "reason" to "Diff detected at ${clock.instant().iso()}",
         "instanceType" to launchConfiguration.instanceType,
         "type" to "createServerGroup",
-        "cloudProvider" to CLOUD_PROVIDER,
+        "cloudProvider" to EC2_CLOUD_PROVIDER,
         "loadBalancers" to dependencies.loadBalancerNames,
         "targetGroups" to dependencies.targetGroups,
         "account" to location.account,
@@ -765,7 +765,7 @@ class ClusterHandler(
         "max" to desired.capacity.max,
         "desired" to desired.capacity.desired
       ),
-      "cloudProvider" to CLOUD_PROVIDER,
+      "cloudProvider" to EC2_CLOUD_PROVIDER,
       "credentials" to desired.location.account,
       "moniker" to current.moniker.orcaClusterMoniker,
       "region" to current.location.region,
@@ -850,7 +850,7 @@ class ClusterHandler(
             },
             "type" to "deleteScalingPolicy",
             "policyName" to it,
-            "cloudProvider" to CLOUD_PROVIDER,
+            "cloudProvider" to EC2_CLOUD_PROVIDER,
             "credentials" to desired.location.account,
             "moniker" to current.moniker.orcaClusterMoniker,
             "region" to current.location.region,
@@ -874,7 +874,7 @@ class ClusterHandler(
           else -> listOf((refId - 1).toString())
         },
         "type" to "upsertScalingPolicy",
-        "cloudProvider" to CLOUD_PROVIDER,
+        "cloudProvider" to EC2_CLOUD_PROVIDER,
         "credentials" to serverGroup.location.account,
         "moniker" to serverGroup.moniker.orcaClusterMoniker,
         "region" to serverGroup.location.region,
@@ -924,7 +924,7 @@ class ClusterHandler(
           else -> listOf((refId - 1).toString())
         },
         "type" to "upsertScalingPolicy",
-        "cloudProvider" to CLOUD_PROVIDER,
+        "cloudProvider" to EC2_CLOUD_PROVIDER,
         "credentials" to serverGroup.location.account,
         "moniker" to serverGroup.moniker.orcaClusterMoniker,
         "region" to serverGroup.location.region,
@@ -1044,7 +1044,7 @@ class ClusterHandler(
               account = account,
               cluster = moniker.toString(),
               region = it,
-              cloudProvider = CLOUD_PROVIDER
+              cloudProvider = EC2_CLOUD_PROVIDER
             )
               .toServerGroup()
           } catch (e: HttpException) {

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/resource/SecurityGroupHandler.kt
@@ -21,12 +21,13 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceDiff
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
+import com.netflix.spinnaker.keel.api.actuation.Job
 import com.netflix.spinnaker.keel.api.actuation.Task
 import com.netflix.spinnaker.keel.api.actuation.TaskLauncher
 import com.netflix.spinnaker.keel.api.ec2.AllPorts
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.CidrRule
 import com.netflix.spinnaker.keel.api.ec2.CrossAccountReferenceRule
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.EC2_SECURITY_GROUP_V1
 import com.netflix.spinnaker.keel.api.ec2.IngressPorts
 import com.netflix.spinnaker.keel.api.ec2.PortRange
@@ -45,8 +46,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.SecurityGroupModel
 import com.netflix.spinnaker.keel.core.name
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.diff.toIndividualDiffs
-import com.netflix.spinnaker.keel.api.actuation.Job
-import com.netflix.spinnaker.keel.filterNotNullValues
 import com.netflix.spinnaker.keel.model.OrcaJob
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.retrofit.isNotFound
@@ -250,7 +249,7 @@ open class SecurityGroupHandler(
             cloudDriverService.getSecurityGroup(
               exportable.user,
               exportable.account,
-              CLOUD_PROVIDER,
+              EC2_CLOUD_PROVIDER,
               summary!!.name,
               region,
               summary.vpcId
@@ -281,7 +280,7 @@ open class SecurityGroupHandler(
             getSecurityGroup(
               serviceAccount,
               spec.locations.account,
-              CLOUD_PROVIDER,
+              EC2_CLOUD_PROVIDER,
               spec.moniker.toString(),
               region.name,
               cloudDriverCache.networkBy(spec.locations.vpc, spec.locations.account, region.name).id
@@ -376,7 +375,7 @@ open class SecurityGroupHandler(
         mapOf(
           "application" to moniker.app,
           "credentials" to location.account,
-          "cloudProvider" to CLOUD_PROVIDER,
+          "cloudProvider" to EC2_CLOUD_PROVIDER,
           "name" to moniker.toString(),
           "regions" to listOf(location.region),
           "vpcId" to cloudDriverCache.networkBy(location.vpc, location.account, location.region).id,
@@ -404,7 +403,7 @@ open class SecurityGroupHandler(
         mapOf(
           "application" to moniker.app,
           "credentials" to location.account,
-          "cloudProvider" to CLOUD_PROVIDER,
+          "cloudProvider" to EC2_CLOUD_PROVIDER,
           "name" to moniker.toString(),
           "regions" to listOf(location.region),
           "vpcId" to cloudDriverCache.networkBy(location.vpc, location.account, location.region).id,

--- a/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
+++ b/keel-ec2-plugin/src/main/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVeto.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.ec2.vetos
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.ResourceSpec
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.LoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.OverrideableClusterDependencyContainer
 import com.netflix.spinnaker.keel.api.ec2.RegionalDependency
@@ -78,7 +78,7 @@ class RequiredSecurityGroupVeto(
       cloudDriver.getSecurityGroup(
         user = DEFAULT_SERVICE_ACCOUNT,
         account = account,
-        type = CLOUD_PROVIDER,
+        type = EC2_CLOUD_PROVIDER,
         securityGroupName = name,
         region = region,
         vpcId = if (subnet == null) null else cloudDriverCache.subnetBy(account, region, subnet).vpcId

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/api/ec2/export/ClusterExportTests.kt
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.keel.api.artifacts.BranchFilter
 import com.netflix.spinnaker.keel.api.artifacts.DEBIAN
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.CapacitySpec
@@ -89,8 +89,8 @@ internal class ClusterExportTests : JUnit5Minutests {
   val blockDeviceConfig = mockk<BlockDeviceConfig>()
   val artifactService = mockk<ArtifactService>()
 
-  val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
-  val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
+  val vpcWest = Network(EC2_CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
+  val vpcEast = Network(EC2_CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
   val sg1East = SecurityGroupSummary("keel", "sg-279585936", "vpc-1")
@@ -426,7 +426,7 @@ internal class ClusterExportTests : JUnit5Minutests {
     account = spec.locations.account,
     cluster = spec.moniker.toString(),
     region = region,
-    cloudProvider = CLOUD_PROVIDER
+    cloudProvider = EC2_CLOUD_PROVIDER
   )
 }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/KeyPairResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/KeyPairResolverTests.kt
@@ -3,7 +3,7 @@ package com.netflix.spinnaker.keel.ec2.resolvers
 import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
@@ -20,8 +20,8 @@ import strikt.assertions.containsExactly
 import strikt.assertions.isEqualTo
 
 internal class KeyPairResolverTests : JUnit5Minutests {
-  val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
-  val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
+  val vpcWest = Network(EC2_CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
+  val vpcEast = Network(EC2_CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
   val baseSpec = ClusterSpec(
     moniker = Moniker(app = "keel", stack = "test"),
     locations = SubnetAwareLocations(

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resolvers/NetworkResolverTests.kt
@@ -9,7 +9,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerHealthCheck
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
@@ -81,10 +81,10 @@ internal abstract class NetworkResolverTests<T : Locatable<SubnetAwareLocations>
     val subjectFactory: (CloudDriverCache) -> NetworkResolver<T>,
     val resource: Resource<T>
   ) {
-    private val vpc0East = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.account, "us-east-1")
-    private val vpc0West = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.account, "us-west-2")
-    private val vpc5East = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc5", resource.spec.locations.account, "us-east-1")
-    private val vpc5West = Network(CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc5", resource.spec.locations.account, "us-west-2")
+    private val vpc0East = Network(EC2_CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.account, "us-east-1")
+    private val vpc0West = Network(EC2_CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc0", resource.spec.locations.account, "us-west-2")
+    private val vpc5East = Network(EC2_CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc5", resource.spec.locations.account, "us-east-1")
+    private val vpc5West = Network(EC2_CLOUD_PROVIDER, "vpc-${randomHex()}", "vpc5", resource.spec.locations.account, "us-west-2")
     private val usEastSubnets =
       setOf(vpc0East, vpc5East).flatMap { vpc ->
         setOf("internal", "external").flatMap { purpose ->

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ApplicationLoadBalancerHandlerTests.kt
@@ -5,8 +5,8 @@ import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancer
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
@@ -44,7 +44,6 @@ import io.mockk.slot
 import kotlinx.coroutines.runBlocking
 import strikt.api.expectThat
 import strikt.assertions.containsExactly
-import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.first
 import strikt.assertions.get
 import strikt.assertions.getValue
@@ -53,11 +52,10 @@ import strikt.assertions.isA
 import strikt.assertions.isEqualTo
 import strikt.assertions.isFalse
 import strikt.assertions.isTrue
-import java.util.UUID
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
 import org.springframework.core.env.Environment as SpringEnv
-
+import java.util.UUID
 
 @Suppress("UNCHECKED_CAST")
 internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
@@ -115,7 +113,7 @@ internal class ApplicationLoadBalancerHandlerTests : JUnit5Minutests {
     spec = spec
   )
 
-  private val vpc = Network(CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
+  private val vpc = Network(EC2_CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
   private val sub1 = Subnet("subnet-1", vpc.id, vpc.account, vpc.region, "${vpc.region}c", "internal (vpc0)")
   private val sub2 = Subnet("subnet-1", vpc.id, vpc.account, vpc.region, "${vpc.region}d", "internal (vpc0)")
   private val sg1 = SecurityGroupSummary("testapp-elb", "sg-55555", "vpc-1")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import com.netflix.spinnaker.keel.api.Environment
 import com.netflix.spinnaker.keel.api.Exportable
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLASSIC_LOAD_BALANCER_V1
 import com.netflix.spinnaker.keel.api.plugins.Resolver
@@ -120,7 +120,7 @@ internal class ClassicLoadBalancerHandlerTests : JUnit5Minutests {
     spec = spec
   )
 
-  private val vpc = Network(CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
+  private val vpc = Network(EC2_CLOUD_PROVIDER, "vpc-23144", "vpc0", "test", "us-east-1")
   private val sub1 = Subnet("subnet-1", vpc.id, vpc.account, vpc.region, "${vpc.region}c", "internal (vpc0)")
   private val sub2 = Subnet("subnet-1", vpc.id, vpc.account, vpc.region, "${vpc.region}d", "internal (vpc0)")
   private val sg1 = SecurityGroupSummary("testapp-elb", "sg-55555", "vpc-1")

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -10,13 +10,13 @@ import com.netflix.spinnaker.keel.api.RedBlack
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.Capacity
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.CapacitySpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.ServerGroupSpec
 import com.netflix.spinnaker.keel.api.ec2.CustomizedMetricSpecification
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.EC2_CLUSTER_V1_1
 import com.netflix.spinnaker.keel.api.ec2.LaunchConfigurationSpec
 import com.netflix.spinnaker.keel.api.ec2.Scaling
@@ -66,8 +66,6 @@ import strikt.assertions.any
 import strikt.assertions.containsExactly
 import strikt.assertions.containsExactlyInAnyOrder
 import strikt.assertions.containsKey
-import strikt.assertions.containsSequence
-import strikt.assertions.first
 import strikt.assertions.get
 import strikt.assertions.hasSize
 import strikt.assertions.isA
@@ -108,8 +106,8 @@ internal class ClusterHandlerTests : JUnit5Minutests {
   val blockDeviceConfig = BlockDeviceConfig(VolumeDefaultConfiguration())
   val artifactService = mockk<ArtifactService>()
 
-  val vpcWest = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
-  val vpcEast = Network(CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
+  val vpcWest = Network(EC2_CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
+  val vpcEast = Network(EC2_CLOUD_PROVIDER, "vpc-4342589", "vpc0", "test", "us-east-1")
   val sg1West = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2West = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
   val sg1East = SecurityGroupSummary("keel", "sg-279585936", "vpc-1")
@@ -1101,7 +1099,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
     account = spec.locations.account,
     cluster = spec.moniker.toString(),
     region = region,
-    cloudProvider = CLOUD_PROVIDER
+    cloudProvider = EC2_CLOUD_PROVIDER
   )
 }
 

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/LaunchConfigTests.kt
@@ -6,7 +6,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.StaggeredRegion
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.CapacitySpec
@@ -132,7 +132,7 @@ internal class LaunchConfigTests {
   val sg1 = SecurityGroupSummary("keel", "sg-325234532", "vpc-1")
   val sg2 = SecurityGroupSummary("keel-elb", "sg-235425234", "vpc-1")
 
-  val vpc = Network(CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
+  val vpc = Network(EC2_CLOUD_PROVIDER, "vpc-1452353", "vpc0", "test", "us-west-2")
   val subnet = Subnet("subnet-1", vpc.id, vpc.account, vpc.region, "${vpc.region}a", "internal (vpc0)")
 
   lateinit var spec : ClusterSpec
@@ -190,6 +190,6 @@ internal class LaunchConfigTests {
     account = spec.locations.account,
     cluster = spec.moniker.toString(),
     region = region,
-    cloudProvider = CLOUD_PROVIDER
+    cloudProvider = EC2_CLOUD_PROVIDER
   )
 }

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/TestUtils.kt
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.keel.ec2.resource
 
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.HealthCheckType
 import com.netflix.spinnaker.keel.api.ec2.Metric
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup
@@ -143,7 +143,7 @@ fun ServerGroup.toCloudDriverResponse(
       targetGroups = dependencies.targetGroups,
       loadBalancers = dependencies.loadBalancerNames,
       capacity = capacity.let { Capacity(it.min, it.max, it.desired) },
-      cloudProvider = CLOUD_PROVIDER,
+      cloudProvider = EC2_CLOUD_PROVIDER,
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       accountName = location.account,
       moniker = parseMoniker("$name-v$sequence"),
@@ -240,7 +240,7 @@ fun ServerGroup.toMultiServerGroupResponse(
       targetGroups = dependencies.targetGroups,
       loadBalancers = dependencies.loadBalancerNames,
       capacity = capacity.let { Capacity(it.min, it.max, it.desired) },
-      cloudProvider = CLOUD_PROVIDER,
+      cloudProvider = EC2_CLOUD_PROVIDER,
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       moniker = parseMoniker("$name-v$sequence1"),
       instanceCounts = instanceCounts.run { InstanceCounts(total, up, down, unknown, outOfService, starting) },
@@ -323,7 +323,7 @@ fun ServerGroup.toMultiServerGroupResponse(
       targetGroups = dependencies.targetGroups,
       loadBalancers = dependencies.loadBalancerNames,
       capacity = capacity.let { Capacity(it.min, it.max, it.desired) },
-      cloudProvider = CLOUD_PROVIDER,
+      cloudProvider = EC2_CLOUD_PROVIDER,
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       moniker = parseMoniker("$name-v$sequence1"),
       instanceCounts = instanceCounts.run { InstanceCounts(total, up, down, unknown, outOfService, starting) },

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVetoTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/vetos/RequiredSecurityGroupVetoTests.kt
@@ -9,7 +9,7 @@ import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.SubnetAwareLocations
 import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
-import com.netflix.spinnaker.keel.api.ec2.CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.ec2.EC2_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerHealthCheck
 import com.netflix.spinnaker.keel.api.ec2.ClassicLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
@@ -270,7 +270,7 @@ internal class RequiredSecurityGroupVetoTests : JUnit5Minutests {
               cloudDriver.getSecurityGroup(
                 user = any(),
                 account = resourceSpec.locations.account,
-                type = CLOUD_PROVIDER,
+                type = EC2_CLOUD_PROVIDER,
                 securityGroupName = sgName,
                 region = region,
                 vpcId = vpcId
@@ -285,7 +285,7 @@ internal class RequiredSecurityGroupVetoTests : JUnit5Minutests {
           cloudDriver.getSecurityGroup(
             user = any(),
             account = resourceSpec.locations.account,
-            type = CLOUD_PROVIDER,
+            type = EC2_CLOUD_PROVIDER,
             securityGroupName = "sg-ap-south-1-only",
             region = "ap-south-1",
             vpcId = vpcId
@@ -295,7 +295,7 @@ internal class RequiredSecurityGroupVetoTests : JUnit5Minutests {
           cloudDriver.getSecurityGroup(
             user = any(),
             account = resourceSpec.locations.account,
-            type = CLOUD_PROVIDER,
+            type = EC2_CLOUD_PROVIDER,
             securityGroupName = "sg-af-south-1-only",
             region = "af-south-1",
             vpcId = vpcId
@@ -340,7 +340,7 @@ internal class RequiredSecurityGroupVetoTests : JUnit5Minutests {
       cloudDriver.getSecurityGroup(
         user = DEFAULT_SERVICE_ACCOUNT,
         account = resourceSpec.locations.account,
-        type = CLOUD_PROVIDER,
+        type = EC2_CLOUD_PROVIDER,
         securityGroupName = match { it in securityGroupNames },
         region = match {
           it in resourceSpec.locations.regions.map(SubnetAwareRegionSpec::name)

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Cache.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Cache.kt
@@ -91,11 +91,11 @@ class Front50Cache(
     }
   }
 
-  fun updateApplicationByName(app: Application) {
+  private fun updateApplicationByName(app: Application) {
     applicationsByNameCache.put(app.name.toLowerCase(), CompletableFuture.supplyAsync { app })
   }
 
-  fun invalidateSearchParamsCache(app: Application) {
+  private fun invalidateSearchParamsCache(app: Application) {
     with(app) {
       // We invalidate the cache, as it's easier than updating it
       if (repoType != null && repoProjectKey != null && repoSlug != null) {
@@ -103,6 +103,11 @@ class Front50Cache(
           .invalidate(GitRepository(repoType, repoProjectKey, repoSlug).toSearchParams())
       }
     }
+  }
+
+  suspend fun updateManagedDeliveryConfig(application: String, user: String, settings: ManagedDeliveryConfig): Application {
+    val front50App = applicationByName(application)
+    return updateManagedDeliveryConfig(front50App, user, settings)
   }
 
   suspend fun updateManagedDeliveryConfig(application: Application, user: String, settings: ManagedDeliveryConfig): Application {

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Cache.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Cache.kt
@@ -105,14 +105,14 @@ class Front50Cache(
     }
   }
 
-  suspend fun toggleGitIntegration(application: String, user: String, isEnabled: Boolean): Application {
+  suspend fun updateManagedDeliveryConfig(application: String, user: String, settings: ManagedDeliveryConfig): Application {
     val front50App = front50Service.updateApplication(
       application,
       user,
       Application(
         name = application,
         email = user,
-        managedDelivery = ManagedDeliveryConfig(importDeliveryConfig = isEnabled)
+        managedDelivery = settings
       )
     )
     updateApplicationByName(front50App)

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Cache.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Cache.kt
@@ -105,13 +105,13 @@ class Front50Cache(
     }
   }
 
-  suspend fun updateManagedDeliveryConfig(application: String, user: String, settings: ManagedDeliveryConfig): Application {
+  suspend fun updateManagedDeliveryConfig(application: Application, user: String, settings: ManagedDeliveryConfig): Application {
     val front50App = front50Service.updateApplication(
-      application,
+      application.name,
       user,
       Application(
-        name = application,
-        email = user,
+        name = application.name,
+        email = application.email,
         managedDelivery = settings
       )
     )

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/Front50Service.kt
@@ -8,6 +8,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PATCH
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 import retrofit2.http.QueryMap
@@ -56,4 +57,11 @@ interface Front50Service {
     @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT,
     @Body app: Application,
   ): Application
+
+  @PUT("/pipelines/{id}")
+  suspend fun updatePipeline(
+    @Path("id") id: String,
+    @Body pipeline: Pipeline,
+    @Header("X-SPINNAKER-USER") user: String = DEFAULT_SERVICE_ACCOUNT
+  )
 }

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -2,10 +2,13 @@ package com.netflix.spinnaker.keel.front50.model
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter
 import com.fasterxml.jackson.annotation.JsonAnySetter
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL
 
 /**
  * A Spinnaker application, as represented in Front50.
  */
+@JsonInclude(NON_NULL)
 data class Application(
   val name: String,
   val email: String,
@@ -14,7 +17,7 @@ data class Application(
   val repoSlug: String? = null,
   val repoType: String? = null,
   val createTs: String? = null,
-  val managedDelivery: ManagedDeliveryConfig? = null,
+  val managedDelivery: ManagedDeliveryConfig = ManagedDeliveryConfig(),
   @get:JsonAnyGetter val details: MutableMap<String, Any?> = mutableMapOf()
 ) {
   @JsonAnySetter
@@ -28,6 +31,8 @@ data class DataSources(
   val disabled: List<String>
 )
 
+@JsonInclude(NON_NULL)
 data class ManagedDeliveryConfig(
-  val importDeliveryConfig: Boolean? = false
+  val importDeliveryConfig: Boolean = false,
+  val manifestPath: String? = null
 )

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Application.kt
@@ -17,7 +17,7 @@ data class Application(
   val repoSlug: String? = null,
   val repoType: String? = null,
   val createTs: String? = null,
-  val managedDelivery: ManagedDeliveryConfig = ManagedDeliveryConfig(),
+  val managedDelivery: ManagedDeliveryConfig? = null,
   @get:JsonAnyGetter val details: MutableMap<String, Any?> = mutableMapOf()
 ) {
   @JsonAnySetter

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/GitRepository.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/GitRepository.kt
@@ -1,0 +1,3 @@
+package com.netflix.spinnaker.keel.front50.model
+
+data class GitRepository(val type: String, val project: String, val slug: String)

--- a/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Pipeline.kt
+++ b/keel-front50/src/main/kotlin/com/netflix/spinnaker/keel/front50/model/Pipeline.kt
@@ -6,7 +6,7 @@ import java.time.Instant
 /**
  * A Spinnaker pipeline.
  */
-class Pipeline(
+data class Pipeline(
   val name: String,
   val id: String,
   val application: String,

--- a/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/Front50CacheTests.kt
+++ b/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/Front50CacheTests.kt
@@ -141,7 +141,7 @@ class Front50CacheTests : JUnit5Minutests {
             subject.applicationByName(app.name)
           }
           runBlocking {
-            subject.updateManagedDeliveryConfig(app.name, "keel", ManagedDeliveryConfig(importDeliveryConfig = true))
+            subject.updateManagedDeliveryConfig(app, "keel", ManagedDeliveryConfig(importDeliveryConfig = true))
           }
           val cachedApp = runBlocking {
             subject.applicationByName(app.name)
@@ -159,7 +159,7 @@ class Front50CacheTests : JUnit5Minutests {
             subject.searchApplicationsByRepo(GitRepository(app.repoType!!, app.repoProjectKey!!, app.repoSlug!!))
           }
           runBlocking {
-            subject.updateManagedDeliveryConfig(app.name, "keel", ManagedDeliveryConfig(importDeliveryConfig = true))
+            subject.updateManagedDeliveryConfig(app, "keel", ManagedDeliveryConfig(importDeliveryConfig = true))
           }
           runBlocking {
             subject.searchApplicationsByRepo(GitRepository(app.repoType!!, app.repoProjectKey!!, app.repoSlug!!))

--- a/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/Front50CacheTests.kt
+++ b/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/Front50CacheTests.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.caffeine.CacheFactory
 import com.netflix.spinnaker.keel.caffeine.CacheProperties
 import com.netflix.spinnaker.keel.front50.model.Application
 import com.netflix.spinnaker.keel.front50.model.GitRepository
+import com.netflix.spinnaker.keel.front50.model.ManagedDeliveryConfig
 import com.netflix.spinnaker.kork.exceptions.SystemException
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
@@ -140,7 +141,7 @@ class Front50CacheTests : JUnit5Minutests {
             subject.applicationByName(app.name)
           }
           runBlocking {
-            subject.toggleGitIntegration(app.name, "keel", true)
+            subject.updateManagedDeliveryConfig(app.name, "keel", ManagedDeliveryConfig(importDeliveryConfig = true))
           }
           val cachedApp = runBlocking {
             subject.applicationByName(app.name)
@@ -149,7 +150,7 @@ class Front50CacheTests : JUnit5Minutests {
             front50Service.applicationByName(any())
           }
 
-          expectThat(cachedApp.managedDelivery?.importDeliveryConfig).isTrue()
+          expectThat(cachedApp.managedDelivery.importDeliveryConfig).isTrue()
         }
 
         test("Verify that we clear the cache and fetch again") {
@@ -158,7 +159,7 @@ class Front50CacheTests : JUnit5Minutests {
             subject.searchApplicationsByRepo(GitRepository(app.repoType!!, app.repoProjectKey!!, app.repoSlug!!))
           }
           runBlocking {
-            subject.toggleGitIntegration(app.name, "keel", true)
+            subject.updateManagedDeliveryConfig(app.name, "keel", ManagedDeliveryConfig(importDeliveryConfig = true))
           }
           runBlocking {
             subject.searchApplicationsByRepo(GitRepository(app.repoType!!, app.repoProjectKey!!, app.repoSlug!!))

--- a/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/Front50CacheTests.kt
+++ b/keel-front50/src/test/kotlin/com/netflix/spinnaker/keel/front50/Front50CacheTests.kt
@@ -150,7 +150,7 @@ class Front50CacheTests : JUnit5Minutests {
             front50Service.applicationByName(any())
           }
 
-          expectThat(cachedApp.managedDelivery.importDeliveryConfig).isTrue()
+          expectThat(cachedApp.managedDelivery?.importDeliveryConfig).isTrue()
         }
 
         test("Verify that we clear the cache and fetch again") {

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/config/IgorConfiguration.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider
 import com.netflix.spinnaker.keel.front50.Front50Cache
-import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.igor.BuildService
-import com.netflix.spinnaker.keel.igor.ScmService
 import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter
+import com.netflix.spinnaker.keel.igor.ScmService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import com.netflix.spinnaker.keel.retrofit.InstrumentedJacksonConverter
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
@@ -49,7 +49,7 @@ class IgorConfiguration {
   fun deliveryConfigImporter(
     scmService: ScmService,
     front50Cache: Front50Cache,
-    yamlMapper: YAMLMapper
+    yamlMapper: YAMLMapper,
   ) = DeliveryConfigImporter(scmService, front50Cache, yamlMapper)
 
   private inline fun <reified T> buildService(

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.front50.Front50Cache
 import com.netflix.spinnaker.keel.parseDeliveryConfig
+import com.netflix.spinnaker.keel.scm.CodeEvent
 import com.netflix.spinnaker.keel.scm.CommitCreatedEvent
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -16,7 +17,7 @@ class DeliveryConfigImporter(
   private val front50Cache: Front50Cache,
   private val yamlMapper: YAMLMapper,
 
-) {
+  ) {
   companion object {
     private val log by lazy { LoggerFactory.getLogger(DeliveryConfigImporter::class.java) }
     const val DEFAULT_MANIFEST_PATH = "spinnaker.yml"
@@ -63,11 +64,17 @@ class DeliveryConfigImporter(
   /**
    * Imports a delivery config from source control based on the details of the [CommitCreatedEvent].
    */
-  fun import(commitEvent: CommitCreatedEvent, manifestPath: String = DEFAULT_MANIFEST_PATH) =
-    with(commitEvent) {
-      import(repoType, projectKey, repoSlug, manifestPath, commitHash)
+  fun import(codeEvent: CodeEvent, manifestPath: String = DEFAULT_MANIFEST_PATH): SubmittedDeliveryConfig {
+    with(codeEvent) {
+      return import(
+        repoType,
+        projectKey,
+        repoSlug,
+        manifestPath,
+        commitHash ?: error("commit hash is missing in commit event $codeEvent")
+      )
     }
-
+  }
 
   /**
    * Imports a delivery config from source control at refs/heads/{defaultBranch},

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
@@ -3,8 +3,7 @@ package com.netflix.spinnaker.keel.igor
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
 import com.netflix.spinnaker.keel.front50.Front50Cache
-import com.netflix.spinnaker.keel.front50.model.Application
-import com.netflix.spinnaker.keel.jackson.readValueInliningAliases
+import com.netflix.spinnaker.keel.parseDeliveryConfig
 import com.netflix.spinnaker.keel.scm.CommitCreatedEvent
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
@@ -16,6 +15,7 @@ class DeliveryConfigImporter(
   private val scmService: ScmService,
   private val front50Cache: Front50Cache,
   private val yamlMapper: YAMLMapper,
+
 ) {
   companion object {
     private val log by lazy { LoggerFactory.getLogger(DeliveryConfigImporter::class.java) }
@@ -39,9 +39,7 @@ class DeliveryConfigImporter(
     val rawDeliveryConfig = runBlocking {
       scmService.getDeliveryConfigManifest(repoType, projectKey, repoSlug, manifestPath, ref, true)
     }.manifest
-    val submittedDeliveryConfig = yamlMapper
-      .readValueInliningAliases<SubmittedDeliveryConfig>(rawDeliveryConfig)
-      .copy(rawConfig = rawDeliveryConfig)
+    val submittedDeliveryConfig = yamlMapper.parseDeliveryConfig(rawDeliveryConfig)
 
     log.debug("Successfully retrieved delivery config from $manifestLocation.")
     return if (addMetadata) {

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
@@ -30,7 +30,7 @@ class DeliveryConfigImporter(
     repoType: String,
     projectKey: String,
     repoSlug: String,
-    manifestPath: String,
+    manifestPath: String?,
     ref: String,
     addMetadata: Boolean = true
   ): SubmittedDeliveryConfig {
@@ -38,7 +38,7 @@ class DeliveryConfigImporter(
 
     log.debug("Retrieving delivery config from $manifestLocation")
     val rawDeliveryConfig = runBlocking {
-      scmService.getDeliveryConfigManifest(repoType, projectKey, repoSlug, manifestPath, ref, true)
+      scmService.getDeliveryConfigManifest(repoType, projectKey, repoSlug, manifestPath ?: DEFAULT_MANIFEST_PATH, ref, true)
     }.manifest
     val submittedDeliveryConfig = yamlMapper.parseDeliveryConfig(rawDeliveryConfig)
 
@@ -64,7 +64,7 @@ class DeliveryConfigImporter(
   /**
    * Imports a delivery config from source control based on the details of the [CommitCreatedEvent].
    */
-  fun import(codeEvent: CodeEvent, manifestPath: String = DEFAULT_MANIFEST_PATH): SubmittedDeliveryConfig {
+  fun import(codeEvent: CodeEvent, manifestPath: String?): SubmittedDeliveryConfig {
     with(codeEvent) {
       return import(
         repoType,
@@ -89,7 +89,7 @@ class DeliveryConfigImporter(
         repoType = repoType ?: error("Missing SCM type in config for application $name"),
         projectKey = repoProjectKey ?: error("Missing SCM project in config for application $name"),
         repoSlug = repoSlug ?: error("Missing SCM repository in config for application $name"),
-        manifestPath = DEFAULT_MANIFEST_PATH, // TODO: make configurable
+        manifestPath = app.managedDelivery.manifestPath,
         ref = "refs/heads/${getDefaultBranch(scmService)}",
         addMetadata = addMetadata
       )

--- a/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
+++ b/keel-igor/src/main/kotlin/com/netflix/spinnaker/keel/igor/DeliveryConfigImporter.kt
@@ -89,7 +89,7 @@ class DeliveryConfigImporter(
         repoType = repoType ?: error("Missing SCM type in config for application $name"),
         projectKey = repoProjectKey ?: error("Missing SCM project in config for application $name"),
         repoSlug = repoSlug ?: error("Missing SCM repository in config for application $name"),
-        manifestPath = app.managedDelivery.manifestPath,
+        manifestPath = app.managedDelivery?.manifestPath,
         ref = "refs/heads/${getDefaultBranch(scmService)}",
         addMetadata = addMetadata
       )

--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/SlackNotificationEvent.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/SlackNotificationEvent.kt
@@ -2,7 +2,7 @@ package com.netflix.spinnaker.keel.notifications.slack
 
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.NotificationDisplay
-import com.netflix.spinnaker.keel.api.NotificationDisplay.*
+import com.netflix.spinnaker.keel.api.NotificationDisplay.NORMAL
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.GitMetadata
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact

--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/ArtifactDeploymentNotificationHandler.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/ArtifactDeploymentNotificationHandler.kt
@@ -4,12 +4,12 @@ import com.netflix.spinnaker.config.BaseUrlConfig
 import com.netflix.spinnaker.keel.api.NotificationDisplay
 import com.netflix.spinnaker.keel.notifications.NotificationType.ARTIFACT_DEPLOYMENT_FAILED
 import com.netflix.spinnaker.keel.notifications.NotificationType.ARTIFACT_DEPLOYMENT_SUCCEEDED
-import com.netflix.spinnaker.keel.notifications.slack.DeploymentStatus.*
+import com.netflix.spinnaker.keel.notifications.slack.DeploymentStatus.FAILED
+import com.netflix.spinnaker.keel.notifications.slack.DeploymentStatus.SUCCEEDED
 import com.netflix.spinnaker.keel.notifications.slack.SlackArtifactDeploymentNotification
 import com.netflix.spinnaker.keel.notifications.slack.SlackService
 import com.slack.api.model.block.LayoutBlock
 import com.slack.api.model.kotlin_extension.block.withBlocks
-import org.apache.logging.log4j.util.Strings
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.stereotype.Component

--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PausedNotificationHandler.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PausedNotificationHandler.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.notifications.slack.handlers
 
 import com.netflix.spinnaker.config.BaseUrlConfig
 import com.netflix.spinnaker.keel.api.NotificationDisplay
-import com.netflix.spinnaker.keel.api.NotificationDisplay.*
 import com.netflix.spinnaker.keel.notifications.NotificationType
 import com.netflix.spinnaker.keel.notifications.slack.SlackPausedNotification
 import com.netflix.spinnaker.keel.notifications.slack.SlackService

--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PinnedNotificationHandler.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PinnedNotificationHandler.kt
@@ -1,13 +1,11 @@
 package com.netflix.spinnaker.keel.notifications.slack.handlers
 
 import com.netflix.spinnaker.keel.api.NotificationDisplay
-import com.netflix.spinnaker.keel.api.NotificationDisplay.*
 import com.netflix.spinnaker.keel.notifications.NotificationType
 import com.netflix.spinnaker.keel.notifications.slack.SlackPinnedNotification
 import com.netflix.spinnaker.keel.notifications.slack.SlackService
 import com.slack.api.model.block.LayoutBlock
 import com.slack.api.model.kotlin_extension.block.withBlocks
-import org.apache.logging.log4j.util.Strings
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 

--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PluginNotificationHandler.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/PluginNotificationHandler.kt
@@ -4,11 +4,12 @@ import com.netflix.spinnaker.config.BaseUrlConfig
 import com.netflix.spinnaker.keel.api.NotificationDisplay
 import com.netflix.spinnaker.keel.api.plugins.PluginNotificationsStatus.FAILED
 import com.netflix.spinnaker.keel.api.plugins.PluginNotificationsStatus.SUCCEEDED
-import com.netflix.spinnaker.keel.notifications.NotificationType.*
+import com.netflix.spinnaker.keel.notifications.NotificationType.PLUGIN_NOTIFICATION_NORMAL
+import com.netflix.spinnaker.keel.notifications.NotificationType.PLUGIN_NOTIFICATION_QUIET
+import com.netflix.spinnaker.keel.notifications.NotificationType.PLUGIN_NOTIFICATION_VERBOSE
 import com.netflix.spinnaker.keel.notifications.slack.SlackPluginNotification
 import com.netflix.spinnaker.keel.notifications.slack.SlackService
 import com.slack.api.model.kotlin_extension.block.withBlocks
-import org.apache.logging.log4j.util.Strings
 import org.slf4j.LoggerFactory
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.core.env.Environment

--- a/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/ResumedNotificationHandler.kt
+++ b/keel-notifications/src/main/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/ResumedNotificationHandler.kt
@@ -2,7 +2,6 @@ package com.netflix.spinnaker.keel.notifications.slack.handlers
 
 import com.netflix.spinnaker.config.BaseUrlConfig
 import com.netflix.spinnaker.keel.api.NotificationDisplay
-import com.netflix.spinnaker.keel.api.NotificationDisplay.*
 import com.netflix.spinnaker.keel.notifications.NotificationType
 import com.netflix.spinnaker.keel.notifications.slack.SlackResumedNotification
 import com.netflix.spinnaker.keel.notifications.slack.SlackService

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListener.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListener.kt
@@ -158,7 +158,7 @@ class PreviewEnvironmentCodeEventListener(
       val commitEvent = event.toCommitEvent()
       val newDeliveryConfig = try {
         deliveryConfigImporter.import(
-          commitEvent = commitEvent,
+          codeEvent = commitEvent,
           manifestPath = DEFAULT_MANIFEST_PATH // TODO: allow location of manifest to be configurable
         ).also {
           event.emitCounterMetric(CODE_EVENT_COUNTER, DELIVERY_CONFIG_RETRIEVAL_SUCCESS, deliveryConfig.application)

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListener.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListener.kt
@@ -289,12 +289,18 @@ class PreviewEnvironmentCodeEventListener(
 
     // update artifact reference if applicable to match the branch filter of the preview environment
     if (spec is ArtifactReferenceProvider) {
+      log.debug("Attempting to replace artifact reference for resource ${this.id}")
       previewResource = previewResource.withBranchArtifact(deliveryConfig, previewEnvSpec)
+    } else {
+      log.debug("Resource ${this.id} (${spec.javaClass.simpleName}) does not provide an artifact reference")
     }
 
     // update dependency names that are part of the preview environment and so have new names
     if (spec is Dependent) {
+      log.debug("Attempting to update dependencies for resource ${this.id}")
       previewResource = previewResource.withDependenciesRenamed(deliveryConfig, previewEnvSpec, branch)
+    } else {
+      log.debug("Resource ${this.id} does not implement the Dependent interface")
     }
 
     log.debug("Copied resource ${this.id} to preview resource ${previewResource.id}")

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListener.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListener.kt
@@ -154,7 +154,7 @@ class PreviewEnvironmentCodeEventListener(
       // We always want to dismiss the previous notifications, and if needed to create a new one
       notificationRepository.dismissNotification(DeliveryConfigImportFailed::class.java, deliveryConfig.application, event.pullRequestBranch)
       val manifestPath = runBlocking {
-        front50Cache.applicationByName(deliveryConfig.application).managedDelivery.manifestPath
+        front50Cache.applicationByName(deliveryConfig.application).managedDelivery?.manifestPath
       }
       val commitEvent = event.toCommitEvent()
       val newDeliveryConfig = try {

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/utils.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/preview/utils.kt
@@ -183,8 +183,11 @@ private fun Collection<Dependency>?.namesForType(type: DependencyType): Set<Stri
 
 /**
  * Use with branch names to normalize them for use in environment and resource names.
+ * This function attempts to generate a DNS-compliant name out of the branch name by
+ * removing any prefixes ending with a forward-slash and replacing underscores with
+ * dashes.
  */
-internal fun String.toPreviewName() = substringAfterLast('/')
+internal fun String.toPreviewName() = substringAfterLast('/').replace('_', '-')
 
 internal const val MAX_RESOURCE_NAME_LENGTH = 32
 

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListener.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListener.kt
@@ -48,8 +48,8 @@ class DeliveryConfigImportListener(
    * it in the database. This is our main path for supporting SCM integration to monitor
    * delivery config changes in source repos.
    */
-  @EventListener(CommitCreatedEvent::class)
-  fun handleCommitCreated(event: CommitCreatedEvent) {
+  @EventListener(CommitCreatedEvent::class, PrMergedEvent::class)
+  fun handleCodeEvent(event: CodeEvent) {
     if (!enabled) {
       log.debug("Importing delivery config from source disabled by feature flag. Ignoring commit event: $event")
       return
@@ -90,7 +90,7 @@ class DeliveryConfigImportListener(
 
       try {
         val deliveryConfig = deliveryConfigImporter.import(
-          commitEvent = event,
+          codeEvent = event,
           manifestPath = DEFAULT_MANIFEST_PATH // TODO: allow location of manifest to be configurable
         ).let {
           if (it.serviceAccount == null) {

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListener.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListener.kt
@@ -70,7 +70,7 @@ class DeliveryConfigImportListener(
     val matchingApps = apps
       .filter { app ->
         app != null
-          && app.managedDelivery.importDeliveryConfig == true
+          && app.managedDelivery?.importDeliveryConfig == true
           && event.matchesApplicationConfig(app)
           && event.targetBranch == scmUtils.getDefaultBranch(app)
       }
@@ -90,7 +90,7 @@ class DeliveryConfigImportListener(
       try {
         val deliveryConfig = deliveryConfigImporter.import(
           codeEvent = event,
-          manifestPath = app.managedDelivery.manifestPath
+          manifestPath = app.managedDelivery?.manifestPath
         ).let {
           if (it.serviceAccount == null) {
             it.copy(serviceAccount = app.email)

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListener.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListener.kt
@@ -4,7 +4,6 @@ import com.netflix.spectator.api.Registry
 import com.netflix.spinnaker.keel.front50.Front50Cache
 import com.netflix.spinnaker.keel.front50.model.GitRepository
 import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter
-import com.netflix.spinnaker.keel.igor.DeliveryConfigImporter.Companion.DEFAULT_MANIFEST_PATH
 import com.netflix.spinnaker.keel.notifications.DeliveryConfigImportFailed
 import com.netflix.spinnaker.keel.persistence.DismissibleNotificationRepository
 import com.netflix.spinnaker.keel.telemetry.safeIncrement
@@ -71,7 +70,7 @@ class DeliveryConfigImportListener(
     val matchingApps = apps
       .filter { app ->
         app != null
-          && app.managedDelivery?.importDeliveryConfig == true
+          && app.managedDelivery.importDeliveryConfig == true
           && event.matchesApplicationConfig(app)
           && event.targetBranch == scmUtils.getDefaultBranch(app)
       }
@@ -91,7 +90,7 @@ class DeliveryConfigImportListener(
       try {
         val deliveryConfig = deliveryConfigImporter.import(
           codeEvent = event,
-          manifestPath = DEFAULT_MANIFEST_PATH // TODO: allow location of manifest to be configurable
+          manifestPath = app.managedDelivery.manifestPath
         ).let {
           if (it.serviceAccount == null) {
             it.copy(serviceAccount = app.email)

--- a/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/ScmUtils.kt
+++ b/keel-scm/src/main/kotlin/com/netflix/spinnaker/keel/scm/ScmUtils.kt
@@ -1,7 +1,6 @@
 package com.netflix.spinnaker.keel.scm
 
 import com.netflix.spinnaker.keel.caffeine.CacheFactory
-import com.netflix.spinnaker.keel.exceptions.UnsupportedScmType
 import com.netflix.spinnaker.keel.front50.model.Application
 import com.netflix.spinnaker.keel.igor.ScmService
 import com.netflix.spinnaker.keel.igor.getDefaultBranch
@@ -32,7 +31,7 @@ class ScmUtils(
     }
   }
 
-  fun getCommitLink(event: CommitCreatedEvent): String? {
+  fun getCommitLink(event: CodeEvent): String? {
     return getCommitLink(event.repoType, event.projectKey, event.repoSlug, event.commitHash)
   }
 

--- a/keel-scm/src/test/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListenerTests.kt
+++ b/keel-scm/src/test/kotlin/com/netflix/spinnaker/keel/preview/PreviewEnvironmentCodeEventListenerTests.kt
@@ -326,7 +326,8 @@ class PreviewEnvironmentCodeEventListenerTests : JUnit5Minutests {
     repoKey = "stash/myorg/myrepo",
     pullRequestBranch = "feature/abc",
     targetBranch = "main",
-    pullRequestId = "42"
+    pullRequestId = "42",
+    commitHash = "a34afb13b"
   )
 
   val prDeclinedEvent = PrDeclinedEvent(
@@ -360,7 +361,7 @@ class PreviewEnvironmentCodeEventListenerTests : JUnit5Minutests {
           test("the delivery config is imported from the branch in the pr event") {
             verify(exactly = 1) {
               importer.import(
-                commitEvent = any(),
+                codeEvent = any(),
                 manifestPath = "spinnaker.yml"
               )
             }

--- a/keel-scm/src/test/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListenerTests.kt
+++ b/keel-scm/src/test/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListenerTests.kt
@@ -125,7 +125,7 @@ class DeliveryConfigImportListenerTests : JUnit5Minutests {
 
       every {
         deliveryConfigUpserter.upsertConfig(deliveryConfig)
-      } returns deliveryConfig.toDeliveryConfig()
+      } returns Pair(deliveryConfig.toDeliveryConfig(), false)
 
       every {
         scmUtils.getDefaultBranch(any())

--- a/keel-scm/src/test/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListenerTests.kt
+++ b/keel-scm/src/test/kotlin/com/netflix/spinnaker/keel/scm/DeliveryConfigImportListenerTests.kt
@@ -127,7 +127,7 @@ class DeliveryConfigImportListenerTests : JUnit5Minutests {
       } just runs
 
       every {
-        front50Cache.searchApplications(any(), any(), any())
+        front50Cache.searchApplicationsByRepo(any())
       } returns listOf(configuredApp, notConfiguredApp)
 
       every {

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlActionRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlActionRepository.kt
@@ -2,11 +2,9 @@ package com.netflix.spinnaker.keel.sql
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.keel.api.ActionStateUpdateContext
+import com.netflix.spinnaker.keel.api.ArtifactInEnvironmentContext
 import com.netflix.spinnaker.keel.api.DeliveryConfig
 import com.netflix.spinnaker.keel.api.Environment
-import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
-import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
-import com.netflix.spinnaker.keel.api.ArtifactInEnvironmentContext
 import com.netflix.spinnaker.keel.api.action.Action
 import com.netflix.spinnaker.keel.api.action.ActionRepository
 import com.netflix.spinnaker.keel.api.action.ActionState
@@ -14,16 +12,15 @@ import com.netflix.spinnaker.keel.api.action.ActionStateFull
 import com.netflix.spinnaker.keel.api.action.ActionType
 import com.netflix.spinnaker.keel.api.action.ActionType.POST_DEPLOY
 import com.netflix.spinnaker.keel.api.action.ActionType.VERIFICATION
-import com.netflix.spinnaker.keel.pause.PauseScope.*
+import com.netflix.spinnaker.keel.api.constraints.ConstraintStatus
+import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ACTION_STATE
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ACTIVE_ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_LAST_VERIFIED
-import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ACTIVE_ENVIRONMENT
 import com.netflix.spinnaker.keel.resources.ResourceFactory
-import com.netflix.spinnaker.keel.resources.ResourceSpecIdentifier
-import com.netflix.spinnaker.keel.resources.SpecMigrator
 import com.netflix.spinnaker.keel.sql.RetryCategory.WRITE
 import com.netflix.spinnaker.keel.sql.deliveryconfigs.deliveryConfigByName
 import org.jooq.*
@@ -34,9 +31,9 @@ import org.jooq.impl.DSL.name
 import org.jooq.impl.DSL.select
 import org.jooq.impl.DSL.value
 import org.slf4j.LoggerFactory
-import org.springframework.core.env.Environment as SpringEnvironment
 import java.time.Clock
 import java.time.Duration
+import org.springframework.core.env.Environment as SpringEnvironment
 
 class SqlActionRepository(
   jooq: DSLContext,

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlArtifactRepository.kt
@@ -70,7 +70,6 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.Instant.EPOCH
-import java.time.temporal.TemporalAccessor
 import javax.xml.bind.DatatypeConverter
 
 class SqlArtifactRepository(
@@ -1905,23 +1904,23 @@ class SqlArtifactRepository(
   override fun deploymentsBetween(
     deliveryConfig: DeliveryConfig,
     environmentName: String,
-    startTime: TemporalAccessor,
-    endTime: TemporalAccessor
-  ): Int =
-    (Instant.from(startTime) to Instant.from(endTime)).let { (start, end) ->
-      require(start < end) {
-        "Start time $startTime must be before end time $endTime"
-      }
-      jooq
-        .selectCount()
-        .from(ENVIRONMENT_ARTIFACT_VERSIONS)
-        .join(ENVIRONMENT).on(ENVIRONMENT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID))
-        .join(DELIVERY_CONFIG).on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
-        .where(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
-        .and(ENVIRONMENT.NAME.eq(environmentName))
-        .and(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.between(start, end))
-        .fetchSingleInto<Int>()
+    startTime: Instant,
+    endTime: Instant
+  ): Int {
+    require(startTime < endTime) {
+      "Start time $startTime must be before end time $endTime"
     }
+    log.debug("checking for deployments to {}:{} between {} and {}", deliveryConfig.name, environmentName, startTime, endTime)
+    return jooq
+      .selectCount()
+      .from(ENVIRONMENT_ARTIFACT_VERSIONS)
+      .join(ENVIRONMENT).on(ENVIRONMENT.UID.eq(ENVIRONMENT_ARTIFACT_VERSIONS.ENVIRONMENT_UID))
+      .join(DELIVERY_CONFIG).on(DELIVERY_CONFIG.UID.eq(ENVIRONMENT.DELIVERY_CONFIG_UID))
+      .where(DELIVERY_CONFIG.NAME.eq(deliveryConfig.name))
+      .and(ENVIRONMENT.NAME.eq(environmentName))
+      .and(ENVIRONMENT_ARTIFACT_VERSIONS.DEPLOYED_AT.between(startTime, endTime))
+      .fetchSingleInto<Int>()
+  }
 
   private fun priorVersionDeployedIn(
     environmentId: String,

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/SqlDeliveryConfigRepository.kt
@@ -192,12 +192,7 @@ class SqlDeliveryConfigRepository(
         val txn = DSL.using(config)
         // delete events
         txn.deleteFrom(EVENT)
-          .where(EVENT.SCOPE.eq(EventScope.RESOURCE))
-          .and(EVENT.REF.`in`(resourceIds))
-          .execute()
-        txn.deleteFrom(EVENT)
-          .where(EVENT.SCOPE.eq(EventScope.APPLICATION))
-          .and(EVENT.REF.eq(application))
+          .where(EVENT.APPLICATION.eq(application))
           .execute()
         // delete pause records
         txn.deleteFrom(PAUSED)

--- a/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/afterDeployment.kt
+++ b/keel-sql/src/main/kotlin/com/netflix/spinnaker/keel/sql/afterDeployment.kt
@@ -1,14 +1,13 @@
 package com.netflix.spinnaker.keel.sql
 
-import com.netflix.spinnaker.keel.core.api.PromotionStatus
-import com.netflix.spinnaker.keel.core.api.PromotionStatus.*
+import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.pause.PauseScope
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables
+import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ACTIVE_ENVIRONMENT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_ARTIFACT
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.DELIVERY_CONFIG
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_ARTIFACT_VERSIONS
 import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ENVIRONMENT_LAST_VERIFIED
-import com.netflix.spinnaker.keel.persistence.metamodel.Tables.ACTIVE_ENVIRONMENT
 import org.jooq.DSLContext
 import org.jooq.Record
 import org.jooq.SelectForUpdateStep

--- a/keel-test/keel-test.gradle
+++ b/keel-test/keel-test.gradle
@@ -7,6 +7,8 @@ dependencies {
   api(project(":keel-artifact"))
   api(project(":keel-igor"))
   api(project(":keel-clouddriver"))
+  implementation(project(":keel-ec2-api"))
+  implementation(project(":keel-titus-api"))
   implementation("io.mockk:mockk")
   implementation(project(":keel-spring-test-support"))
 }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/artifacts.kt
@@ -1,17 +1,22 @@
 package com.netflix.spinnaker.keel.test
 
-import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
+import com.netflix.spinnaker.keel.api.artifacts.ArtifactOriginFilter
 import com.netflix.spinnaker.keel.api.artifacts.ArtifactType
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
 import com.netflix.spinnaker.keel.api.artifacts.PublishedArtifact
 import com.netflix.spinnaker.keel.api.artifacts.SortingStrategy
+import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.api.artifacts.branchName
 import com.netflix.spinnaker.keel.api.plugins.ArtifactSupplier
 import com.netflix.spinnaker.keel.api.support.SpringEventPublisherBridge
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
 import com.netflix.spinnaker.keel.artifacts.DebianArtifactSupplier
+import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.artifacts.DockerArtifactSupplier
 import com.netflix.spinnaker.keel.artifacts.NpmArtifactSupplier
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import com.netflix.spinnaker.keel.igor.artifact.ArtifactMetadataService
+import com.netflix.spinnaker.keel.igor.artifact.ArtifactService
 import io.mockk.mockk
 import org.springframework.core.env.Environment
 
@@ -44,3 +49,15 @@ fun defaultArtifactSuppliers(): List<ArtifactSupplier<*, *>> {
     NpmArtifactSupplier(eventBridge, artifactService, artifactMetadataService)
   )
 }
+
+fun debianArtifact() = DebianArtifact(
+  name ="fnord-debian",
+  vmOptions = VirtualMachineOptions(baseOs = "ubuntu", regions = setOf("us-east-1", "us-west-2")),
+  from = ArtifactOriginFilter(branchName("main"))
+)
+
+fun dockerArtifact() = DockerArtifact(
+  name = "org/fnord",
+  reference = "fnord-docker",
+  from = ArtifactOriginFilter(branchName("main"))
+)

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/submittedDeliveryConfig.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/test/submittedDeliveryConfig.kt
@@ -1,0 +1,39 @@
+package com.netflix.spinnaker.keel.test
+
+import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact
+import com.netflix.spinnaker.keel.api.artifacts.VirtualMachineOptions
+import com.netflix.spinnaker.keel.artifacts.DebianArtifact
+import com.netflix.spinnaker.keel.core.api.SubmittedDeliveryConfig
+import com.netflix.spinnaker.keel.core.api.SubmittedEnvironment
+import com.netflix.spinnaker.keel.core.api.SubmittedResource
+
+fun deliveryArtifact(
+  name: String = "fnord",
+  configName: String = "myconfig",
+): DeliveryArtifact {
+  return DebianArtifact(
+    name = name,
+    deliveryConfigName = configName,
+    vmOptions = VirtualMachineOptions(
+      baseOs = "bionic",
+      regions = setOf("us-west-2")
+    )
+  )
+}
+
+fun submittedDeliveryConfig(
+  resource: SubmittedResource<*> = submittedResource(),
+  env: SubmittedEnvironment = SubmittedEnvironment("test", setOf(resource)),
+  application: String = "fnord",
+  configName: String = "myconfig",
+  artifact: DeliveryArtifact = deliveryArtifact(configName = configName),
+  deliveryConfig: SubmittedDeliveryConfig = SubmittedDeliveryConfig(
+    application = application,
+    name = configName,
+    serviceAccount = "keel@keel.io",
+    artifacts = setOf(artifact),
+    environments = setOf(env)
+  )
+): SubmittedDeliveryConfig {
+  return deliveryConfig
+}

--- a/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/titus.kt
+++ b/keel-titus-api/src/main/kotlin/com/netflix/spinnaker/keel/api/titus/titus.kt
@@ -15,11 +15,10 @@
  * limitations under the License.
  *
  */
-package com.netflix.spinnaker.keel.titus
+package com.netflix.spinnaker.keel.api.titus
 
 import com.netflix.spinnaker.keel.api.plugins.kind
-import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 
-const val CLOUD_PROVIDER = "titus"
+const val TITUS_CLOUD_PROVIDER = "titus"
 
 val TITUS_CLUSTER_V1 = kind<TitusClusterSpec>("titus/cluster@v1")

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolver.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.titus
 
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolver.kt
@@ -2,6 +2,7 @@ package com.netflix.spinnaker.keel.titus
 
 import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.plugins.Resolver
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
 import org.springframework.core.env.Environment

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusClusterHandler.kt
@@ -50,7 +50,9 @@ import com.netflix.spinnaker.keel.api.plugins.CurrentImages
 import com.netflix.spinnaker.keel.api.plugins.ImageInRegion
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.ResourcesSpec
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroup
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroup.Constraints
@@ -400,7 +402,7 @@ class TitusClusterHandler(
 
     return mapOf(
       "type" to "disableServerGroup",
-      "cloudProvider" to CLOUD_PROVIDER,
+      "cloudProvider" to TITUS_CLOUD_PROVIDER,
       "credentials" to desired.location.account,
       "moniker" to sgToDisable.moniker.orcaClusterMoniker,
       "region" to sgToDisable.region,
@@ -420,7 +422,7 @@ class TitusClusterHandler(
         "max" to desired.capacity.max,
         "desired" to desired.capacity.desired
       ),
-      "cloudProvider" to CLOUD_PROVIDER,
+      "cloudProvider" to TITUS_CLOUD_PROVIDER,
       "credentials" to desired.location.account,
       "moniker" to current.moniker.orcaClusterMoniker,
       "region" to current.location.region,
@@ -488,7 +490,7 @@ class TitusClusterHandler(
             },
             "type" to "deleteScalingPolicy",
             "scalingPolicyID" to it,
-            "cloudProvider" to CLOUD_PROVIDER,
+            "cloudProvider" to TITUS_CLOUD_PROVIDER,
             "credentials" to desired.location.account,
             "moniker" to current.moniker.orcaClusterMoniker,
             "region" to current.location.region,
@@ -516,7 +518,7 @@ class TitusClusterHandler(
         },
         "type" to "upsertScalingPolicy",
         "jobId" to serverGroup.id,
-        "cloudProvider" to CLOUD_PROVIDER,
+        "cloudProvider" to TITUS_CLOUD_PROVIDER,
         "credentials" to serverGroup.location.account,
         "moniker" to serverGroup.moniker.orcaClusterMoniker,
         "region" to serverGroup.location.region,
@@ -573,7 +575,7 @@ class TitusClusterHandler(
         },
         "type" to "upsertScalingPolicy",
         "jobId" to serverGroup.id,
-        "cloudProvider" to CLOUD_PROVIDER,
+        "cloudProvider" to TITUS_CLOUD_PROVIDER,
         "credentials" to serverGroup.location.account,
         "moniker" to serverGroup.moniker.orcaClusterMoniker,
         "region" to serverGroup.location.region,
@@ -655,7 +657,7 @@ class TitusClusterHandler(
         "moniker" to moniker.orcaClusterMoniker,
         "reason" to "Diff detected at ${clock.instant().iso()}",
         "type" to "createServerGroup",
-        "cloudProvider" to CLOUD_PROVIDER,
+        "cloudProvider" to TITUS_CLOUD_PROVIDER,
         "securityGroups" to securityGroupIds(),
         "loadBalancers" to dependencies.loadBalancerNames,
         "targetGroups" to dependencies.targetGroups,
@@ -840,7 +842,7 @@ class TitusClusterHandler(
               account,
               moniker.toString(),
               it,
-              CLOUD_PROVIDER
+              TITUS_CLOUD_PROVIDER
             )
               .toTitusServerGroup()
           } catch (e: HttpException) {

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusImageResolver.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/TitusImageResolver.kt
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.keel.titus
 
 import com.netflix.spinnaker.keel.api.Resource
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache

--- a/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/exceptions/NoDockerImageFound.kt
+++ b/keel-titus-plugin/src/main/kotlin/com/netflix/spinnaker/keel/titus/exceptions/NoDockerImageFound.kt
@@ -19,9 +19,13 @@ package com.netflix.spinnaker.keel.titus.exceptions
 
 import com.netflix.spinnaker.keel.core.ResourceCurrentlyUnresolvable
 import com.netflix.spinnaker.kork.exceptions.IntegrationException
+import java.time.Instant
 
 class NoDigestFound(repository: String, tag: String) :
   ResourceCurrentlyUnresolvable("No digest found for docker image $repository:$tag in any registry")
 
 class RegistryNotFound(titusAccount: String) :
-  IntegrationException("Unable to find docker registry for titus account $titusAccount")
+  IntegrationException("Unable to find docker registry for Titus account $titusAccount")
+
+class ImageTooOld(repository: String, tag: String, createdAt: Instant) :
+  ResourceCurrentlyUnresolvable("The docker image $repository:$tag (created at $createdAt) is too old. To fix this, please publish a new image.")

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolverTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/ContainerAttributesResolverTests.kt
@@ -5,6 +5,7 @@ import com.netflix.spinnaker.keel.api.Resource
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolverTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/EnvironmentVariablesResolverTests.kt
@@ -4,6 +4,7 @@ import com.netflix.spinnaker.keel.api.Moniker
 import com.netflix.spinnaker.keel.api.SimpleLocations
 import com.netflix.spinnaker.keel.api.SimpleRegionSpec
 import com.netflix.spinnaker.keel.api.plugins.supporting
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
 import com.netflix.spinnaker.keel.docker.ReferenceProvider

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/TitusImageResolverTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/TitusImageResolverTests.kt
@@ -1,0 +1,76 @@
+package com.netflix.spinnaker.keel.titus
+
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverCache
+import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
+import com.netflix.spinnaker.keel.persistence.KeelRepository
+import com.netflix.spinnaker.keel.test.dockerArtifact
+import com.netflix.spinnaker.keel.titus.TitusImageResolver.Companion.TITUS_REGISTRY_IMAGE_TTL
+import com.netflix.spinnaker.keel.titus.exceptions.ImageTooOld
+import com.netflix.spinnaker.keel.titus.exceptions.NoDigestFound
+import com.netflix.spinnaker.time.MutableClock
+import io.mockk.coEvery as every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectCatching
+import strikt.assertions.isA
+import strikt.assertions.isFailure
+import java.time.Duration
+
+class TitusImageResolverTests {
+  private val repository: KeelRepository = mockk()
+  private val cloudDriverService: CloudDriverService = mockk()
+  private val cloudDriverCache: CloudDriverCache = mockk()
+  private val clock = MutableClock()
+  private val subject = TitusImageResolver(repository, clock, cloudDriverCache, cloudDriverService)
+  private val dockerArtifact = dockerArtifact()
+
+  @BeforeEach
+  fun setup() {
+    every {
+      cloudDriverService.findDockerImages(any(), any(), any())
+    } returns emptyList()
+  }
+
+  @Test
+  fun `throws NoDigestFound if digest not found and published version not known`() {
+    every {
+      repository.getArtifactVersion(dockerArtifact, any())
+    } returns null
+
+    expectCatching {
+      subject.getDigest("test", dockerArtifact, "1.0.0")
+    }.isFailure()
+      .isA<NoDigestFound>()
+  }
+
+  @Test
+  fun `throws NoDigestFound if digest not found and published version within TTL`() {
+    every {
+      repository.getArtifactVersion(dockerArtifact, any())
+    } returns dockerArtifact.toArtifactVersion(
+      version = "1.0.0",
+      createdAt = clock.instant() - TITUS_REGISTRY_IMAGE_TTL + Duration.ofDays(5)
+    )
+
+    expectCatching {
+      subject.getDigest("test", dockerArtifact, "1.0.0")
+    }.isFailure()
+      .isA<NoDigestFound>()
+  }
+
+  @Test
+  fun `throws ImageTooOld if digest not found and published version is too old`() {
+    every {
+      repository.getArtifactVersion(dockerArtifact, any())
+    } returns dockerArtifact.toArtifactVersion(
+      version = "1.0.0",
+      createdAt = clock.instant() - TITUS_REGISTRY_IMAGE_TTL - Duration.ofDays(5)
+    )
+
+    expectCatching {
+      subject.getDigest("test", dockerArtifact, "1.0.0")
+    }.isFailure()
+      .isA<ImageTooOld>()
+  }
+}

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TestUtils.kt
@@ -1,6 +1,7 @@
 package com.netflix.spinnaker.keel.titus.resource
 
 import com.netflix.spinnaker.keel.api.ec2.ServerGroup.InstanceCounts
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.Capacity
 import com.netflix.spinnaker.keel.clouddriver.model.Constraints
@@ -12,7 +13,6 @@ import com.netflix.spinnaker.keel.clouddriver.model.ServiceJobProcesses
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroup
 import com.netflix.spinnaker.keel.clouddriver.model.TitusActiveServerGroupImage
 import com.netflix.spinnaker.keel.core.parseMoniker
-import com.netflix.spinnaker.keel.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.titus.moniker
 import org.apache.commons.lang3.RandomStringUtils
 import java.util.UUID.randomUUID
@@ -38,7 +38,7 @@ fun TitusServerGroup.toClouddriverResponse(
       loadBalancers = dependencies.loadBalancerNames,
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       capacity = capacity.run { Capacity(min, max, desired) },
-      cloudProvider = CLOUD_PROVIDER,
+      cloudProvider = TITUS_CLOUD_PROVIDER,
       moniker = parseMoniker("$name-v$sequence"),
       env = env,
       constraints = constraints.run { Constraints(hard, soft) },
@@ -76,7 +76,7 @@ fun TitusServerGroup.toMultiServerGroupResponse(
       loadBalancers = dependencies.loadBalancerNames,
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       capacity = capacity.run { Capacity(min, max, desired) },
-      cloudProvider = CLOUD_PROVIDER,
+      cloudProvider = TITUS_CLOUD_PROVIDER,
       moniker = parseMoniker("$name-v$sequence1"),
       env = env,
       constraints = constraints.run { Constraints(hard, soft) },
@@ -104,7 +104,7 @@ fun TitusServerGroup.toMultiServerGroupResponse(
       loadBalancers = dependencies.loadBalancerNames,
       securityGroups = securityGroups.map(SecurityGroupSummary::id).toSet(),
       capacity = capacity.run { Capacity(min, max, desired) },
-      cloudProvider = CLOUD_PROVIDER,
+      cloudProvider = TITUS_CLOUD_PROVIDER,
       moniker = parseMoniker("$name-v$sequence2"),
       env = env,
       constraints = constraints.run { Constraints(hard, soft) },

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusBaseClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusBaseClusterHandlerTests.kt
@@ -11,6 +11,7 @@ import com.netflix.spinnaker.keel.api.ec2.ClusterSpec
 import com.netflix.spinnaker.keel.api.plugins.BaseClusterHandlerTests
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroup
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
@@ -20,7 +21,6 @@ import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.docker.DigestProvider
 import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
-import com.netflix.spinnaker.keel.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import com.netflix.spinnaker.keel.titus.byRegion
 import com.netflix.spinnaker.keel.titus.resolve

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterDesiredStateResolutionTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterDesiredStateResolutionTests.kt
@@ -17,7 +17,7 @@ import com.netflix.spinnaker.keel.orca.ClusterExportHelper
 import com.netflix.spinnaker.keel.orca.OrcaService
 import com.netflix.spinnaker.keel.test.resource
 import com.netflix.spinnaker.keel.titus.NETFLIX_CONTAINER_ENV_VARS
-import com.netflix.spinnaker.keel.titus.TITUS_CLUSTER_V1
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterExportTests.kt
@@ -15,6 +15,8 @@ import com.netflix.spinnaker.keel.api.ec2.ClusterSpec.CapacitySpec
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
 import com.netflix.spinnaker.keel.api.titus.ResourcesSpec
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact
@@ -33,9 +35,7 @@ import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.test.resource
-import com.netflix.spinnaker.keel.titus.CLOUD_PROVIDER
 import com.netflix.spinnaker.keel.titus.NETFLIX_CONTAINER_ENV_VARS
-import com.netflix.spinnaker.keel.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import com.netflix.spinnaker.keel.titus.resolve
 import dev.minutest.junit.JUnit5Minutests
@@ -58,7 +58,7 @@ import strikt.assertions.isEqualTo
 import strikt.assertions.isNotNull
 import strikt.assertions.isNull
 import java.time.Clock
-import java.util.*
+import java.util.UUID
 
 internal class TitusClusterExportTests : JUnit5Minutests {
   val cloudDriverService = mockk<CloudDriverService>()
@@ -383,7 +383,7 @@ internal class TitusClusterExportTests : JUnit5Minutests {
     account = spec.locations.account,
     cluster = spec.moniker.toString(),
     region = region,
-    cloudProvider = CLOUD_PROVIDER
+    cloudProvider = TITUS_CLOUD_PROVIDER
   )
 
   private fun TitusActiveServerGroup.withDoubleCapacity(): TitusActiveServerGroup =

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterHandlerTests.kt
@@ -36,6 +36,8 @@ import com.netflix.spinnaker.keel.api.events.ArtifactVersionDeployed
 import com.netflix.spinnaker.keel.api.events.ArtifactVersionDeploying
 import com.netflix.spinnaker.keel.api.plugins.Resolver
 import com.netflix.spinnaker.keel.api.support.EventPublisher
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroup
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
@@ -54,8 +56,6 @@ import com.netflix.spinnaker.keel.orca.OrcaTaskLauncher
 import com.netflix.spinnaker.keel.orca.TaskRefResponse
 import com.netflix.spinnaker.keel.persistence.KeelRepository
 import com.netflix.spinnaker.keel.test.resource
-import com.netflix.spinnaker.keel.titus.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import com.netflix.spinnaker.keel.titus.byRegion
 import com.netflix.spinnaker.keel.titus.resolve
@@ -776,7 +776,7 @@ class TitusClusterHandlerTests : JUnit5Minutests {
     account = spec.locations.account,
     cluster = spec.moniker.toString(),
     region = region,
-    cloudProvider = CLOUD_PROVIDER
+    cloudProvider = TITUS_CLOUD_PROVIDER
   )
 }
 

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterScalingPolicyTests.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/resource/TitusClusterScalingPolicyTests.kt
@@ -12,6 +12,8 @@ import com.netflix.spinnaker.keel.api.ec2.CustomizedMetricSpecification
 import com.netflix.spinnaker.keel.api.ec2.MetricDimension
 import com.netflix.spinnaker.keel.api.ec2.StepAdjustment
 import com.netflix.spinnaker.keel.api.ec2.TargetTrackingPolicy
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLOUD_PROVIDER
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusScalingSpec
 import com.netflix.spinnaker.keel.clouddriver.CloudDriverService
@@ -40,8 +42,6 @@ import com.netflix.spinnaker.keel.core.api.randomUID
 import com.netflix.spinnaker.keel.diff.DefaultResourceDiff
 import com.netflix.spinnaker.keel.docker.DigestProvider
 import com.netflix.spinnaker.keel.test.resource
-import com.netflix.spinnaker.keel.titus.CLOUD_PROVIDER
-import com.netflix.spinnaker.keel.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.titus.TitusClusterHandler
 import io.mockk.mockk
 import io.mockk.slot
@@ -88,7 +88,7 @@ class TitusClusterScalingPolicyTests {
     loadBalancers = emptySet(),
     securityGroups = emptySet(),
     capacity = Capacity(min = 1, max = 10, desired = 5),
-    cloudProvider = CLOUD_PROVIDER,
+    cloudProvider = TITUS_CLOUD_PROVIDER,
     moniker = Moniker(app = application, stack = "test"),
     env = mapOf(
       "EC2_REGION" to region,

--- a/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/testHelpers.kt
+++ b/keel-titus-plugin/src/test/kotlin/com/netflix/spinnaker/keel/titus/testHelpers.kt
@@ -10,6 +10,7 @@ import com.netflix.spinnaker.keel.api.SubnetAwareRegionSpec
 import com.netflix.spinnaker.keel.api.ec2.ApplicationLoadBalancerSpec
 import com.netflix.spinnaker.keel.api.ec2.ClusterDependencies
 import com.netflix.spinnaker.keel.api.ec2.EC2_APPLICATION_LOAD_BALANCER_V1_2
+import com.netflix.spinnaker.keel.api.titus.TITUS_CLUSTER_V1
 import com.netflix.spinnaker.keel.api.titus.TitusClusterSpec
 import com.netflix.spinnaker.keel.api.titus.TitusServerGroupSpec
 import com.netflix.spinnaker.keel.artifacts.DockerArtifact

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ActionsDataLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ActionsDataLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.context.DgsContext

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationContext.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationContext.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.context.DgsCustomContextBuilder

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationFetcher.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationFetcher.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsData

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationFetcherSupport.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationFetcherSupport.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.context.DgsContext
 import com.netflix.graphql.dgs.exceptions.DgsEntityNotFoundException

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ArtifactInEnvironmentDataLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ArtifactInEnvironmentDataLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.context.DgsContext

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ConfigFetcher.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ConfigFetcher.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
 import com.netflix.graphql.dgs.DgsComponent

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ConstraintsDataLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ConstraintsDataLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.context.DgsContext

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/EnvironmentArtifactAndVersion.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/EnvironmentArtifactAndVersion.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.spinnaker.keel.api.action.ActionType
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/EnvironmentDeletionStatusLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/EnvironmentDeletionStatusLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.spinnaker.keel.api.Environment

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
@@ -47,16 +47,16 @@ class GitIntegration(
     @InputArgument payload: MdUpdateGitIntegrationPayload,
     @RequestHeader("X-SPINNAKER-USER") user: String
   ): MdGitIntegration {
-    val existingConfig = runBlocking {
+    val front50Application = runBlocking {
       front50Cache.applicationByName(payload.application)
-    }.managedDelivery
+    }
     val updatedFront50App = runBlocking {
       front50Cache.updateManagedDeliveryConfig(
-        payload.application,
+        front50Application,
         user,
         ManagedDeliveryConfig(
-          importDeliveryConfig = payload.isEnabled ?: existingConfig.importDeliveryConfig,
-          manifestPath = payload.manifestPath ?: existingConfig.manifestPath
+          importDeliveryConfig = payload.isEnabled ?: front50Application.managedDelivery.importDeliveryConfig,
+          manifestPath = payload.manifestPath ?: front50Application.managedDelivery.manifestPath
         )
       )
     }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsData

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
@@ -5,9 +5,9 @@ import com.netflix.graphql.dgs.DgsData
 import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
 import com.netflix.graphql.dgs.InputArgument
 import com.netflix.spinnaker.keel.auth.AuthorizationSupport
+import com.netflix.spinnaker.keel.front50.Front50Cache
 import com.netflix.spinnaker.keel.front50.Front50Service
 import com.netflix.spinnaker.keel.front50.model.Application
-import com.netflix.spinnaker.keel.front50.model.ManagedDeliveryConfig
 import com.netflix.spinnaker.keel.graphql.DgsConstants
 import com.netflix.spinnaker.keel.graphql.types.MdApplication
 import com.netflix.spinnaker.keel.graphql.types.MdGitIntegration
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestHeader
 @DgsComponent
 class GitIntegration(
   private val front50Service: Front50Service,
+  private val front50Cache: Front50Cache,
   private val authorizationSupport: AuthorizationSupport,
   private val applicationFetcherSupport: ApplicationFetcherSupport,
   private val scmUtils: ScmUtils,
@@ -46,15 +47,7 @@ class GitIntegration(
     @RequestHeader("X-SPINNAKER-USER") user: String
   ): MdGitIntegration {
     val front50Application = runBlocking {
-      front50Service.updateApplication(
-        payload.application,
-        user,
-        Application(
-          name = payload.application,
-          email = user,
-          managedDelivery = ManagedDeliveryConfig(importDeliveryConfig = payload.isEnabled)
-        )
-      )
+      front50Cache.toggleGitIntegration(payload.application, user, payload.isEnabled)
     }
     return front50Application.toGitIntegration()
   }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/GitIntegration.kt
@@ -55,8 +55,8 @@ class GitIntegration(
         front50Application,
         user,
         ManagedDeliveryConfig(
-          importDeliveryConfig = payload.isEnabled ?: front50Application.managedDelivery.importDeliveryConfig,
-          manifestPath = payload.manifestPath ?: front50Application.managedDelivery.manifestPath
+          importDeliveryConfig = payload.isEnabled ?: front50Application.managedDelivery?.importDeliveryConfig ?: false,
+          manifestPath = payload.manifestPath ?: front50Application.managedDelivery?.manifestPath
         )
       )
     }
@@ -69,8 +69,8 @@ class GitIntegration(
       id = "${name}-git-integration",
       repository = "${repoProjectKey}/${repoSlug}",
       branch = branch,
-      isEnabled = managedDelivery.importDeliveryConfig,
-      manifestPath = managedDelivery.manifestPath,
+      isEnabled = managedDelivery?.importDeliveryConfig,
+      manifestPath = managedDelivery?.manifestPath,
       link = scmUtils.getBranchLink(repoType, repoProjectKey, repoSlug, branch),
     )
   }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/InstantTimeScalar.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/InstantTimeScalar.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import graphql.schema.CoercingParseLiteralException
 import graphql.schema.CoercingParseValueException

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/JsonScalarRegistration.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/JsonScalarRegistration.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import graphql.schema.idl.RuntimeWiring
 

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/LifecycleEventsByVersionDataLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/LifecycleEventsByVersionDataLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.spinnaker.keel.api.artifacts.DeliveryArtifact

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/Mutations.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/Mutations.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsComponent
 import com.netflix.graphql.dgs.DgsData

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/PinnedVersionInEnvironmentDataLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/PinnedVersionInEnvironmentDataLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.context.DgsContext

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ResourceDetailsFetcher.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/ResourceDetailsFetcher.kt
@@ -1,0 +1,30 @@
+package com.netflix.spinnaker.keel.dgs
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper
+import com.netflix.graphql.dgs.DgsComponent
+import com.netflix.graphql.dgs.DgsData
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
+import com.netflix.spinnaker.keel.graphql.DgsConstants
+import com.netflix.spinnaker.keel.graphql.types.MdResource
+
+/**
+ * Fetches details about a specific resource
+ */
+@DgsComponent
+class ResourceDetailsFetcher(
+  private val applicationFetcherSupport: ApplicationFetcherSupport,
+  private val yamlMapper: YAMLMapper
+) {
+  /**
+   * Returns the raw definition of the resource in scope in YAML format. This will include metadata added by Keel.
+   */
+  @DgsData(parentType = DgsConstants.MDRESOURCE.TYPE_NAME, field = DgsConstants.MDRESOURCE.RawDefinition)
+  fun rawDefinition(dfe: DgsDataFetchingEnvironment): String? {
+    val resource: MdResource = dfe.getSource()
+    val config = applicationFetcherSupport.getDeliveryConfigFromContext(dfe)
+    return config.resources.find { it.id == resource.id }
+      ?.let {
+        yamlMapper.writeValueAsString(it)
+      }
+  }
+}

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/VetoedDataLoader.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/VetoedDataLoader.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.graphql.dgs.DgsDataLoader
 import com.netflix.graphql.dgs.context.DgsContext

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/conversions.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/dgs/conversions.kt
@@ -1,4 +1,4 @@
-package com.netflix.spinnaker.keel.rest.dgs
+package com.netflix.spinnaker.keel.dgs
 
 import com.netflix.spinnaker.keel.api.AccountAwareLocations
 import com.netflix.spinnaker.keel.api.DeliveryConfig

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -1,9 +1,8 @@
 package com.netflix.spinnaker.keel.rest
 
-import com.netflix.spinnaker.keel.events.NotificationEvent
 import com.netflix.spinnaker.keel.services.AdminService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
-import com.netflix.spinnaker.kork.exceptions.UserException
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.http.HttpStatus.NO_CONTENT
@@ -19,7 +18,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.time.Duration
-import java.time.format.DateTimeParseException
 
 @RestController
 @RequestMapping(path = ["/poweruser"])
@@ -145,5 +143,14 @@ class AdminController(
   )
   fun refreshApplicationCache() {
     adminService.refreshApplicationCache()
+  }
+
+  @PostMapping(
+    path = ["/git/migrate-pipelines"]
+  )
+  fun runGitIntegrationMigration() {
+    runBlocking {
+      launch { adminService.migrateImportPipelinesToGitIntegration() }
+    }
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/AdminController.kt
@@ -2,8 +2,8 @@ package com.netflix.spinnaker.keel.rest
 
 import com.netflix.spinnaker.keel.services.AdminService
 import com.netflix.spinnaker.keel.yaml.APPLICATION_YAML_VALUE
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory.getLogger
 import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.MediaType
@@ -149,8 +149,6 @@ class AdminController(
     path = ["/git/migrate-pipelines"]
   )
   fun runGitIntegrationMigration() {
-    runBlocking {
-      launch { adminService.migrateImportPipelinesToGitIntegration() }
-    }
+    GlobalScope.launch { adminService.migrateImportPipelinesToGitIntegration() }
   }
 }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/dgs/ApplicationFetcher.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/rest/dgs/ApplicationFetcher.kt
@@ -131,8 +131,8 @@ class ApplicationFetcher(
           number = env.pullRequestId,
           link = scmUtils.getPullRequestLink(
             env.repoType,
-            env.repoKey,
-            env.repoKey,
+            env.projectKey,
+            env.repoSlug,
             env.pullRequestId
           )
         )

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -210,7 +210,7 @@ class AdminService(
         return@forEach
       }
 
-      if (app.managedDelivery.importDeliveryConfig == true) {
+      if (app.managedDelivery?.importDeliveryConfig == true) {
         log.debug("App ${app.name} already configured for git integration. Skipping migration.")
         return@forEach
       }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -210,7 +210,7 @@ class AdminService(
         return@forEach
       }
 
-      if (app.managedDelivery?.importDeliveryConfig == true) {
+      if (app.managedDelivery.importDeliveryConfig == true) {
         log.debug("App ${app.name} already configured for git integration. Skipping migration.")
         return@forEach
       }

--- a/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
+++ b/keel-web/src/main/kotlin/com/netflix/spinnaker/keel/services/AdminService.kt
@@ -195,6 +195,7 @@ class AdminService(
   suspend fun migrateImportPipelinesToGitIntegration() {
     val configs = repository.allDeliveryConfigs()
     var migrated = 0
+    val startTime = clock.instant()
     log.debug("Retrieved ${configs.size} delivery configs for git integration migration")
 
     configs.forEach { config ->
@@ -254,6 +255,7 @@ class AdminService(
 
       migrated++
     }
-    log.debug("Migrated $migrated/${configs.size} apps")
+    val duration = Duration.between(startTime, clock.instant())
+    log.debug("Migrated $migrated/${configs.size} apps (${configs.size - migrated} skipped) in ${duration.toSeconds()} seconds")
   }
 }

--- a/keel-web/src/main/resources/schema/schema.graphql
+++ b/keel-web/src/main/resources/schema/schema.graphql
@@ -206,6 +206,7 @@ type MdResource {
   artifact: MdArtifact
   displayName: String
   location: MdLocation
+  rawDefinition: String
 }
 
 type MdMoniker {

--- a/keel-web/src/main/resources/schema/schema.graphql
+++ b/keel-web/src/main/resources/schema/schema.graphql
@@ -22,6 +22,7 @@ type MdGitIntegration {
   repository: String
   branch: String
   isEnabled: Boolean
+  manifestPath: String
   link: String
 }
 
@@ -286,7 +287,8 @@ type Mutation @extends {
 
 input MdUpdateGitIntegrationPayload {
   application: String!
-  isEnabled: Boolean!
+  isEnabled: Boolean
+  manifestPath: String
 }
 
 input MdRetryArtifactActionPayload {

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationFetcherSupportTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/ApplicationFetcherSupportTests.kt
@@ -9,9 +9,6 @@ import com.netflix.spinnaker.keel.core.api.DEFAULT_SERVICE_ACCOUNT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.PromotionStatus.PREVIOUS
 import com.netflix.spinnaker.keel.core.api.PublishedArtifactInEnvironment
-import com.netflix.spinnaker.keel.rest.dgs.ApplicationFetcherSupport
-import com.netflix.spinnaker.keel.rest.dgs.ArtifactDiffContext
-import com.netflix.spinnaker.keel.rest.dgs.toDgs
 import com.netflix.spinnaker.keel.test.artifactReferenceResource
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import graphql.schema.DataFetchingEnvironment

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/ConstraintsDataLoaderTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/ConstraintsDataLoaderTests.kt
@@ -22,8 +22,6 @@ import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
 import com.netflix.spinnaker.keel.core.api.windowsNumeric
 import com.netflix.spinnaker.keel.persistence.ArtifactRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
-import com.netflix.spinnaker.keel.rest.dgs.ConstraintsDataLoader
-import com.netflix.spinnaker.keel.rest.dgs.EnvironmentArtifactAndVersion
 import com.netflix.spinnaker.keel.test.deliveryConfig
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/DgsTestConfig.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/DgsTestConfig.kt
@@ -4,5 +4,5 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ComponentScan(basePackages = ["com.netflix.spinnaker.keel.rest.dgs"])
+@ComponentScan(basePackages = ["com.netflix.spinnaker.keel.dgs"])
 class DgsTestConfig

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/ResourceDetailsFetcherTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/dgs/ResourceDetailsFetcherTests.kt
@@ -1,0 +1,41 @@
+package com.netflix.spinnaker.keel.dgs
+
+import com.netflix.graphql.dgs.DgsDataFetchingEnvironment
+import com.netflix.spinnaker.keel.graphql.types.MdResource
+import com.netflix.spinnaker.keel.serialization.configuredYamlMapper
+import com.netflix.spinnaker.keel.test.deliveryConfig
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import strikt.api.expectThat
+import strikt.assertions.isEqualTo
+
+class ResourceDetailsFetcherTests {
+  private val applicationFetcherSupport: ApplicationFetcherSupport = mockk()
+  private val yamlMapper = configuredYamlMapper()
+  private val resourceDetailsFetcher = ResourceDetailsFetcher(applicationFetcherSupport, yamlMapper)
+  private val dfe: DgsDataFetchingEnvironment = mockk()
+  private val deliveryConfig = deliveryConfig()
+  private val environment = deliveryConfig.environments.first()
+  private val resource = environment.resources.first()
+
+  @BeforeEach
+  fun setup() {
+    every {
+      dfe.getSource<MdResource>()
+    } returns resource.toDgs(deliveryConfig, environment.name)
+
+    every {
+      applicationFetcherSupport.getDeliveryConfigFromContext(dfe)
+    } returns deliveryConfig
+  }
+
+  @Test
+  fun `returns the raw resource definition as YAML`() {
+    val yaml = resourceDetailsFetcher.rawDefinition(dfe)
+
+    expectThat(yaml)
+      .isEqualTo(yamlMapper.writeValueAsString(resource))
+  }
+}

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
@@ -184,7 +184,7 @@ class AdminServiceTests : JUnit5Minutests {
         verify {
           front50Service.updatePipeline(importPipeline.id, capture(updatedPipeline), any())
         }
-        expectThat(updatedApp.captured.managedDelivery.importDeliveryConfig).isTrue()
+        expectThat(updatedApp.captured.managedDelivery?.importDeliveryConfig).isTrue()
         expectThat(updatedPipeline.captured.disabled).isTrue()
       }
 

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
@@ -11,6 +11,12 @@ import com.netflix.spinnaker.keel.core.api.PromotionStatus.CURRENT
 import com.netflix.spinnaker.keel.core.api.TimeWindow
 import com.netflix.spinnaker.keel.core.api.TimeWindowConstraint
 import com.netflix.spinnaker.keel.front50.Front50Cache
+import com.netflix.spinnaker.keel.front50.Front50Service
+import com.netflix.spinnaker.keel.front50.model.Application
+import com.netflix.spinnaker.keel.front50.model.ManagedDeliveryConfig
+import com.netflix.spinnaker.keel.front50.model.Pipeline
+import com.netflix.spinnaker.keel.front50.model.Stage
+import com.netflix.spinnaker.keel.front50.model.Trigger
 import com.netflix.spinnaker.keel.pause.ActuationPauser
 import com.netflix.spinnaker.keel.persistence.DiffFingerprintRepository
 import com.netflix.spinnaker.keel.persistence.KeelRepository
@@ -19,12 +25,17 @@ import com.netflix.spinnaker.keel.test.DummySortingStrategy
 import com.netflix.spinnaker.time.MutableClock
 import dev.minutest.junit.JUnit5Minutests
 import dev.minutest.rootContext
-import io.mockk.every
+import io.mockk.Runs
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import io.mockk.verify
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationEventPublisher
+import strikt.api.expectThat
+import strikt.assertions.isTrue
+import io.mockk.coEvery as every
+import io.mockk.coVerify as verify
 
 class AdminServiceTests : JUnit5Minutests {
   class Fixture {
@@ -33,6 +44,7 @@ class AdminServiceTests : JUnit5Minutests {
     val actuationPauser: ActuationPauser = mockk()
     private val artifactSupplier = mockk<ArtifactSupplier<DummyArtifact, DummySortingStrategy>>(relaxUnitFun = true)
     val front50Cache: Front50Cache = mockk()
+    val front50Service: Front50Service = mockk()
     val publisher: ApplicationEventPublisher = mockk(relaxed = true)
     val clock = MutableClock()
 
@@ -47,7 +59,7 @@ class AdminServiceTests : JUnit5Minutests {
       )
     )
 
-    val artifact = mockk<DeliveryArtifact>() {
+    val artifact = mockk<DeliveryArtifact> {
       every { reference } returns "myartifact"
     }
 
@@ -59,15 +71,45 @@ class AdminServiceTests : JUnit5Minutests {
       environments = setOf(environment)
     )
 
+    val front50Application = Application(
+      name = deliveryConfig.name,
+      email = "keel@keel.io",
+      repoType = "stash",
+      repoProjectKey = "proj",
+      repoSlug = "repo",
+    )
+
+    val importPipeline = Pipeline(
+      name = "Import",
+      id = "config",
+      application = front50Application.name,
+      disabled = false,
+      triggers = listOf(Trigger(type = "trigger", enabled = true, application = front50Application.name)),
+      _stages = listOf(Stage(type = "importDeliveryConfig", name = "Import config", refId = "1"))
+    )
+
     val subject = AdminService(
       repository,
       actuationPauser,
       diffFingerprintRepository,
       listOf(artifactSupplier),
       front50Cache,
+      front50Service,
       publisher,
       clock
     )
+
+    fun verifyMigrationWasSkipped() {
+      runBlocking {
+        subject.migrateImportPipelinesToGitIntegration()
+      }
+      verify(exactly = 0) {
+        front50Service.updateApplication(front50Application.name, any(), any())
+      }
+      verify(exactly = 0) {
+        front50Service.updatePipeline(importPipeline.id, any(), any())
+      }
+    }
   }
 
   fun adminServiceTests() = rootContext<Fixture> {
@@ -98,7 +140,7 @@ class AdminServiceTests : JUnit5Minutests {
     }
 
     test("forcing an artifact version to be skipped") {
-      val current = mockk<PublishedArtifact>() {
+      val current = mockk<PublishedArtifact> {
         every { reference } returns artifact.reference
         every { version } returns "v16"
       }
@@ -118,6 +160,110 @@ class AdminServiceTests : JUnit5Minutests {
 
       test("delegates to the cache") {
         verify { front50Cache.primeCaches() }
+      }
+    }
+
+    context("git integration migration") {
+      before {
+        every { repository.allDeliveryConfigs() } returns setOf(deliveryConfig)
+        every { front50Cache.applicationByName(deliveryConfig.application) } returns front50Application
+        every { front50Cache.pipelinesByApplication(front50Application.name) } returns listOf(importPipeline)
+        every { front50Service.updateApplication(front50Application.name, any(), any()) } returns front50Application
+        every { front50Service.updatePipeline(importPipeline.id, any(), any()) } just Runs
+      }
+
+      test("migrated successfully") {
+        val updatedApp = slot<Application>()
+        val updatedPipeline = slot<Pipeline>()
+        runBlocking {
+          subject.migrateImportPipelinesToGitIntegration()
+        }
+        verify {
+          front50Service.updateApplication(front50Application.name, any(), capture(updatedApp))
+        }
+        verify {
+          front50Service.updatePipeline(importPipeline.id, capture(updatedPipeline), any())
+        }
+        expectThat(updatedApp.captured.managedDelivery?.importDeliveryConfig).isTrue()
+        expectThat(updatedPipeline.captured.disabled).isTrue()
+      }
+
+      context("git integration already enabled") {
+        before {
+          every { front50Cache.applicationByName(deliveryConfig.application) } returns front50Application.copy(
+            managedDelivery = ManagedDeliveryConfig(
+              importDeliveryConfig = true
+            )
+          )
+        }
+        test("skipping migration") {
+          runBlocking {
+            subject.migrateImportPipelinesToGitIntegration()
+          }
+          verifyMigrationWasSkipped()
+        }
+      }
+
+      context("no import config pipeline") {
+        before {
+          every { front50Cache.pipelinesByApplication(front50Application.name) } returns listOf(
+            importPipeline.copy(
+              _stages = listOf(Stage(type = "coolStage", name = "cool", refId = "1"))
+            )
+          )
+        }
+        test("skipping migration") {
+          verifyMigrationWasSkipped()
+        }
+      }
+
+      context("pipeline is disabled") {
+        before {
+          every { front50Cache.pipelinesByApplication(front50Application.name) } returns listOf(
+            importPipeline.copy(
+              disabled = true
+            )
+          )
+        }
+        test("skipping migration") {
+          verifyMigrationWasSkipped()
+        }
+      }
+
+      context("pipeline triggers are disabled") {
+        before {
+          every { front50Cache.pipelinesByApplication(front50Application.name) } returns listOf(
+            importPipeline.copy(
+              triggers = listOf(Trigger(type = "trigger", enabled = false, application = front50Application.name))
+            )
+          )
+        }
+        test("skipping migration") {
+          verifyMigrationWasSkipped()
+        }
+      }
+
+      context("failure to update git integration") {
+        before {
+          every {
+            front50Service.updateApplication(
+              front50Application.name,
+              any(),
+              any()
+            )
+          } throws Exception("This is awful")
+        }
+        test("pipeline update is skipped") {
+          runBlocking {
+            subject.migrateImportPipelinesToGitIntegration()
+          }
+          verify(exactly = 1) {
+            front50Service.updateApplication(front50Application.name, any(), any())
+          }
+          verify(exactly = 0) {
+            front50Service.updatePipeline(importPipeline.id, any(), any())
+          }
+        }
       }
     }
   }

--- a/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
+++ b/keel-web/src/test/kotlin/com/netflix/spinnaker/keel/services/AdminServiceTests.kt
@@ -184,7 +184,7 @@ class AdminServiceTests : JUnit5Minutests {
         verify {
           front50Service.updatePipeline(importPipeline.id, capture(updatedPipeline), any())
         }
-        expectThat(updatedApp.captured.managedDelivery?.importDeliveryConfig).isTrue()
+        expectThat(updatedApp.captured.managedDelivery.importDeliveryConfig).isTrue()
         expectThat(updatedPipeline.captured.disabled).isTrue()
       }
 


### PR DESCRIPTION
This includes the following PRs vetted internally at Netflix:
- fix(constraints): test to ensure correct time zone is used when checking deploy window
- fix(git): enable git integration for new apps
- fix(preview-envs): Make preview resource names DNS-compliant
- fix(sql): Attempt at fixing deletion of event records
- fix(front50): make managedDelivery in Application nullable
- fix(git): use the correct email for updating the app
- fix(constraints): ensure we're querying in UTC for deploys in a time window
- fix(preview-envs): Multiple fixes for preview environments
- feat(import): allow customizing the manifest path
- chore(logs): Add more logging for preview resource handling
- fix(config): handle PR merged events that include delivery config changes
- fix(import): add service account from app if missing
- fix(front50): update and clear front50 cache on git integration update
- feat(resources): Expose raw resource definition in GraphQL API
- refactor(packages): Move DGS code outside REST package
- chore(api): add app name to error message
- refactor(config): one centralized location for delivery upserts
- fix(admin): Fix launch of background coroutine for admin API
- feat(git): Add admin API to migrate apps to new git integration
- fix(preview): fix preview environment links to use the right fields

As discussed in the SIG meeting of [August 24](https://drive.google.com/file/d/1P0YrhXt64V5Os3VCMhWFmWldY6tSvPXa/view?usp=sharing), we'll attempt to make this process better and automate the generation of 1 open-source PR for each internal PR. We're not there yet, so this is in support keeping OSS current for the time being.