### PR TITLE
fix(artifacts): use normalized artifact versions

### DIFF
--- a/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
+++ b/keel-artifact/src/main/kotlin/com/netflix/spinnaker/keel/artifacts/ArtifactListener.kt
@@ -97,7 +97,7 @@ class ArtifactListener(
             log.debug("Latest available versions of $artifact: ${latestAvailableVersions.map { it.version }}")
 
             val newVersions = latestAvailableVersions
-              .filterNot { currentVersions.contains(it.version) }
+              .filterNot { currentVersions.contains(it.normalized().version) }
               .filter { artifactSupplier.shouldProcessArtifact(it) }
             if (newVersions.isNotEmpty()) {
               log.debug("$artifact has a missing version(s) ${newVersions.map { it.version }}, persisting.")


### PR DESCRIPTION
Use normalized version when comparing latest available artifact and the current artifact from the DB.