### PR TITLE
chore(dependencies): bump spinnakerGradleVersion

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.parallel=true
 testContainersVersion=1.15.3
 okHttpVersion=4.5.0
 resilience4jVersion=1.5.0
-spinnakerGradleVersion=8.15.0
+spinnakerGradleVersion=8.23.0
 
 # Used to control whether to spin up docker to run liquibase before jooq
 buildingInDocker=false


### PR DESCRIPTION
to pick up google artifact registry publishing fixes

Doing this manually rather than backporting ~7 PRs
