### PR TITLE
chore(dependencies): bump kork version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlinVersion=1.4.32
 fiatVersion=1.27.1
-korkVersion=7.105.0
+korkVersion=7.132.0
 kapt.use.worker.api=true
 liquibaseTaskPrefix=liquibase
 org.gradle.parallel=true

--- a/keel-ec2-plugin/keel-ec2-plugin.gradle
+++ b/keel-ec2-plugin/keel-ec2-plugin.gradle
@@ -23,7 +23,6 @@ dependencies {
   testImplementation("io.strikt:strikt-jvm")
   testImplementation("dev.minutest:minutest")
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-  testImplementation("org.funktionale:funktionale-partials")
   testImplementation("org.apache.commons:commons-lang3")
 
   // the following are needed to use keel's real(-ish) Spring configuration

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClassicLoadBalancerHandlerTests.kt
@@ -49,14 +49,7 @@ import kotlinx.coroutines.runBlocking
 import strikt.api.Assertion
 import strikt.api.DescribeableBuilder
 import strikt.api.expectThat
-import strikt.assertions.containsExactly
-import strikt.assertions.get
-import strikt.assertions.hasSize
-import strikt.assertions.isEmpty
-import strikt.assertions.isEqualTo
-import strikt.assertions.isFalse
-import strikt.assertions.isNotNull
-import strikt.assertions.isTrue
+import strikt.assertions.*
 import java.util.UUID
 import io.mockk.coEvery as every
 import io.mockk.coVerify as verify
@@ -368,8 +361,12 @@ fun Assertion.Builder<DiffNode>.getChild(propertyName: String): Assertion.Builde
   }
 
 fun Assertion.Builder<DiffNode>.getChild(vararg selectors: ElementSelector): Assertion.Builder<DiffNode?> =
-  get("child node with path $path") {
-    getChild(selectors.toList())
+  runBlocking {
+    val pathBuilder = path
+    pathBuilder.isNotEqualTo(null)
+    get("child node with path $pathBuilder") {
+      getChild(selectors.toList())
+   }
   }
 
 val Assertion.Builder<DiffNode>.path: Assertion.Builder<NodePath>

--- a/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
+++ b/keel-ec2-plugin/src/test/kotlin/com/netflix/spinnaker/keel/ec2/resource/ClusterHandlerTests.kt
@@ -61,23 +61,7 @@ import kotlinx.coroutines.runBlocking
 import strikt.api.Assertion
 import strikt.api.expectCatching
 import strikt.api.expectThat
-import strikt.assertions.all
-import strikt.assertions.any
-import strikt.assertions.containsExactly
-import strikt.assertions.containsExactlyInAnyOrder
-import strikt.assertions.containsKey
-import strikt.assertions.get
-import strikt.assertions.hasSize
-import strikt.assertions.isA
-import strikt.assertions.isEmpty
-import strikt.assertions.isEqualTo
-import strikt.assertions.isFalse
-import strikt.assertions.isNotEmpty
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
-import strikt.assertions.isSuccess
-import strikt.assertions.isTrue
-import strikt.assertions.map
+import strikt.assertions.*
 import java.time.Clock
 import java.time.Duration
 import java.util.UUID.randomUUID
@@ -739,7 +723,7 @@ internal class ClusterHandlerTests : JUnit5Minutests {
                       statistic = metricSpec.statistic
                     )
                   )
-              }
+              }.isNotEqualTo(null)
           }
         }
       }

--- a/keel-titus-plugin/keel-titus-plugin.gradle
+++ b/keel-titus-plugin/keel-titus-plugin.gradle
@@ -19,7 +19,6 @@ dependencies {
   testImplementation("io.strikt:strikt-mockk")
   testImplementation("dev.minutest:minutest")
   testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-  testImplementation("org.funktionale:funktionale-partials")
   testImplementation("org.apache.commons:commons-lang3")
   testImplementation(project(":keel-core-test"))
 }


### PR DESCRIPTION
This fixes test failures in https://github.com/spinnaker/keel/pull/2006
Root cause seems to be due to this change in strikt: https://github.com/robfletcher/strikt/commit/2ff8361476da86da4fd2ab1a80f103375e769c31

When `Assertion.Builder<DiffNode>.path` is called, it creates a `Assertion.Builder<NodePath>` object. This object does not have any assertions and is left alone. This was not a problem before strikt 0.31.0 because it did not care about assertion builder objects left in pending state. 
Starting version 0.31.0, any assertion builder in pending state raises `IncompleteAssertion` exception and thus this was failing. So the fix is to attach an assertion to it. 
