### PR TITLE
fix(test): Bump testcontainers version

### DIFF
--- a/keel-sql/src/test/resources/testcontainers.properties
+++ b/keel-sql/src/test/resources/testcontainers.properties
@@ -1,1 +1,1 @@
-ryuk.container.image = public.ecr.aws/s4w6t4b6/testcontainers/ryuk:0.3.0 
+ryuk.container.image = public.ecr.aws/s4w6t4b6/testcontainers/ryuk:0.3.4


### PR DESCRIPTION
Upgrade testcontainers/ryuk to 0.3.4 since 0.3.0 is [no longer available](https://gallery.ecr.aws/s4w6t4b6/testcontainers/ryuk).

Fixes the following error in the build:
```
  java.lang.ExceptionInInitializerError
      at com.netflix.spinnaker.keel.sql.ArtifactVersionApprovalCountTests.<init>(ArtifactVersionApprovalCountTests.kt:21)
  Caused by: com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"manifest for public.ecr.aws/s4w6t4b6/testcontainers/ryuk:0.3.0 not found: manifest unknown: Requested image not found"}
```

