### PR TITLE
fix(artifacts): Add support for github enterprise

### DIFF
--- a/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
+++ b/keel-core/src/test/kotlin/com/netflix/spinnaker/keel/services/ComparableLinksTests.kt
@@ -304,7 +304,7 @@ class ComparableLinksTests : JUnit5Minutests {
         before {
           every { repository.artifactVersions(releaseArtifact, limit) } returns versions.toArtifactVersions(
             releaseArtifact,
-            "stash"
+            "https://stash"
           )
         }
 

--- a/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
+++ b/keel-echo/src/test/kotlin/com/netflix/spinnaker/keel/echo/ManualJudgementNotifierTests.kt
@@ -279,7 +279,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
               project = "myproj",
               branch = "master",
               repo = Repo("myapp"),
-              commitInfo = Commit(message = "A test commit #2", link = "stash", sha = "v2.0.0")
+              commitInfo = Commit(message = "A test commit #2", link = "https://stash", sha = "v2.0.0")
             )
           )
         }
@@ -312,7 +312,7 @@ internal class ManualJudgementNotifierTests : JUnit5Minutests {
                 project = "myproj",
                 branch = "master",
                 repo = Repo("myapp"),
-                commitInfo = Commit(message = "A test commit", link = "stash", sha = "v1.0.0")
+                commitInfo = Commit(message = "A test commit", link = "https://stash", sha = "v1.0.0")
               )
             )
           }

--- a/keel-notifications/src/test/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/GitDataGeneratorTests.kt
+++ b/keel-notifications/src/test/kotlin/com/netflix/spinnaker/keel/notifications/slack/handlers/GitDataGeneratorTests.kt
@@ -67,9 +67,9 @@ class GitDataGeneratorTests : JUnit5Minutests {
                 project = "spkr",
                 repo = Repo("keel", null),
                 branch = "main",
-                pullRequest = PullRequest("1", "stash/pr/1"),
+                pullRequest = PullRequest("1", "https://stash/pr/1"),
                 commitInfo = Commit(
-                  link = "stash",
+                  link = "https://stash",
                   sha = "676fea96a33cbc774685ff8b511092d9a3809f90",
                   message = null
                 )
@@ -87,8 +87,8 @@ class GitDataGeneratorTests : JUnit5Minutests {
         expect {
           that(text.toString().contains("text=<https://stash/projects/spkr/repos/keel|spkr/keel>")).isTrue()
           that(text.toString().contains("<https://stash/projects/spkr/repos/keel/branches|main>")).isTrue()
-          that(text.toString().contains("<stash/pr/1|PR#1>")).isTrue()
-          that(text.toString().contains("<stash|676fea9>")).isTrue()
+          that(text.toString().contains("<https://stash/pr/1|PR#1>")).isTrue()
+          that(text.toString().contains("<https://stash|676fea9>")).isTrue()
         }
       }
     }

--- a/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/services/versionLinksUtils.kt
+++ b/keel-test/src/main/kotlin/com/netflix/spinnaker/keel/services/versionLinksUtils.kt
@@ -12,7 +12,8 @@ import java.util.function.Function
 
 val scmData = mapOf(
   "stash" to "https://stash",
-  "gitHub" to "https://github.com")
+  "gitHub" to "https://github.com",
+  "gitHubEnterprise" to "https://git.foo.com")
 
 fun mockScmInfo(): ScmInfo {
   return mockk() {


### PR DESCRIPTION
Signed-off-by: Jesse Sanford <jesse.sanford@autodesk.com>

Adds support for github enterprise. Currently the gui shows up broken because it doesn't understand URLs that don't contain "github". This will allow those as long as they are "mapped to github" in the list of scm accounts.
