### PR TITLE
chore(ci): give gradle more memory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     - release-*
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx4g -Xms4g
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR Build
 on: [ pull_request ]
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx4g -Xms4g
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx2g -Xms2g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx4g -Xms4g
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:


### PR DESCRIPTION
to try to avoid errors like:
```
ApplicationControllerTests initializationError FAILED

  org.junit.jupiter.api.extension.ParameterResolutionException: Failed to resolve parameter [org.springframework.test.web.servlet.MockMvc arg0] in constructor [public com.netflix.spinnaker.keel.rest.ApplicationControllerTests(org.springframework.test.web.servlet.MockMvc,com.fasterxml.jackson.databind.ObjectMapper)]: Failed to load ApplicationContext

  Caused by: java.lang.IllegalStateException: Failed to load ApplicationContext

  Caused by: org.springframework.beans.factory.BeanDefinitionStoreException: Failed to process import candidates for configuration class [springfox.documentation.swagger2.configuration.Swagger2DocumentationConfiguration]; nested exception is java.lang.OutOfMemoryError: Java heap space

  Caused by: java.lang.OutOfMemoryError: Java heap space
```
from https://github.com/spinnaker/keel/runs/6115232379?check_suite_focus=true
