### PR TITLE
chore(ci): give gradle yet more memory (6g)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     - release-*
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx4g -Xms4g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,7 +3,7 @@ name: PR Build
 on: [ pull_request ]
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx4g -Xms4g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
 
 env:
-  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx4g -Xms4g
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Xmx6g -Xms6g
   CONTAINER_REGISTRY: us-docker.pkg.dev/spinnaker-community/docker
 
 jobs:


### PR DESCRIPTION
https://github.com/spinnaker/keel/runs/6117954393?check_suite_focus=true failed with:
```
Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "default housekeeper"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "slack-api-client-metrics-memory:38741d9e-worker-32"
*** java.lang.instrument ASSERTION FAILED ***: "!errorOutstanding" with message can't create name string at src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 827

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "slack-api-client-metrics-memory:607a9eaa-worker-34"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "default housekeeper"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "default housekeeper"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "default housekeeper"

Exception: java.lang.OutOfMemoryError thrown from the UncaughtExceptionHandler in thread "default housekeeper"
ApplicationControllerTests initializationError FAILED (4.4s)
```