### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 LABEL maintainer="sig-platform@spinnaker.io"
-RUN apt-get update && apt-get -y install openjdk-17-jre-headless wget
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get -y install openjdk-17-jre-headless wget
 RUN adduser --system --uid 10111 --group spinnaker
 COPY keel-web/build/install/keel /opt/keel
 RUN mkdir -p /opt/keel/plugins && chown -R spinnaker:nogroup /opt/keel/plugins


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#10 95.64 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
#10 95.72 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 96.07 Segmentation fault (core dumped)
#10 96.12 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#10 96.48 Segmentation fault (core dumped)
#10 96.48 dpkg: error processing package libc-bin (--configure):
#10 96.48  installed libc-bin package post-installation script subprocess returned error exit status 139
```
from https://github.com/spinnaker/keel/actions/runs/13294120220/job/37121777972?pr=2121

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834