### PR TITLE
feat(imagehandler): allow opting out of base updates

### DIFF
--- a/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/VirtualMachineOptions.kt
+++ b/keel-api/src/main/kotlin/com/netflix/spinnaker/keel/api/artifacts/VirtualMachineOptions.kt
@@ -7,5 +7,6 @@ data class VirtualMachineOptions(
   val baseLabel: BaseLabel = RELEASE,
   val baseOs: String,
   val regions: Set<String>,
-  val storeType: StoreType = EBS
+  val storeType: StoreType = EBS,
+  val ignoreBaseUpdates: Boolean = false
 )

--- a/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
+++ b/keel-bakery-plugin/src/main/kotlin/com/netflix/spinnaker/keel/bakery/artifact/ImageHandler.kt
@@ -72,7 +72,7 @@ class ImageHandler(
             log.info("No AMI found for {}", desiredAppVersion)
             launchBake(artifact, desiredAppVersion)
           }
-          imagesWithOlderBaseImages.isNotEmpty() -> {
+          imagesWithOlderBaseImages.isNotEmpty() && !artifact.vmOptions.ignoreBaseUpdates -> {
             log.info("AMIs for {} are outdated, rebaking…", desiredAppVersion)
             launchBake(
               artifact,


### PR DESCRIPTION
Allow setting `ignoreBaseUpdates` in vmOptions to skip rebaking/deploying when new base images are available.